### PR TITLE
Header chain time diff is now considered in pruning processor, also made configurable 

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -61,6 +61,11 @@ ergo {
 
     # Minimal fee amount of transactions mempool accepts
     minimalFeeAmount = 1000000
+
+    # A node is considering that the chain is synced if sees a block header with timestamp no more
+    # than headerChainTimeDiff blocks on average from future
+    # default value is 800 blocks ~= 1600 minutes
+    headerChainTimeDiff = 800
   }
 
   testing {
@@ -308,7 +313,7 @@ scorex {
     # to `bind-address:port`. Please note, however, that this setup is not recommended.
     # declaredAddress = ""
 
-    # Enable UPnP tunnel creation only if you router/gateway supports it. Useful if your node is runnin in home
+    # Enable UPnP tunnel creation only if you router/gateway supports it. Useful if your node is running in home
     # network. Completely useless if you node is in cloud.
     upnpEnabled = no
 

--- a/src/main/resources/testnet.conf
+++ b/src/main/resources/testnet.conf
@@ -3,6 +3,12 @@
 
 ergo {
   networkType = "testnet"
+  node {
+    # A node is considering that the chain is synced if sees a block header with timestamp no more
+    # than headerChainTimeDiff blocks on average from future
+    # testnet value is 2000 blocks ~= 4000 minutes (~2.5 days)
+    headerChainTimeDiff = 2000
+  }
   chain {
     # Network address prefix, currently reserved values are 0 (money chain mainnet) and 16 (money chain testnet)
     addressPrefix = 16

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -237,8 +237,6 @@ trait FullBlockProcessor extends HeadersProcessor {
         s"full height $fullBlockHeight")
   }
 
-  private def storageVersion(newModRow: ErgoPersistentModifier) = Algos.idToBAW(newModRow.id)
-
 }
 
 object FullBlockProcessor {

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -1,6 +1,5 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
-import akka.util.ByteString
 import io.iohk.iodb.ByteArrayWrapper
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
@@ -45,7 +45,8 @@ class FullBlockPruningProcessor(config: NodeConfigurationSettings, chainSettings
       ErgoHistory.GenesisHeight // keep all blocks in history
     } else if (!isHeadersChainSynced && !config.stateType.requireProofs) {
       // just synced with the headers chain - determine first full block to apply
-      ErgoHistory.GenesisHeight //TODO start with the height of UTXO snapshot applied. Start from genesis util this is implemented
+      //TODO start with the height of UTXO snapshot applied. For now we start from genesis until this is implemented
+      ErgoHistory.GenesisHeight
     } else {
       // Start from config.blocksToKeep blocks back
       val h = Math.max(minimalFullBlockHeight, header.height - config.blocksToKeep + 1)

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
@@ -32,8 +32,9 @@ class FullBlockPruningProcessor(config: NodeConfigurationSettings, chainSettings
 
   /** Check if headers chain is synchronized with the network and modifier is not too old
     */
-  def shouldDownloadBlockAtHeight(height: Int): Boolean =
-    isHeadersChainSynced && minimalFullBlockHeight <= height
+  def shouldDownloadBlockAtHeight(height: Int): Boolean = {
+    isHeadersChainSynced && height >= minimalFullBlockHeight
+  }
 
   /** Update minimal full block height and header chain synced flag
     *
@@ -49,7 +50,7 @@ class FullBlockPruningProcessor(config: NodeConfigurationSettings, chainSettings
       ErgoHistory.GenesisHeight
     } else {
       // Start from config.blocksToKeep blocks back
-      val h = Math.max(minimalFullBlockHeight, header.height - config.blocksToKeep + 1)
+      val h = Math.max(minimalFullBlockHeight, header.height - config.blocksToKeep + 1 - 500)
       // ... but not later than the beginning of a voting epoch
       if (h > VotingEpochLength) {
         Math.min(h, extensionWithParametersHeight(h))

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -18,9 +18,9 @@ trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
   protected val settings: ErgoSettings
 
   //A node is considering that the chain is synced if sees a block header with timestamp no more
-  // than maxTimeDiffFactor blocks on average
+  // than maxTimeDiffFactor blocks on average from future
   private val maxTimeDiffFactor = if (settings.networkType.isMainNet) {
-    300 //600 minutes in main network
+    400 //800 minutes in main network
   } else {
     2000 //4000 minutes (~2.5 days) for test and dev networks
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -13,11 +13,17 @@ import scala.annotation.tailrec
   */
 trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
 
-  private val maxTimeDiffFactor = 100
-
   protected val timeProvider: NetworkTimeProvider
 
   protected val settings: ErgoSettings
+
+  //A node is considering that the chain is synced if sees a block header with timestamp no more
+  // than maxTimeDiffFactor blocks on average
+  private val maxTimeDiffFactor = if (settings.networkType.isMainNet) {
+    300 //600 minutes in main network
+  } else {
+    2000 //4000 minutes (~2.5 days) for test and dev networks
+  }
 
   protected[history] lazy val pruningProcessor: FullBlockPruningProcessor =
     new FullBlockPruningProcessor(nodeSettings, chainSettings)

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -19,7 +19,7 @@ trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
 
   //A node is considering that the chain is synced if sees a block header with timestamp no more
   // than maxTimeDiffFactor blocks on average from future
-  private val maxTimeDiffFactor = if (settings.networkType.isMainNet) {
+  private lazy val maxTimeDiffFactor = if (settings.networkType.isMainNet) {
     400 //800 minutes in main network
   } else {
     2000 //4000 minutes (~2.5 days) for test and dev networks

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -17,8 +17,8 @@ trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
 
   protected val settings: ErgoSettings
 
-  //A node is considering that the chain is synced if sees a block header with timestamp no more
-  // than maxTimeDiffFactor blocks on average from future
+  // A node is considering that the chain is synced if sees a block header with timestamp no more
+  // than headerChainTimeDiff blocks on average from future
   private lazy val headerChainTimeDiff = settings.nodeSettings.headerChainTimeDiff
 
   protected[history] lazy val pruningProcessor: FullBlockPruningProcessor =

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -60,11 +60,15 @@ trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
     }
 
     bestFullBlockOpt match {
+        //do not download full blocks if no headers-chain synced yet or SPV mode
       case _ if !isHeadersChainSynced || !nodeSettings.verifyTransactions =>
         Seq.empty
+        //download children blocks of last full block applied in the best chain
       case Some(fb) if isInBestChain(fb.id) =>
         continuation(fb.header.height + 1, Seq.empty)
+        //if headers-chain is synced and no full blocks applied yet, find full block height to go from
       case _ =>
+        println("go sync full blocks from: " + pruningProcessor.minimalFullBlockHeight)
         continuation(pruningProcessor.minimalFullBlockHeight, Seq.empty)
     }
   }

--- a/src/main/scala/org/ergoplatform/settings/NodeConfigurationSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/NodeConfigurationSettings.scala
@@ -27,7 +27,8 @@ case class NodeConfigurationSettings(stateType: StateType,
                                      blacklistCapacity: Int,
                                      mempoolCleanupDuration: FiniteDuration,
                                      rebroadcastCount: Int,
-                                     minimalFeeAmount: Long)
+                                     minimalFeeAmount: Long,
+                                     headerChainTimeDiff: Int)
 
 trait NodeConfigurationReaders extends StateTypeReaders with ModifierIdReader {
 
@@ -51,7 +52,8 @@ trait NodeConfigurationReaders extends StateTypeReaders with ModifierIdReader {
       cfg.as[Int](s"$path.blacklistCapacity"),
       cfg.as[FiniteDuration](s"$path.mempoolCleanupDuration"),
       cfg.as[Int](s"$path.rebroadcastCount"),
-      cfg.as[Long](s"$path.minimalFeeAmount")
+      cfg.as[Long](s"$path.minimalFeeAmount"),
+      cfg.as[Int](s"$path.headerChainTimeDiff")
     )
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history
 
-import org.ergoplatform.modifiers.history.{Extension, Header, HeaderChain, PoPowAlgos}
+import org.ergoplatform.modifiers.history.{Extension, Header, HeaderChain}
 import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
 import org.ergoplatform.nodeView.ErgoModifiersCache
 import org.ergoplatform.nodeView.state.StateType

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/PrunedNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/PrunedNodeViewHolderSpec.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.mining.DefaultFakePowScheme
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{DigestState, StateType}
-import org.ergoplatform.settings.{Args, ErgoSettings, VotingSettings}
+import org.ergoplatform.settings.{ErgoSettings, VotingSettings}
 import org.ergoplatform.utils.fixtures.NodeViewFixture
 import org.ergoplatform.utils.{ErgoPropertyTest, NodeViewTestOps}
 import scorex.core.NodeViewHolder.ReceivableMessages.LocallyGeneratedModifier

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -17,21 +17,21 @@ class ErgoSettingsSpecification extends ErgoPropertyTest {
     settings.nodeSettings shouldBe NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true, 1000,
       poPoWBootstrap = false, 10, mining = false, Constants.DefaultComplexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
       offlineGeneration = false, keepVersions = 200, mempoolCapacity = 100000, blacklistCapacity = 100000,
-      mempoolCleanupDuration = 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0)
+      mempoolCleanupDuration = 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0, headerChainTimeDiff = 800)
   }
 
   property("should read user settings from json file") {
     val settings = ErgoSettings.read(Args(Some("src/test/resources/settings.json"), None))
     settings.nodeSettings shouldBe NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true, 12,
       poPoWBootstrap = false, 10, mining = false, Constants.DefaultComplexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 100000, 100000, 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0)
+      offlineGeneration = false, 200, 100000, 100000, 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0, headerChainTimeDiff = 800)
   }
 
   property("should read user settings from HOCON file") {
     val settings = ErgoSettings.read(Args(Some("src/test/resources/settings.conf"), None))
     settings.nodeSettings shouldBe NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true, 13,
       poPoWBootstrap = false, 10, mining = false, Constants.DefaultComplexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 100000, 100000, 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0)
+      offlineGeneration = false, 200, 100000, 100000, 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0, headerChainTimeDiff = 800)
   }
 
 }

