### PR TITLE
Fix for #1326: /blocks?limit=N now returns N block ids, not N-1

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -12,7 +12,7 @@ trait ErgoBaseApiRoute extends ApiRoute {
 
   implicit val ec: ExecutionContextExecutor = context.dispatcher
 
-  val paging: Directive[(Int, Int)] = parameters("offset".as[Int] ? 0, "limit".as[Int] ? 50)
+  val paging: Directive[(Int, Int)] = parameters("offset".as[Int] ? 1, "limit".as[Int] ? 50)
 
   val modifierId: Directive1[ModifierId] = pathPrefix(Segment).flatMap(handleModifierId)
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -206,7 +206,7 @@ trait ErgoHistoryReader
   /**
     * @return ids of count headers starting from offset
     */
-  def headerIdsAt(offset: Int = 0, limit: Int): Seq[ModifierId] = {
+  def headerIdsAt(offset: Int, limit: Int): Seq[ModifierId] = {
     (offset until (limit + offset)).flatMap(height => bestHeaderIdAtHeight(height))
   }
 


### PR DESCRIPTION
As the genesis block has height = 1, and offset value by default was 0, /blocks?limit=N returned N-1 block ids. Fixed in this PR, now /blocks?limit=N now returns N block ids.