### PR TITLE
Fix for #1165: double-spending transactions not allowed in mempool (with RBF replacement strategy)

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -61,8 +61,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         log.debug(s"Transaction $tx invalidated. Cause: ${e.getMessage}")
         updateNodeView(updatedMempool = Some(newPool))
         context.system.eventStream.publish(FailedTransaction(tx.id, e, immediateFailure = true))
-      case (_, ProcessingOutcome.DoubleSpendingLoser(winnerTx)) => // do nothing
-        log.debug(s"Transaction $tx declined, as another transaction $winnerTx is paying more")
+      case (_, ProcessingOutcome.DoubleSpendingLoser(winnerTxs)) => // do nothing
+        log.debug(s"Transaction $tx declined, as other transactions $winnerTxs are paying more")
       case (_, ProcessingOutcome.Declined(e)) => // do nothing
         log.debug(s"Transaction $tx declined, reason: ${e.getMessage}")
     }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -61,6 +61,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         log.debug(s"Transaction $tx invalidated. Cause: ${e.getMessage}")
         updateNodeView(updatedMempool = Some(newPool))
         context.system.eventStream.publish(FailedTransaction(tx.id, e, immediateFailure = true))
+      case (_, ProcessingOutcome.DoubleSpendingLoser(winnerTx)) => // do nothing
+        log.debug(s"Transaction $tx declined, as another transaction $winnerTx is paying more")
       case (_, ProcessingOutcome.Declined(e)) => // do nothing
         log.debug(s"Transaction $tx declined, reason: ${e.getMessage}")
     }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -14,7 +14,7 @@ import scala.util.Try
 /**
   * Immutable memory pool implementation.
   */
