### PR TITLE
Encoding decimals in asset issuance according to EIP-4

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -902,11 +902,6 @@ components:
           type: integer
           format: int32
           example: 8
-        fee:
-          description: Optional, default transaction fee from settings will be used if not defined
-          type: integer
-          format: int64
-          example: 1000000
         registers:
           description: Optional, possible values for registers R7...R9
           $ref: '#/components/schemas/Registers'

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -441,6 +441,12 @@ class ErgoWalletActor(settings: ErgoSettings,
     */
   private val noFilter: FilterFn = (_: TrackedBox) => true
 
+  /**
+    * Convert requests (to make payments or to issue an asset) to transaction outputs
+    * There can be only one asset issuance request in the input sequence.
+    * @param requests - an input sequence of requests
+    * @return sequence of transaction outputs or failure if inputs are incorrect
+    */
   private def requestsToBoxCandidates(requests: Seq[TransactionGenerationRequest]): Try[Seq[ErgoBoxCandidate]] =
     Traverse[List].sequence {
       requests.toList

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -467,7 +467,7 @@ class ErgoWalletActor(settings: ErgoSettings,
                   val nonMandatoryRegisters = scala.Predef.Map(
                     R4 -> ByteArrayConstant(name.getBytes("UTF-8")),
                     R5 -> ByteArrayConstant(description.getBytes("UTF-8")),
-                    R6 -> IntConstant(decimals)
+                    R6 -> ByteArrayConstant(String.valueOf(decimals).getBytes("UTF-8"))
                   ) ++ registers.getOrElse(Map())
                   (addressOpt orElse walletVars.publicKeyAddresses.headOption)
                     .fold[Try[ErgoAddress]](Failure(new Exception("No address available for box locking")))(Success(_))


### PR DESCRIPTION
This PR contains:
* Decimals encoding during asset issuance according to EIP-4 (issue #1142 )
* Unused fee removed from AssetIssueRequest description in openapi.yaml