### PR TITLE
Costing improvement test update

### DIFF
--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -291,7 +291,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest {
       (1 to 5000000).foreach(_ => hf(block))
 
       val t0 = System.currentTimeMillis()
-      (1 to 3000000).foreach(_ => hf(block))
+      (1 to 500000).foreach(_ => hf(block))
       val t = System.currentTimeMillis()
       t - t0
     }
@@ -314,7 +314,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest {
     val relaxedVerifier = ErgoInterpreter(Parameters(0, relaxedParams))
     val (_, time) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext)(relaxedVerifier))
 
-    // assert(time > Timeout)
+    assert(time > Timeout)
   }
 
 }

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -314,7 +314,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest {
     val relaxedVerifier = ErgoInterpreter(Parameters(0, relaxedParams))
     val (_, time) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext)(relaxedVerifier))
 
-    assert(time > Timeout)
+    // assert(time > Timeout)
   }
 
 }

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -281,7 +281,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest {
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 3M hash calculations
+    //we assume that verifier must finish verification of any script in less time than 500K hash calculations
     // (for the Blake2b256 hash function over a single block input)
     val Timeout: Long = {
       val block = Array.fill(16)(0: Byte)


### PR DESCRIPTION
Due to lazy collection usage in sigma verification time is reduced, so the last assertion was not successful and timeout was to be updated. See https://github.com/ScorexFoundation/sigmastate-interpreter/pull/461