### PR TITLE
Allow signing arbitrary transactions with arbitrary private inputs (DLog and DHT)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/src/main/scala/org/ergoplatform/SecretsProvingInterpreter.scala
+++ b/src/main/scala/org/ergoplatform/SecretsProvingInterpreter.scala
@@ -1,0 +1,71 @@
+package org.ergoplatform
+
+import java.util
+
+import org.ergoplatform._
+import org.ergoplatform.validation.ValidationRules
+import org.ergoplatform.wallet.protocol.context.{ErgoLikeParameters, ErgoLikeStateContext, TransactionContext}
+import org.ergoplatform.wallet.interpreter.ErgoInterpreter
+import sigmastate.basics.DLogProtocol.{DLogProverInput, ProveDlog}
+import sigmastate.basics.SigmaProtocolPrivateInput
+import sigmastate.eval.{IRContext, RuntimeIRContext}
+import sigmastate.interpreter.{ContextExtension, ProverInterpreter}
+
+import scala.util.{Failure, Success, Try}
+
+class SecretsProvingInterpreter(params: ErgoLikeParameters, s: IndexedSeq[SigmaProtocolPrivateInput[_, _]]) (implicit IR: IRContext)
+  extends ErgoInterpreter(params) with ProverInterpreter {
+
+  val secrets = s
+
+  /**
+    * @note requires `unsignedTx` and `boxesToSpend` have the same boxIds in the same order.
+    */
+  def sign(unsignedTx: UnsignedErgoLikeTransaction,
+           boxesToSpend: IndexedSeq[ErgoBox],
+           dataBoxes: IndexedSeq[ErgoBox],
+           stateContext: ErgoLikeStateContext): Try[ErgoLikeTransaction] = {
+    if (unsignedTx.inputs.length != boxesToSpend.length) Failure(new Exception("Not enough boxes to spend"))
+    else if (unsignedTx.dataInputs.length != dataBoxes.length) Failure(new Exception("Not enough data boxes"))
+    else boxesToSpend
+      .zipWithIndex
+      .foldLeft(Try(IndexedSeq[Input]() -> 0L)) { case (inputsCostTry, (inputBox, boxIdx)) =>
+        val unsignedInput = unsignedTx.inputs(boxIdx)
+        require(util.Arrays.equals(unsignedInput.boxId, inputBox.id))
+
+        val transactionContext = TransactionContext(boxesToSpend, dataBoxes, unsignedTx, boxIdx.toShort)
+
+        inputsCostTry.flatMap { case (ins, totalCost) =>
+
+          // Cost of transaction initialization: we should read and parse all inputs and data inputs,
+          // and also iterate through all outputs to check rules
+          val initialCost: Long = boxesToSpend.size * params.inputCost +
+          dataBoxes.size * params.dataInputCost +
+          unsignedTx.outputCandidates.size * params.outputCost
+
+          val context = new ErgoLikeContext(ErgoInterpreter.avlTreeFromDigest(stateContext.previousStateDigest),
+            stateContext.sigmaLastHeaders,
+            stateContext.sigmaPreHeader,
+            transactionContext.dataBoxes,
+            transactionContext.boxesToSpend,
+            transactionContext.spendingTransaction,
+            transactionContext.selfIndex,
+            ContextExtension.empty,
+            ValidationRules.currentSettings,
+            params.maxBlockCost,
+            initialCost
+          )
+
+          prove(inputBox.ergoTree, context, unsignedTx.messageToSign).flatMap { proverResult =>
+            val newTC = totalCost + proverResult.cost
+            if (newTC > context.costLimit)
+              Failure(new Exception(s"Cost of transaction $unsignedTx exceeds limit ${context.costLimit}"))
+            else Success((ins :+ Input(unsignedInput.boxId, proverResult)) -> newTC)
+          }
+        }
+      }
+      .map { case (inputs, _) =>
+        new ErgoLikeTransaction(inputs, unsignedTx.dataInputs, unsignedTx.outputCandidates)
+      }
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -17,6 +17,7 @@ import org.ergoplatform.settings._
 import org.ergoplatform.utils.{AssetUtils, BoxUtils}
 import org.ergoplatform.wallet.boxes.{BoxCertainty, BoxSelector, ChainStatus, TrackedBox}
 import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
+import org.ergoplatform.SecretsProvingInterpreter
 import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.ergoplatform.wallet.protocol.context.TransactionContext
 import org.ergoplatform.wallet.secrets.{DerivationPath, ExtendedSecretKey, Index, JsonSecretStorage}
@@ -27,6 +28,7 @@ import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 import sigmastate.Values.{ByteArrayConstant, IntConstant}
+import sigmastate.basics.SigmaProtocolPrivateInput
 import sigmastate.eval.Extensions._
 import sigmastate.eval._
 import sigmastate.interpreter.ContextExtension
@@ -262,6 +264,9 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
 
     case GenerateTransaction(requests, inputsRaw) =>
       sender() ! generateTransactionWithOutputs(requests, inputsRaw)
+
+    case SignTransaction(secrets, tx, boxesToSpend, dataBoxes) =>
+      sender() ! signTransaction(secrets, tx, boxesToSpend, dataBoxes)
 
     case DeriveKey(encodedPath) =>
       withWalletLockHandler(sender()) {
@@ -501,6 +506,16 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
       .fold(e => Failure(new Exception(s"Failed to sign boxes due to ${e.getMessage}: $inputs", e)), tx => Success(tx))
   }
 
+  private def signTransaction(secrets: Seq[SigmaProtocolPrivateInput[_, _]], tx: ErgoTransaction, boxesToSpend: Seq[ErgoBox], dataBoxes: Seq[ErgoBox]): Try[ErgoTransaction] = {
+    val secretsProver = new SecretsProvingInterpreter(parameters, secrets.toIndexedSeq)(new RuntimeIRContext)
+    val unsignedTx = new UnsignedErgoTransaction(
+      boxesToSpend.toIndexedSeq.map(box => new UnsignedInput(box.id)),
+      dataBoxes.toIndexedSeq.map(box => new DataInput(box.id)),
+      tx.outputCandidates,
+    )
+    secretsProver.sign(unsignedTx, boxesToSpend.toIndexedSeq, dataBoxes.toIndexedSeq, stateContext).map(ErgoTransaction.apply)
+  }
+
   /**
     * Updates indexes according to a given wallet-critical data.
     */
@@ -646,6 +661,8 @@ object ErgoWalletActor {
   final case class Rollback(version: VersionTag, height: Int)
 
   final case class GenerateTransaction(requests: Seq[TransactionRequest], inputsRaw: Seq[String])
+
+  final case class SignTransaction(secrets: Seq[SigmaProtocolPrivateInput[_, _]], tx: ErgoTransaction, boxesToSpend: Seq[ErgoBox], dataBoxes: Seq[ErgoBox])
 
   final case class ReadBalances(chainStatus: ChainStatus)
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
+import org.ergoplatform.ErgoBox;
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.ErgoWalletActor._
 import org.ergoplatform.nodeView.wallet.persistence.RegistryIndex
@@ -16,6 +17,7 @@ import org.ergoplatform.{ErgoAddress, P2PKAddress}
 import scorex.core.transaction.wallet.VaultReader
 import scorex.util.ModifierId
 import sigmastate.basics.DLogProtocol.DLogProverInput
+import sigmastate.basics.SigmaProtocolPrivateInput
 
 import scala.concurrent.Future
 import scala.util.Try
@@ -86,5 +88,8 @@ trait ErgoWalletReader extends VaultReader {
   def generateTransaction(requests: Seq[TransactionRequest],
                           inputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
     (walletActor ? GenerateTransaction(requests, inputsRaw)).mapTo[Try[ErgoTransaction]]
+
+  def signTransaction(secrets: Seq[SigmaProtocolPrivateInput[_, _]], tx: ErgoTransaction, boxesToSpend: Seq[ErgoBox], dataBoxes: Seq[ErgoBox]): Future[Try[ErgoTransaction]] =
+    (walletActor ? SignTransaction(secrets, tx, boxesToSpend, dataBoxes)).mapTo[Try[ErgoTransaction]]
 
 }


### PR DESCRIPTION
I'm not really that familiar with Scala, so I would appreciate some help parsing the JSON:

```json
{
  "tx": ErgoTransaction,
  "secrets": {
    "dlog": ["base16" (32 bytes BigInt), ...], // DLogProverInput(SigmaDsl.BigInt(new BigInteger(1, Base16.decode("base16").get)))
    "dht": [["base16" (32 bytes BigInt), ["base16" (33 bytes compressed GroupElement), "same", "same", "same"]], ...] // DiffieHellmanTupleProverInput(..., ProveDHTuple(...))
  }
}
```

I've tested this with hard-coded private inputs and it works.

I also imagine there may be a better way to handoff secrets; I had to create my own `SecretsProvingInterpreter` class because I didn't want to mess around with the stuff in dependencies (sigmastate-interpreter).