### PR TITLE
Make builds reproducible

### DIFF
--- a/avldb/build.sbt
+++ b/avldb/build.sbt
@@ -45,3 +45,5 @@ scalacOptions ++= Seq("-Xfatal-warnings", "-feature", "-deprecation")
 // these options applied only in "compile" task since scalac crashes on scaladoc compilation with "-release 8"
 // see https://github.com/scala/community-builds/issues/796#issuecomment-423395500
 scalacOptions in(Compile, compile) ++= Seq("-release", "8")
+
+enablePlugins(ReproducibleBuildsPlugin)

--- a/avldb/project/plugins.sbt
+++ b/avldb/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
+
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.25")

--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,7 @@ assemblyMergeStrategy in assembly := {
 
 enablePlugins(sbtdocker.DockerPlugin)
 enablePlugins(JavaAppPackaging)
+enablePlugins(ReproducibleBuildsPlugin)
 
 mappings in Universal += {
   val sampleFile = (resourceDirectory in Compile).value / "samples" / "local.conf.sample"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,3 +25,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.25")


### PR DESCRIPTION
https://github.com/ergoplatform/ergo/issues/845

Stable JAR is created after `sbt assembly` under:
`target/scala-${scalaBinaryVersion}/stripped/ergo-${version}.jar`

sbt-reproducible-builds's 0.25 release supports sbt-assembly
Ran `sbt clean` and `sbt assembly` a few times, the stable jar has the same md5sum.

Couldn't find a CONTRIBUTING.md, please let me know if I'm doing something wrong.