### PR TITLE
Updated TransactionGenerator

### DIFF
--- a/src/main/scala/org/ergoplatform/local/TransactionGenerator.scala
+++ b/src/main/scala/org/ergoplatform/local/TransactionGenerator.scala
@@ -36,9 +36,7 @@ class TransactionGenerator(viewHolder: ActorRef, settings: TestingSettings) exte
             val txBoxes = (1 to Random.nextInt(10) + 1).flatMap(_ => v.state.randomBox())
             val txInputs = txBoxes.map(_.nonce)
             val values = txBoxes.map(_.value)
-
             val txOutputs = if(values.head % 2 == 0) IndexedSeq.fill(2)(values.head / 2) ++ values.tail else values
-
             AnyoneCanSpendTransaction(txInputs, txOutputs)
           }
         } else {

--- a/src/main/scala/org/ergoplatform/local/TransactionGenerator.scala
+++ b/src/main/scala/org/ergoplatform/local/TransactionGenerator.scala
@@ -25,16 +25,21 @@ class TransactionGenerator(viewHolder: ActorRef, settings: TestingSettings) exte
   override def receive: Receive = {
     case StartGeneration =>
       if (!isStarted) {
-        context.system.scheduler.schedule(500.millis, 500.millis)(self ! FetchBoxes)
+        context.system.scheduler.schedule(1500.millis, 1500.millis)(self ! FetchBoxes)
       }
 
     case FetchBoxes =>
       viewHolder ! GetDataFromCurrentView[ErgoHistory, UtxoState, ErgoWallet, ErgoMemPool,
         Seq[AnyoneCanSpendTransaction]] { v =>
         if (v.pool.size < settings.keepPoolSize) {
-          (0 until settings.keepPoolSize - v.pool.size).map { i =>
+          (0 until settings.keepPoolSize - v.pool.size).map { _ =>
             val txBoxes = (1 to Random.nextInt(10) + 1).flatMap(_ => v.state.randomBox())
-            AnyoneCanSpendTransaction(txBoxes.map(_.nonce), txBoxes.map(_.value))
+            val txInputs = txBoxes.map(_.nonce)
+            val values = txBoxes.map(_.value)
+
+            val txOutputs = if(values.head % 2 == 0) IndexedSeq.fill(2)(values.head / 2) ++ values.tail else values
+
+            AnyoneCanSpendTransaction(txInputs, txOutputs)
           }
         } else {
           Seq()


### PR DESCRIPTION
Now transaction generator is increasing UTXO by dividing first input into two outputs, if input value is even. Delay between calls is increased to 1500 ms