### PR TITLE
Candidate for version 4.0.6

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/Utils.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/Utils.scala
@@ -1,9 +1,8 @@
 package org.ergoplatform.wallet
 
-import org.ergoplatform.{ErgoAddress, ErgoBox, ErgoBoxCandidate, UnsignedErgoLikeTransaction, UnsignedInput}
+import org.ergoplatform.{ErgoAddress, ErgoBox, ErgoBoxCandidate, ErgoScriptPredef, UnsignedErgoLikeTransaction, UnsignedInput}
 import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
-import sigmastate.Values.TrueLeaf
 import sigmastate.eval.Extensions._
 import sigmastate.eval._
 
@@ -37,7 +36,7 @@ object Utils {
     )
     val fee = new ErgoBoxCandidate(
       feeAmt,
-      TrueLeaf.toSigmaProp,
+      ErgoScriptPredef.feeProposition(),
       currentHeight,
       Seq.empty[(ErgoBox.TokenId, Long)].toColl,
       Map.empty

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -28,7 +28,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
 
   import ReplaceCompactCollectBoxSelector._
 
-  val ScanDepthFactor = 10
+  val ScanDepthFactor = 20
 
   /**
     * A method which is selecting boxes to spend in order to collect needed amounts of ergo tokens and assets.

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -28,7 +28,11 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int, optimalInputs: Int) exten
 
   import ReplaceCompactCollectBoxSelector._
 
-  val ScanDepthFactor = 20
+  /**
+    * Factor which is showing how many input selector is going through to optimize inputs.
+    * Bigger factor is slowing down inputs selection but minimizing chance of transaction failure.
+    */
+  val ScanDepthFactor = 300
 
   /**
     * A method which is selecting boxes to spend in order to collect needed amounts of ergo tokens and assets.

--- a/src/main/scala/org/ergoplatform/mining/ProofOfUpcomingTransactions.scala
+++ b/src/main/scala/org/ergoplatform/mining/ProofOfUpcomingTransactions.scala
@@ -9,7 +9,7 @@ import io.circe.syntax._
 /**
   * Proof of inclusion of certain transactions into a block with known and yet unproven header.
   *
-  * In particular, can be useful for collateralized pools, see [[org.ergoplatform.examples.LiteClientExamples]]
+  * In particular, can be useful for collateralized pools, see `LiteClientExamples` in tests
   * for details. But there are could be more examples where a miner needs to show that a transaction is included
   * into upcoming block the miner is working on.
   *

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -25,7 +25,7 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
   // and also optimal number of inputs(a selector is collecting dust if transaction has less inputs than optimal).
   // Now these settings are hard-coded, however, they should be parameterized
   // https://github.com/ergoplatform/ergo/issues/856
-  val maxInputs = 64
+  val maxInputs = 120
   val optimalInputs = 3
 
   val boxSelector = new ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -25,7 +25,7 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
   // and also optimal number of inputs(a selector is collecting dust if transaction has less inputs than optimal).
   // Now these settings are hard-coded, however, they should be parameterized
   // https://github.com/ergoplatform/ergo/issues/856
-  val maxInputs = 120
+  val maxInputs = 100
   val optimalInputs = 3
 
   val boxSelector = new ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -55,7 +55,7 @@ class WalletRegistry(store: LDBVersionedStore)(ws: WalletSettings) extends Score
 
 
   /**
-    * Read wallet-related boxes with metadata, see [[getBox()]]
+    * Read wallet-related boxes with metadata, see getBox()
     *
     * @param ids - box identifier
     * @return wallet related boxes (optional result for each box)


### PR DESCRIPTION
Candidate for Ergo protocol reference client 4.0.6. It contains:

* Fix for fee script in Utils.paymentTransaction
* Scaladoc errors fixed
* Wallet settings improved towards environment with many small inputs (like exchanges)