-class ErgoMemPool private[mempool](pool: OrderedTxPool)(implicit settings: ErgoSettings)
+class ErgoMemPool private[mempool](val pool: OrderedTxPool)(implicit settings: ErgoSettings)
   extends MemoryPool[ErgoTransaction, ErgoMemPool] with ErgoMemPoolReader {
 
   import ErgoMemPool._

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.mempool
 
+import org.ergoplatform.ErgoBox.BoxId
 import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.mempool.OrderedTxPool.WeightedTxId
@@ -14,7 +15,7 @@ import scala.util.Try
 /**
   * Immutable memory pool implementation.
   */
-class ErgoMemPool private[mempool](val pool: OrderedTxPool)(implicit settings: ErgoSettings)
+class ErgoMemPool private[mempool](pool: OrderedTxPool)(implicit settings: ErgoSettings)
   extends MemoryPool[ErgoTransaction, ErgoMemPool] with ErgoMemPoolReader {
 
   import ErgoMemPool._
@@ -61,6 +62,11 @@ class ErgoMemPool private[mempool](val pool: OrderedTxPool)(implicit settings: E
   def invalidate(tx: ErgoTransaction): ErgoMemPool = {
     new ErgoMemPool(pool.invalidate(tx))
   }
+
+  /**
+    * @return inputs spent by the mempool transactions
+    */
+  def spentInputs: Iterator[BoxId] = pool.inputs.keysIterator
 
   // Check if transaction is double-spending inputs spent in the mempool.
   // If so, the new transacting is replacing older ones if it has bigger weight (fee/byte) than them on average.

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -66,7 +66,11 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransact
       newPool
     }
   }
-  
+
+  def remove(txs: Seq[ErgoTransaction]): OrderedTxPool = {
+    txs.foldLeft(this) { case (pool, tx) => pool.remove(tx) }
+  }
+
   def remove(tx: ErgoTransaction): OrderedTxPool = {
     transactionsRegistry.get(tx.id) match {
       case Some(wtx) =>

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -66,7 +66,7 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransact
       newPool
     }
   }
-
+  
   def remove(tx: ErgoTransaction): OrderedTxPool = {
     transactionsRegistry.get(tx.id) match {
       case Some(wtx) =>

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable.TreeMap
   * @param invalidated          - collection containing invalidated transaction ids as keys
   *                             ordered by invalidation timestamp (values)
   * @param outputs              - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its output box
-  * @param inputs               - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its output box
+  * @param inputs               - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its input box id
   */
 case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransaction],
                          transactionsRegistry: TreeMap[ModifierId, WeightedTxId],

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -16,14 +16,16 @@ import scala.collection.immutable.TreeMap
   * @param invalidated          - collection containing invalidated transaction ids as keys
   *                             ordered by invalidation timestamp (values)
   * @param outputs              - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its output box
+  * @param inputs               - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its output box
   */
 case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransaction],
                          transactionsRegistry: TreeMap[ModifierId, WeightedTxId],
                          invalidated: TreeMap[ModifierId, Long],
-                         outputs: TreeMap[BoxId, WeightedTxId])
+                         outputs: TreeMap[BoxId, WeightedTxId],
+                         inputs: TreeMap[BoxId, WeightedTxId])
                         (implicit settings: ErgoSettings) extends ScorexLogging {
 
-  import OrderedTxPool.weighted
+  import ErgoMemPool.weighted
 
   private implicit val ms: MonetarySettings = settings.chainSettings.monetary
 
@@ -51,9 +53,12 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransact
     */
   def put(tx: ErgoTransaction): OrderedTxPool = {
     val wtx = weighted(tx)
-    val newPool = OrderedTxPool(orderedTransactions.updated(wtx, tx),
+    val newPool = OrderedTxPool(
+      orderedTransactions.updated(wtx, tx),
       transactionsRegistry.updated(wtx.id, wtx), invalidated,
-      outputs ++ tx.outputs.map(_.id -> wtx)).updateFamily(tx, wtx.weight)
+      outputs ++ tx.outputs.map(_.id -> wtx),
+      inputs ++ tx.inputs.map(_.boxId -> wtx)
+    ).updateFamily(tx, wtx.weight)
     if (newPool.orderedTransactions.size > mempoolCapacity) {
       val victim = newPool.orderedTransactions.last._2
       newPool.remove(victim)
@@ -63,16 +68,34 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransact
   }
 
   def remove(tx: ErgoTransaction): OrderedTxPool = {
-    transactionsRegistry.get(tx.id).fold(this)(wtx =>
-      OrderedTxPool(orderedTransactions - wtx, transactionsRegistry - tx.id, invalidated, outputs -- tx.outputs.map(_.id)).updateFamily(tx, -wtx.weight))
+    transactionsRegistry.get(tx.id) match {
+      case Some(wtx) =>
+        OrderedTxPool(
+          orderedTransactions - wtx,
+          transactionsRegistry - tx.id,
+          invalidated,
+          outputs -- tx.outputs.map(_.id),
+          inputs -- tx.inputs.map(_.boxId)
+        ).updateFamily(tx, -wtx.weight)
+      case None => this
+    }
   }
 
   def invalidate(tx: ErgoTransaction): OrderedTxPool = {
     val inv = if (invalidated.size >= blacklistCapacity) invalidated - invalidated.firstKey else invalidated
     val ts = System.currentTimeMillis()
-    transactionsRegistry.get(tx.id).fold(OrderedTxPool(orderedTransactions, transactionsRegistry, inv.updated(tx.id, ts), outputs))(wtx =>
-      OrderedTxPool(orderedTransactions - wtx, transactionsRegistry - tx.id, inv.updated(tx.id, ts),
-        outputs -- tx.outputs.map(_.id)).updateFamily(tx, -wtx.weight))
+    transactionsRegistry.get(tx.id) match {
+      case Some(wtx) =>
+        OrderedTxPool(
+          orderedTransactions - wtx,
+          transactionsRegistry - tx.id,
+          inv.updated(tx.id, ts),
+          outputs -- tx.outputs.map(_.id),
+          inputs -- tx.inputs.map(_.boxId)
+        ).updateFamily(tx, -wtx.weight)
+      case None =>
+        OrderedTxPool(orderedTransactions, transactionsRegistry, inv.updated(tx.id, ts), outputs, inputs)
+    }
   }
 
   def filter(condition: ErgoTransaction => Boolean): OrderedTxPool = {
@@ -122,10 +145,13 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransact
         pool.orderedTransactions.get(wtx) match {
           case Some(parent) =>
             val newWtx = WeightedTxId(wtx.id, wtx.weight + weight)
-            val newPool = OrderedTxPool(pool.orderedTransactions - wtx + (newWtx -> parent),
+            val newPool = OrderedTxPool(
+              pool.orderedTransactions - wtx + (newWtx -> parent),
               pool.transactionsRegistry.updated(parent.id, newWtx),
               invalidated,
-              parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)))
+              parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)),
+              parent.inputs.foldLeft(pool.inputs)((newInputs, inp) => newInputs.updated(inp.boxId, newWtx))
+            )
             newPool.updateFamily(parent, weight)
           case None =>
             //shouldn't be the case, but better not to hide this possibility
