### PR TITLE
Data inputs added to API methods /wallet/transaction/{generate, sent}

### DIFF
--- a/avldb/src/main/scala/scorex/db/LDBFactory.scala
+++ b/avldb/src/main/scala/scorex/db/LDBFactory.scala
@@ -111,11 +111,11 @@ object LDBFactory extends ScorexLogging {
 
   private val nativeFactory = "org.fusesource.leveldbjni.JniDBFactory"
   private val javaFactory = "org.iq80.leveldb.impl.Iq80DBFactory"
-  private val memoryPoolSize = 512*1024
+  private val memoryPoolSize = 512 * 1024
 
   def setLevelDBParams(factory: DBFactory): Unit = {
     val pushMemoryPool = factory.getClass().getDeclaredMethod("pushMemoryPool", classOf[Int])
-    pushMemoryPool.invoke(null, new Integer(memoryPoolSize))
+    pushMemoryPool.invoke(null, Integer.valueOf(memoryPoolSize))
   }
 
   lazy val factory: DBFactory = {

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/AssetUtils.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/AssetUtils.scala
@@ -1,4 +1,4 @@
-package org.ergoplatform.utils
+package org.ergoplatform.wallet
 
 import scorex.util.ModifierId
 
@@ -7,10 +7,11 @@ import scala.collection.mutable
 object AssetUtils {
 
   @inline
-  def mergeAssetsMut(into: mutable.Map[ModifierId, Long], from: Map[ModifierId, Long]): Unit = {
-    from.foreach { case (id, amount) =>
-      into.put(id, into.getOrElse(id, 0L) + amount)
-    }
+  def mergeAssetsMut(into: mutable.Map[ModifierId, Long], from: Map[ModifierId, Long]*): Unit = {
+    from.foreach(_.foreach {
+      case (id, amount) =>
+        into.put(id, into.getOrElse(id, 0L) + amount)
+    })
   }
 
   @inline

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
@@ -4,7 +4,6 @@ import org.ergoplatform.ErgoBoxAssets
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionError
 import scorex.util.ModifierId
-import scala.collection.mutable
 import org.ergoplatform.SigmaConstants.MaxBoxSize
 
 
@@ -50,31 +49,6 @@ object BoxSelector {
 
   trait BoxSelectionError {
     def message: String
-  }
-
-  def mergeAssetsMut(
-    into: mutable.Map[ModifierId, Long],
-    from: Map[ModifierId, Long]*
-  ): Unit = {
-    from.foreach(_.foreach {
-      case (id, amount) =>
-        into.put(id, into.getOrElse(id, 0L) + amount)
-    })
-  }
-
-  def subtractAssetsMut(
-    from: mutable.Map[ModifierId, Long],
-    subtractor: Map[ModifierId, Long]
-  ): Unit = {
-    subtractor.foreach {
-      case (id, subtractAmt) =>
-        val fromAmt = from.getOrElse(id, 0L)
-        if (fromAmt == subtractAmt) {
-          from.remove(id)
-        } else {
-          from.put(id, fromAmt - subtractAmt)
-        }
-    }
   }
 
 }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -4,6 +4,8 @@ import scorex.util.ModifierId
 import org.ergoplatform.ErgoBoxAssets
 import org.ergoplatform.ErgoBoxAssetsHolder
 import org.ergoplatform.ErgoBox.MaxTokens
+import org.ergoplatform.wallet.AssetUtils
+
 import scala.annotation.tailrec
 import scala.collection.mutable
 import org.ergoplatform.wallet.Utils._
@@ -17,9 +19,9 @@ object DefaultBoxSelector extends BoxSelector {
 
   import BoxSelector._
 
-  final case class NotEnoughCoinsError(val message: String) extends BoxSelectionError
-  final case class NotEnoughTokensError(val message: String) extends BoxSelectionError
-  final case class NotEnoughCoinsForChangeBoxesError(val message: String) extends BoxSelectionError
+  final case class NotEnoughCoinsError(message: String) extends BoxSelectionError
+  final case class NotEnoughTokensError(message: String) extends BoxSelectionError
+  final case class NotEnoughCoinsForChangeBoxesError(message: String) extends BoxSelectionError
 
   override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
                       externalFilter: T => Boolean,
@@ -32,7 +34,7 @@ object DefaultBoxSelector extends BoxSelector {
 
     def pickUp(unspentBox: T) = {
       currentBalance = currentBalance + unspentBox.value
-      mergeAssetsMut(currentAssets, unspentBox.tokens)
+      AssetUtils.mergeAssetsMut(currentAssets, unspentBox.tokens)
       res += unspentBox
     }
 
@@ -80,7 +82,7 @@ object DefaultBoxSelector extends BoxSelector {
         Left(NotEnoughTokensError(s"not enough boxes to meet token needs $targetAssets (found only $currentAssets)"))
       }
     } else {
-      Left(NotEnoughCoinsError(s"not enough boxes to meet ERG needs $targetBalance (found only ${currentBalance})"))
+      Left(NotEnoughCoinsError(s"not enough boxes to meet ERG needs $targetBalance (found only $currentBalance)"))
     }
   }
 
@@ -90,7 +92,7 @@ object DefaultBoxSelector extends BoxSelector {
     foundBoxAssets: mutable.Map[ModifierId, Long],
     targetBoxAssets: Map[ModifierId, Long]
   ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
-    subtractAssetsMut(foundBoxAssets, targetBoxAssets)
+    AssetUtils.subtractAssetsMut(foundBoxAssets, targetBoxAssets)
     val changeBoxesAssets: Seq[mutable.Map[ModifierId, Long]] = foundBoxAssets.grouped(MaxTokens).toSeq
     val changeBalance = foundBalance - targetBalance
     //at least a minimum amount of ERG should be assigned per a created box

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.wallet.boxes
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionError
 import org.ergoplatform.ErgoBoxAssets
+import org.ergoplatform.wallet.AssetUtils
 import scorex.util.ModifierId
 import org.ergoplatform.wallet.Utils._
 
@@ -76,7 +77,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
   ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
     val compactedBalance = boxes.map(_.value).sum
     val compactedAssets  = mutable.Map[ModifierId, Long]()
-    BoxSelector.mergeAssetsMut(compactedAssets, boxes.map(_.tokens): _*)
+    AssetUtils.mergeAssetsMut(compactedAssets, boxes.map(_.tokens): _*)
     DefaultBoxSelector.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets)
   }
 

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -305,8 +305,8 @@ components:
           items:
             type: string
             description: hex-encoded serialized box bytes
-        inputsRaw:
-          description: List of inputs to be used in serialized form
+        dataInputsRaw:
+          description: List of data inputs to be used in serialized form
           type: array
           items:
             type: string

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -305,6 +305,12 @@ components:
           items:
             type: string
             description: hex-encoded serialized box bytes
+        inputsRaw:
+          description: List of inputs to be used in serialized form
+          type: array
+          items:
+            type: string
+            description: hex-encoded serialized box bytes
 
     SourceHolder:
       type: object

--- a/src/main/resources/panel/service-worker.js
+++ b/src/main/resources/panel/service-worker.js
@@ -18,10 +18,11 @@ importScripts(
 );
 
 self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING';) {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
     self.skipWaiting();
   }
-})
+});
+
 workbox.core.clientsClaim();
 
 /**

--- a/src/main/resources/panel/service-worker.js
+++ b/src/main/resources/panel/service-worker.js
@@ -18,11 +18,10 @@ importScripts(
 );
 
 self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
+  if (event.data && event.data.type === 'SKIP_WAITING';) {
     self.skipWaiting();
   }
-});
-
+})
 workbox.core.clientsClaim();
 
 /**

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -126,7 +126,7 @@ case class WalletApiRoute(readersHolder: ActorRef, nodeViewActorRef: ActorRef, e
                                             inputsRaw: Seq[String],
                                             dataInputsRaw: Seq[String],
                                             processFn: ErgoTransaction => Route): Route = {
-    withWalletOp(_.generateTransaction(requests, inputsRaw)) {
+    withWalletOp(_.generateTransaction(requests, inputsRaw, dataInputsRaw)) {
       case Failure(e) => BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
       case Success(tx) => processFn(tx)
     }

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -122,32 +122,44 @@ case class WalletApiRoute(readersHolder: ActorRef, nodeViewActorRef: ActorRef, e
     withWalletOp(op)(ApiResponse.apply[T])
   }
 
-  private def generateTransaction(requests: Seq[TransactionRequest], inputsRaw: Seq[String]): Route = {
+  private def generateTransactionAndProcess(requests: Seq[TransactionRequest],
+                                            inputsRaw: Seq[String],
+                                            dataInputsRaw: Seq[String],
+                                            processFn: ErgoTransaction => Route): Route = {
     withWalletOp(_.generateTransaction(requests, inputsRaw)) {
       case Failure(e) => BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
-      case Success(tx) => ApiResponse(tx)
+      case Success(tx) => processFn(tx)
     }
   }
 
-  private def sendTransaction(requests: Seq[TransactionRequest], inputsRaw: Seq[String]): Route = {
-    withWalletOp(_.generateTransaction(requests, inputsRaw)) {
-      case Failure(e) =>
-        BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
-      case Success(tx) =>
-        nodeViewActorRef ! LocallyGeneratedTransaction[ErgoTransaction](tx)
-        ApiResponse(tx.id)
-    }
+  private def generateTransaction(requests: Seq[TransactionRequest],
+                                  inputsRaw: Seq[String],
+                                  dataInputsRaw: Seq[String]): Route = {
+    generateTransactionAndProcess(requests, inputsRaw, dataInputsRaw, tx => ApiResponse(tx))
   }
 
-  def sendTransactionR: Route = (path("transaction" / "send") & post
-    & entity(as[RequestsHolder])) (holder => sendTransaction(holder.withFee, holder.inputsRaw))
+  private def sendTransaction(requests: Seq[TransactionRequest],
+                              inputsRaw: Seq[String],
+                              dataInputsRaw: Seq[String]): Route = {
+    generateTransactionAndProcess(requests, inputsRaw, dataInputsRaw, {tx =>
+      nodeViewActorRef ! LocallyGeneratedTransaction[ErgoTransaction](tx)
+      ApiResponse(tx.id)
+    })
+  }
 
-  def generateTransactionR: Route = (path("transaction" / "generate") & post
-    & entity(as[RequestsHolder])) (holder => generateTransaction(holder.withFee, holder.inputsRaw))
+  def sendTransactionR: Route =
+    (path("transaction" / "send") & post & entity(as[RequestsHolder])){ holder =>
+      sendTransaction(holder.withFee, holder.inputsRaw, holder.dataInputsRaw)
+    }
+
+  def generateTransactionR: Route =
+    (path("transaction" / "generate") & post & entity(as[RequestsHolder])){ holder =>
+      generateTransaction(holder.withFee, holder.inputsRaw, holder.dataInputsRaw)
+    }
 
   def sendPaymentTransactionR: Route = (path("payment" / "send") & post
     & entity(as[Seq[PaymentRequest]])) { requests =>
-    sendTransaction(withFee(requests), Seq.empty)
+    sendTransaction(withFee(requests), Seq.empty, Seq.empty)
   }
 
   def balancesR: Route = (path("balances") & get) {

--- a/src/main/scala/org/ergoplatform/local/TransactionGenerator.scala
+++ b/src/main/scala/org/ergoplatform/local/TransactionGenerator.scala
@@ -104,7 +104,7 @@ class TransactionGenerator(viewHolder: ActorRef,
       }
     }
     payloadReq.flatMap { payloadReqOpt =>
-      wallet.generateTransaction(payloadReqOpt.toSeq :+ feeReq, Seq.empty)
+      wallet.generateTransaction(payloadReqOpt.toSeq :+ feeReq, Seq.empty, Seq.empty)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -419,18 +419,18 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
     */
   private def generateTransactionWithOutputs(requests: Seq[TransactionRequest],
                                              inputsRaw: Seq[String],
-                                             dataInputsRaw: Seq[String]): Try[ErgoTransaction] =
+                                             dataInputsRaw: Seq[String]): Try[ErgoTransaction] = Try {
     proverOpt match {
       case Some(prover) =>
-         val inputs = inputsRaw
-                .toList
-                .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
-                .map(_.get) //todo .get
+        val inputs = inputsRaw
+          .toList
+          .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
+          .map(_.get)
 
-         val dataInputs = dataInputsRaw
-                .toIndexedSeq
-                .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
-                .map(_.get) //todo .get
+        val dataInputs = dataInputsRaw
+          .toIndexedSeq
+          .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
+          .map(_.get)
 
         requestsToBoxCandidates(requests).flatMap { payTo =>
           require(prover.pubKeys.nonEmpty, "No public keys in the prover to extract change address from")
@@ -466,7 +466,7 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
 
           val selectionOpt = boxSelector.select(inputBoxes, filter, targetBalance, targetAssets)
 
-          selectionOpt.map {selectionResult =>
+          selectionOpt.map { selectionResult =>
             prepareTransaction(prover, payTo, selectionResult, dataInputs)
           } match {
             case Right(txTry) => txTry.map(ErgoTransaction.apply)
@@ -479,6 +479,7 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
       case None =>
         Failure(new Exception(s"Cannot generateTransactionWithOutputs($requests, $inputsRaw): Wallet is locked"))
     }
+  }.flatten
 
   private def prepareTransaction(prover: ErgoProvingInterpreter,
                                  payTo: Seq[ErgoBoxCandidate],

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -260,8 +260,8 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
     case WatchFor(address) =>
       storage.addTrackedAddress(address)
 
-    case GenerateTransaction(requests, inputsRaw) =>
-      sender() ! generateTransactionWithOutputs(requests, inputsRaw)
+    case GenerateTransaction(requests, inputsRaw, dataInputsRaw) =>
+      sender() ! generateTransactionWithOutputs(requests, inputsRaw, dataInputsRaw)
 
     case DeriveKey(encodedPath) =>
       withWalletLockHandler(sender()) {
@@ -418,68 +418,75 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
     * Generates new transaction according to a given requests using available boxes.
     */
   private def generateTransactionWithOutputs(requests: Seq[TransactionRequest],
-                                             inputsRaw: Seq[String]): Try[ErgoTransaction] =
+                                             inputsRaw: Seq[String],
+                                             dataInputsRaw: Seq[String]): Try[ErgoTransaction] =
     proverOpt match {
       case Some(prover) =>
-        Traverse[List]
-          .sequence {
-            inputsRaw
-              .toList
-              .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
-          }
-          .flatMap { inputs =>
-            requestsToBoxCandidates(requests).flatMap { payTo =>
-              require(prover.pubKeys.nonEmpty, "No public keys in the prover to extract change address from")
-              require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issue requests")
-              require(payTo.forall(c => c.value >= BoxUtils.minimalErgoAmountSimulated(c, parameters)), "Minimal ERG value not met")
-              require(payTo.forall(_.additionalTokens.forall(_._2 >= 0)), "Negative asset value")
+         val inputs = inputsRaw
+                .toList
+                .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
+                .map(_.get) //todo .get
 
-              val assetIssueBox = payTo
-                .zip(requests)
-                .filter(_._2.isInstanceOf[AssetIssueRequest])
-                .map(_._1)
-                .headOption
+         val dataInputs = dataInputsRaw
+                .toIndexedSeq
+                .map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry))
+                .map(_.get) //todo .get
 
-              val targetBalance = payTo
-                .map(_.value)
-                .sum
+        requestsToBoxCandidates(requests).flatMap { payTo =>
+          require(prover.pubKeys.nonEmpty, "No public keys in the prover to extract change address from")
+          require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issue requests")
+          require(payTo.forall(c => c.value >= BoxUtils.minimalErgoAmountSimulated(c, parameters)), "Minimal ERG value not met")
+          require(payTo.forall(_.additionalTokens.forall(_._2 >= 0)), "Negative asset value")
 
-              val targetAssets = payTo
-                .filterNot(bx => assetIssueBox.contains(bx))
-                .foldLeft(Map.empty[ModifierId, Long]) { case (acc, bx) =>
-                  // TODO optimize: avoid toArray and use mapFirst
-                  val boxTokens = bx.additionalTokens.toArray.map(t => bytesToId(t._1) -> t._2).toMap
-                  AssetUtils.mergeAssets(boxTokens, acc)
-                }
+          val assetIssueBox = payTo
+            .zip(requests)
+            .filter(_._2.isInstanceOf[AssetIssueRequest])
+            .map(_._1)
+            .headOption
 
-              val (inputBoxes, filter) = if (inputs.nonEmpty) {
-                //inputs are provided externally, no need for filtering
-                (boxesToFakeTracked(inputs), noFilter)
-              } else {
-                //inputs are to be selected by the wallet
-                (registry.readCertainUnspentBoxes.toIterator, onChainFilter)
-              }
+          val targetBalance = payTo
+            .map(_.value)
+            .sum
 
-              val selectionOpt = boxSelector.select(inputBoxes, filter, targetBalance, targetAssets)
-
-              val makeTx = prepareTransaction(prover, payTo) _
-
-              selectionOpt.map(makeTx) match {
-                case Right(txTry) => txTry.map(ErgoTransaction.apply)
-                case Left(e) => Failure(
-                  new Exception(s"Failed to find boxes to assemble a transaction for $payTo, \nreason: ${e}")
-                )
-              }
+          val targetAssets = payTo
+            .filterNot(bx => assetIssueBox.contains(bx))
+            .foldLeft(Map.empty[ModifierId, Long]) { case (acc, bx) =>
+              // TODO optimize: avoid toArray and use mapFirst
+              val boxTokens = bx.additionalTokens.toArray.map(t => bytesToId(t._1) -> t._2).toMap
+              AssetUtils.mergeAssets(boxTokens, acc)
             }
+
+          val (inputBoxes, filter) = if (inputs.nonEmpty) {
+            //inputs are provided externally, no need for filtering
+            (boxesToFakeTracked(inputs), noFilter)
+          } else {
+            //inputs are to be selected by the wallet
+            (registry.readCertainUnspentBoxes.toIterator, onChainFilter)
           }
+
+          val selectionOpt = boxSelector.select(inputBoxes, filter, targetBalance, targetAssets)
+
+          selectionOpt.map {selectionResult =>
+            prepareTransaction(prover, payTo, selectionResult, dataInputs)
+          } match {
+            case Right(txTry) => txTry.map(ErgoTransaction.apply)
+            case Left(e) => Failure(
+              new Exception(s"Failed to find boxes to assemble a transaction for $payTo, \nreason: ${e}")
+            )
+          }
+        }
 
       case None =>
         Failure(new Exception(s"Cannot generateTransactionWithOutputs($requests, $inputsRaw): Wallet is locked"))
     }
 
-  private def prepareTransaction(prover: ErgoProvingInterpreter, payTo: Seq[ErgoBoxCandidate])
-                                (r: BoxSelector.BoxSelectionResult[TrackedBox]): Try[ErgoLikeTransaction] = {
+  private def prepareTransaction(prover: ErgoProvingInterpreter,
+                                 payTo: Seq[ErgoBoxCandidate],
+                                 r: BoxSelector.BoxSelectionResult[TrackedBox],
+                                 dataInputBoxes: IndexedSeq[ErgoBox]
+                                ): Try[ErgoLikeTransaction] = {
     val inputs = r.boxes.map(_.box).toIndexedSeq
+    val dataInputs = dataInputBoxes.map(dataInputBox => DataInput(dataInputBox.id))
 
     val changeAddress = storage.readChangeAddress
       .map(_.pubkey)
@@ -488,18 +495,18 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
         prover.pubKeys.head
       }
 
-    val changeBoxCandidates = r.changeBoxes.map { changeBox => 
+    val changeBoxCandidates = r.changeBoxes.map { changeBox =>
       val assets = changeBox.tokens.map(t => Digest32 @@ idToBytes(t._1) -> t._2).toIndexedSeq
       new ErgoBoxCandidate(changeBox.value, changeAddress, height, assets.toColl)
     }
 
     val unsignedTx = new UnsignedErgoTransaction(
       inputs.map(_.id).map(id => new UnsignedInput(id)),
-      IndexedSeq(),
+      dataInputs,
       (payTo ++ changeBoxCandidates).toIndexedSeq
     )
 
-    prover.sign(unsignedTx, inputs, IndexedSeq(), stateContext)
+    prover.sign(unsignedTx, inputs, dataInputBoxes, stateContext)
       .fold(e => Failure(new Exception(s"Failed to sign boxes due to ${e.getMessage}: $inputs", e)), tx => Success(tx))
   }
 
@@ -648,7 +655,9 @@ object ErgoWalletActor {
 
   final case class Rollback(version: VersionTag, height: Int)
 
-  final case class GenerateTransaction(requests: Seq[TransactionRequest], inputsRaw: Seq[String])
+  final case class GenerateTransaction(requests: Seq[TransactionRequest],
+                                       inputsRaw: Seq[String],
+                                       dataInputsRaw: Seq[String])
 
   final case class ReadBalances(chainStatus: ChainStatus)
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -436,7 +436,7 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
           require(prover.pubKeys.nonEmpty, "No public keys in the prover to extract change address from")
           require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issue requests")
           require(payTo.forall(c => c.value >= BoxUtils.minimalErgoAmountSimulated(c, parameters)), "Minimal ERG value not met")
-          require(payTo.forall(_.additionalTokens.forall(_._2 >= 0)), "Negative asset value")
+          require(payTo.forall(_.additionalTokens.forall(_._2 > 0)), "Non-positive asset value")
 
           val assetIssueBox = payTo
             .zip(requests)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -84,7 +84,8 @@ trait ErgoWalletReader extends VaultReader {
     (walletActor ? ReadTrackedAddresses).mapTo[Seq[ErgoAddress]]
 
   def generateTransaction(requests: Seq[TransactionRequest],
-                          inputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
-    (walletActor ? GenerateTransaction(requests, inputsRaw)).mapTo[Try[ErgoTransaction]]
+                          inputsRaw: Seq[String] = Seq.empty,
+                          dataInputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw)).mapTo[Try[ErgoTransaction]]
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
@@ -7,6 +7,7 @@ import org.ergoplatform.nodeView.wallet.ErgoAddressJsonEncoder
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, ErgoScriptPredef, Pay2SAddress}
 
+
 case class RequestsHolder(requests: Seq[TransactionRequest],
                           feeOpt: Option[Long] = None,
                           inputsRaw: Seq[String] = Seq.empty,
@@ -49,9 +50,9 @@ class RequestsHolderDecoder(settings: ErgoSettings) extends Decoder[RequestsHold
     for {
       requests <- cursor.downField("requests").as[Seq[TransactionRequest]]
       fee <- cursor.downField("fee").as[Option[Long]]
-      inputs <- cursor.downField("inputsRaw").as[Seq[String]]
-      dataInputs <- cursor.downField("dataInputsRaw").as[Seq[String]]
-    } yield RequestsHolder(requests, fee, inputs, dataInputs)
+      inputs <- cursor.downField("inputsRaw").as[Option[Seq[String]]]
+      dataInputs <- cursor.downField("dataInputsRaw").as[Option[Seq[String]]]
+    } yield RequestsHolder(requests, fee, inputs.getOrElse(Seq.empty), dataInputs.getOrElse(Seq.empty))
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
@@ -9,7 +9,8 @@ import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, ErgoScriptPredef, Pay2
 
 case class RequestsHolder(requests: Seq[TransactionRequest],
                           feeOpt: Option[Long] = None,
-                          inputsRaw: Seq[String] = Seq.empty)
+                          inputsRaw: Seq[String] = Seq.empty,
+                          dataInputsRaw: Seq[String] = Seq.empty)
                          (implicit val addressEncoder: ErgoAddressEncoder) {
 
   // Add separate payment request with fee.
@@ -32,7 +33,8 @@ class RequestsHolderEncoder(settings: ErgoSettings) extends Encoder[RequestsHold
     Json.obj(
       "requests" -> holder.requests.asJson,
       "fee" -> holder.feeOpt.asJson,
-      "inputsRaw" -> holder.inputsRaw.asJson
+      "inputsRaw" -> holder.inputsRaw.asJson,
+      "dataInputsRaw" -> holder.dataInputsRaw.asJson
     )
   }
 
@@ -48,7 +50,8 @@ class RequestsHolderDecoder(settings: ErgoSettings) extends Decoder[RequestsHold
       requests <- cursor.downField("requests").as[Seq[TransactionRequest]]
       fee <- cursor.downField("fee").as[Option[Long]]
       inputs <- cursor.downField("inputsRaw").as[Seq[String]]
-    } yield RequestsHolder(requests, fee, inputs)
+      dataInputs <- cursor.downField("dataInputsRaw").as[Seq[String]]
+    } yield RequestsHolder(requests, fee, inputs, dataInputs)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
@@ -9,9 +9,9 @@ import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, ErgoScriptPredef, Pay2
 
 
 case class RequestsHolder(requests: Seq[TransactionRequest],
-                          feeOpt: Option[Long] = None,
-                          inputsRaw: Seq[String] = Seq.empty,
-                          dataInputsRaw: Seq[String] = Seq.empty)
+                          feeOpt: Option[Long],
+                          inputsRaw: Seq[String],
+                          dataInputsRaw: Seq[String])
                          (implicit val addressEncoder: ErgoAddressEncoder) {
 
   // Add separate payment request with fee.

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -36,7 +36,12 @@ class WalletApiRouteSpec extends FlatSpec
 
   val paymentRequest = PaymentRequest(Pay2SAddress(Constants.FalseLeaf), 100L, Seq.empty, Map.empty)
   val assetIssueRequest = AssetIssueRequest(Pay2SAddress(Constants.FalseLeaf), 100L, "TEST", "Test", 8)
-  val requestsHolder = RequestsHolder((0 to 10).flatMap(_ => Seq(paymentRequest, assetIssueRequest)), Some(10000L))
+  val requestsHolder = RequestsHolder(
+    (0 to 10).flatMap(_ => Seq(paymentRequest, assetIssueRequest)),
+    Some(10000L),
+    Seq.empty,
+    Seq.empty
+  )
 
 
   it should "generate arbitrary transaction" in {

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -169,7 +169,7 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
       case ReadTrackedAddresses =>
         sender ! trackedAddresses
 
-      case GenerateTransaction(_, _) =>
+      case GenerateTransaction(_, _, _) =>
         val input = ErgoTransactionGenerators.inputGen.sample.value
         val tx = ErgoTransaction(IndexedSeq(input), IndexedSeq(ergoBoxCandidateGen.sample.value))
         sender ! Success(tx)


### PR DESCRIPTION
This PR adds "dataInputsRaw" field to /wallet/transaction/{generate, sent} API methods inputs and corresponding processing for provided data inputs.