--- a/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
@@ -58,7 +58,7 @@ object ChainGenerator extends App with ErgoTestHelpers {
   val minimalSuffix = 2
   val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true,
     -1, poPoWBootstrap = false, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false,
-    miningPubKeyHex = None, offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 20, 1000000)
+    miningPubKeyHex = None, offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 20, 1000000, 20)
   val ms = settings.chainSettings.monetary.copy(
     minerRewardDelay = RewardDelay
   )

--- a/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
@@ -58,7 +58,7 @@ object ChainGenerator extends App with ErgoTestHelpers {
   val minimalSuffix = 2
   val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true,
     -1, poPoWBootstrap = false, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false,
-    miningPubKeyHex = None, offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 20, 1000000, 20)
+    miningPubKeyHex = None, offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 20, 1000000, 0)
   val ms = settings.chainSettings.monetary.copy(
     minerRewardDelay = RewardDelay
   )

--- a/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
+++ b/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
@@ -45,7 +45,7 @@ trait HistoryTestHelpers extends ErgoPropertyTest {
     val minimalSuffix = 2
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
       PoPoWBootstrap, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 20)
+      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 0)
     val scorexSettings: ScorexSettings = null
     val testingSettings: TestingSettings = null
     val walletSettings: WalletSettings = null

--- a/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
+++ b/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
@@ -45,7 +45,7 @@ trait HistoryTestHelpers extends ErgoPropertyTest {
     val minimalSuffix = 2
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
       PoPoWBootstrap, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000)
