### PR TITLE
3.0.5 Candidate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ lazy val commonSettings = Seq(
 )
 
 val scorexVersion = "6ffeafc8-SNAPSHOT"
-val sigmaStateVersion = "master-0e75c9b0-SNAPSHOT"
-val ergoWalletVersion = "master-351dd620-SNAPSHOT"
+val sigmaStateVersion = "master-bd486374-SNAPSHOT"
+val ergoWalletVersion = "master-d4cf1f7f-SNAPSHOT"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)
 val effectiveSigmaStateVersion = Option(System.getenv().get("SIGMASTATE_VERSION")).getOrElse(sigmaStateVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbt._
 lazy val commonSettings = Seq(
   organization := "org.ergoplatform",
   name := "ergo",
-  version := "3.0.4",
+  version := "3.0.5",
   scalaVersion := "2.12.8",
   resolvers ++= Seq("Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/",
     "SonaType" at "https://oss.sonatype.org/content/groups/public",

--- a/lock.sbt
+++ b/lock.sbt
@@ -51,7 +51,7 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.bitbucket.inkytonik.kiama" % "kiama_2.12" % "2.1.0",
   "org.bitlet" % "weupnp" % "0.1.4",
   "org.bouncycastle" % "bcprov-jdk15on" % "1.62",
-  "org.ergoplatform" % "ergo-wallet_2.12" % "master-351dd620-SNAPSHOT",
+  "org.ergoplatform" % "ergo-wallet_2.12" % "master-d4cf1f7f-SNAPSHOT",
   "org.objenesis" % "objenesis" % "2.4",
   "org.ow2.asm" % "asm" % "5.0.4",
   "org.reactivestreams" % "reactive-streams" % "1.0.2",
@@ -69,10 +69,10 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.scorexfoundation" % "scorex-core_2.12" % "6ffeafc8-SNAPSHOT",
   "org.scorexfoundation" % "scorex-util_2.12" % "0.1.4",
   "org.scorexfoundation" % "scrypto_2.12" % "2.1.6",
-  "org.scorexfoundation" % "sigma-api_2.12" % "master-0e75c9b0-SNAPSHOT",
-  "org.scorexfoundation" % "sigma-impl_2.12" % "master-0e75c9b0-SNAPSHOT",
-  "org.scorexfoundation" % "sigma-library_2.12" % "master-0e75c9b0-SNAPSHOT",
-  "org.scorexfoundation" % "sigma-state_2.12" % "master-0e75c9b0-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-api_2.12" % "master-bd486374-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-impl_2.12" % "master-bd486374-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-library_2.12" % "master-bd486374-SNAPSHOT",
+  "org.scorexfoundation" % "sigma-state_2.12" % "master-bd486374-SNAPSHOT",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.spire-math" % "debox_2.12" % "0.8.0",
   "org.spire-math" % "jawn-parser_2.12" % "0.13.0",
@@ -87,4 +87,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "spire_2.12" % "0.14.1",
   "org.whispersystems" % "curve25519-java" % "0.5.0"
 )
-// LIBRARY_DEPENDENCIES_HASH 912e526d70e45a563ed390e8200629117318d55c
+// LIBRARY_DEPENDENCIES_HASH 7eb39cd1eb0d27b8c9660e7bf052985508f44d79

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.state.ErgoState
 import org.ergoplatform.nodeView.wallet.ErgoWalletActor._
 import org.ergoplatform.settings.ErgoSettings
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector
+import org.ergoplatform.wallet.boxes.ReplaceCompactCollectBoxSelector
 import scorex.core.VersionTag
 import scorex.core.transaction.wallet.Vault
 import scorex.util.ScorexLogging
@@ -21,10 +21,19 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
     with ErgoWalletReader
     with ScorexLogging {
 
+  // A replace-compact-collect selector is parameterized with max number of inputs a transaction could has,
+  // and also optimal number of inputs(a selector is collecting dust if transaction has less inputs than optimal).
+  // Now these settings are hard-coded, however, they should be parameterized
+  // https://github.com/ergoplatform/ergo/issues/856
+  val maxInputs = 32
+  val optimalInputs = 12
+
+  val boxSelector = new ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs)
+
   override type NVCT = this.type
 
   override val walletActor: ActorRef =
-    actorSystem.actorOf(Props(classOf[ErgoWalletActor], settings, DefaultBoxSelector))
+    actorSystem.actorOf(Props(classOf[ErgoWalletActor], settings, boxSelector))
 
   def watchFor(address: ErgoAddress): ErgoWallet = {
     walletActor ! WatchFor(address)

--- a/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
@@ -17,7 +17,7 @@ import org.ergoplatform.nodeView.history.ErgoHistory.Height
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.settings._
 import org.ergoplatform.utils.{ErgoTestHelpers, HistoryTestHelpers}
-import org.ergoplatform.wallet.boxes.{BoxSelector, DefaultBoxSelector}
+import org.ergoplatform.wallet.boxes.{BoxSelector, ReplaceCompactCollectBoxSelector}
 import scorex.util.ModifierId
 import sigmastate.basics.DLogProtocol.ProveDlog
 
@@ -51,7 +51,7 @@ object ChainGenerator extends TestKit(ActorSystem()) with App with ErgoTestHelpe
   val pow = new AutolykosPowScheme(powScheme.k, powScheme.n)
   val blockInterval = 2.minute
 
-  val boxSelector: BoxSelector = DefaultBoxSelector
+  val boxSelector: BoxSelector = new ReplaceCompactCollectBoxSelector(30, 2)
 
   val startTime = args.headOption.map(_.toLong).getOrElse(timeProvider.time - (blockInterval * 10).toMillis)
   val dir = if (args.length < 2) new File("/tmp/ergo/data") else new File(args(1))


### PR DESCRIPTION
This release is introducing an improved box selector (aka transaction assembler)  and also memory footprint reduction, mostly due to optimized (de-)serialization.

The new replace-compact-collect is parameterized by maximum number of inputs a transaction can have, and optimal number of inputs.

Say, the selector is given boxes denoted by their values (1,2,3,4,...10). Then the selector is working as follows:

    1) the selector first picking up boxes in given order (1,2,3,4,...)
    2) if number of inputs exceeds the limit, the selector is sorting remaining boxes(actually, only 3*maximum inputs of them) by value in descending order and replaces small-value boxes in the inputs by big-value from the tail (1,2,3,4 => 10)
    3) if the number of inputs still exceeds the limit, the selector is trying to throw away the dust if possible. E.g. if inputs are (100, 200, 1, 2, 1000), target value is 1300 and maximum number of inputs is 3, the selector kicks out (1, 2)
     4) if number of inputs after the previous steps is below optimal, the selector is trying to append the dust, by sorting remaining boxes in ascending order and appending them till optimal number of inputs.