### PR TITLE
createCandidate fixes()

### DIFF
--- a/src/main/scala/org/ergoplatform/local/ErgoMiner.scala
+++ b/src/main/scala/org/ergoplatform/local/ErgoMiner.scala
@@ -147,20 +147,26 @@ class ErgoMiner(ergoSettings: ErgoSettings,
     val bestHeaderOpt: Option[Header] = history.bestFullBlockOpt.map(_.header)
 
     //only transactions valid from against the current utxo state we take from the mem pool
-    // todo: size should be limited, size limit should be chosen by miners votes. fix after voting implementation
-    val externalTransactions = state.filterValid(pool.unconfirmed.values.toSeq).take(10)
-    // TODO use wallet to extract boxes from transactions in this block miner can spend. Use wallet when create coinbase
-    val feeBoxes: Seq[ErgoBox] = ErgoState.boxChanges(externalTransactions)._2.filter(_.proposition == TrueLeaf)
-    val coinbase = ErgoMiner.createCoinbase(state, feeBoxes, minerProp, emission)
-    val txs = externalTransactions :+ coinbase
+    // todo: size should be limitedby network, size limit should be chosen by miners votes. fix after voting implementation
+    val maxBlockSize = 512 * 1024 // honest miner is generating a block of no more than 512Kb
+    var totalSize = 0
+    val externalTransactions = state.filterValid(pool.unconfirmed.values.toSeq).takeWhile { tx =>
+      totalSize = totalSize + tx.bytes.length
+      totalSize <= maxBlockSize
+    }
 
     //we also filter transactions which are trying to spend the same box. Currently, we pick just the first one
     //of conflicting transaction. Another strategy is possible(e.g. transaction with highest fee)
     //todo: move this logic to MemPool.put? Problem we have now is that conflicting transactions are still in
     // the pool
-    val txsNoConflict = fixTxsConflicts(txs)
+    val txsNoConflict = fixTxsConflicts(externalTransactions)
 
-    val (adProof, adDigest) = state.proofsForTransactions(txsNoConflict).get
+    // TODO use wallet to extract boxes from transactions in this block miner can spend. Use wallet when create coinbase
+    val feeBoxes: Seq[ErgoBox] = ErgoState.boxChanges(txsNoConflict)._2.filter(_.proposition == TrueLeaf)
+    val coinbase = ErgoMiner.createCoinbase(state, feeBoxes, minerProp, emission)
+    val txs = txsNoConflict :+ coinbase
+
+    val (adProof, adDigest) = state.proofsForTransactions(txs).get
 
     val timestamp = timeProvider.time()
 
@@ -172,7 +178,7 @@ class ErgoMiner(ergoSettings: ErgoSettings,
     //TODO real extension should be there. Hash from empty array for now to be able to implement it later without forks
     val extensionHash = Algos.hash(Array[Byte]())
 
-    CandidateBlock(bestHeaderOpt, nBits, adDigest, adProof, txsNoConflict, timestamp, extensionHash)
+    CandidateBlock(bestHeaderOpt, nBits, adDigest, adProof, txs, timestamp, extensionHash)
   }
 
   def requestCandidate: Unit = readersHolderRef ! GetReaders


### PR DESCRIPTION
1. createCandidate() is setting up 512 kb total size limit for transactions in a block
2. bug happened if externalTransactions.size != txsNoConflictSize is fixed. However, there are maybe a bug if tx_i (i-th transaction in a block) is spending TrueLeaf created in tx_j, an i<j. 