### PR TITLE
Fix openapi.yaml: HTML responses must be strings

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -336,7 +336,7 @@ paths:
             format: int32
             default: 0
       responses:
-        200:
+        '200':
           # TODO : decide whether without `heightFrom` and/or `heightTo` the response will contain `limit` blocks stating from 0 + `offset`, or last `limit` blocks
           description: Array of header ids
           example: ["D2bXMwWN8P9nWJ9qqwZJLauAdcZHX9n6s91QQ9vK6Zu4"]
@@ -369,7 +369,7 @@ paths:
             schema:
               $ref: '#/components/schemas/FullBlock'
       responses:
-        200:
+        '200':
           description: Block is valid
         default:
           description: Error
@@ -394,7 +394,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        '200':
           description: Array of header ids
           content:
             application/json:
@@ -405,7 +405,7 @@ paths:
                 items:
                   type: string
                   example: D2bXMwWN8P9nWJ9qqwZJLauAdcZHX9n6s91QQ9vK6Zu4
-        404:
+        '404':
           description: Blocks at this height doesn't exist
         default:
           description: Error
@@ -432,13 +432,13 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Block object
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FullBlock'
-        404:
+        '404':
           description: Block with this id doesn't exist
         default:
           description: Error
@@ -465,13 +465,13 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Block header object
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlockHeader'
-        404:
+        '404':
           description: Block with this id doesn't exist
         default:
           description: Error
@@ -498,13 +498,13 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Block transaction object
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlockTransactions'
-        404:
+        '404':
           description: Block with this id doesn't exist
         default:
           description: Error
@@ -523,7 +523,7 @@ paths:
       tags:
         - blocks
       responses:
-        200:
+        '200':
           description: Candidate Full Block object
           content:
             application/json:
@@ -545,7 +545,7 @@ paths:
           schema:
             type: number
       responses:
-        200:
+        '200':
           description: Array of block headers
           content:
             application/json:
@@ -561,7 +561,7 @@ paths:
       tags:
         - info
       responses:
-        200:
+        '200':
           description: Node info object
           content:
             application/json:
@@ -581,7 +581,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AnyoneCanSpendTransaction'
       responses:
-        200:
+        '200':
           description: JSON with ID of the new transaction
           content:
             application/json:
@@ -621,12 +621,12 @@ paths:
           schema:
             $ref: '#/components/schemas/TransactionId'
       responses:
-        200:
+        '200':
           description: Anyone can spend transactions object
           content:
             application/json:
               $ref: '#/components/schemas/AnyoneCanSpendTransaction'
-        404:
+        '404':
           description: Transaction with this id doesn't exist
         default:
           description: Error
@@ -666,7 +666,7 @@ paths:
       tags:
         - transactions
       responses:
-        200:
+        '200':
           description: Array with anyone can spend transactions objects
           content:
             application/json:
@@ -682,7 +682,7 @@ paths:
       tags:
         - peers
       responses:
-        200:
+        '200':
           description: Array of peer objects
           content:
             application/json:
@@ -698,7 +698,7 @@ paths:
       tags:
         - peers
       responses:
-        200:
+        '200':
           description: Array of peer objects
           content:
             application/json:
@@ -721,7 +721,7 @@ paths:
               type: string
               example: 127.0.0.1:5673
       responses:
-        200:
+        '200':
           description: Attempt to connect to the peer
         default:
           description: Error
@@ -740,7 +740,7 @@ paths:
       tags:
         - peers
       responses:
-        200:
+        '200':
           description: Array of the addresses
           content:
             application/json:
@@ -757,7 +757,7 @@ paths:
       tags:
         - utils
       responses:
-        200:
+        '200':
           description: Base58-encoded 32 byte seed
           content:
             text/plain:
@@ -779,7 +779,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Base58-encoded N byte seed
           content:
             text/plain:
@@ -801,7 +801,7 @@ paths:
               type: string
               example: 7yaASMijGEGTbttYHg1MrXnWB8EbzjJnFLSWvmNoHrXV
       responses:
-        200:
+        '200':
           description: Base58-encoded 32 byte hash
           content:
             text/plain:


### PR DESCRIPTION
HTML response codes must be strings.

See [OAI/OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0) examples, every example yaml use strings instead of integers.
