### PR TITLE
increase akka-http-server request timeout

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -242,6 +242,14 @@ ergo {
   }
 }
 
+akka {
+  http {
+    server {
+      request-timeout = 1 minute
+    }
+  }
+}
+
 scorex {
 
   # Execution context for all tasks, except of akka actors.


### PR DESCRIPTION
Exchanges complain about request timeouts. Having a problem/complaint that it takes too long is always better than that it fails.

I think that proper solution is about establishing backpressure in the stack ... ie. avoiding the message queues to fill ... that's why there is a trend to reduce Actors to being just state holders and using akka-stream as much as possible ... so if wallet is unavailable, it might be caused by this `ScanOnChain(newBlock)` which is called heavily during syncing.