### PR TITLE
Prevent access to the same working directory from more than one node instance

### DIFF
--- a/avldb/src/test/scala/scorex/crypto/authds/avltree/batch/helpers/TestHelper.scala
+++ b/avldb/src/test/scala/scorex/crypto/authds/avltree/batch/helpers/TestHelper.scala
@@ -5,7 +5,7 @@ import scorex.crypto.authds.avltree.batch._
 import scorex.crypto.authds.{ADDigest, SerializedAdProof}
 import scorex.util.encode.Base58
 import scorex.crypto.hash.{Blake2b256, Digest32}
-import scorex.utils.ScryptoLogging
+import scorex.util.ScorexLogging
 
 trait TestHelper extends FileHelper with ScorexLogging {
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -213,11 +213,11 @@ object ErgoHistory extends ScorexLogging {
       val db = factory.open(dir, options)
       new LDBKVStore(db)
     } catch {
-      case x: Throwable => {
-        log.error(s"Failed to initialize storage: ${x}. Please check that directory ${path} exists and is not used by some other active node")
+      case x: Throwable =>
+        log.error(s"Failed to initialize storage: $x. Please check that directory $path could be accessed " +
+          s"and is not used by some other active node")
         java.lang.System.exit(2)
         null
-      }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -209,8 +209,16 @@ object ErgoHistory extends ScorexLogging {
     dir.mkdirs()
     val options = new Options()
     options.createIfMissing(true)
-    val db = factory.open(dir, options)
-    new LDBKVStore(db)
+    try {
+      val db = factory.open(dir, options)
+      new LDBKVStore(db)
+    } catch {
+      case x: Throwable => {
+        log.error(s"Failed to initialize storage: ${x}. Please check that directory ${path} exists and is not used by some other active node")
+        java.lang.System.exit(2)
+        null
+      }
+    }
   }
 
   def readOrGenerate(ergoSettings: ErgoSettings, ntp: NetworkTimeProvider): ErgoHistory = {


### PR DESCRIPTION
Issue: https://github.com/ergoplatform/ergo/issues/975

LevelDB protects its working directory from concurrent access.
So we just need to catch this error and terminate application.
