### PR TITLE
Testnet1 docker fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ CMD ["/usr/bin/java", "-jar", "/ergo.jar"]
 FROM openjdk:9-jre-slim
 MAINTAINER Andrey Andreev <andyceo@yandex.ru> (@andyceo)
 COPY --from=builder /ergo.jar /ergo.jar
-EXPOSE 9001 9051
+EXPOSE 9002 9052
 WORKDIR /root
 VOLUME ["/root/ergo/data"]
 ENTRYPOINT ["/usr/bin/java", "-jar", "/ergo.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:jre-slim as builder
+FROM openjdk:9-jre-slim as builder
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apt-transport-https apt-utils bc dirmngr gnupg && \
     echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
@@ -12,7 +12,7 @@ RUN sbt reload clean assembly
 RUN mv `find . -name ergo-assembly*.jar` /ergo.jar
 CMD ["/usr/bin/java", "-jar", "/ergo.jar"]
 
-FROM openjdk:jre-alpine
+FROM openjdk:9-jre-slim
 MAINTAINER Andrey Andreev <andyceo@yandex.ru> (@andyceo)
 COPY --from=builder /ergo.jar /ergo.jar
 EXPOSE 9001 9051

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ and currently the reference implementation code should be considered as a specif
 
 Ergo has officially supported Docker package. To run Ergo as a console application with logs in console:
 
-    sudo docker run --rm -p 9001:9001 -p 9051:9051 -v ergo-testnet:/root/ergo/data ergoplatform/ergo
+    sudo docker run --rm -p 9002:9002 -p 9052:9052 -v ergo-testnet:/root/ergo/data ergoplatform/ergo
     
-This will connect to Ergo testnet with default config and open ports 9001 and 9051 on host system. All data will be stored in your named Docker volume `ergo-testnet`. 
+This will connect to Ergo testnet with default config and open ports 9002 and 9052 on host system. All data will be stored in your named Docker volume `ergo-testnet`.
 
 To run certain Ergo version as a service with custom config:
 
-    sudo docker run -d -p 9001:9001 -p 9051:9051
+    sudo docker run -d -p 9002:9002 -p 9052:9052
 		-v ergo:/root/ergo/data
 		-v /path/on/host/system/to/myergo.conf:/root/ergo/myergo.conf
 		ergoplatform/ergo:v0.2.1 /root/ergo/myergo.conf
 
-This will connect to Ergo mainnet or testnet respecting your configuration passed in `myergo.conf`. Every default config value would be overwritten with corresponding value in `myergo.conf`. This also would store your data in named Docker volume `ergo` (if you change default data location in your config file, do not forget mount `ergo` volume to changed location) and open ports 9001 and 9051 on host system.
+This will connect to Ergo mainnet or testnet respecting your configuration passed in `myergo.conf`. Every default config value would be overwritten with corresponding value in `myergo.conf`. This also would store your data in named Docker volume `ergo` (if you change default data location in your config file, do not forget mount `ergo` volume to changed location) and open ports 9002 and 9052 on host system.

--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ dockerfile in docker := {
   val startErgo = (sourceDirectory in IntegrationTest).value / "container" / "start-ergo.sh"
 
   new Dockerfile {
-    from("anapsix/alpine-java:8_server-jre")
+    from("openjdk:9-jre-slim")
     label("ergo-integration-tests", "ergo-integration-tests")
     add(assembly.value, "/opt/ergo/ergo.jar")
     add(Seq(configTemplate, startErgo), "/opt/ergo/")


### PR DESCRIPTION
- Move node building and runtime to Java 9
- Change ports in Dockerfile for testnet-1
- Move integration tests to Java 9
