### PR TITLE
Support for multiple keys in UnsafeProver

### DIFF
--- a/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
+++ b/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
@@ -2,7 +2,9 @@ package org.ergoplatform.wallet.interface4j.crypto;
 
 import org.ergoplatform.ErgoLikeTransaction;
 import org.ergoplatform.UnsignedErgoLikeTransaction;
+import scala.collection.JavaConverters;
 import sigmastate.basics.DLogProtocol;
+import java.util.Map;
 
 /**
  * A wrapper over naive Ergo prover implementation.
@@ -16,6 +18,15 @@ public class ErgoUnsafeProver {
      */
     public ErgoLikeTransaction prove(UnsignedErgoLikeTransaction unsignedTx, DLogProtocol.DLogProverInput sk) {
         return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, sk);
+    }
+
+    /**
+     * Signs all inputs of a given `unsignedTx`.
+     *
+     * @return signed transaction
+     */
+    public ErgoLikeTransaction prove(UnsignedErgoLikeTransaction unsignedTx, Map<String, DLogProtocol.DLogProverInput> sks) {
+        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, JavaConverters.mapAsScalaMap(sks));
     }
 
 }

--- a/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
+++ b/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
@@ -2,7 +2,7 @@ package org.ergoplatform.wallet.interface4j.crypto;
 
 import org.ergoplatform.ErgoLikeTransaction;
 import org.ergoplatform.UnsignedErgoLikeTransaction;
-import scala.collection.JavaConverters;
+import scala.collection.JavaConversions;
 import sigmastate.basics.DLogProtocol;
 import java.util.Map;
 
@@ -26,7 +26,8 @@ public class ErgoUnsafeProver {
      * @return signed transaction
      */
     public ErgoLikeTransaction prove(UnsignedErgoLikeTransaction unsignedTx, Map<String, DLogProtocol.DLogProverInput> sks) {
-        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, JavaConverters.mapAsScalaMap(sks));
+        // JavaConversions used to support Scala 2.11
+        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, JavaConversions.mapAsScalaMap(sks));
     }
 
 }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoUnsafeProver.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoUnsafeProver.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.wallet.interpreter
 
 import org.ergoplatform.{ErgoLikeTransaction, Input, UnsignedErgoLikeTransaction}
+import scorex.util.encode.Base16
 import sigmastate.basics.DLogProtocol.DLogProverInput
 import sigmastate.interpreter.{ContextExtension, ProverResult}
 
