### PR TITLE
Uncertain boxes processing fixed

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -82,11 +82,13 @@ final class WalletRegistry(store: Store)(ws: WalletSettings) extends ScorexLoggi
     val update = for {
       _ <- putBoxes(certainBxs ++ uncertainBxs)
       _ <- putTxs(txs)
-      spentBoxesWithTx <- getBoxes(inputs.map(x => decodedBoxId(x._2))).map(_.flatten.flatMap(bx =>
-        inputs.find(_._2 == encodedBoxId(bx.box.id)).map { case (txId, _) => txId -> bx })
+      spentBoxesWithTx <- getBoxes(inputs.map(x => decodedBoxId(x._2))).map(
+        _.flatten.filter(_.certainty.certain).flatMap(bx =>
+          inputs.find(_._2 == encodedBoxId(bx.box.id)).map { case (txId, _) => txId -> bx })
       )
       _ <- processHistoricalBoxes(spentBoxesWithTx, blockHeight)
       _ <- updateIndex { case RegistryIndex(_, balance, tokensBalance, _) =>
+        log.info(s"SpentBoxes at (h: $blockHeight) *> $spentBoxesWithTx")
         val spentBoxes = spentBoxesWithTx.map(_._2)
         val spentAmt = spentBoxes.map(_.box.value).sum
         val spentTokensAmt = spentBoxes


### PR DESCRIPTION
Close #853

The bug described in #853 was caused by inability of wallet to correctly process spending of uncertain boxes. With changes from this PR the wallet does not subtract from initial balance the value of an uncertain box when processing its spending.