+      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 20)
     val scorexSettings: ScorexSettings = null
     val testingSettings: TestingSettings = null
     val walletSettings: WalletSettings = null

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -254,7 +254,7 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
     val minimalSuffix = 2
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
       PoPoWBootstrap, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 20)
+      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 0)
     val scorexSettings: ScorexSettings = null
     val testingSettings: TestingSettings = null
     val walletSettings: WalletSettings = null

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -254,7 +254,7 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
     val minimalSuffix = 2
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
       PoPoWBootstrap, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000)
+      offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 20)
     val scorexSettings: ScorexSettings = null
     val testingSettings: TestingSettings = null
     val walletSettings: WalletSettings = null


### PR DESCRIPTION
A node is doing headers-chain sync first. It is considered that the headers-chain is synced if currently observed tip is no older than some some parameter (previously hardcoded, 100 blocks ~= 200 minutes on average). After syncing headers-chain the node is deciding which full blocks to download. In pruned regime, it downloads only certain suffix of the blockchain (determined by blocksToKeep parameter). 

However, checks seem to be pretty tight, thus if a node is still catching up with the headers it may ban other nodes on the way for sending blocks from pruned prefix of the blockchain. 

In this PR, gap to decide syncing status made configurable, also pruning processor is now have relaxed rules. It can download more full blocks during initial bootstrapping, but not banning other nodes at least. 