### PR TITLE
Consider mempool if minConfirmations==-1 in /wallet/boxes and /wallet/boxes/unspent

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2814,7 +2814,7 @@ paths:
         schema:
           type: integer
           format: int32
-          minimum: 0
+          minimum: -1
           default: 0
       - in: query
         name: minInclusionHeight
@@ -2828,7 +2828,8 @@ paths:
     get:
       security:
         - ApiKeyAuth: [api_key]
-      summary: Get a list of all wallet-related boxes
+      summary: Get a list of all wallet-related boxes, both spent and unspent. Set minConfirmations to -1 to get
+               mempool boxes included.
       operationId: walletBoxes
       tags:
         - wallet
@@ -2857,7 +2858,7 @@ paths:
         schema:
           type: integer
           format: int32
-          minimum: 0
+          minimum: -1
           default: 0
       - in: query
         name: minInclusionHeight
@@ -2871,7 +2872,7 @@ paths:
     get:
       security:
         - ApiKeyAuth: [api_key]
-      summary: Get a list of unspent boxes
+      summary: Get a list of unspent boxes. Set minConfirmations to -1 to have mempool boxes considered.
       operationId: walletUnspentBoxes
       tags:
         - wallet

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
@@ -24,7 +24,7 @@ trait WalletApiOperations extends ErgoBaseApiRoute {
     */
   val boxFilterPredicate: (WalletBox, Int, Int) => Boolean = { (bx: WalletBox, minConfNum: Int, minHeight: Int) =>
     bx.confirmationsNumOpt.getOrElse(0) >= minConfNum &&
-      bx.trackedBox.inclusionHeightOpt.getOrElse(-1) >= minHeight
+      bx.trackedBox.inclusionHeightOpt.getOrElse(0) >= minHeight
   }
 
 

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -228,8 +228,9 @@ case class WalletApiRoute(readersHolder: ActorRef, nodeViewActorRef: ActorRef, e
   }
 
   def unspentBoxesR: Route = (path("boxes" / "unspent") & get & boxParams) { (minConfNum, minHeight) =>
+    val considerUnconfirmed = minConfNum == -1
     withWallet {
-      _.walletBoxes(unspentOnly = true)
+      _.walletBoxes(unspentOnly = true, considerUnconfirmed)
         .map {
           _.filter(boxFilterPredicate(_, minConfNum, minHeight))
         }
@@ -237,8 +238,9 @@ case class WalletApiRoute(readersHolder: ActorRef, nodeViewActorRef: ActorRef, e
   }
 
   def boxesR: Route = (path("boxes") & get & boxParams) { (minConfNum, minHeight) =>
+    val considerUnconfirmed = minConfNum == -1
     withWallet {
-      _.walletBoxes()
+      _.walletBoxes(unspentOnly = false, considerUnconfirmed = considerUnconfirmed)
         .map {
           _.filter(boxFilterPredicate(_, minConfNum, minHeight))
         }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -71,8 +71,8 @@ trait ErgoWalletReader extends VaultReader {
   def firstSecret: Future[Try[DLogProverInput]] =
     (walletActor ? GetFirstSecret).mapTo[Try[DLogProverInput]]
 
-  def walletBoxes(unspentOnly: Boolean = false): Future[Seq[WalletBox]] =
-    (walletActor ? GetWalletBoxes(unspentOnly)).mapTo[Seq[WalletBox]]
+  def walletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean): Future[Seq[WalletBox]] =
+    (walletActor ? GetWalletBoxes(unspentOnly, considerUnconfirmed)).mapTo[Seq[WalletBox]]
 
   def appBoxes(scanId: ScanId, unspentOnly: Boolean = false): Future[Seq[WalletBox]] =
     (walletActor ? GetScanBoxes(scanId, unspentOnly)).mapTo[Seq[WalletBox]]

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -157,7 +157,9 @@ class ErgoMinerSpec extends FlatSpec with ErgoTestHelpers with ValidBlocksGenera
 
     @tailrec
     def loop(toSend: Int): Unit = {
-      val toSpend: Seq[ErgoBox] = await(wallet.walletBoxes()).map(_.trackedBox.box).toList
+      val toSpend: Seq[ErgoBox] = await(
+        wallet.walletBoxes(unspentOnly = false, considerUnconfirmed = false)
+      ).map(_.trackedBox.box).toList
       log.debug(s"Generate more transactions from ${toSpend.length} boxes. $toSend remains," +
         s"pool size: ${requestReaders.m.size}")
       val txs: Seq[ErgoTransaction] = toSpend.take(toSend) map { boxToSend =>

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -162,7 +162,7 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
 
       case _: CheckSeed => sender() ! true
 
-      case GetWalletBoxes(unspentOnly) =>
+      case GetWalletBoxes(unspentOnly, _) =>
         val boxes = if (unspentOnly) {
           Seq(walletBox10_10, walletBox20_30)
         } else {


### PR DESCRIPTION
Currently, wallet/boxes and /wallet/boxes/unspent return only confirmed boxes.

This PR is introducing a possibility to get boxes from the pool also, and filter out boxes spent in the pool in /wallet/boxes/unspent , if minConfirmations parameter equals to -1. 