### PR TITLE
Backwards compatibility fix for block transactions serialization 

### DIFF
--- a/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
@@ -133,7 +133,9 @@ object BlockTransactionsSerializer extends ScorexSerializer[BlockTransactions] {
 
   override def serialize(bt: BlockTransactions, w: Writer): Unit = {
     w.putBytes(idToBytes(bt.headerId))
-    w.putUInt(MaxTransactionsInBlock + bt.blockVersion)
+    if (bt.blockVersion > 1) {
+      w.putUInt(MaxTransactionsInBlock + bt.blockVersion)
+    }
     w.putUInt(bt.txs.size)
     bt.txs.foreach { tx =>
       ErgoTransactionSerializer.serialize(tx, w)


### PR DESCRIPTION
In this PR backwards compatibility with 3.x in BlockTransactions serialization fixed