### PR TITLE
Candidate for version 3.2.6

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -20,17 +20,19 @@ object DefaultBoxSelector extends BoxSelector {
   import BoxSelector._
 
   final case class NotEnoughCoinsError(message: String) extends BoxSelectionError
+
   final case class NotEnoughTokensError(message: String) extends BoxSelectionError
+
   final case class NotEnoughCoinsForChangeBoxesError(message: String) extends BoxSelectionError
 
   override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
-                      externalFilter: T => Boolean,
-                      targetBalance: Long,
-                      targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                          externalFilter: T => Boolean,
+                                          targetBalance: Long,
+                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     //mutable structures to collect results
-    val res            = mutable.Buffer[T]()
+    val res = mutable.Buffer[T]()
     var currentBalance = 0L
-    val currentAssets  = mutable.Map[ModifierId, Long]()
+    val currentAssets = mutable.Map[ModifierId, Long]()
 
     def pickUp(unspentBox: T) = {
       currentBalance = currentBalance + unspentBox.value
@@ -39,16 +41,13 @@ object DefaultBoxSelector extends BoxSelector {
     }
 
     def balanceMet = currentBalance >= targetBalance
+
     def assetsMet = targetAssets.forall {
       case (id, targetAmt) => currentAssets.getOrElse(id, 0L) >= targetAmt
     }
 
     @tailrec
-    def pickBoxes(
-      boxesIterator: Iterator[T],
-      filterFn: T => Boolean,
-      successFn: => Boolean
-    ): Boolean =
+    def pickBoxes(boxesIterator: Iterator[T], filterFn: T => Boolean, successFn: => Boolean): Boolean =
       if (successFn) {
         true
       } else if (!boxesIterator.hasNext) {
@@ -65,16 +64,16 @@ object DefaultBoxSelector extends BoxSelector {
       //If this condition is satisfied on the previous step, we will do one extra call to pickBoxes
       //with no touching the iterator (which is not that much).
       if (pickBoxes(
-            inputBoxes,
-            bc =>
-              externalFilter(bc) && bc.tokens.exists {
-                case (id, _) =>
-                  val targetAmt       = targetAssets.getOrElse(id, 0L)
-                  lazy val currentAmt = currentAssets.getOrElse(id, 0L)
-                  targetAmt > 0 && targetAmt > currentAmt
-              },
-            assetsMet
-          )) {
+        inputBoxes,
+        bc =>
+          externalFilter(bc) && bc.tokens.exists {
+            case (id, _) =>
+              val targetAmt = targetAssets.getOrElse(id, 0L)
+              lazy val currentAmt = currentAssets.getOrElse(id, 0L)
+              targetAmt > 0 && targetAmt > currentAmt
+          },
+        assetsMet
+      )) {
         formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets).mapRight { changeBoxes =>
           BoxSelectionResult(res, changeBoxes)
         }
@@ -87,11 +86,11 @@ object DefaultBoxSelector extends BoxSelector {
   }
 
   def formChangeBoxes(
-    foundBalance: Long,
-    targetBalance: Long,
-    foundBoxAssets: mutable.Map[ModifierId, Long],
-    targetBoxAssets: TokensMap
-  ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+                       foundBalance: Long,
+                       targetBalance: Long,
+                       foundBoxAssets: mutable.Map[ModifierId, Long],
+                       targetBoxAssets: TokensMap
+                     ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
     AssetUtils.subtractAssetsMut(foundBoxAssets, targetBoxAssets)
     val changeBoxesAssets: Seq[mutable.Map[ModifierId, Long]] = foundBoxAssets.grouped(MaxTokens).toSeq
     val changeBalance = foundBalance - targetBalance

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -19,7 +19,7 @@ object DefaultBoxSelector extends BoxSelector {
 
   import BoxSelector._
 
-  final case class NotEnoughCoinsError(message: String) extends BoxSelectionError
+  final case class NotEnoughErgsError(message: String) extends BoxSelectionError
 
   final case class NotEnoughTokensError(message: String) extends BoxSelectionError
 
@@ -81,7 +81,7 @@ object DefaultBoxSelector extends BoxSelector {
         Left(NotEnoughTokensError(s"not enough boxes to meet token needs $targetAssets (found only $currentAssets)"))
       }
     } else {
-      Left(NotEnoughCoinsError(s"not enough boxes to meet ERG needs $targetBalance (found only $currentBalance)"))
+      Left(NotEnoughErgsError(s"not enough boxes to meet ERG needs $targetBalance (found only $currentBalance)"))
     }
   }
 

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
   * Say, the selector is given boxes denoted by their values (1,2,3,4,...10). Then the selector is working as follows:
   *
   * 1) the selector first picking up boxes in given order (1,2,3,4,...) by using DefaultBoxSelector
-  * 2) if number of inputs exceeds the limit, the selector is sorting remaining boxes(actually, only 4*maximum inputs of them) by value in descending order and replaces small-value boxes in the inputs by big-value from the tail (1,2,3,4 => 10)
+  * 2) if number of inputs exceeds the limit, the selector is sorting remaining boxes(actually, only 10*maximum inputs of them) by value in descending order and replaces small-value boxes in the inputs by big-value from the tail (1,2,3,4 => 10)
   * 3) if the number of inputs still exceeds the limit, the selector is trying to throw away the dust if possible. E.g. if inputs are (100, 200, 1, 2, 1000), target value is 1300 and maximum number of inputs is 3, the selector kicks out (1, 2)
   * 4) if number of inputs after the previous steps is below optimal, the selector is trying to append the dust, by sorting remaining boxes in ascending order and appending them till optimal number of inputs.
   *
