### PR TITLE
Candidate for 4.0.4

### DIFF
--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -23,7 +23,7 @@ ergo {
       version2ActivationHeight = 417792 // around Feb, 1st, 2021
 
       # Difficulty for Autolykos version 2 activation (corresponding to ~ 1 TH/s hashrate)
-      version2ActivationDifficultyHex = "6f98d5555555"
+      version2ActivationDifficultyHex = "6f98d5000000"
     }
   }
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -241,7 +241,7 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     */
   def requiredDifficultyAfter(parent: Header,
                               nextBlockTimestampOpt: Option[Long] = None): Difficulty = {
-    if (parent.height + 1 == settings.chainSettings.voting.version2ActivationHeight) {
+    if (parent.height == settings.chainSettings.voting.version2ActivationHeight || parent.height + 1 == settings.chainSettings.voting.version2ActivationHeight) {
       // Set difficulty for version 2 activation height (where specific difficulty is needed due to PoW change)
       settings.chainSettings.initialDifficultyVersion2
     } else {


### PR DESCRIPTION
it seems that if the parent height % epochLength == 0, then it will do a diff calc based on last epochs

so basically because you picked activation height being exactly 417792, when computing difficulty for the child, it is computing diff for last epochs, not just the parent

well difficulty always changes on the epochLength * n + 1 of a new epoch
