### PR TITLE
Wait for concurrent thread completion in concurrent modification test

### DIFF
--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -23,7 +23,8 @@ import sigmastate.basics.DLogProtocol.{DLogProverInput, ProveDlog}
 import sigmastate.interpreter.ProverResult
 import sigmastate.helpers.TestingHelpers._
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.{Random, Try}
 
 
@@ -187,7 +188,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
     var us2 = createUtxoState(BoxHolder(Seq(genesisEmissionBox)))
     val stateReader = us2.getReader.asInstanceOf[UtxoState]
     // parallel thread that generates proofs
-    Future {
+    val f = Future {
       (0 until 1000) foreach { _ =>
         Try {
           val boxes = stateReader.randomBox().toSeq
@@ -200,6 +201,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
     chain.foreach { fb =>
       us2 = us2.applyModifier(fb).get
     }
+    Await.result(f, Duration.Inf);
   }
 
   property("proofsForTransactions() to be deterministic") {


### PR DESCRIPTION
Wait for concurrent thread completion in concurrent applyModifier() and proofsForTransactions() test