### PR TITLE
Candidate for 3.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ EXPOSE 9020 9052
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G
-ENTRYPOINT java -Xmx${MAX_HEAP} -jar /home/ergo/ergo.jar
-CMD [""]
+ENTRYPOINT java -Xmx${MAX_HEAP} -jar /home/ergo/ergo.jar $0 $1 $2 $3
+CMD []

--- a/benchmarks/src/test/scala/org/ergoplatform/bench/CrawlerRunner.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/bench/CrawlerRunner.scala
@@ -68,7 +68,7 @@ class CrawlerRunner(args: Array[String]) extends Application {
 
   override val nodeViewSynchronizer: ActorRef =
     ErgoNodeViewSynchronizer(networkControllerRef, nodeViewHolderRef, ErgoSyncInfoMessageSpec,
-      settings.network, timeProvider)
+      ergoSettings, timeProvider)
 
 }
 

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success}
 
 class ErgoApp(args: Args) extends ScorexLogging {
 
-  private var ergoSettings: ErgoSettings = ErgoSettings.read(args)
+  private val ergoSettings: ErgoSettings = ErgoSettings.read(args)
 
   implicit private def settings: ScorexSettings = ergoSettings.scorexSettings
 
@@ -104,7 +104,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   private val nodeViewSynchronizer: ActorRef =
     ErgoNodeViewSynchronizer(networkControllerRef, nodeViewHolderRef, ErgoSyncInfoMessageSpec,
-      settings.network, timeProvider)
+      ergoSettings, timeProvider)
 
   private val apiRoutes: Seq[ApiRoute] = Seq(
     EmissionApiRoute(ergoSettings),

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -13,7 +13,6 @@ import org.ergoplatform.local._
 import org.ergoplatform.mining.ErgoMinerRef
 import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ModeFeature}
 import org.ergoplatform.nodeView.history.ErgoSyncInfoMessageSpec
-import org.ergoplatform.nodeView.state.ErgoState
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
 import org.ergoplatform.settings.{Args, ErgoSettings, NetworkType}
 import scorex.core.api.http._
@@ -32,6 +31,8 @@ import scala.io.Source
 import scala.util.{Failure, Success}
 
 class ErgoApp(args: Args) extends ScorexLogging {
+
+  log.info(s"Running with args: $args")
 
   private val ergoSettings: ErgoSettings = ErgoSettings.read(args)
 
@@ -180,11 +181,6 @@ class ErgoApp(args: Args) extends ScorexLogging {
       log.info("Exiting from the app...")
       System.exit(0)
     }
-  }
-
-  private def isEmptyState: Boolean = {
-    val dir = ErgoState.stateDir(ergoSettings)
-    Option(dir.listFiles()).fold(true)(_.isEmpty)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -22,6 +22,9 @@ import scorex.util.ModifierId
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+/**
+  * Tweaks on top of Scorex' NodeViewSynchronizer made for optimizing Ergo network
+  */
 class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                                viewHolderRef: ActorRef,
                                syncInfoSpec: ErgoSyncInfoMessageSpec.type,

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -82,8 +82,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool)(implicit settings: ErgoS
               _ => new ErgoMemPool(pool.put(tx)) -> ProcessingOutcome.Accepted
             )
           case _ =>