@@ -152,17 +178,12 @@ object OrderedTxPool {
   private implicit val ordBoxId: Ordering[BoxId] = Ordering[String].on(b => Algos.encode(b))
 
   def empty(settings: ErgoSettings): OrderedTxPool = {
-    OrderedTxPool(TreeMap.empty[WeightedTxId, ErgoTransaction], TreeMap.empty[ModifierId, WeightedTxId],
-      TreeMap.empty[ModifierId, Long], TreeMap.empty[BoxId, WeightedTxId])(settings)
-  }
-
-  private def weighted(tx: ErgoTransaction)(implicit ms: MonetarySettings): WeightedTxId = {
-    val fee = tx.outputs
-      .filter(b => java.util.Arrays.equals(b.propositionBytes, ms.feePropositionBytes))
-      .map(_.value)
-      .sum
-    // We multiply by 1024 for better precision
-    WeightedTxId(tx.id, fee * 1024 / tx.size)
+    OrderedTxPool(
+      TreeMap.empty[WeightedTxId, ErgoTransaction],
+      TreeMap.empty[ModifierId, WeightedTxId],
+      TreeMap.empty[ModifierId, Long],
+      TreeMap.empty[BoxId, WeightedTxId],
+      TreeMap.empty[BoxId, WeightedTxId])(settings)
   }
 
 }

--- a/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.local
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{TestActorRef, TestProbe}
+import org.ergoplatform.{ErgoAddressEncoder, ErgoScriptPredef}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.mempool.{ErgoMemPoolReader, OrderedTxPool}
 import org.ergoplatform.nodeView.state.ErgoState
@@ -14,12 +15,18 @@ import scorex.core.NodeViewHolder.ReceivableMessages.LocallyGeneratedTransaction
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import scorex.core.network.NodeViewSynchronizer.ReceivableMessages.{ChangedMempool, ChangedState, FailedTransaction, SuccessfulTransaction}
 import scorex.util.ModifierId
+import sigmastate.Values.ErgoTree
+import sigmastate.eval.{IRContext, RuntimeIRContext}
+import sigmastate.interpreter.Interpreter.emptyEnv
+
 
 import scala.concurrent.duration._
 import scala.util.Random
