### PR TITLE
Docker touchup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ CMD ["java", "-jar", "/ergo.jar"]
 FROM openjdk:11-jre-slim
 RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatform" ergo && \
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
-COPY --from=builder /ergo.jar /home/ergo/ergo.jar
 USER ergo
 EXPOSE 9020 9052 9030 9053
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G
 ENV _JAVA_OPTIONS "-Xmx${MAX_HEAP}"
+COPY --from=builder /ergo.jar /home/ergo/ergo.jar
 ENTRYPOINT ["java", "-jar", "/home/ergo/ergo.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
-FROM openjdk:11-jdk-slim as builder
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-transport-https apt-utils bc dirmngr gnupg && \
-    echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \
-    # seems that dash package upgrade is broken in Debian, so we hold it's version before update
-    echo "dash hold" | dpkg --set-selections && \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends sbt
+FROM mozilla/sbt:11.0.8_1.3.13 as builder
 COPY ["build.sbt", "/ergo/"]
 COPY ["project", "/ergo/project"]
 RUN sbt -Dsbt.rootdir=true update

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ EXPOSE 9020 9052
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G
-ENTRYPOINT java -Xmx${MAX_HEAP} -jar /home/ergo/ergo.jar $0 $1 $2 $3
-CMD []
+ENV _JAVA_OPTIONS "-Xmx${MAX_HEAP}"
+ENTRYPOINT ["java", "-jar", "/home/ergo/ergo.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatfo
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
 COPY --from=builder /ergo.jar /home/ergo/ergo.jar
 USER ergo
-EXPOSE 9020 9052
+EXPOSE 9020 9052 9030 9053
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN mv `find . -name ergo-*.jar` /ergo.jar
 CMD ["java", "-jar", "/ergo.jar"]
 
 FROM openjdk:11-jre-slim
-LABEL maintainer="Andrey Andreev <andyceo@yandex.ru> (@andyceo)"
 RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatform" ergo && \
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
 COPY --from=builder /ergo.jar /home/ergo/ergo.jar


### PR DESCRIPTION
Most importantly:
Fixes an issue where the container would not receive the SIGTERM which
docker stop sends and would always have to timeout and be SIGKILLed,
potentially resulting in data corruption.

Additionally, I took the opportunity to tune it to take advantage of docker build caching and clean it up. You should see a nice improvement in building times.