### PR TITLE
Allow unconfirmed boxes to be spent via /transactions 

### DIFF
--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -20,7 +20,7 @@ class BlocksApiRouteSpec extends FlatSpec
 
   val prefix = "/blocks"
 
-  val route: Route = BlocksApiRoute(nodeViewRef, readersRef, settings).route
+  val route: Route = BlocksApiRoute(nodeViewRef, digestReadersRef, settings).route
 
   val headerIdBytes: ModifierId = history.lastHeaders(1).headers.head.id
   val headerIdString: String = Algos.encode(headerIdBytes)

--- a/src/test/scala/org/ergoplatform/http/routes/ScriptApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ScriptApiRouteSpec.scala
@@ -25,7 +25,7 @@ class ScriptApiRouteSpec  extends FlatSpec
 
   val ergoSettings: ErgoSettings = ErgoSettings.read(
     Args(userConfigPathOpt = Some("src/test/resources/application.conf"), networkTypeOpt = None))
-  val route: Route = ScriptApiRoute(readersRef, settings).route
+  val route: Route = ScriptApiRoute(digestReadersRef, settings).route
 
   val scriptSource: String =
     """

--- a/src/test/scala/org/ergoplatform/http/routes/UtxoApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/UtxoApiRouteSpec.scala
@@ -24,25 +24,6 @@ class UtxoApiRouteSpec extends FlatSpec
 
   val prefix = "/utxo"
 
-  val utxoSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(stateType = StateType.Utxo))
-
-  lazy val utxoState = boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, utxoSettings)).sample.value
-
-  lazy val utxoReaders = Readers(history, utxoState, memPool, wallet)
-
-  class UtxoReadersStub extends Actor {
-    def receive: PartialFunction[Any, Unit] = {
-      case GetReaders => sender() ! utxoReaders
-      case GetDataFromHistory(f) => sender() ! f(history)
-    }
-  }
-
-  object UtxoReadersStub {
-    def props(): Props = Props(new UtxoReadersStub)
-  }
-
-  lazy val utxoReadersRef: ActorRef = system.actorOf(UtxoReadersStub.props())
-
   val route: Route = UtxoApiRoute(utxoReadersRef, utxoSettings.scorexSettings.restApi).route
 
   it should "get utxo box with /byId" in {

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -27,7 +27,7 @@ class WalletApiRouteSpec extends FlatSpec
 
   val ergoSettings: ErgoSettings = ErgoSettings.read(
     Args(userConfigPathOpt = Some("src/test/resources/application.conf"), networkTypeOpt = None))
-  val route: Route = WalletApiRoute(readersRef, nodeViewRef, settings).route
+  val route: Route = WalletApiRoute(digestReadersRef, nodeViewRef, settings).route
 
   implicit val paymentRequestEncoder: PaymentRequestEncoder = new PaymentRequestEncoder(ergoSettings)
   implicit val assetIssueRequestEncoder: AssetIssueRequestEncoder = new AssetIssueRequestEncoder(ergoSettings)


### PR DESCRIPTION
Close #1090 :

This PR allows transactions chaining in /transactions API methods, namely POST requests to /transactions  (to submit the transaction to the memory pool) and /transactions/check (to check the transaction without submitting it). 