@@ -15,7 +16,7 @@ object ErgoUnsafeProver {
   import org.ergoplatform.wallet.crypto.ErgoSignature._
 
   /**
-    * Signs all inputs of a given `unsignedTx`.
+    * Signs all inputs of a given `unsignedTx`, if all the inputs are associated with the same keypair.
     *
     * @note this method does not validate the cost of the given transaction
     * @return signed transaction
@@ -24,6 +25,26 @@ object ErgoUnsafeProver {
             sk: DLogProverInput): ErgoLikeTransaction = {
     val sig = ProverResult(sign(unsignedTx.messageToSign, sk.w), ContextExtension.empty)
     val inputs = unsignedTx.inputs.map { unsignedInput =>
+      Input(unsignedInput.boxId, sig)
+    }
+    new ErgoLikeTransaction(inputs, unsignedTx.dataInputs, unsignedTx.outputCandidates)
+  }
+
+  /**
+    * Signs all inputs of a given `unsignedTx`.
+    *
+    * @note this method does not validate the cost of the given transaction
+    * @return signed transaction
+    */
+  def prove(unsignedTx: UnsignedErgoLikeTransaction,
+            sks: scala.collection.Map[String, DLogProverInput]): ErgoLikeTransaction = {
+
+    val inputs = unsignedTx.inputs.map { unsignedInput =>
+      val inputId = Base16.encode(unsignedInput.boxId)
+
+      val sk = sks(inputId)
+
+      val sig = ProverResult(sign(unsignedTx.messageToSign, sk.w), ContextExtension.empty)
       Input(unsignedInput.boxId, sig)
     }
     new ErgoLikeTransaction(inputs, unsignedTx.dataInputs, unsignedTx.outputCandidates)

--- a/ergo-wallet/src/test/java/org/ergoplatform/wallet/CreateTransactionDemo.java
+++ b/ergo-wallet/src/test/java/org/ergoplatform/wallet/CreateTransactionDemo.java
@@ -6,11 +6,15 @@ import org.ergoplatform.wallet.interface4j.crypto.ErgoUnsafeProver;
 import org.ergoplatform.wallet.secrets.ExtendedSecretKey;
 import org.ergoplatform.wallet.serialization.JsonCodecsWrapper;
 import scorex.util.Random;
+import sigmastate.basics.DLogProtocol;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class CreateTransactionDemo {
 
     /**
-     * A demo describing the process of creating simple payment transaction.
+     * A demo describing the process of creating simple payment transaction with one key.
      * Note, more complex transaction would require more steps which are not described in this demo.
      */
     public void createTransaction() throws Exception {
@@ -54,4 +58,52 @@ public class CreateTransactionDemo {
         System.out.println(json.toString());
     }
 
+    /**
+     * A demo describing the process of creating simple payment transaction with multiple keys.
+     * Note, more complex transaction would require more steps which are not described in this demo.
+     */
+    public static void createTransactionMultipleKeys() throws Exception {
+        ErgoAddressEncoder encoder = new ErgoAddressEncoder((byte) 0x00);
+
+        String receiverAddressStr = "9fKYyGuV3wMYFYzWBR1FDgc61CFV2hbGLrY6S3wgH1r4xJcwLnq";
+        ErgoAddress receiverAddress = encoder.fromString(receiverAddressStr).get();
+
+        // Create second address
+        byte[] entropy1 = Random.randomBytes(32);
+        ExtendedSecretKey extendedSecretKey1 = ExtendedSecretKey.deriveMasterKey(entropy1);
+        ErgoAddress changeAddress = P2PKAddress.apply(extendedSecretKey1.privateInput().publicImage(), encoder);
+
+        byte[] entropy2 = Random.randomBytes(32);
+        ExtendedSecretKey extendedSecretKey2 = ExtendedSecretKey.deriveMasterKey(entropy2);
+
+
+        int transferAmt = 25000000; // amount to transfer
+        int feeAmt = 1000000; // minimal fee amount
+        int changeAmt = 20000; // amount to return back
+
+        int currentNetworkHeight = 32987; // from explorer `https://api.ergoplatform.com/blocks`
+
+        // from explorer `https://api.ergoplatform.com/transactions/boxes/byAddress/unspent/{myAddress}`
+        Map<String, DLogProtocol.DLogProverInput> myInputs = new HashMap<String, DLogProtocol.DLogProverInput>();
+        myInputs.put("430e80ca31a25400e77dac0ad14c1cd39cb09dc3f7c1c384dce9aef19b604e27", extendedSecretKey1.privateInput());
+        myInputs.put("d9ba3ed2f55bc61ec90b7ee3949362a9a20fbf8514d2306eb97f14e07d234797", extendedSecretKey2.privateInput());
+
+        UnsignedErgoLikeTransaction unsignedTx = Utils.paymentTransaction(
+                receiverAddress,
+                changeAddress,
+                transferAmt,
+                feeAmt,
+                changeAmt,
+                myInputs.keySet().toArray(new String[0]),
+                currentNetworkHeight
+        );
+
+        ErgoLikeTransaction tx = new ErgoUnsafeProver().prove(unsignedTx, myInputs);
+
+        // print transaction JSON
+        // then the transaction can be broadcasted by sending the json to
+        // https://api.ergoplatform.com/api/v0/transactions/send (POST request)
+        Json json = JsonCodecsWrapper.ergoLikeTransactionEncoder().apply(tx);
+        System.out.println(json.toString());
+    }
 }


### PR DESCRIPTION
In this PR, support for multiple secrets added to UnsafeProver. User needs to resolve secret -> inputs correspondence on its end. 