### PR TITLE
Do not use outputs that are already spent offchain

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -269,7 +269,8 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
 
   private def trackedAddresses: Seq[ErgoAddress] = storage.readTrackedAddresses
 
-  private def onChainFilter(trackedBox: TrackedBox): Boolean = trackedBox.chainStatus.onChain
+  private def onChainFilter(trackedBox: TrackedBox): Boolean = trackedBox.chainStatus.onChain &&
+    offChainRegistry.onChainBalances.exists(_.id == encodedBoxId(trackedBox.box.id))
 
   /**
     * Tries to prove given box in order to define whether it could be spent by this wallet.

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -33,15 +33,12 @@ class ErgoWalletSpec extends PropSpec with WalletTestOps {
       addresses.length should be > 0
       val genesisBlock = makeGenesisBlock(pubkey, randomNewAsset)
       val genesisTx = genesisBlock.transactions.head
-      val initialBoxes = boxesAvailable(genesisTx, pubkey)
       applyBlock(genesisBlock) shouldBe 'success //scan by wallet happens during apply
       waitForScanning(genesisBlock)
       val snap = getConfirmedBalances
-      val assetsToSpend = assetsByTokenId(initialBoxes).toSeq
-      assetsToSpend should not be empty
 
       // prepare a lot of inputs
-      val inputsToCreate = 100
+      val inputsToCreate = 50
       val sumToSpend = snap.balance / (inputsToCreate + 1)
       val req = (0 until inputsToCreate).map(a => PaymentRequest(addresses.head, sumToSpend, None, None))
       log.info(s"Confirmed balance $snap")

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -41,10 +41,9 @@ class ErgoWalletSpec extends PropSpec with WalletTestOps {
       assetsToSpend should not be empty
 
       // prepare a lot of inputs
-      val sumToSpend = snap.balance / (addresses.length + 1)
-      val req =
-        PaymentRequest(addresses.head, sumToSpend, Some(assetsToSpend), None) +:
-          addresses.tail.map(a => PaymentRequest(a, sumToSpend, None, None))
+      val inputsToCreate = 100
+      val sumToSpend = snap.balance / (inputsToCreate + 1)
+      val req = (0 until inputsToCreate).map(a => PaymentRequest(addresses.head, sumToSpend, None, None))
       log.info(s"Confirmed balance $snap")
       log.info(s"Payment request $req")
       val tx = await(wallet.generateTransaction(req)).get
@@ -64,6 +63,7 @@ class ErgoWalletSpec extends PropSpec with WalletTestOps {
       log.info(s"Generated transaction $tx2")
       wallet.scanOffchain(tx2)
       blocking(Thread.sleep(1000))
+      tx2.inputs.size should be < tx.outputs.size
 
       // trying to create a new transaction
       val tx3 = await(wallet.generateTransaction(req2)).get


### PR DESCRIPTION
Wallet update. Now it does not use boxes, that are already spent by any transaction in mempool