### PR TITLE
Fix for docker build failing because of sbt-1458

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends sbt
 COPY ["build.sbt", "/ergo/"]
 COPY ["project", "/ergo/project"]
-RUN sbt update
+RUN sbt -Dsbt.rootdir=true update
 COPY . /ergo
 WORKDIR /ergo
-RUN sbt assembly
+RUN sbt -Dsbt.rootdir=true assembly
 RUN mv `find . -name ergo-*.jar` /ergo.jar
 CMD ["java", "-jar", "/ergo.jar"]
 


### PR DESCRIPTION
In this PR, sbt is getting additional parameter "sbt.rootdir=true" , as otherwise Docker is failing with 

[error] java.lang.IllegalStateException: cannot run sbt from root directory without -Dsbt.rootdir=true; see sbt/sbt#1458