-            this -> ProcessingOutcome.Declined(
-              new Exception("Transaction validation not supported"))
+            new ErgoMemPool(pool.put(tx)) -> ProcessingOutcome.Accepted
         }
       } else {
         this -> ProcessingOutcome.Declined(

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -25,6 +25,12 @@ class ErgoMemPoolSpec extends FlatSpec
     txs.foreach { tx =>
       pool.process(tx, us)._2 shouldBe ProcessingOutcome.Accepted
     }
+
+    // light mode
+    val poolLight = ErgoMemPool.empty(lightModeSettings)
+    txs.foreach { tx =>
+      poolLight.process(tx, us)._2 shouldBe ProcessingOutcome.Accepted
+    }
   }
 
   it should "decline already contained transaction" in {

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanity.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanity.scala
@@ -10,7 +10,7 @@ import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoSyncInfo, ErgoSyncInf
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.{DigestState, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
-import org.ergoplatform.settings.Constants
+import org.ergoplatform.settings.{Constants, ErgoSettings}
 import org.ergoplatform.settings.Constants.HashLength
 import org.ergoplatform.utils.{ErgoTestHelpers, HistoryTestHelpers}
 import org.scalacheck.Gen
@@ -91,7 +91,7 @@ trait ErgoSanity[ST <: MinimalState[PM, ST]] extends HistoryTests[TX, PM, SI, HT
   class SyncronizerMock(networkControllerRef: ActorRef,
                         viewHolderRef: ActorRef,
                         syncInfoSpec: ErgoSyncInfoMessageSpec.type,
-                        networkSettings: NetworkSettings,
+                        settings: ErgoSettings,
                         timeProvider: NetworkTimeProvider,
                         history: ErgoHistory,
                         pool: ErgoMemPool)
@@ -99,7 +99,7 @@ trait ErgoSanity[ST <: MinimalState[PM, ST]] extends HistoryTests[TX, PM, SI, HT
     networkControllerRef,
     viewHolderRef,
     syncInfoSpec,
-    networkSettings,
+    settings,
     timeProvider)(ec) {
 
     override def preStart(): Unit = {

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanityDigest.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanityDigest.scala
@@ -71,7 +71,7 @@ class ErgoSanityDigest extends ErgoSanity[DIGEST_ST] {
         ncProbe.ref,
         vhProbe.ref,
         ErgoSyncInfoMessageSpec,
-        settings.scorexSettings.network,
+        settings,
         tp,
         h,
         pool)

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanityUTXO.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanityUTXO.scala
@@ -9,7 +9,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.sanity.ErgoSanity._
-import org.ergoplatform.settings.{Args, ErgoSettings}
+import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.scalacheck.Gen
 import scorex.core.network.ConnectedPeer
@@ -66,7 +66,7 @@ class ErgoSanityUTXO extends ErgoSanity[UTXO_ST] with ErgoTestHelpers {
         ncProbe.ref,
         vhProbe.ref,
         ErgoSyncInfoMessageSpec,
-        settings.scorexSettings.network,
+        settings,
         tp,
         h,
         pool)

--- a/src/test/scala/org/ergoplatform/utils/ErgoTestConstants.scala
+++ b/src/test/scala/org/ergoplatform/utils/ErgoTestConstants.scala
@@ -5,7 +5,7 @@ import org.ergoplatform.mining.difficulty.LinearDifficultyControl
 import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.mining.{AutolykosPowScheme, DefaultFakePowScheme}
 import org.ergoplatform.modifiers.history.ExtensionCandidate
-import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateConstants, UpcomingStateContext}
+import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateConstants, StateType, UpcomingStateContext}
 import org.ergoplatform.settings.Constants.HashLength
 import org.ergoplatform.settings.ValidationRules._
 import org.ergoplatform.settings._
@@ -38,6 +38,11 @@ trait ErgoTestConstants extends ScorexLogging {
   val initSettings: ErgoSettings = ErgoSettings.read(Args(Some("src/test/resources/application.conf"), None))
 
   val settings: ErgoSettings = initSettings
+
+  val lightModeSettings: ErgoSettings = initSettings.copy(
+    nodeSettings = initSettings.nodeSettings.copy(stateType = StateType.Digest)
+  )
+
   val emission: EmissionRules = settings.chainSettings.emissionRules
   val coinsTotal: Long = emission.coinsTotal
   val stateConstants: StateConstants = StateConstants(None, settings)


### PR DESCRIPTION
This PR contains candidate for 3.3.3 release. Changes are as follows: 

* #1186 : fix for #1185: command-line parameters support back for docker containers
* #1184 : Accept to the mempool and propagate locally generated transactions in the digest mode (also, do not download transactions in this mode)