@@ -43,9 +43,10 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
     *         (wrapped in a special BoxSelectionResult class).
     */
   override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
-                      filterFn: T => Boolean,
-                      targetBalance: Long,
-                      targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                          filterFn: T => Boolean,
+                                          targetBalance: Long,
+                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+
     DefaultBoxSelector.select(inputBoxes, filterFn, targetBalance, targetAssets).flatMapRight { initialSelection =>
       val tail = inputBoxes.take(maxInputs * ScanDepthFactor).filter(filterFn).toSeq
       (if (initialSelection.boxes.length > maxInputs) {
@@ -70,21 +71,20 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
     }
   }
 
-  protected[boxes] def calcChange[T <: ErgoBoxAssets](
-    boxes: Seq[T],
-    targetBalance: Long,
-    targetAssets: TokensMap
-  ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+  protected[boxes] def calcChange[T <: ErgoBoxAssets](boxes: Seq[T],
+                                                      targetBalance: Long,
+                                                      targetAssets: TokensMap
+                                                     ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
     val compactedBalance = boxes.map(_.value).sum
-    val compactedAssets  = mutable.Map[ModifierId, Long]()
+    val compactedAssets = mutable.Map[ModifierId, Long]()
     AssetUtils.mergeAssetsMut(compactedAssets, boxes.map(_.tokens): _*)
     DefaultBoxSelector.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets)
   }
 
   protected[boxes] def collectDust[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
-                  tail: Seq[T],
-                  targetBalance: Long,
-                  targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                                       tail: Seq[T],
+                                                       targetBalance: Long,
+                                                       targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     val diff = optimalInputs - bsr.boxes.length
     val dust = tail.sortBy(_.value).take(diff).filter(b => !bsr.boxes.contains(b))
 
@@ -93,8 +93,8 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
   }
 
   protected[boxes] def compress[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
-               targetBalance: Long,
-               targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                                    targetBalance: Long,
+                                                    targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     val boxes = bsr.boxes
     val diff = boxes.map(_.value).sum - targetBalance
 
@@ -116,9 +116,9 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
   }
 
   protected[boxes] def replace[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
-              tail: Seq[T],
-              targetBalance: Long,
-              targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                                   tail: Seq[T],
+                                                   targetBalance: Long,
+                                                   targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     val bigBoxes = tail.sortBy(-_.value)
     val boxesToThrowAway = bsr.boxes.filter(!_.tokens.keySet.exists(tid => targetAssets.keySet.contains(tid)))
     val sorted = boxesToThrowAway.sortBy(_.value)
@@ -155,5 +155,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
 }
 
 object ReplaceCompactCollectBoxSelector {
-    final case class MaxInputsExceededError(message: String) extends BoxSelectionError
+
+  final case class MaxInputsExceededError(message: String) extends BoxSelectionError
+
 }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -155,5 +155,5 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
 }
 
 object ReplaceCompactCollectBoxSelector {
-    final case class MaxInputsExceededError(val message: String) extends BoxSelectionError
+    final case class MaxInputsExceededError(message: String) extends BoxSelectionError
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -33,7 +33,7 @@ class DefaultBoxSelectorSpec extends PropSpec with Matchers with EitherValues {
     select(Seq(uBox).toIterator, onChainFilter, 1, Map()).left.value shouldBe a [NotEnoughCoinsError]
 
     //no target asset in the input box
-    select(Seq(uBox).toIterator, noFilter, 1, Map(bytesToId(Array.fill(32)(0: Byte)) -> 1L)).left.value shouldBe 
+    select(Seq(uBox).toIterator, noFilter, 1, Map(bytesToId(Array.fill(32)(0: Byte)) -> 1L)).left.value shouldBe
       a [NotEnoughTokensError]
 
     //otherwise, everything is fine

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -7,7 +7,7 @@ import sigmastate.Values
 import sigmastate.Values.SigmaPropValue
 import scorex.util.{bytesToId, idToBytes}
 import org.scalatest.EitherValues
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughCoinsError
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughErgsError
 import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughTokensError
 import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughCoinsForChangeBoxesError
 
@@ -27,10 +27,10 @@ class DefaultBoxSelectorSpec extends PropSpec with Matchers with EitherValues {
     val uBox = TrackedBox(parentTx, 0, None, box, BoxCertainty.Certain, 1)
 
     //target amount is too high
-    select(Seq(uBox).toIterator, noFilter, 10, Map()).left.value shouldBe a [NotEnoughCoinsError]
+    select(Seq(uBox).toIterator, noFilter, 10, Map()).left.value shouldBe a [NotEnoughErgsError]
 
     //filter(which is about selecting only onchain boxes) is preventing from picking the proper box
-    select(Seq(uBox).toIterator, onChainFilter, 1, Map()).left.value shouldBe a [NotEnoughCoinsError]
+    select(Seq(uBox).toIterator, onChainFilter, 1, Map()).left.value shouldBe a [NotEnoughErgsError]
 
     //no target asset in the input box
     select(Seq(uBox).toIterator, noFilter, 1, Map(bytesToId(Array.fill(32)(0: Byte)) -> 1L)).left.value shouldBe

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
@@ -103,5 +103,12 @@ class ReplaceCompactCollectBoxSelectorSpec extends PropSpec with Matchers with E
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
       res.boxes.length shouldBe optimalInputs
     }
+
+    {
+      val targetBalance = 1
+      val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
+      res.boxes.length shouldBe res.boxes.distinct.length
+      res.boxes.length shouldBe optimalInputs
+    }
   }
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -26,7 +26,7 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
   // Now these settings are hard-coded, however, they should be parameterized
   // https://github.com/ergoplatform/ergo/issues/856
   val maxInputs = 48
-  val optimalInputs = 5
+  val optimalInputs = 6
 
   val boxSelector = new ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs)
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -25,8 +25,8 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
   // and also optimal number of inputs(a selector is collecting dust if transaction has less inputs than optimal).
   // Now these settings are hard-coded, however, they should be parameterized
   // https://github.com/ergoplatform/ergo/issues/856
-  val maxInputs = 32
-  val optimalInputs = 12
+  val maxInputs = 48
+  val optimalInputs = 5
 
   val boxSelector = new ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs)
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -471,7 +471,7 @@ class ErgoWalletActor(settings: ErgoSettings, boxSelector: BoxSelector)
           } else {
             //inputs are to be selected by the wallet
             require(prover.hdPubKeys.nonEmpty, "No public keys in the prover to extract change address from")
-            val boxesToSpend = registry.readCertainUnspentBoxes ++ offChainRegistry.offChainBoxes
+            val boxesToSpend = (registry.readCertainUnspentBoxes ++ offChainRegistry.offChainBoxes).distinct
             (boxesToSpend.toIterator, walletFilter)
           }
 


### PR DESCRIPTION
This bugfix release is fixing a problem appeared in 3.2.5 with possibility of duplicate inputs for transaction assembler, see #1126  for details. 

Other changes in the code are mostly cosmetic, aside of changing values for replace-compact-collect box selector (they still hardcoded, see #856 ).