### PR TITLE
Fix for config issues

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -253,7 +253,7 @@ scorex {
     bindAddress = "0.0.0.0:9052"
 
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    apiKeyHash = "1111"
+    apiKeyHash = null
 
     # Enable/disable CORS support.
     # This is an optional param. It would allow cors in case if this setting is set.

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -1,6 +1,5 @@
 package org.ergoplatform
 
-import java.io.File
 import java.net.InetSocketAddress
 
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
@@ -35,6 +34,8 @@ class ErgoApp(args: Args) extends ScorexLogging {
   log.info(s"Running with args: $args")
 
   private val ergoSettings: ErgoSettings = ErgoSettings.read(args)
+
+  require(ergoSettings.scorexSettings.restApi.apiKeyHash.isDefined, "API key hash must be set")
 
   log.info(s"Working directory: ${ergoSettings.directory}")
   log.info(s"Secret directory: ${ergoSettings.walletSettings.secretStorage.secretDir}")

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -1,8 +1,9 @@
 package org.ergoplatform
 
+import java.io.File
 import java.net.InetSocketAddress
 
-import akka.actor.{ActorRef, PoisonPill, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.http.scaladsl.Http
 import akka.stream.SystemMaterializer
 import org.ergoplatform.http._
@@ -10,16 +11,16 @@ import org.ergoplatform.mining.ErgoMiner.StartMining
 import org.ergoplatform.http.api.{ScanApiRoute, _}
 import org.ergoplatform.local._
 import org.ergoplatform.mining.ErgoMinerRef
-import org.ergoplatform.network.{ModeFeature, ErgoNodeViewSynchronizer}
+import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ModeFeature}
 import org.ergoplatform.nodeView.history.ErgoSyncInfoMessageSpec
-import org.ergoplatform.nodeView.{ErgoReadersHolderRef, ErgoNodeViewRef}
-import org.ergoplatform.settings.{Args, NetworkType, ErgoSettings}
+import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
+import org.ergoplatform.settings.{Args, ErgoSettings, NetworkType}
 import scorex.core.api.http._
 import scorex.core.app.{Application, ScorexContext}
 import scorex.core.network.NetworkController.ReceivableMessages.ShutdownNetwork
 import scorex.core.network.message._
 import scorex.core.network.peer.PeerManagerRef
-import scorex.core.network.{PeerSynchronizerRef, UPnP, UPnPGateway, PeerFeature, NetworkControllerRef}
+import scorex.core.network.{NetworkControllerRef, PeerFeature, PeerSynchronizerRef, UPnP, UPnPGateway}
 import scorex.core.settings.ScorexSettings
 import scorex.core.utils.NetworkTimeProvider
 import scorex.util.ScorexLogging
@@ -27,13 +28,16 @@ import scorex.util.ScorexLogging
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 import scala.io.Source
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 class ErgoApp(args: Args) extends ScorexLogging {
 
   log.info(s"Running with args: $args")
 
   private val ergoSettings: ErgoSettings = ErgoSettings.read(args)
+
+  log.info(s"Working directory: ${ergoSettings.directory}")
+  log.info(s"Secret directory: ${ergoSettings.walletSettings.secretStorage.secretDir}")
 
   implicit private def settings: ScorexSettings = ergoSettings.scorexSettings
 

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
@@ -85,8 +85,7 @@ object ErgoSettings extends ScorexLogging
   }
 
   // Helper method to read user-provided `configFile` with network-specific `fallbackConfig`
-  // to be used before
-
+  // to be used for default fallback values before reference.conf (which is the last resort)
   private def configWithOverrides(configFile: File, fallbackConfig: Option[File]) = {
     val firstFallBack = fallbackConfig.map(ConfigFactory.parseFile).getOrElse(ConfigFactory.defaultApplication())
 


### PR DESCRIPTION
In this PR:

* apiKeyHash is set to null in reference.conf to avoid "Bad API Key" message when the node is unable to parse user-provided config  
* if *ergo.directory* is set, but *ergo.wallet.secretStorage.secretDir* is not, the node is setting ergo.wallet.secretStorage.secretDir = ergo.directory + "/wallet/keystore" like in reference.conf (previously, ergo.wallet.secretStorage.secretDir = default ergo.directory from reference.conf + "/wallet/keystore"). Previous behavior led to many confusing issues, especially with PowerShell