### PR TITLE
Complexity limit raised to 250K

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1220,7 +1220,7 @@ components:
         maxBlockCost:
           type: integer
           format: int32
-          description: Maximum cumulative computational complexity of input scripts in block transactions
+          description: Maximum cumulative computational cost of input scripts in block transactions
           minimum: 0
           example: 104876
           nullable: false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -29,7 +29,7 @@ ergo {
     mining = false
 
     # Node will only include transactions to own blocks with lower complexity
-    maxTransactionComplexity = 100000
+    maxTransactionComplexity = 250000
 
     # Use external miner, native miner is used if set to `false`
     useExternalMiner = true

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
@@ -38,7 +38,7 @@ trait UtxoStateReader extends ErgoStateReader with TransactionValidation[ErgoTra
       val boxesToSpend = tx.inputs.flatMap(i => boxById(i.boxId))
       val txComplexity = boxesToSpend.map(_.ergoTree.complexity).sum
       if (txComplexity > complexityLimit) {
-        throw new Exception(s"Transaction $tx have too high complexity $txComplexity")
+        throw new Exception(s"Transaction $tx has too high complexity $txComplexity")
       }
       tx.statefulValidity(
         boxesToSpend,

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -58,10 +58,13 @@ object Constants {
 
   // Maximum extension size
   val MaxExtensionSize: Int = 32 * 1024
+
   // Maximum extension size during bytes parsing. Allows to move MaxExtensionSize to Parameters in future
   val MaxExtensionSizeMax: Int = 1024 * 1024
+
   // Default limit for transaction complexity to be included into block.
-  val DefaultComplexityLimit: Int = 100000
+  // Used in tests only.
+  val DefaultComplexityLimit: Int = 250000
 
   // SimplePayments application identifier
   val DefaultAppId: Short = 1

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -62,10 +62,6 @@ object Constants {
   // Maximum extension size during bytes parsing. Allows to move MaxExtensionSize to Parameters in future
   val MaxExtensionSizeMax: Int = 1024 * 1024
 
-  // Default limit for transaction complexity to be included into block.
-  // Used in tests only.
-  val DefaultComplexityLimit: Int = 250000
-
   // SimplePayments application identifier
   val DefaultAppId: Short = 1
 

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -286,6 +286,7 @@ class ErgoMinerSpec extends FlatSpec with ErgoTestHelpers with ValidBlocksGenera
 }
 
 class Listener extends Actor {
+
   var generatedBlocks: Int = 0
 
   override def preStart(): Unit = {
@@ -296,6 +297,7 @@ class Listener extends Actor {
     case SemanticallySuccessfulModifier(_) => generatedBlocks += 1
     case Status => sender ! generatedBlocks
   }
+
 }
 
 object Listener {

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions, Extensio
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
-import org.ergoplatform.settings.Constants
+import org.ergoplatform.settings.{Constants, ErgoSettings}
 import org.ergoplatform.utils.ErgoPropertyTest
 import org.ergoplatform.utils.generators.ErgoTransactionGenerators
 import scorex.core._
@@ -44,7 +44,8 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
       val newBoxes = IndexedSeq(newFoundersBox, rewardBox)
       val unsignedTx = new UnsignedErgoTransaction(inputs, IndexedSeq(), newBoxes)
       val tx: ErgoTransaction = ErgoTransaction(defaultProver.sign(unsignedTx, IndexedSeq(foundersBox), emptyDataBoxes, us.stateContext).get)
-      us.validateWithCost(tx, None, Constants.DefaultComplexityLimit).get should be <= 100000L
+      val complexityLimit = initSettings.nodeSettings.maxTransactionComplexity
+      us.validateWithCost(tx, None, complexityLimit).get should be <= 100000L
       val block1 = validFullBlock(Some(lastBlock), us, Seq(ErgoTransaction(tx)))
       us = us.applyModifier(block1).get
       foundersBox = tx.outputs.head

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -6,6 +6,8 @@ import org.ergoplatform.utils.ErgoPropertyTest
 import scala.concurrent.duration._
 
 class ErgoSettingsSpecification extends ErgoPropertyTest {
+  
+  private val complexityLimit = initSettings.nodeSettings.maxTransactionComplexity
 
   property("should keep data user home  by default") {
     val settings = ErgoSettings.read()
@@ -15,7 +17,7 @@ class ErgoSettingsSpecification extends ErgoPropertyTest {
   property("should read default settings") {
     val settings = ErgoSettings.read()
     settings.nodeSettings shouldBe NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true, 1000,
-      poPoWBootstrap = false, 10, mining = false, Constants.DefaultComplexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
+      poPoWBootstrap = false, 10, mining = false, complexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
       offlineGeneration = false, keepVersions = 200, mempoolCapacity = 100000, blacklistCapacity = 100000,
       mempoolCleanupDuration = 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0, headerChainDiff = 100)
   }
@@ -23,14 +25,14 @@ class ErgoSettingsSpecification extends ErgoPropertyTest {
   property("should read user settings from json file") {
     val settings = ErgoSettings.read(Args(Some("src/test/resources/settings.json"), None))
     settings.nodeSettings shouldBe NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true, 12,
-      poPoWBootstrap = false, 10, mining = false, Constants.DefaultComplexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
+      poPoWBootstrap = false, 10, mining = false, complexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
       offlineGeneration = false, 200, 100000, 100000, 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0, headerChainDiff = 100)
   }
 
   property("should read user settings from HOCON file") {
     val settings = ErgoSettings.read(Args(Some("src/test/resources/settings.conf"), None))
     settings.nodeSettings shouldBe NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true, 13,
-      poPoWBootstrap = false, 10, mining = false, Constants.DefaultComplexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
+      poPoWBootstrap = false, 10, mining = false, complexityLimit, 1.second, useExternalMiner = false, miningPubKeyHex = None,
       offlineGeneration = false, 200, 100000, 100000, 10.seconds, rebroadcastCount = 3, minimalFeeAmount = 0, headerChainDiff = 100)
   }
 

--- a/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
@@ -56,8 +56,9 @@ object ChainGenerator extends App with ErgoTestHelpers {
 
   val miningDelay = 1.second
   val minimalSuffix = 2
+  val complexityLimit = initSettings.nodeSettings.maxTransactionComplexity
   val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true,
-    -1, poPoWBootstrap = false, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false,
+    -1, poPoWBootstrap = false, minimalSuffix, mining = false, complexityLimit, miningDelay, useExternalMiner = false,
     miningPubKeyHex = None, offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 20, 1000000, 100)
   val ms = settings.chainSettings.monetary.copy(
     minerRewardDelay = RewardDelay

--- a/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
+++ b/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
@@ -43,8 +43,9 @@ trait HistoryTestHelpers extends ErgoPropertyTest {
 
     val miningDelay = 1.second
     val minimalSuffix = 2
+    val complexityLimit = initSettings.nodeSettings.maxTransactionComplexity
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
-      PoPoWBootstrap, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
+      PoPoWBootstrap, minimalSuffix, mining = false, complexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
       offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 100)
     val scorexSettings: ScorexSettings = null
     val testingSettings: TestingSettings = null

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -277,8 +277,9 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
 
     val miningDelay = 1.second
     val minimalSuffix = 2
+    val complexityLimit = initSettings.nodeSettings.maxTransactionComplexity
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
-      PoPoWBootstrap, minimalSuffix, mining = false, Constants.DefaultComplexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
+      PoPoWBootstrap, minimalSuffix, mining = false, complexityLimit, miningDelay, useExternalMiner = false, miningPubKeyHex = None,
       offlineGeneration = false, 200, 100000, 100000, 1.minute, rebroadcastCount = 200, 1000000, 100)
     val scorexSettings: ScorexSettings = null
     val testingSettings: TestingSettings = null


### PR DESCRIPTION
This PR is raising default complexity limit per transaction to 250K. 