### PR TITLE
Block assembly fix

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
@@ -189,6 +189,9 @@ object UtxoState {
     new UtxoState(persistentProver, version, store, constants)
   }
 
+  /**
+    * Used in tests and to generate a genesis state.
+    */
   @SuppressWarnings(Array("OptionGet", "TryGet"))
   def fromBoxHolder(bh: BoxHolder,
                     currentEmissionBoxOpt: Option[ErgoBox],


### PR DESCRIPTION
Previously, block assembly procedure stopped to collect transactions on first transaction which is double-spending or spending inputs. This PR is introducing a fix for that, along with minor improvements in comments and refactoring. 