### PR TITLE
Filter out transactions for external scans from the /wallet/transactions endpoint

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -12,6 +12,7 @@ import org.ergoplatform.nodeView.state.UtxoStateReader
 import org.ergoplatform.nodeView.wallet._
 import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.wallet.Constants
 import scorex.core.NodeViewHolder.ReceivableMessages.LocallyGeneratedTransaction
 import scorex.core.api.http.ApiError.{BadRequest, NotExists}
 import scorex.core.api.http.ApiResponse
@@ -249,6 +250,7 @@ case class WalletApiRoute(readersHolder: ActorRef, nodeViewActorRef: ActorRef, e
         _.transactions
           .map {
             _.filter(tx =>
+              tx.wtx.scanIds.exists(scanId => scanId <= Constants.PaymentsScanId) &&
               tx.wtx.inclusionHeight >= minHeight && tx.wtx.inclusionHeight <= maxHeight &&
                 tx.numConfirmations >= minConfNum && tx.numConfirmations <= maxConfNum
             )

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -15,6 +15,7 @@ import org.ergoplatform.utils.Stubs
 import org.ergoplatform.utils.generators.ErgoTransactionGenerators
 import org.ergoplatform.{ErgoAddress, Pay2SAddress}
 import org.scalatest.{FlatSpec, Matchers}
+import org.ergoplatform.wallet.{Constants => WalletConstants}
 
 import scala.util.{Random, Try}
 import scala.concurrent.duration._
@@ -202,8 +203,12 @@ class WalletApiRouteSpec extends FlatSpec
     Get(prefix + "/transactions") ~> route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
-      response.size shouldBe 2
-      responseAs[Seq[AugWalletTransaction]] shouldEqual WalletActorStub.walletTxs
+      val walletTxs = WalletActorStub.walletTxs.filter { awtx =>
+        awtx.wtx.scanIds.exists(_ <= WalletConstants.PaymentsScanId)
+      }
+
+      response.size shouldBe walletTxs.size
+      responseAs[Seq[AugWalletTransaction]] shouldEqual walletTxs
     }
   }
 

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -16,7 +16,7 @@ import org.ergoplatform.nodeView.wallet._
 import org.ergoplatform.nodeView.wallet.persistence.WalletDigest
 import org.ergoplatform.sanity.ErgoSanity.HT
 import org.ergoplatform.settings.Constants.HashLength
-import org.ergoplatform.wallet.Constants.{ScanId, PaymentsScanId}
+import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.settings._
 import org.ergoplatform.utils.generators.{ChainGenerator, ErgoGenerators, ErgoTransactionGenerators}
 import org.ergoplatform.wallet.boxes.{ChainStatus, TrackedBox}
@@ -24,6 +24,7 @@ import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.wallet.secrets.DerivationPath
 import org.ergoplatform.P2PKAddress
 import org.ergoplatform.nodeView.wallet.scanning.Scan
+import org.scalacheck.Gen
 import scorex.core.app.Version
 import scorex.core.network.NetworkController.ReceivableMessages.GetConnectedPeers
 import scorex.core.network.peer.PeerManager.ReceivableMessages.{GetAllPeers, GetBlacklistedPeers}
@@ -246,7 +247,8 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
         spendingTxIdOpt = Some(modifierIdGen.sample.get)
       )
     )
-    val walletTxs: Seq[AugWalletTransaction] = Seq(augWalletTransactionGen.sample.get, augWalletTransactionGen.sample.get)
+    val walletTxs: Seq[AugWalletTransaction] =
+      Gen.listOf(augWalletTransactionGen).sample.get
 
     def props(): Props = Props(new WalletActorStub)
 


### PR DESCRIPTION
Currently (in 3.3.0) /wallet/transactions endpoint shows transactions from all the scans. However, for external scans another endpoint is planned (see #1040 ).

This PR is filtering out external scans transactions, thus /wallet/transactions now shows only mining rewards transactions and wallet payments. 

Likely the filtering can be done more efficiently in the DB layer, will be considered during #1139 implementations