### PR TITLE
ErgoMiner - race condition and calcN() fixes

### DIFF
--- a/papers/whitepaper/currency.tex
+++ b/papers/whitepaper/currency.tex
@@ -77,7 +77,7 @@ All \Erg{} tokens that will ever circulate in the system are presented in the in
     \begin{itemize}
     \item{} The first output should be protected by the same script and the number of \Erg{}s in it should
     equal to the remaining miners' reward.
-    During blocks 1 - 655,199, a miner will be able to collect 67.5 \Erg{}s from this box. During blocks 655,200 - 720,000 (3 months), a miner will be able to collect 66 \Erg{}s, and after that, the block reward will be reduced by 3 \Erg{}s every 64,800 blocks (3 months) until it reaches zero at block 2,080,800.
+    During blocks 1 - 655,199, a miner will be able to collect 67.5 \Erg{}s from this box. During blocks 655,200 - 719,999 (3 months), a miner will be able to collect 66 \Erg{}s, and after that, the block reward will be reduced by 3 \Erg{}s every 64,800 blocks (3 months) until it reaches zero at block 2,080,800.
 
     \item{} The second output should contain the remaining coins and should be protected by the following condition:
     it can be spent by a miner that solved the block's PoW puzzle and not earlier than 720 blocks after the current block.

--- a/papers/yellow/pow/ErgoPow.tex
+++ b/papers/yellow/pow/ErgoPow.tex
@@ -55,8 +55,8 @@
         \item{} $sum$ is always about 256 bits (32 bytes)
         \item{} $h$ is height of a block (32 bits = 4 bytes)
         \item{} $N$ value is growing with time as follows. Until block $614,400$, $N = 2^{26} = 67,108,864$.
-                From this block, and until block $9,216,000$, every 51,200 blocks $N$ is increased by 5 percent.
-                Since block $9,216,000$, value of $N$ is fixed and equals to $2,147,387,550$. Test vectors for
+                From this block, and until block $4,198,400$, every 51,200 blocks $N$ is increased by 5 percent.
+                Since block $4,198,400$, value of $N$ is fixed and equals to $2,143,944,600$. Test vectors for
                 $N$ values are provided in Table \ref{ntbl}.
 
         \item{} $M$ is still equal to $8 * 1,024$ (bytes)
@@ -104,8 +104,8 @@
     700,000 & 73,987,410 \\
     788,400 & 81,571,035 \\
     1,051,200 & 104,107,290 \\
-    9,216,000 & 2,147,387,550 \\
-    29,216,000 & 2,147,387,550 \\
+    4,198,400 & 2,143,944,600 \\
+    24,198,400 & 2,143,944,600 \\
     \hline
     \end{tabular}
     \label{ntbl}

--- a/src/main/resources/testnet.conf
+++ b/src/main/resources/testnet.conf
@@ -55,8 +55,7 @@ scorex {
     nodeName = "ergo-testnet-4.0.0"
     nodeName = ${?NODENAME}
     knownPeers = [
-      "93.123.180.164:9020",
-      "88.198.13.202:9020"
+      "213.239.193.208:9020"
     ]
   }
   restApi {

--- a/src/main/scala/org/ergoplatform/mining/AutolykosPowScheme.scala
+++ b/src/main/scala/org/ergoplatform/mining/AutolykosPowScheme.scala
@@ -59,7 +59,7 @@ class AutolykosPowScheme(val k: Int, val n: Int) extends ScorexLogging {
   /**
     * On this height, the table (`N` value) will stop to grow
     */
-  val NIncreasementHeightMax: Height = 9216000
+  val NIncreasementHeightMax: Height = 4198400
 
   /**
     * Calculates table size (N value) for a given height (moment of time)

--- a/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
+++ b/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
@@ -276,7 +276,7 @@ class ErgoMiner(ergoSettings: ErgoSettings,
 
     case PrepareCandidate(txsToInclude, reply) =>
       val candF: Future[CandidateCache] = if (candidateGenerating) {
-        Future.failed(new Exception("Candidate generation is in progress"))
+        Future.failed(new Exception("Skipping candidate generation, one is already in progress"))
       } else {
         candidateGenerating = true
         val f = if (cachedFor(txsToInclude)) {

--- a/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
+++ b/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
@@ -451,7 +451,7 @@ class ErgoMiner(ergoSettings: ErgoSettings,
     }
   }.flatten
 
-  def refreshCandidate(): Unit = {
+  private def refreshCandidate(): Unit = {
     log.info("Requesting candidate")
     candidateOpt = None
     self ! PrepareCandidate(candidateOpt.map(_.txsToInclude).getOrElse(Seq.empty), reply = false)

--- a/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -58,9 +58,8 @@ class AutolykosPowSchemeSpec extends ErgoPropertyTest with NoShrink {
     pow.calcN(2, 700000) shouldBe 73987410
     pow.calcN(2, 788400) shouldBe 81571035 // 3 years
     pow.calcN(2, 1051200) shouldBe 104107290 // 4 years
-    pow.calcN(2, 9216000) shouldBe 2147387550 // max height
-    pow.calcN(2, 29216000) shouldBe 2147387550
-    pow.calcN(2, 292160000) shouldBe 2147387550
+    pow.calcN(2, 4198400) shouldBe 2143944600 // max height
+    pow.calcN(2, 41984000) shouldBe 2143944600
   }
 
 }

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -97,7 +97,9 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
 
   class MinerStub extends Actor {
     def receive: Receive = {
-      case ErgoMiner.PrepareCandidate(_) => sender() ! Future.successful(externalCandidateBlock)
+      case ErgoMiner.PrepareCandidate(_, reply) => if (reply) {
+        sender() ! Future.successful(externalCandidateBlock)
+      }
       case _: AutolykosSolution => sender() ! Future.successful(())
       case ErgoMiner.ReadMinerPk => sender() ! Some(pk)
     }


### PR DESCRIPTION
In this PR:

* a race condition fixed in ErgoMiner. It was about a possibility for two block candidates to be generated via internal trigger and also external request. Lead to improper solutions found sometimes when external miner polling the node often (e.g. every 10 ms).
* calcN() had a bug with integer overflows towards old NIncreasementHeightMax which were unnoticed. In this PR NIncreasementHeightMax reduced to 4,198,400. This will be consensus issue 14 years after! (Means 4.0.0 & 4.0.1 nodes will diverge from 4.0.2). Should not be a big issue though.
* *knownPeers* set to ["213.239.193.208:9020"] for the testnet (as old 88... server is dead now)
* minor fixes in documentation