-
+import sigmastate.lang.Terms.ValueOps
+import sigmastate.serialization.ErgoTreeSerializer
 
 class MempoolAuditorSpec extends FlatSpec with NodeViewTestOps with ErgoTestHelpers {
+  implicit lazy val context: IRContext = new RuntimeIRContext
 
   val cleanupDuration: FiniteDuration = 2.seconds
   val settingsToTest: ErgoSettings = settings.copy(
@@ -46,19 +53,27 @@ class MempoolAuditorSpec extends FlatSpec with NodeViewTestOps with ErgoTestHelp
     val boxes = ErgoState.boxChanges(genesis.transactions)._2.find(_.ergoTree == Constants.TrueLeaf)
     boxes.nonEmpty shouldBe true
 
-    val validTx = validTransactionFromBoxes(boxes.toIndexedSeq)
-    val doubleSpendTx = validTransactionFromBoxes(boxes.toIndexedSeq, outputsProposition = proveDlogGen.sample.get)
+    val script = s"{sigmaProp(HEIGHT == ${genesis.height})}"
+    val prop = ErgoScriptPredef.compileWithCosting(emptyEnv, script, ErgoAddressEncoder.MainnetNetworkPrefix)
+    val tree = ErgoTree.fromProposition(prop.asSigmaProp)
+
+    val bs = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(tree)
+    ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bs) shouldBe tree
+
+    val validTx = validTransactionFromBoxes(boxes.toIndexedSeq, outputsProposition = tree)
+
+    val temporarilyValidTx = validTransactionFromBoxes(validTx.outputs, outputsProposition = proveDlogGen.sample.get)
 
     subscribeEvents(classOf[FailedTransaction])
     nodeViewHolderRef ! LocallyGeneratedTransaction[ErgoTransaction](validTx)
     testProbe.expectMsgClass(cleanupDuration, newTx)
-    nodeViewHolderRef ! LocallyGeneratedTransaction[ErgoTransaction](doubleSpendTx)
+    nodeViewHolderRef ! LocallyGeneratedTransaction[ErgoTransaction](temporarilyValidTx)
     testProbe.expectMsgClass(cleanupDuration, newTx)
     getPoolSize shouldBe 2
 
     val _: ActorRef = MempoolAuditorRef(nodeViewHolderRef, nodeViewHolderRef, settingsToTest)
 
-    // include first transaction in the block so that second tx becomes invalid
+    // include first transaction in the block
     val block = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))
 
     applyBlock(block) shouldBe 'success

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -242,13 +242,12 @@ class ErgoMinerSpec extends FlatSpec with ErgoTestHelpers with ValidBlocksGenera
     val tx1 = defaultProver.sign(unsignedTx1, IndexedSeq(boxToDoubleSpend), IndexedSeq(), r.s.stateContext).get
     val outputs2 = IndexedSeq(new ErgoBoxCandidate(boxToDoubleSpend.value, prop2, r.s.stateContext.currentHeight))
     val unsignedTx2 = new UnsignedErgoTransaction(IndexedSeq(input), IndexedSeq(), outputs2)
-    val tx2 = defaultProver.sign(unsignedTx2, IndexedSeq(boxToDoubleSpend), IndexedSeq(), r.s.stateContext).get
+    val tx2 = ErgoTransaction(defaultProver.sign(unsignedTx2, IndexedSeq(boxToDoubleSpend), IndexedSeq(), r.s.stateContext).get)
 
+    // As double-spending transactions are filtered out in the mempool, the only way to push them is to order to
+    // include double-spending transaction directly via mandatoryTransactions argument of PrepareCandidate command
     nodeViewHolderRef ! LocallyGeneratedTransaction[ErgoTransaction](ErgoTransaction(tx1))
-    nodeViewHolderRef ! LocallyGeneratedTransaction[ErgoTransaction](ErgoTransaction(tx2))
-    expectNoMessage(1 seconds)
-
-    await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 2
+    minerRef ! PrepareCandidate(Seq(tx2))
 
     testProbe.expectMsgClass(newBlockDelay, newBlock)
     testProbe.expectMsgClass(newBlockDelay, newBlock)

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -32,7 +32,7 @@ class ErgoMemPoolSpec extends FlatSpec
       }
       p
     }
-    poolAfter.pool.inputs.size shouldBe txs.flatMap(_.inputs).size
+    poolAfter.spentInputs.size shouldBe txs.flatMap(_.inputs).size
 
     // light mode
     val poolLight = ErgoMemPool.empty(lightModeSettings)


### PR DESCRIPTION
In this PR, a double-spending spending transaction is being rejected from the mempool if it is not paying more than all the conflicting transactions (along with dependent transactions) already sitting in the pool altogether. 