### PR TITLE
Update sigmastate (Height is Int)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
     - v2.0
     - master
     - /^\d\.\d+$/
-    - sigma-for-v2
+    - height-as-int
 jdk:
 - oraclejdk9
 scala:

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val commonSettings = Seq(
 val scorexVersion = "53207304-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  ("org.scorexfoundation" %% "sigma-state" % "box-creationInfo-height-int-6f53e5fb-SNAPSHOT")
+  ("org.scorexfoundation" %% "sigma-state" % "master-97f53b6c-SNAPSHOT")
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto"),
   "org.scala-lang.modules" %% "scala-async" % "0.9.7",

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val commonSettings = Seq(
 val scorexVersion = "53207304-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  ("org.scorexfoundation" %% "sigma-state" % "master-099dfbde-SNAPSHOT")
+  ("org.scorexfoundation" %% "sigma-state" % "box-creationInfo-height-int-6f53e5fb-SNAPSHOT")
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto"),
   "org.scala-lang.modules" %% "scala-async" % "0.9.7",

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val commonSettings = Seq(
 val scorexVersion = "53207304-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  ("org.scorexfoundation" %% "sigma-state" % "master-59e73398-SNAPSHOT")
+  ("org.scorexfoundation" %% "sigma-state" % "master-099dfbde-SNAPSHOT")
     .exclude("ch.qos.logback", "logback-classic")
     .exclude("org.scorexfoundation", "scrypto"),
   "org.scala-lang.modules" %% "scala-async" % "0.9.7",

--- a/lock.sbt
+++ b/lock.sbt
@@ -39,9 +39,9 @@ dependencyOverrides in ThisBuild ++= Seq(
   "io.github.scalan" % "library_2.12" % "master-c19564fd-SNAPSHOT",
   "io.github.scalan" % "macros_2.12" % "master-c19564fd-SNAPSHOT",
   "io.github.scalan" % "meta_2.12" % "master-c19564fd-SNAPSHOT",
-  "io.github.scalan" % "sigma-api_2.12" % "master-3e6ecb36-SNAPSHOT",
-  "io.github.scalan" % "sigma-impl_2.12" % "master-3e6ecb36-SNAPSHOT",
-  "io.github.scalan" % "sigma-library_2.12" % "master-3e6ecb36-SNAPSHOT",
+  "io.github.scalan" % "sigma-api_2.12" % "box-creationInfo-height-int-48244aee-SNAPSHOT",
+  "io.github.scalan" % "sigma-impl_2.12" % "box-creationInfo-height-int-48244aee-SNAPSHOT",
+  "io.github.scalan" % "sigma-library_2.12" % "box-creationInfo-height-int-48244aee-SNAPSHOT",
   "javax.activation" % "javax.activation-api" % "1.2.0",
   "javax.xml.bind" % "jaxb-api" % "2.4.0-b180830.0359",
   "jline" % "jline" % "2.14.3",
@@ -69,7 +69,7 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.scorexfoundation" % "scorex-core_2.12" % "53207304-SNAPSHOT",
   "org.scorexfoundation" % "scorex-util_2.12" % "0.1.1",
   "org.scorexfoundation" % "scrypto_2.12" % "2.1.4",
-  "org.scorexfoundation" % "sigma-state_2.12" % "master-099dfbde-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-state_2.12" % "box-creationInfo-height-int-6f53e5fb-SNAPSHOT",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.spire-math" % "jawn-parser_2.12" % "0.11.0",
   "org.typelevel" % "cats-core_2.12" % "1.0.1",
@@ -79,4 +79,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "macro-compat_2.12" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.5.0"
 )
-// LIBRARY_DEPENDENCIES_HASH edf990b428fe4f13755eee84216a62b35881ae2b
+// LIBRARY_DEPENDENCIES_HASH cfb45b9df2069ebb4d65ee04aa97505f1c4e7c32

--- a/lock.sbt
+++ b/lock.sbt
@@ -39,9 +39,9 @@ dependencyOverrides in ThisBuild ++= Seq(
   "io.github.scalan" % "library_2.12" % "master-c19564fd-SNAPSHOT",
   "io.github.scalan" % "macros_2.12" % "master-c19564fd-SNAPSHOT",
   "io.github.scalan" % "meta_2.12" % "master-c19564fd-SNAPSHOT",
-  "io.github.scalan" % "sigma-api_2.12" % "master-2e83859e-SNAPSHOT",
-  "io.github.scalan" % "sigma-impl_2.12" % "master-2e83859e-SNAPSHOT",
-  "io.github.scalan" % "sigma-library_2.12" % "master-2e83859e-SNAPSHOT",
+  "io.github.scalan" % "sigma-api_2.12" % "master-3e6ecb36-SNAPSHOT",
+  "io.github.scalan" % "sigma-impl_2.12" % "master-3e6ecb36-SNAPSHOT",
+  "io.github.scalan" % "sigma-library_2.12" % "master-3e6ecb36-SNAPSHOT",
   "javax.activation" % "javax.activation-api" % "1.2.0",
   "javax.xml.bind" % "jaxb-api" % "2.4.0-b180830.0359",
   "jline" % "jline" % "2.14.3",
@@ -69,7 +69,7 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.scorexfoundation" % "scorex-core_2.12" % "53207304-SNAPSHOT",
   "org.scorexfoundation" % "scorex-util_2.12" % "0.1.1",
   "org.scorexfoundation" % "scrypto_2.12" % "2.1.4",
-  "org.scorexfoundation" % "sigma-state_2.12" % "master-59e73398-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-state_2.12" % "master-099dfbde-SNAPSHOT",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.spire-math" % "jawn-parser_2.12" % "0.11.0",
   "org.typelevel" % "cats-core_2.12" % "1.0.1",
@@ -79,4 +79,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "macro-compat_2.12" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.5.0"
 )
-// LIBRARY_DEPENDENCIES_HASH 8d8c6fc79c52f5dc71b3c143813ce79d082ac844
+// LIBRARY_DEPENDENCIES_HASH edf990b428fe4f13755eee84216a62b35881ae2b

--- a/lock.sbt
+++ b/lock.sbt
@@ -39,9 +39,9 @@ dependencyOverrides in ThisBuild ++= Seq(
   "io.github.scalan" % "library_2.12" % "master-c19564fd-SNAPSHOT",
   "io.github.scalan" % "macros_2.12" % "master-c19564fd-SNAPSHOT",
   "io.github.scalan" % "meta_2.12" % "master-c19564fd-SNAPSHOT",
-  "io.github.scalan" % "sigma-api_2.12" % "box-creationInfo-height-int-48244aee-SNAPSHOT",
-  "io.github.scalan" % "sigma-impl_2.12" % "box-creationInfo-height-int-48244aee-SNAPSHOT",
-  "io.github.scalan" % "sigma-library_2.12" % "box-creationInfo-height-int-48244aee-SNAPSHOT",
+  "io.github.scalan" % "sigma-api_2.12" % "master-51cf49fb-SNAPSHOT",
+  "io.github.scalan" % "sigma-impl_2.12" % "master-51cf49fb-SNAPSHOT",
+  "io.github.scalan" % "sigma-library_2.12" % "master-51cf49fb-SNAPSHOT",
   "javax.activation" % "javax.activation-api" % "1.2.0",
   "javax.xml.bind" % "jaxb-api" % "2.4.0-b180830.0359",
   "jline" % "jline" % "2.14.3",
@@ -69,7 +69,7 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.scorexfoundation" % "scorex-core_2.12" % "53207304-SNAPSHOT",
   "org.scorexfoundation" % "scorex-util_2.12" % "0.1.1",
   "org.scorexfoundation" % "scrypto_2.12" % "2.1.4",
-  "org.scorexfoundation" % "sigma-state_2.12" % "box-creationInfo-height-int-6f53e5fb-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-state_2.12" % "master-97f53b6c-SNAPSHOT",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.spire-math" % "jawn-parser_2.12" % "0.11.0",
   "org.typelevel" % "cats-core_2.12" % "1.0.1",
@@ -79,4 +79,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "macro-compat_2.12" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.5.0"
 )
-// LIBRARY_DEPENDENCIES_HASH cfb45b9df2069ebb4d65ee04aa97505f1c4e7c32
+// LIBRARY_DEPENDENCIES_HASH 96bd9aa21c2b3deb66fdb26bc48a014e88c03475

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -77,7 +77,7 @@ ergo {
       # delay between the block mined and a time, when the reward can be spend. ~ 1 day.
       minerRewardDelay = 720
       # Base16 representation of state roothash after genesis
-      afterGenesisStateDigestHex = "67ace8d8b5174205f3ee17c2c6a5b0af7c2c9677a3716943459923a84c589e7b01"
+      afterGenesisStateDigestHex = "d801a0e4573d6993caa2eda7dc97aad2b4c8ed51ebb0afe0dd272c8d7e26d5fd01"
     }
 
     # Desired time interval between blocks

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -206,7 +206,7 @@ object ErgoTransaction extends ApiCodecs with ModifierValidator with ScorexLoggi
     for {
       maybeId <- cursor.downField("boxId").as[Option[BoxId]]
       value <- cursor.downField("value").as[Long]
-      creationHeight <- cursor.downField("creationHeight").as[Long]
+      creationHeight <- cursor.downField("creationHeight").as[Int]
       proposition <- cursor.downField("proposition").as[Value[SBoolean.type]]
       assets <- cursor.downField("assets").as[Seq[(ErgoBox.TokenId, Long)]]
       registers <- cursor.downField("additionalRegisters").as[Map[NonMandatoryRegisterId, EvaluatedValue[SType]]]

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
@@ -94,7 +94,7 @@ object ErgoState extends ScorexLogging {
   }
 
   private def boxCreationHeight(box: Value[SBox.type]): Value[SInt.type] =
-    Downcast(SelectField(ExtractCreationInfo(box), 1).asLongValue, SInt)
+    SelectField(ExtractCreationInfo(box), 1).asIntValue
 
   /**
     * @param emission - emission curve

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -40,7 +40,7 @@ ergo {
       # delay between the block mined and a time, when the reward can be spent. ~ 1 day.
       minerRewardDelay = -1000
       # Base16 representation of state roothash after genesis
-      afterGenesisStateDigestHex = "f7a819495f15fb3a3e1910aebc7f75452c7bf8ef2dc5f17c37858c2f355b77b501"
+      afterGenesisStateDigestHex = "89fdf63b08d35e9abf8af2158306cad03f38491a8077448914ea4a6d9de4f02101"
     }
 
 

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -40,7 +40,7 @@ ergo {
       # delay between the block mined and a time, when the reward can be spent. ~ 1 day.
       minerRewardDelay = -1000
       # Base16 representation of state roothash after genesis
-      afterGenesisStateDigestHex = "094cffb0e124466058a97d6f2b754cb2f811efbcb4bb82bf5c022884db69eb7901"
+      afterGenesisStateDigestHex = "3fac723df71b2f8ee26eec67ffcb95506acc2fea03bae36ea6d7b606bee6c9e401"
     }
 
 

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -40,7 +40,7 @@ ergo {
       # delay between the block mined and a time, when the reward can be spent. ~ 1 day.
       minerRewardDelay = -1000
       # Base16 representation of state roothash after genesis
-      afterGenesisStateDigestHex = "89fdf63b08d35e9abf8af2158306cad03f38491a8077448914ea4a6d9de4f02101"
+      afterGenesisStateDigestHex = "fa3ee5df9e74403121218894765656dfc8c33be77d24acc4346ef70b40ca5f9101"
     }
 
 

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -40,7 +40,7 @@ ergo {
       # delay between the block mined and a time, when the reward can be spent. ~ 1 day.
       minerRewardDelay = -1000
       # Base16 representation of state roothash after genesis
-      afterGenesisStateDigestHex = "3fac723df71b2f8ee26eec67ffcb95506acc2fea03bae36ea6d7b606bee6c9e401"
+      afterGenesisStateDigestHex = "f7a819495f15fb3a3e1910aebc7f75452c7bf8ef2dc5f17c37858c2f355b77b501"
     }
 
 

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerPropSpec.scala
@@ -170,7 +170,7 @@ class ErgoMinerPropSpec extends ErgoPropertyTest {
 
     forAll(Gen.nonEmptyListOf(validErgoTransactionGenTemplate(0, propositionGen = feeProp))) { btxs =>
       val blockTxs = btxs.map(_._2)
-      val height = Int.MaxValue
+      val height = ErgoHistory.EmptyHistoryHeight
       val txs = ErgoMiner.collectRewards(us.emissionBoxOpt, height, blockTxs, defaultMinerPk, settings.emission)
       txs.length shouldBe 2
 

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
@@ -12,7 +12,7 @@ import sigmastate.interpreter.{ContextExtension, ProverResult}
 
 class ExpirationSpecification extends ErgoPropertyTest {
 
-  type Height = Long
+  type Height = Int
 
   private implicit val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
 

--- a/src/test/scala/org/ergoplatform/utils/ErgoTestHelpers.scala
+++ b/src/test/scala/org/ergoplatform/utils/ErgoTestHelpers.scala
@@ -24,7 +24,7 @@ trait ErgoTestHelpers
 
   def await[A](f: Future[A]): A = Await.result[A](f, defaultAwaitDuration)
 
-  def updateHeight(box: ErgoBoxCandidate, creationHeight: Long): ErgoBoxCandidate =
+  def updateHeight(box: ErgoBoxCandidate, creationHeight: Int): ErgoBoxCandidate =
     new ErgoBoxCandidate(box.value, box.proposition, creationHeight, box.additionalTokens, box.additionalRegisters)
 
   def changeValue(box: ErgoBoxCandidate, delta: Long): Option[ErgoBoxCandidate] = {

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
@@ -24,7 +24,7 @@ import scala.util.Random
 
 trait ErgoTransactionGenerators extends ErgoGenerators {
 
-  val creationHeightGen: Gen[Int] = Gen.choose(0, Int.MaxValue)
+  val creationHeightGen: Gen[Int] = Gen.choose(0, Int.MaxValue / 2)
 
   val boxIndexGen: Gen[Short] = for {
     v <- Gen.chooseNum(0, Short.MaxValue)


### PR DESCRIPTION
References:
https://github.com/ScorexFoundation/sigmastate-interpreter/pull/340
https://github.com/ScorexFoundation/sigmastate-interpreter/issues/335

Todo:
- [x] switch `box.creationInfo._1` to Int (height when block got included) in sigmastate and remove `Downcast`;
- [x] find and fix one extra (compared to `voting`) failing test;
- [x] switch to sigmastate's snapshot from `master`; 