### PR TITLE
Scorex version updated to master-3946bdb-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val commonSettings = Seq(
   publishTo := sonatypePublishToBundle.value
 )
 
-val scorexVersion = "master-226bbef1-SNAPSHOT"
+val scorexVersion = "master-3946bdb5-SNAPSHOT"
 val sigmaStateVersion = "3.1.1"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val commonSettings = Seq(
   publishTo := sonatypePublishToBundle.value
 )
 
-val scorexVersion = "4ca3e400-SNAPSHOT"
+val scorexVersion = "master-226bbef1-SNAPSHOT"
 val sigmaStateVersion = "3.1.1"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)


### PR DESCRIPTION
Scorex version update brings the following changes (Scorex PRs):

* https://github.com/ScorexFoundation/Scorex/pull/361 - Circe updated to 0.9.0
* https://github.com/ScorexFoundation/Scorex/pull/359  - keep-alive flag removed from socket options
* https://github.com/ScorexFoundation/Scorex/pull/358 - improved banning of peers for sending inappropriate messages
* https://github.com/ScorexFoundation/Scorex/pull/355 - terminate application if port to bind is in use 