### PR TITLE
Improved transactions downloading and mempool optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val commonSettings = Seq(
   publishTo := sonatypePublishToBundle.value,
 )
 
-val scorexVersion = "master-07d30caa-SNAPSHOT"
+val scorexVersion = "tx-delivery-01d4efff-SNAPSHOT"
 val sigmaStateVersion = "3.2.1"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -343,7 +343,7 @@ scorex {
     deliveryTimeout = 10s
 
     # Max number of delivery checks. Stop expecting modifier (and penalize peer) if it was not delivered on time
-    maxDeliveryChecks = 20
+    maxDeliveryChecks = 2
 
     ############
     # Timeouts #

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -57,7 +57,7 @@ ergo {
     mempoolCleanupDuration = 20s
 
     # Number of transactions from mempool to be re-broadcasted at each epoch
-    rebroadcastCount = 30
+    rebroadcastCount = 3
 
     # Minimal fee amount of transactions mempool accepts
     minimalFeeAmount = 1000000

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -57,7 +57,7 @@ ergo {
     mempoolCleanupDuration = 20s
 
     # Number of transactions from mempool to be re-broadcasted at each epoch
-    rebroadcastCount = 3
+    rebroadcastCount = 30
 
     # Minimal fee amount of transactions mempool accepts
     minimalFeeAmount = 1000000
@@ -343,7 +343,7 @@ scorex {
     deliveryTimeout = 10s
 
     # Max number of delivery checks. Stop expecting modifier (and penalize peer) if it was not delivered on time
-    maxDeliveryChecks = 40
+    maxDeliveryChecks = 20
 
     ############
     # Timeouts #

--- a/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
+++ b/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
@@ -119,6 +119,6 @@ object CleanupWorker {
   case class RunCleanup(validator: TransactionValidation[ErgoTransaction],
                         mempool: ErgoMemPoolReader)
 
-  val IndexRevisionInterval: Int = 16
+  val IndexRevisionInterval: Int = 4
 
 }

--- a/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
+++ b/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
@@ -116,8 +116,7 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
 
 object CleanupWorker {
 
-  case class RunCleanup(validator: TransactionValidation[ErgoTransaction],
-                        mempool: ErgoMemPoolReader)
+  case class RunCleanup(validator: TransactionValidation[ErgoTransaction], mempool: ErgoMemPoolReader)
 
   val IndexRevisionInterval: Int = 4
 

--- a/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
+++ b/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
@@ -102,7 +102,7 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
     val (validatedIds, invalidatedIds) = validationLoop(txsToValidate, Seq.empty, Seq.empty, 0L)
 
     epochNr += 1
-    if (epochNr % CleanupWorker.IndexRevisionInterval == 0) {
+    if (epochNr % CleanupWorker.RevisionInterval == 0) {
       // drop old index in order to check potentially outdated transactions again.
       validatedIndex = TreeSet(validatedIds: _*)
     } else {
@@ -116,8 +116,22 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
 
 object CleanupWorker {
 
-  case class RunCleanup(validator: TransactionValidation[ErgoTransaction], mempool: ErgoMemPoolReader)
+  /**
+    * Constant which shows on how many cleanup operations (called when a new block arrives) a transaction
+    * re-check happens.
+    *
+    * If transactions set is large and stable, then about (1/RevisionInterval)-th of the pool is checked
+    *
+    */
+  val RevisionInterval: Int = 4
 
-  val IndexRevisionInterval: Int = 4
+  /**
+    *
+    * A command to run (partial) memory pool cleanup
+    *
+    * @param validator - a state implementation which provides transaction validation
+    * @param mempool - mempool reader instance
+    */
+  case class RunCleanup(validator: TransactionValidation[ErgoTransaction], mempool: ErgoMemPoolReader)
 
 }

--- a/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
+++ b/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
@@ -105,16 +105,15 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
     log.debug("Rebroadcasting transactions")
     poolReaderOpt.foreach { pr =>
       pr.take(settings.nodeSettings.rebroadcastCount).foreach { tx =>
-        if (tx.inputs.forall(i => utxo.boxById(i.boxId).isDefined)) {
-          log.info(s"Rebroadcasting $tx")
-          val msg = Message(
-            new InvSpec(settings.scorexSettings.network.maxInvObjects),
-            Right(InvData(Transaction.ModifierTypeId, Seq(tx.id))),
-            None
-          )
-          networkControllerRef ! SendToNetwork(msg, Broadcast)
-        }
+        log.info(s"Rebroadcasting $tx")
+        val msg = Message(
+          new InvSpec(settings.scorexSettings.network.maxInvObjects),
+          Right(InvData(Transaction.ModifierTypeId, Seq(tx.id))),
+          None
+        )
+        networkControllerRef ! SendToNetwork(msg, Broadcast)
       }
+
     }
 
   }

--- a/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
+++ b/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
@@ -103,31 +103,21 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
 
   private def rebroadcastTransactions(): Unit = {
     log.debug("Rebroadcasting transactions")
-    stateReaderOpt.foreach { st =>
-      poolReaderOpt.foreach { pr =>
-        pr.take(settings.nodeSettings.rebroadcastCount).foreach { tx =>
-          st match {
-            case utxo: UtxoState =>
-              //todo: currently we're rebroadcasting transactions which are spending on-chain outputs only
-              //todo: this is to be changed when most of the nodes on the network will support transactions spending
-              //todo: offchain outputs in the mempool (versions 3.2.1 and further)
-              if (tx.inputs.forall(i => utxo.boxById(i.boxId).isDefined)) {
-                log.info(s"Rebroadcasting $tx")
-                val msg = Message(
-                  new InvSpec(settings.scorexSettings.network.maxInvObjects),
-                  Right(InvData(Transaction.ModifierTypeId, Seq(tx.id))),
-                  None
-                )
-                networkControllerRef ! SendToNetwork(msg, Broadcast)
-              } else {
-                log.info(s"Not all the inputs of $tx is in UTXO set")
-              }
-          }
+    poolReaderOpt.foreach { pr =>
+      pr.take(settings.nodeSettings.rebroadcastCount).foreach { tx =>
+        if (tx.inputs.forall(i => utxo.boxById(i.boxId).isDefined)) {
+          log.info(s"Rebroadcasting $tx")
+          val msg = Message(
+            new InvSpec(settings.scorexSettings.network.maxInvObjects),
+            Right(InvData(Transaction.ModifierTypeId, Seq(tx.id))),
+            None
+          )
+          networkControllerRef ! SendToNetwork(msg, Broadcast)
         }
       }
     }
-  }
 
+  }
 }
 
 object MempoolAuditor {

--- a/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
+++ b/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
@@ -8,7 +8,6 @@ import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
-import org.ergoplatform.nodeView.state.UtxoState
 import org.ergoplatform.settings.ErgoSettings
 import scorex.core.NodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import scorex.core.network.Broadcast

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -13,6 +13,7 @@ import org.ergoplatform.settings.{Algos, ErgoValidationSettings}
 import org.ergoplatform.utils.BoxUtils
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.wallet.protocol.context.TransactionContext
+import scorex.core.EphemerealNodeViewModifier
 import scorex.core.serialization.ScorexSerializer
 import scorex.core.transaction.Transaction
 import scorex.core.utils.ScorexEncoding
@@ -53,7 +54,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
                            override val sizeOpt: Option[Int] = None)
   extends ErgoLikeTransaction(inputs, dataInputs, outputCandidates)
     with Transaction
-    with MempoolModifier
+    with EphemerealNodeViewModifier
     with ErgoNodeViewModifier
     with ScorexLogging {
 

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/MempoolModifier.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/MempoolModifier.scala
@@ -1,5 +1,0 @@
-package org.ergoplatform.modifiers.mempool
-
-import scorex.core.EphemerealNodeViewModifier
-
-trait MempoolModifier extends EphemerealNodeViewModifier

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -10,10 +10,12 @@ import org.ergoplatform.settings.Constants
 import scorex.core.NodeViewHolder._
 import scorex.core.{ModifierTypeId, PersistentNodeViewModifier}
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
+import scorex.core.network.NetworkControllerSharedMessages.ReceivableMessages.DataFromPeer
 import scorex.core.network.NodeViewSynchronizer.ReceivableMessages.SemanticallySuccessfulModifier
-import scorex.core.network.message.{InvData, Message}
+import scorex.core.network.message.{InvData, InvSpec, Message}
 import scorex.core.network.{ModifiersStatus, NodeViewSynchronizer, SendToRandom}
 import scorex.core.settings.NetworkSettings
+import scorex.core.transaction.Transaction
 import scorex.core.utils.NetworkTimeProvider
 import scorex.util.ModifierId
 
@@ -63,10 +65,49 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       }
   }
 
+  // todo: this method is just a copy of the ancestor from Scorex, however, smarter logic is needed, not just
+  //  asking from a random peer
   override protected def requestDownload(modifierTypeId: ModifierTypeId, modifierIds: Seq[ModifierId]): Unit = {
     deliveryTracker.setRequested(modifierIds, modifierTypeId, None)
     val msg = Message(requestModifierSpec, Right(InvData(modifierTypeId, modifierIds)), None)
     networkControllerRef ! SendToNetwork(msg, SendToRandom)
+  }
+
+  /**
+    * Object ids coming from other node.
+    * Filter out modifier ids that are already in process (requested, received or applied),
+    * request unknown ids from peer and set this ids to requested state.
+    */
+  override protected def processInv: Receive = {
+    case DataFromPeer(spec, invData: InvData@unchecked, peer)
+      if spec.messageCode == InvSpec.MessageCode =>
+
+      (mempoolReaderOpt, historyReaderOpt) match {
+        case (Some(mempool), Some(history)) =>
+
+          val modifierTypeId = invData.typeId
+
+          val newModifierIds = modifierTypeId match {
+            case Transaction.ModifierTypeId =>
+              // We download transactions only if the chain is synced
+              if (history.isHeadersChainSynced && history.fullBlockHeight == history.headersHeight) {
+                invData.ids.filter(mid => deliveryTracker.status(mid, mempool) == ModifiersStatus.Unknown)
+              } else {
+                Seq.empty
+              }
+            case _ =>
+              invData.ids.filter(mid => deliveryTracker.status(mid, history) == ModifiersStatus.Unknown)
+          }
+
+          if (newModifierIds.nonEmpty) {
+            val msg = Message(requestModifierSpec, Right(InvData(modifierTypeId, newModifierIds)), None)
+            peer.handlerRef ! msg
+            deliveryTracker.setRequested(newModifierIds, modifierTypeId, Some(peer))
+          }
+
+        case _ =>
+          log.warn(s"Got data from peer while readers are not ready ${(mempoolReaderOpt, historyReaderOpt)}")
+      }
   }
 
   /**

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -30,8 +30,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     ErgoHistory, ErgoMemPool](networkControllerRef, viewHolderRef, syncInfoSpec, networkSettings, timeProvider,
     Constants.modifierSerializers) {
 
-  override protected val deliveryTracker = new ErgoDeliveryTracker(context.system, deliveryTimeout, maxDeliveryChecks,
-    self, timeProvider)
+  override protected val deliveryTracker =
+    new ErgoDeliveryTracker(context.system, deliveryTimeout, maxDeliveryChecks, self, timeProvider)
 
   /**
     * Approximate number of modifiers to be downloaded simultaneously
@@ -57,7 +57,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         val toDownload =
           h.nextModifiersToDownload(desiredSizeOfExpectingQueue - deliveryTracker.requestedSize, downloadRequired)
 
-        log.info(s"${toDownload.length} modifiers to be downloaded")
+        log.info(s"${toDownload.length} persistent modifiers to be downloaded")
 
         toDownload.groupBy(_._1).foreach(ids => requestDownload(ids._1, ids._2.map(_._2)))
       }
@@ -111,6 +111,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
   def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,
             syncInfoSpec: ErgoSyncInfoMessageSpec.type,
@@ -127,16 +128,6 @@ object ErgoNodeViewSynchronizer {
             timeProvider: NetworkTimeProvider)
            (implicit context: ActorRefFactory, ex: ExecutionContext): ActorRef =
     context.actorOf(props(networkControllerRef, viewHolderRef, syncInfoSpec, networkSettings, timeProvider))
-
-  def apply(networkControllerRef: ActorRef,
-            viewHolderRef: ActorRef,
-            syncInfoSpec: ErgoSyncInfoMessageSpec.type,
-            networkSettings: NetworkSettings,
-            timeProvider: NetworkTimeProvider,
-            name: String)
-           (implicit context: ActorRefFactory, ex: ExecutionContext): ActorRef =
-    context.actorOf(props(networkControllerRef, viewHolderRef, syncInfoSpec, networkSettings, timeProvider), name)
-
 
   case object CheckModifiersToDownload
 

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -63,22 +63,26 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool)(implicit settings: ErgoS
   def process(tx: ErgoTransaction, state: ErgoState[_]): (ErgoMemPool, ProcessingOutcome) = {
     val fee = extractFee(tx)
     val minFee = settings.nodeSettings.minimalFeeAmount
+    val canAccept = pool.canAccept(tx)
+
     if (fee >= minFee) {
       state match {
-        case utxo: UtxoState if pool.canAccept(tx) =>
+        case utxo: UtxoState if canAccept =>
           // Allow proceeded transaction to spend outputs of pooled transactions.
           utxo.withTransactions(getAll).validate(tx).fold(
             new ErgoMemPool(pool.invalidate(tx)) -> ProcessingOutcome.Invalidated(_),
             _ => new ErgoMemPool(pool.put(tx)) -> ProcessingOutcome.Accepted
           )
-
-        case validator: TransactionValidation[ErgoTransaction@unchecked] if pool.canAccept(tx) =>
+        case validator: TransactionValidation[ErgoTransaction@unchecked] if canAccept =>
           // transaction validation currently works only for UtxoState, so this branch currently
           // will not be triggered probably
           validator.validate(tx).fold(
             new ErgoMemPool(pool.invalidate(tx)) -> ProcessingOutcome.Invalidated(_),
             _ => new ErgoMemPool(pool.put(tx)) -> ProcessingOutcome.Accepted
           )
+        case _: TransactionValidation[ErgoTransaction@unchecked] if !canAccept =>
+          this -> ProcessingOutcome.Declined(
+            new Exception(s"Pool can not accept transaction ${tx.id}, it is invalidated earlier or pool is full"))
         case _ =>
           this -> ProcessingOutcome.Declined(
             new Exception("Transaction validation not supported"))


### PR DESCRIPTION
This PR is containing improvements in transactions downloading and mempool broadcasting:

* Fix for #1137 : transactions now asked only once from a peer announced them and forgotten if no delivery happens
* Fix for #1146  : node does not download transactions when it is not synced
* Mempool now rebroadcasts transactions spending offchain outputs