### PR TITLE
Fix for improper block extension in ExpirationSpecification tests

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
+            <level>WARN</level>
         </filter>
         <encoder>
             <pattern>[%thread] >> [%-5level] %logger{36} >> %d{HH:mm:ss.SSS} %msg%n</pattern>

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
@@ -30,26 +30,28 @@ class ExpirationSpecification extends ErgoPropertyTest {
                     heightDelta: Int,
                     outsConstructor: Height => IndexedSeq[ErgoBoxCandidate],
                     expectedValidity: Boolean): Assertion = {
-    val in = Input(from.id,
-      ProverResult(Array.emptyByteArray, ContextExtension(Map(Constants.StorageIndexVarId -> ShortConstant(0)))))
+    whenever((from.creationHeight + Constants.StoragePeriod + heightDelta) % votingSettings.votingLength != 0 ) {
+      val in = Input(from.id,
+        ProverResult(Array.emptyByteArray, ContextExtension(Map(Constants.StorageIndexVarId -> ShortConstant(0)))))
 
-    val h: Int = from.creationHeight + Constants.StoragePeriod + heightDelta
+      val h: Int = from.creationHeight + Constants.StoragePeriod + heightDelta
 
-    val oc = outsConstructor(h).map(c => updateHeight(c, h))
-    val tx = ErgoTransaction(inputs = IndexedSeq(in), dataInputs = IndexedSeq(), outputCandidates = oc)
+      val oc = outsConstructor(h).map(c => updateHeight(c, h))
+      val tx = ErgoTransaction(inputs = IndexedSeq(in), dataInputs = IndexedSeq(), outputCandidates = oc)
 
-    val fb0 = invalidErgoFullBlockGen.sample.get
-    val fakeHeader = fb0.header.copy(height = h - 1)
-    val fb = fb0.copy(fb0.header.copy(height = h, parentId = fakeHeader.id))
+      val fb0 = invalidErgoFullBlockGen.sample.get
+      val fakeHeader = fb0.header.copy(height = h - 1)
+      val fb = fb0.copy(fb0.header.copy(height = h, parentId = fakeHeader.id))
 
-    val updContext = {
-      val inContext = new ErgoStateContext(Seq(fakeHeader), None, genesisStateDigest, LaunchParameters, validationSettingsNoIl,
-        VotingData.empty)(votingSettings)
-      inContext.appendFullBlock(fb, votingSettings).get
+      val updContext = {
+        val inContext = new ErgoStateContext(Seq(fakeHeader), None, genesisStateDigest, LaunchParameters, validationSettingsNoIl,
+          VotingData.empty)(votingSettings)
+        inContext.appendFullBlock(fb, votingSettings).get
+      }
+
+      tx.statelessValidity.isSuccess shouldBe true
+      tx.statefulValidity(IndexedSeq(from), emptyDataBoxes, updContext).isSuccess shouldBe expectedValidity
     }
-
-    tx.statelessValidity.isSuccess shouldBe true
-    tx.statefulValidity(IndexedSeq(from), emptyDataBoxes, updContext).isSuccess shouldBe expectedValidity
   }
 
   property("successful spending w. same value") {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
@@ -30,7 +30,9 @@ class ExpirationSpecification extends ErgoPropertyTest {
                     heightDelta: Int,
                     outsConstructor: Height => IndexedSeq[ErgoBoxCandidate],
                     expectedValidity: Boolean): Assertion = {
-    whenever((from.creationHeight + Constants.StoragePeriod + heightDelta) % votingSettings.votingLength != 0 ) {
+    // We are filtering out certain heights to avoid problems with improperly generated extension
+    // at the beginning of a voting epoch
+    whenever((from.creationHeight + Constants.StoragePeriod + heightDelta) % votingSettings.votingLength != 0) {
       val in = Input(from.id,
         ProverResult(Array.emptyByteArray, ContextExtension(Map(Constants.StorageIndexVarId -> ShortConstant(0)))))
 

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoGenerators.scala
@@ -132,7 +132,7 @@ trait ErgoGenerators extends CoreGenerators with Matchers with ErgoTestConstants
     adRoot <- digest32Gen
     transactionsRoot <- digest32Gen
     requiredDifficulty <- requiredDifficultyGen
-    height <- Gen.choose(1, Int.MaxValue)
+    height <- Gen.choose(1, Int.MaxValue).retryUntil(_ % settings.chainSettings.voting.votingLength != 0)
     powSolution <- powSolutionGen
     timestamp <- positiveLongGen
     extensionHash <- digest32Gen
@@ -150,6 +150,7 @@ trait ErgoGenerators extends CoreGenerators with Matchers with ErgoTestConstants
     Array.fill(3)(0: Byte),
     None
   )
+
   lazy val randomADProofsGen: Gen[ADProofs] = for {
     headerId <- modifierIdGen
     proof <- serializedAdProofGen

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoGenerators.scala
@@ -114,17 +114,16 @@ trait ErgoGenerators extends CoreGenerators with Matchers with ErgoTestConstants
   } yield AutolykosSolution(pk, w, n, d)
 
   /**
-    * Header generator with default miner pk in pow solution
-    */
-  lazy val defaultHeaderGen: Gen[Header] = invalidHeaderGen.map { h =>
-    h.copy(powSolution = h.powSolution.copy(pk = defaultMinerPkPoint))
-  }
-
-  /**
-    * Generates required difficulty in interval [1, 2^255]
+    * Generates required difficulty in interval [1, 2^^255]
     **/
   lazy val requiredDifficultyGen: Gen[BigInt] = Arbitrary.arbitrary[BigInt].map(_.mod(BigInt(2).pow(255)).abs + 1)
 
+  /*
+    TODO: this generator is used sometimes to construct a full block. A generator for the latter is not generating
+     a proper extension section for a beginning of a voting epoch (network parameter values should be in the  extension
+     in this case. Currently we're fixing it here with filtering out heights corresponding to the beginning of voting
+     epochs. A more careful solution would be to implement proper generators.
+   */
   lazy val invalidHeaderGen: Gen[Header] = for {
     version <- Arbitrary.arbitrary[Byte]
     parentId <- modifierIdGen
@@ -150,6 +149,13 @@ trait ErgoGenerators extends CoreGenerators with Matchers with ErgoTestConstants
     Array.fill(3)(0: Byte),
     None
   )
+
+  /**
+    * Header generator with default miner pk in pow solution
+    */
+  lazy val defaultHeaderGen: Gen[Header] = invalidHeaderGen.map { h =>
+    h.copy(powSolution = h.powSolution.copy(pk = defaultMinerPkPoint))
+  }
 
   lazy val randomADProofsGen: Gen[ADProofs] = for {
     headerId <- modifierIdGen


### PR DESCRIPTION
This PR is avoiding creating blocks at the beginning of voting epoch in ExpirationSpecification