### PR TITLE
Prevent running multiple node instances in the same working directory or bounded to the same port

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/difficulty/LinearDifficultyControl.scala
+++ b/src/main/scala/org/ergoplatform/mining/difficulty/LinearDifficultyControl.scala
@@ -24,10 +24,10 @@ class LinearDifficultyControl(val chainSettings: ChainSettings) extends ScorexLo
     * @return heights of previous headers required for block recalculation
     */
   def previousHeadersRequiredForRecalculation(height: Height): Seq[Int] = {
-    if ((height - 1) % epochLength == 0 && epochLength > 1) {
-      (0 to useLastEpochs).map(i => (height - 1) - i * epochLength).filter(_ >= 0).reverse
-    } else if ((height - 1) % epochLength == 0 && height > epochLength * useLastEpochs) {
+    if ((height - 1) % epochLength == 0 && height > epochLength * useLastEpochs) {
       (0 to useLastEpochs).map(i => (height - 1) - i * epochLength).reverse
+    } else if ((height - 1) % epochLength == 0 && epochLength > 1) {
+      (0 to useLastEpochs).map(i => (height - 1) - i * epochLength).filter(_ >= 0).reverse
     } else {
       Seq(height - 1)
     }

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -209,8 +209,16 @@ object ErgoHistory extends ScorexLogging {
     dir.mkdirs()
     val options = new Options()
     options.createIfMissing(true)
-    val db = factory.open(dir, options)
-    new LDBKVStore(db)
+    try {
+      val db = factory.open(dir, options)
+      new LDBKVStore(db)
+    } catch {
+      case x: Throwable => {
+        log.error(s"Failed to initialize storage: ${x}. Please check that directory ${path} exists and is not used by some other active node")
+        java.lang.System.exit(2)
+        null
+      }
+    }
   }
 
   def readOrGenerate(ergoSettings: ErgoSettings, ntp: NetworkTimeProvider): ErgoHistory = {

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -249,8 +249,7 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     if (heights.lengthCompare(1) == 0) {
       difficultyCalculator.calculate(Seq(parent))
     } else {
-      val chain = headerChainBack(heights.max - heights.min + 1, parent, _ => false)
-      val headers = chain.headers.filter(p => heights.contains(p.height))
+      val headers = heights.map(height => headerIdsAtHeight(height).lastOption).flatten.map(id=>typedModifierById[Header](id)).flatten
       difficultyCalculator.calculate(headers)
     }
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -249,8 +249,8 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     if (heights.lengthCompare(1) == 0) {
       difficultyCalculator.calculate(Seq(parent))
     } else {
-      val headers = heights.map(height => headerIdsAtHeight(height).lastOption).flatten.map(id=>typedModifierById[Header](id)).flatten
-      difficultyCalculator.calculate(headers)
+       val headers = heights.flatMap(height => headerIdsAtHeight(height).headOption).flatMap(typedModifierById[Header])
+       difficultyCalculator.calculate(headers)
     }
   }
 


### PR DESCRIPTION
Issue: https://github.com/ergoplatform/ergo/issues/975

Terminate process when attempt to bind socket to the port failed or storage can not be opened (due to level-db lock, preventing concurrent access)