### PR TITLE
handle db errors at higher level

### DIFF
--- a/benchmarks/src/test/scala/org/ergoplatform/db/LDBStoreBench.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/db/LDBStoreBench.scala
@@ -39,7 +39,7 @@ object LDBStoreBench
   val txsWithDbGen: Gen[(Seq[BlockTransactions], LDBKVStore)] = txsGen.map { bts =>
     val toInsert = bts.map(bt => idToBytes(bt.headerId) -> bt.bytes)
     val db = storeLDB()
-    toInsert.grouped(5).foreach(db.insert)
+    toInsert.grouped(5).foreach(db.insert(_).get)
     bts -> storeLDB
   }
 
@@ -55,7 +55,7 @@ object LDBStoreBench
   private def benchWriteLDB(bts: Seq[BlockTransactions]): Unit = {
     val toInsert = bts.map(bt => idToBytes(bt.headerId) -> bt.bytes)
     val db = storeLDB()
-    toInsert.grouped(5).foreach(db.insert)
+    toInsert.grouped(5).foreach(db.insert(_).get)
   }
 
   private def benchReadLDB(bts: Seq[BlockTransactions], db: LDBKVStore): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val circeVersion = "0.13.0"
 val akkaVersion = "2.6.10"
 val akkaHttpVersion = "10.2.1"
 
-val scorexVersion = "main-a6fe1419-SNAPSHOT"
+val scorexVersion = "handle-db-issues-explicitly-a6fe1419-SNAPSHOT"
 val sigmaStateVersion = "4.0.3"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -19,7 +19,7 @@ import scorex.core.validation.RecoverableModifierError
 import scorex.db.LDBFactory
 import scorex.util.{ScorexLogging, idToBytes}
 
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
   * History implementation. It is processing persistent modifiers generated locally or coming from the network.
@@ -52,18 +52,18 @@ trait ErgoHistory
     */
   override def append(modifier: ErgoPersistentModifier): Try[(ErgoHistory, ProgressInfo[ErgoPersistentModifier])] = synchronized {
     log.debug(s"Trying to append modifier ${modifier.encodedId} of type ${modifier.modifierTypeId} to history")
-    applicableTry(modifier).map { _ =>
+    applicableTry(modifier).flatMap { _ =>
       modifier match {
         case header: Header =>
-          (this, process(header))
+          process(header)
         case section: BlockSection =>
-          (this, process(section))
+          process(section)
         case poPoWProof: NipopowProofModifier =>
-          (this, process(poPoWProof))
+          process(poPoWProof)
         case chunk: UTXOSnapshotChunk =>
-          (this, process(chunk))
+          process(chunk)
       }
-    }.recoverWith { case e =>
+    }.map(this -> _).recoverWith { case e =>
       if (!e.isInstanceOf[RecoverableModifierError]) {
         log.warn(s"Error while applying modifier ${modifier.encodedId} of type ${modifier.modifierTypeId}, " +
           s"reason: ${LoggingUtil.getReasonMsg(e)} ")
@@ -75,7 +75,7 @@ trait ErgoHistory
   /**
     * Mark modifier as valid
     */
-  override def reportModifierIsValid(modifier: ErgoPersistentModifier): ErgoHistory = synchronized {
+  override def reportModifierIsValid(modifier: ErgoPersistentModifier): Try[ErgoHistory] = synchronized {
     log.debug(s"Modifier ${modifier.encodedId} of type ${modifier.modifierTypeId} is marked as valid ")
     modifier match {
       case fb: ErgoFullBlock =>
@@ -85,14 +85,13 @@ trait ErgoHistory
         if (nonMarkedIds.nonEmpty) {
           historyStorage.insert(
             nonMarkedIds.map(id => validityKey(id) -> Array(1.toByte)),
-            Seq.empty)
-        }
+            Seq.empty).map(_ => this)
+        } else Success(this)
       case _ =>
         historyStorage.insert(
           Seq(validityKey(modifier.id) -> Array(1.toByte)),
-          Seq.empty)
+          Seq.empty).map(_ => this)
     }
-    this
   }
 
   /**
@@ -104,7 +103,7 @@ trait ErgoHistory
   @SuppressWarnings(Array("OptionGet", "TraversableHead"))
   override def reportModifierIsInvalid(modifier: ErgoPersistentModifier,
                                        progressInfo: ProgressInfo[ErgoPersistentModifier]
-                                      ): (ErgoHistory, ProgressInfo[ErgoPersistentModifier]) = synchronized {
+                                      ): Try[(ErgoHistory, ProgressInfo[ErgoPersistentModifier])] = synchronized {
     log.debug(s"Modifier ${modifier.encodedId} of type ${modifier.modifierTypeId} is marked as invalid")
     correspondingHeader(modifier) match {
       case Some(invalidatedHeader) =>
@@ -118,8 +117,9 @@ trait ErgoHistory
         (bestHeaderIsInvalidated, bestFullIsInvalidated) match {
           case (false, false) =>
             // Modifiers from best header and best full chain are not involved, no rollback and links change required
-            historyStorage.insert(validityRow, Seq.empty)
-            this -> ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+            historyStorage.insert(validityRow, Seq.empty).map { _ =>
+              this -> ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+            }
           case _ =>
             // Modifiers from best header and best full chain are involved, links change required
             val newBestHeaderOpt = loopHeightDown(headersHeight, id => !invalidatedIds.contains(id))
@@ -129,8 +129,9 @@ trait ErgoHistory
               historyStorage.insert(
                 newBestHeaderOpt.map(h => BestHeaderKey -> idToBytes(h.id)).toSeq,
                 Seq.empty
-              )
-              this -> ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+              ).map { _ =>
+                this -> ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+              }
             } else {
               val invalidatedChain: Seq[ErgoFullBlock] = bestFullBlockOpt.toSeq
                 .flatMap(f => headerChainBack(fullBlockHeight + 1, f.header, h => !invalidatedIds.contains(h.id)).headers)
@@ -155,18 +156,19 @@ trait ErgoHistory
               val changedLinks = validHeadersChain.lastOption.map(b => BestFullBlockKey -> idToBytes(b.id)) ++
                 newBestHeaderOpt.map(h => BestHeaderKey -> idToBytes(h.id)).toSeq
               val toInsert = validityRow ++ changedLinks ++ chainStatusRow
-              historyStorage.insert(toInsert, Seq.empty)
-              val toRemove = if (genesisInvalidated) invalidatedChain else invalidatedChain.tail
-
-              this -> ProgressInfo(Some(branchPointHeader.id), toRemove, validChain, Seq.empty)
+              historyStorage.insert(toInsert, Seq.empty).map { _ =>
+                val toRemove = if (genesisInvalidated) invalidatedChain else invalidatedChain.tail
+                this -> ProgressInfo(Some(branchPointHeader.id), toRemove, validChain, Seq.empty)
+              }
             }
         }
       case None =>
         //No headers become invalid. Just valid this modifier as invalid
         historyStorage.insert(
           Seq(validityKey(modifier.id) -> Array(0.toByte)),
-          Seq.empty)
-        this -> ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+          Seq.empty).map { _ =>
+            this -> ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+         }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/BlockSectionProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/BlockSectionProcessor.scala
@@ -21,7 +21,7 @@ trait BlockSectionProcessor extends ScorexEncoding {
     * @param m - modifier to process
     * @return ProgressInfo - info required for State to be consistent with History
     */
-  protected def process(m: BlockSection): ProgressInfo[ErgoPersistentModifier]
+  protected def process(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]]
 
   /**
     * @param m - modifier to validate

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/EmptyBlockSectionProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/EmptyBlockSectionProcessor.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.history.storage.modifierprocessors
 import org.ergoplatform.modifiers.{BlockSection, ErgoPersistentModifier}
 import scorex.core.consensus.History.ProgressInfo
 
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
   * Trait that implements BlockSectionProcessor interfaces for a regime where the node only
@@ -11,8 +11,8 @@ import scala.util.{Failure, Try}
   */
 trait EmptyBlockSectionProcessor extends BlockSectionProcessor {
 
-  override protected def process(m: BlockSection): ProgressInfo[ErgoPersistentModifier] =
-    ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty)
+  override protected def process(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]] =
+    Success(ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty))
 
   override protected def validate(m: BlockSection): Try[Unit] =
     Failure(new Error("Regime that does not support block sections processing"))

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -10,7 +10,7 @@ import scorex.util.{ModifierId, bytesToId, idToBytes}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /**
   * Contains functions required by History to process Transactions and Proofs when we have them.
@@ -45,7 +45,7 @@ trait FullBlockProcessor extends HeadersProcessor {
     * @return ProgressInfo required for State to process to be consistent with the history
     */
   protected def processFullBlock(fullBlock: ErgoFullBlock,
-                                 newMod: ErgoPersistentModifier): ProgressInfo[ErgoPersistentModifier] = {
+                                 newMod: ErgoPersistentModifier): Try[ProgressInfo[ErgoPersistentModifier]] = {
     val bestFullChainAfter = calculateBestChain(fullBlock.header)
     val newBestBlockHeader = typedModifierById[Header](bestFullChainAfter.last).ensuring(_.isDefined)
     processing(ToProcess(fullBlock, newMod, newBestBlockHeader, bestFullChainAfter))
@@ -73,8 +73,9 @@ trait FullBlockProcessor extends HeadersProcessor {
         .flatten
       logStatus(Seq(), toApply, fullBlock, None)
       val additionalIndexes = toApply.map(b => chainStatusKey(b.id) -> FullBlockProcessor.BestChainMarker)
-      updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes)
-      ProgressInfo(None, Seq.empty, headers.headers.dropRight(1) ++ toApply, Seq.empty)
+      updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes).map { _ =>
+        ProgressInfo(None, Seq.empty, headers.headers.dropRight(1) ++ toApply, Seq.empty)
+      }
   }
 
   private def processBetterChain: BlockProcessing = {
@@ -97,19 +98,19 @@ trait FullBlockProcessor extends HeadersProcessor {
       // insert updated chains statuses
       val additionalIndexes = toApply.map(b => chainStatusKey(b.id) -> FullBlockProcessor.BestChainMarker) ++
         toRemove.map(b => chainStatusKey(b.id) -> FullBlockProcessor.NonBestChainMarker)
-      updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes)
+      updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes).map { _ =>
+        // remove block ids which have no chance to be applied
+        val minForkRootHeight = toApply.last.height - nodeSettings.keepVersions
+        if (nonBestChainsCache.nonEmpty) nonBestChainsCache = nonBestChainsCache.dropUntil(minForkRootHeight)
 
-      // remove block ids which have no chance to be applied
-      val minForkRootHeight = toApply.last.height - nodeSettings.keepVersions
-      if (nonBestChainsCache.nonEmpty) nonBestChainsCache = nonBestChainsCache.dropUntil(minForkRootHeight)
-
-      if (nodeSettings.isFullBlocksPruned) {
-        val lastKept = pruningProcessor.updateBestFullBlock(fullBlock.header)
-        val bestHeight: Int = newBestBlockHeader.height
-        val diff = bestHeight - prevBest.header.height
-        pruneBlockDataAt(((lastKept - diff) until lastKept).filter(_ >= 0))
+        if (nodeSettings.isFullBlocksPruned) {
+          val lastKept = pruningProcessor.updateBestFullBlock(fullBlock.header)
+          val bestHeight: Int = newBestBlockHeader.height
+          val diff = bestHeight - prevBest.header.height
+          pruneBlockDataAt(((lastKept - diff) until lastKept).filter(_ >= 0))
+        }
+        ProgressInfo(branchPoint, toRemove, toApply, Seq.empty)
       }
-      ProgressInfo(branchPoint, toRemove, toApply, Seq.empty)
   }
 
   /**
@@ -132,8 +133,9 @@ trait FullBlockProcessor extends HeadersProcessor {
       }
       //Orphaned block or full chain is not initialized yet
       logStatus(Seq(), Seq(), params.fullBlock, None)
-      historyStorage.insert(Seq.empty, Seq(params.newModRow))
-      ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
+      historyStorage.insert(Seq.empty, Seq(params.newModRow)).map { _ =>
+        ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
+      }
   }
 
   /**
@@ -154,12 +156,12 @@ trait FullBlockProcessor extends HeadersProcessor {
       }
     }
 
-    if (bestFullBlockIdOpt.exists(_ == header.parentId)) {
+    if (bestFullBlockIdOpt.contains(header.parentId)) {
       true
     } else {
       // follow links back until main chain or absent section is reached
       val headOpt = loop(header.parentId, header.height - 1, Seq.empty).headOption
-      headOpt.exists(_ == Header.GenesisParentId) ||
+      headOpt.contains(Header.GenesisParentId) ||
         headOpt.orElse(Some(header.parentId))
           .flatMap(id => typedModifierById[Header](id).flatMap(getFullBlock)) // check whether first block actually exists
           .isDefined
@@ -225,7 +227,7 @@ trait FullBlockProcessor extends HeadersProcessor {
       s"going to apply ${toApply.length}$toRemoveStr modifiers. $newStatusStr")
   }
 
-  private def pruneBlockDataAt(heights: Seq[Int]): Try[Unit] = Try {
+  private def pruneBlockDataAt(heights: Seq[Int]): Try[Unit] = {
     val toRemove: Seq[ModifierId] = heights.flatMap(h => headerIdsAtHeight(h))
       .flatMap(id => typedModifierById[Header](id))
       .flatMap(_.sectionIds.map(_._2))
@@ -234,18 +236,22 @@ trait FullBlockProcessor extends HeadersProcessor {
 
   private def updateStorage(newModRow: ErgoPersistentModifier,
                             bestFullHeaderId: ModifierId,
-                            additionalIndexes: Seq[(ByteArrayWrapper, Array[Byte])] = Seq.empty): Unit = {
+                            additionalIndexes: Seq[(ByteArrayWrapper, Array[Byte])] = Seq.empty): Try[Unit] = {
     val indicesToInsert = Seq(BestFullBlockKey -> idToBytes(bestFullHeaderId)) ++ additionalIndexes
-    historyStorage.insert(indicesToInsert, Seq(newModRow))
-      .ensuring(headersHeight >= fullBlockHeight, s"Headers height $headersHeight should be >= " +
-        s"full height $fullBlockHeight")
+    historyStorage.insert(indicesToInsert, Seq(newModRow)).flatMap { _ =>
+      if (headersHeight >= fullBlockHeight)
+        Success(())
+      else
+        Failure(new RuntimeException(s"Headers height $headersHeight should be >= " +
+          s"full height $fullBlockHeight"))
+    }
   }
 
 }
 
 object FullBlockProcessor {
 
-  type BlockProcessing = PartialFunction[ToProcess, ProgressInfo[ErgoPersistentModifier]]
+  type BlockProcessing = PartialFunction[ToProcess, Try[ProgressInfo[ErgoPersistentModifier]]]
 
   case class ToProcess(fullBlock: ErgoFullBlock,
                        newModRow: ErgoPersistentModifier,

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockSectionProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockSectionProcessor.scala
@@ -26,7 +26,7 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     * Otherwise - try to construct full block with this block section, if possible - process this new full block,
     * if not - just put new block section to storage.
     */
-  override protected def process(m: BlockSection): ProgressInfo[ErgoPersistentModifier] = {
+  override protected def process(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]] = {
     m match {
       case _: ADProofs if !requireProofs =>
         // got proofs in UTXO mode. Don't need to try to update better chain
@@ -79,9 +79,10 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     }
   }
 
-  private def justPutToHistory(m: BlockSection): ProgressInfo[ErgoPersistentModifier] = {
-    historyStorage.insert(Seq.empty, Seq(m))
-    ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
+  private def justPutToHistory(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]] = {
+    historyStorage.insert(Seq.empty, Seq(m)).map { _ =>
+      ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
+    }
   }
 
   /**

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -88,20 +88,20 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     * @param h - header to process
     * @return ProgressInfo - info required for State to be consistent with History
     */
-  protected def process(h: Header): ProgressInfo[ErgoPersistentModifier] = synchronized {
+  protected def process(h: Header): Try[ProgressInfo[ErgoPersistentModifier]] = synchronized {
     val dataToInsert: (Seq[(ByteArrayWrapper, Array[Byte])], Seq[ErgoPersistentModifier]) = toInsert(h)
 
-    historyStorage.insert(dataToInsert._1, dataToInsert._2)
-
-    bestHeaderIdOpt match {
-      case Some(bestHeaderId) =>
-        // If we verify transactions, we don't need to send this header to state.
-        // If we don't and this is the best header, we should send this header to state to update state root hash
-        val toProcess = if (nodeSettings.verifyTransactions || !(bestHeaderId == h.id)) Seq.empty else Seq(h)
-        ProgressInfo(None, Seq.empty, toProcess, toDownload(h))
-      case None =>
-        log.error("Should always have best header after header application")
-        ErgoApp.forceStopApplication()
+    historyStorage.insert(dataToInsert._1, dataToInsert._2).map { _ =>
+      bestHeaderIdOpt match {
+        case Some(bestHeaderId) =>
+          // If we verify transactions, we don't need to send this header to state.
+          // If we don't and this is the best header, we should send this header to state to update state root hash
+          val toProcess = if (nodeSettings.verifyTransactions || !(bestHeaderId == h.id)) Seq.empty else Seq(h)
+          ProgressInfo(None, Seq.empty, toProcess, toDownload(h))
+        case None =>
+          log.error("Should always have best header after header application")
+          ErgoApp.forceStopApplication()
+      }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UTXOSnapshotChunkProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UTXOSnapshotChunkProcessor.scala
@@ -16,11 +16,12 @@ trait UTXOSnapshotChunkProcessor extends ScorexLogging with ScorexEncoding {
 
   protected val historyStorage: HistoryStorage
 
-  def process(m: UTXOSnapshotChunk): ProgressInfo[ErgoPersistentModifier] = {
+  def process(m: UTXOSnapshotChunk): Try[ProgressInfo[ErgoPersistentModifier]] = {
     //TODO
     val toInsert = ???
-    historyStorage.insert(Seq.empty, toInsert)
-    ProgressInfo(None, Seq.empty, Seq(m), Seq.empty)
+    historyStorage.insert(Seq.empty, toInsert).map { _ =>
+      ProgressInfo(None, Seq.empty, Seq(m), Seq.empty)
+    }
   }
 
   def validate(m: UTXOSnapshotChunk): Try[Unit] = if (historyStorage.contains(m.id)) {

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/EmptyPoPoWProofsProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/EmptyPoPoWProofsProcessor.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.modifiers.ErgoPersistentModifier
 import org.ergoplatform.modifiers.history.NipopowProofModifier
 import scorex.core.consensus.History.ProgressInfo
 
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
   * Contains all functions required by History to process PoPoWProofs for regime that do not accept them.
@@ -13,6 +13,7 @@ trait EmptyPoPoWProofsProcessor extends PoPoWProofsProcessor {
 
   def validate(m: NipopowProofModifier): Try[Unit] = Failure(new Error("Regime that do not process PoPoWProof"))
 
-  def process(m: NipopowProofModifier): ProgressInfo[ErgoPersistentModifier] = ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
+  def process(m: NipopowProofModifier): Try[ProgressInfo[ErgoPersistentModifier]] =
+    Success(ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty))
 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/FullPoPoWProofsProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/FullPoPoWProofsProcessor.scala
@@ -5,7 +5,7 @@ import org.ergoplatform.modifiers.history.NipopowProofModifier
 import org.ergoplatform.nodeView.history.storage.modifierprocessors.HeadersProcessor
 import scorex.core.consensus.History.ProgressInfo
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 /**
   * Contains all functions required by History to process PoPoWProofs for regime that accept them.
@@ -14,6 +14,7 @@ trait FullPoPoWProofsProcessor extends PoPoWProofsProcessor with HeadersProcesso
 
   def validate(m: NipopowProofModifier): Try[Unit] = throw new Error("PoPow not yet supported")
 
-  def process(m: NipopowProofModifier): ProgressInfo[ErgoPersistentModifier] = ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
+  def process(m: NipopowProofModifier): Try[ProgressInfo[ErgoPersistentModifier]] =
+    Success(ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty))
 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/PoPoWProofsProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/PoPoWProofsProcessor.scala
@@ -15,7 +15,7 @@ trait PoPoWProofsProcessor extends HeadersProcessor with ScorexLogging {
 
   def validate(m: NipopowProofModifier): Try[Unit]
 
-  def process(m: NipopowProofModifier): ProgressInfo[ErgoPersistentModifier]
+  def process(m: NipopowProofModifier): Try[ProgressInfo[ErgoPersistentModifier]]
 
   def lastHeaders(count: Int, offset: Int = 0): HeaderChain
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -170,7 +170,7 @@ class ErgoWalletActor(settings: ErgoSettings,
 
     case ChangedState(s: ErgoStateReader@unchecked) =>
       val stateContext = s.stateContext
-      state.storage.updateStateContext(stateContext)
+      state.storage.updateStateContext(stateContext) // TODO unhandled https://github.com/ergoplatform/ergo/issues/1398
       val cp = stateContext.currentParameters
       val newState = ergoWalletService.updateUtxoState(state.copy(stateReaderOpt = Some(s), parameters = cp))
       context.become(loadedWallet(newState))
@@ -326,7 +326,7 @@ class ErgoWalletActor(settings: ErgoSettings,
       }
 
     case UpdateChangeAddress(address) =>
-      state.storage.updateChangeAddress(address)
+      state.storage.updateChangeAddress(address) // TODO unhandled https://github.com/ergoplatform/ergo/issues/1398
 
     case RemoveScan(scanId) =>
       ergoWalletService.removeScan(state, scanId) match {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -543,8 +543,7 @@ class ErgoWalletServiceImpl extends ErgoWalletService with ErgoWalletSupport {
       case None =>
         Failure(new Exception(s"Scan #$scanId not found"))
       case Some(_) =>
-        Try {
-          state.storage.removeScan(scanId)
+        state.storage.removeScan(scanId).map { _ =>
           state.copy(walletVars = state.walletVars.removeScan(scanId))
         }
     }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -37,11 +37,10 @@ trait ErgoWalletSupport extends ScorexLogging {
 
   protected def addSecretToStorage(state: ErgoWalletState, secret: ExtendedSecretKey): Try[ErgoWalletState] =
     state.walletVars.withExtendedKey(secret).flatMap { newWalletVars =>
-      Try {
-        state.storage.addKey(secret.publicKey)
-        val newPk = secret.publicKey
-        val updCache = newWalletVars.stateCacheOpt.get.withNewPubkey(newPk).get
-        state.copy(walletVars = newWalletVars.copy(stateCacheProvided = Some(updCache))(newWalletVars.settings))
+      state.storage.addKey(secret.publicKey).flatMap { _ =>
+        newWalletVars.stateCacheOpt.get.withNewPubkey(secret.publicKey).map { updCache =>
+          state.copy(walletVars = newWalletVars.copy(stateCacheProvided = Some(updCache))(newWalletVars.settings))
+        }
       }
     }
 
@@ -76,7 +75,7 @@ trait ErgoWalletSupport extends ScorexLogging {
     state.copy(walletVars = state.walletVars.withProver(prover))
   }
 
-  private def convertLegacyClientPaths(storage: WalletStorage, masterKey: ExtendedSecretKey): Unit = {
+  private def convertLegacyClientPaths(storage: WalletStorage, masterKey: ExtendedSecretKey): Try[Unit] = Try {
     // first, we're trying to find in the database paths written by clients prior 3.3.0 and convert them into a new format (pubkeys with paths stored instead of paths)
     val oldPaths = storage.readPaths()
     if (oldPaths.nonEmpty) {
@@ -84,39 +83,43 @@ trait ErgoWalletSupport extends ScorexLogging {
         path => masterKey.derive(path)
       }
       val oldPubKeys = oldDerivedSecrets.map(_.publicKey)
-      oldPubKeys.foreach(storage.addKey)
-      storage.removePaths()
+      oldPubKeys.foreach(storage.addKey(_).get)
+      storage.removePaths().get
     }
   }
 
   protected def processUnlock(state: ErgoWalletState, masterKey: ExtendedSecretKey, usePreEip3Derivation: Boolean)(implicit addrEncoder: ErgoAddressEncoder): Try[ErgoWalletState] = {
     log.info("Starting wallet unlock")
-    convertLegacyClientPaths(state.storage, masterKey)
-    // Now we read previously stored, or just stored during the conversion procedure above, public keys
-    // If no public keys in the database yet, add master's public key into it
-    val pubKeys = state.storage.readAllKeys().toIndexedSeq
-    if (pubKeys.isEmpty) {
-      if (usePreEip3Derivation) {
-        // If usePreEip3Derivation flag is set in the wallet settings, the first key is the master key
-        val masterPubKey = masterKey.publicKey
-        state.storage.addKey(masterPubKey)
-        log.info("Wallet unlock finished using usePreEip3Derivation")
-        Try(updatePublicKeys(state, masterKey, Vector(masterPubKey)))
-      } else {
-        // If no usePreEip3Derivation flag is set, add first derived key (for m/44'/429'/0'/0/0) to the db
-        deriveNextKeyForMasterKey(state, masterKey, usePreEip3Derivation).flatMap { case (derivationResult, newState) =>
-          derivationResult.result.map { case (_, _, firstSk) =>
-            val firstPk = firstSk.publicKey
-            newState.storage.addKey(firstPk)
-            newState.storage.updateChangeAddress(P2PKAddress(firstPk.key))
-            log.info("Wallet unlock finished")
-            updatePublicKeys(newState, masterKey, Vector(firstPk))
+    convertLegacyClientPaths(state.storage, masterKey).flatMap { _ =>
+      // Now we read previously stored, or just stored during the conversion procedure above, public keys
+      // If no public keys in the database yet, add master's public key into it
+      val pubKeys = state.storage.readAllKeys().toIndexedSeq
+      if (pubKeys.isEmpty) {
+        if (usePreEip3Derivation) {
+          // If usePreEip3Derivation flag is set in the wallet settings, the first key is the master key
+          val masterPubKey = masterKey.publicKey
+          state.storage.addKey(masterPubKey).map { _ =>
+            log.info("Wallet unlock finished using usePreEip3Derivation")
+            updatePublicKeys(state, masterKey, Vector(masterPubKey))
+          }
+        } else {
+          // If no usePreEip3Derivation flag is set, add first derived key (for m/44'/429'/0'/0/0) to the db
+          deriveNextKeyForMasterKey(state, masterKey, usePreEip3Derivation).flatMap { case (derivationResult, newState) =>
+            derivationResult.result.flatMap { case (_, _, firstSk) =>
+              val firstPk = firstSk.publicKey
+              newState.storage.addKey(firstPk).flatMap { _ =>
+                newState.storage.updateChangeAddress(P2PKAddress(firstPk.key)).map { _ =>
+                  log.info("Wallet unlock finished")
+                  updatePublicKeys(newState, masterKey, Vector(firstPk))
+                }
+              }
+            }
           }
         }
+      } else {
+        log.info("Wallet unlock finished using existing keys in storage")
+        Try(updatePublicKeys(state, masterKey, pubKeys))
       }
-    } else {
-      log.info("Wallet unlock finished using existing keys in storage")
-      Try(updatePublicKeys(state, masterKey, pubKeys))
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
@@ -46,13 +46,13 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings)
   /**
     * Remove pre-3.3.0 derivation paths
     */
-  def removePaths(): Unit = store.remove(Seq(SecretPathsKey))
+  def removePaths(): Try[Unit] = store.remove(Seq(SecretPathsKey))
 
   /**
     * Store wallet-related public key in the database
     * @param publicKey - public key to store
     */
-  def addKey(publicKey: ExtendedPublicKey): Unit = {
+  def addKey(publicKey: ExtendedPublicKey): Try[Unit] = {
     store.insert(Seq(pubKeyPrefixKey(publicKey) -> ExtendedPublicKeySerializer.toBytes(publicKey)))
   }
 
@@ -68,7 +68,7 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings)
     * Write state context into the database
     * @param ctx - state context
     */
-  def updateStateContext(ctx: ErgoStateContext): Unit = store
+  def updateStateContext(ctx: ErgoStateContext): Try[Unit] = store
     .insert(Seq(StateContextKey -> ctx.bytes))
 
   /**
@@ -84,7 +84,7 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings)
     * Update address used by the wallet for change outputs
     * @param address - new changed address
     */
-  def updateChangeAddress(address: P2PKAddress): Unit = {
+  def updateChangeAddress(address: P2PKAddress): Try[Unit] = {
     val bytes = addressEncoder.toString(address).getBytes(Constants.StringEncoding)
     store.insert(Seq(ChangeAddressKey -> bytes))
   }
@@ -109,10 +109,10 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings)
   def addScan(scanReq: ScanRequest): Try[Scan] = {
     val id = ScanId @@ (lastUsedScanId + 1).toShort
     scanReq.toScan(id).flatMap { app =>
-      Try(store.insert(Seq(
+      store.insert(Seq(
         scanPrefixKey(id) -> ScanSerializer.toBytes(app),
         lastUsedScanIdKey -> Shorts.toByteArray(id)
-      ))).map(_ => app)
+      )).map(_ => app)
     }
   }
 
@@ -120,7 +120,7 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings)
     * Remove an scan from the database
     * @param id scan identifier
     */
-  def removeScan(id: Short): Unit =
+  def removeScan(id: Short): Try[Unit] =
     store.remove(Seq(scanPrefixKey(id)))
 
   /**

--- a/src/test/scala/org/ergoplatform/db/KvStoreReaderSpec.scala
+++ b/src/test/scala/org/ergoplatform/db/KvStoreReaderSpec.scala
@@ -11,10 +11,10 @@ class KvStoreReaderSpec extends AnyPropSpec with Matchers with DBSpec {
       val keyEnd = byteString("Z")
       store.getRange(keyStart, keyEnd).length shouldBe 0
 
-      store.insert(Seq(keyStart -> keyStart))
+      store.insert(Seq(keyStart -> keyStart)).get
       store.getRange(keyStart, keyEnd).length shouldBe 1
 
-      store.insert(Seq(keyEnd -> keyEnd))
+      store.insert(Seq(keyEnd -> keyEnd)).get
       store.getRange(keyStart, keyEnd).length shouldBe 2
 
       // keys before the range
@@ -27,7 +27,7 @@ class KvStoreReaderSpec extends AnyPropSpec with Matchers with DBSpec {
       store.getRange(byteString("<"), byteString("?")).length shouldBe 0
 
       //removing keys
-      store.remove(Seq(keyStart, keyEnd))
+      store.remove(Seq(keyStart, keyEnd)).get
       store.getRange(keyStart, keyEnd).length shouldBe 0
     }
   }

--- a/src/test/scala/org/ergoplatform/db/LDBKVStoreSpec.scala
+++ b/src/test/scala/org/ergoplatform/db/LDBKVStoreSpec.scala
@@ -10,14 +10,14 @@ class LDBKVStoreSpec extends AnyPropSpec with Matchers with DBSpec {
       val valueA = (byteString("A"), byteString("1"))
       val valueB = (byteString("B"), byteString("2"))
 
-      store.update(toInsert = Seq(valueA, valueB), toRemove = Seq.empty)
+      store.update(toInsert = Seq(valueA, valueB), toRemove = Seq.empty).get
 
       store.get(valueA._1).toBs shouldBe Some(valueA._2).toBs
       store.get(valueB._1).toBs shouldBe Some(valueB._2).toBs
 
       store.getAll.toSeq.toBs shouldBe Seq(valueA, valueB).toBs
 
-      store.update(toInsert = Seq.empty, toRemove = Seq(valueA._1))
+      store.update(toInsert = Seq.empty, toRemove = Seq(valueA._1)).get
       store.get(valueA._1) shouldBe None
     }
   }
@@ -28,11 +28,11 @@ class LDBKVStoreSpec extends AnyPropSpec with Matchers with DBSpec {
       val valA = byteString("1")
       val valB = byteString("2")
 
-      store.insert(Seq(key -> valA))
+      store.insert(Seq(key -> valA)).get
 
       store.get(key).toBs shouldBe Some(valA).toBs
 
-      store.insert(Seq(key -> valB))
+      store.insert(Seq(key -> valB)).get
 
       store.get(key).toBs shouldBe Some(valB).toBs
 
@@ -49,7 +49,7 @@ class LDBKVStoreSpec extends AnyPropSpec with Matchers with DBSpec {
       val valueE = (byteString("E"), byteString("3"))
       val valueF = (byteString("F"), byteString("4"))
 
-      store.insert(Seq(valueA, valueB, valueC, valueD, valueE, valueF))
+      store.insert(Seq(valueA, valueB, valueC, valueD, valueE, valueF)).get
 
       store.lastKeyInRange(valueA._1, valueC._1).get.toSeq shouldBe valueC._1.toSeq
       store.lastKeyInRange(valueD._1, valueF._1).get.toSeq shouldBe valueF._1.toSeq

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
@@ -78,10 +78,10 @@ class BlockSectionValidationSpecification extends HistoryTestHelpers {
 
     // should not be able to apply if corresponding header is marked as invalid
     history.applicableTry(section) shouldBe 'success
-    history.historyStorage.insert(Seq(history.validityKey(header.id) -> Array(0.toByte)), Seq.empty)
+    history.historyStorage.insert(Seq(history.validityKey(header.id) -> Array(0.toByte)), Seq.empty).get
     history.isSemanticallyValid(header.id) shouldBe ModifierSemanticValidity.Invalid
     history.applicableTry(section) shouldBe 'failure
-    history.historyStorage.insert(Seq(history.validityKey(header.id) -> Array(1.toByte)), Seq.empty)
+    history.historyStorage.insert(Seq(history.validityKey(header.id) -> Array(1.toByte)), Seq.empty).get
 
     // should not be able to apply if already in history
     history.applicableTry(section) shouldBe 'success

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -324,7 +324,7 @@ class VerifyADHistorySpecification extends HistoryTestHelpers with NoShrink {
     val invalidChain = chain.takeRight(2)
 
     val progressInfo = ProgressInfo[PM](Some(invalidChain.head.parentId), invalidChain, Seq.empty, Seq.empty)
-    val report = history.reportModifierIsInvalid(invalidChain.head.header, progressInfo)
+    val report = history.reportModifierIsInvalid(invalidChain.head.header, progressInfo).get
     history = report._1
     val processInfo = report._2
     processInfo.toApply.isEmpty shouldBe true
@@ -347,7 +347,7 @@ class VerifyADHistorySpecification extends HistoryTestHelpers with NoShrink {
       history.contains(parentHeader.ADProofsId) shouldBe true
 
       val progressInfo = ProgressInfo[PM](Some(parentHeader.id), Seq(fullBlock), Seq.empty, Seq.empty)
-      val (repHistory, _) = history.reportModifierIsInvalid(fullBlock.blockTransactions, progressInfo)
+      val (repHistory, _) = history.reportModifierIsInvalid(fullBlock.blockTransactions, progressInfo).get
       repHistory.bestFullBlockOpt.value.header shouldBe history.bestHeaderOpt.value
       repHistory.bestHeaderOpt.value shouldBe parentHeader
     }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistryBenchmark.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistryBenchmark.scala
@@ -40,7 +40,7 @@ object WalletRegistryBenchmark extends App with ErgoTestConstants {
 
   val derivedSecrets = (1 to 15000).map { i =>
     val k = rootSecret.derive(DerivationPath.fromEncoded(s"m/44'/429'/0'/0/$i").get)
-    storage.addKey(k.publicKey)
+    storage.addKey(k.publicKey).get
     k
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
@@ -33,7 +33,7 @@ class WalletStorageSpec
           val bytes = DerivationPathSerializer.toBytes(path)
           acc ++ Ints.toByteArray(bytes.length) ++ bytes
         }
-      store.insert(Seq(SecretPathsKey -> toInsert))
+      store.insert(Seq(SecretPathsKey -> toInsert)).get
     }
 
     forAll(Gen.nonEmptyListOf(derivationPathGen)) { paths =>
@@ -49,7 +49,7 @@ class WalletStorageSpec
     forAll(extendedPubKeyListGen) { pubKeys =>
       withStore { store =>
         val storage = new WalletStorage(store, settings)
-        pubKeys.foreach(storage.addKey)
+        pubKeys.foreach(storage.addKey(_).get)
         val keysRead = storage.readAllKeys()
         keysRead.length shouldBe pubKeys.length
         keysRead should contain theSameElementsAs pubKeys.toSet
@@ -67,7 +67,7 @@ class WalletStorageSpec
           ScanRequest(app.scanName, app.trackingRule, Some(ScanWalletInteraction.Off))
         }
         storageRequests.foreach(r => externalScanReqs.contains(r) shouldBe true)
-        storageApps.map(_.scanId).foreach(storage.removeScan)
+        storageApps.map(_.scanId).foreach(storage.removeScan(_).get)
         storage.allScans.length shouldBe 0
       }
     }
@@ -81,7 +81,7 @@ class WalletStorageSpec
 
         storage.lastUsedScanId shouldBe scan.scanId
 
-        storage.removeScan(scan.scanId)
+        storage.removeScan(scan.scanId).get
         storage.lastUsedScanId shouldBe scan.scanId
 
         val scan2 = storage.addScan(externalScanReq).get


### PR DESCRIPTION
See https://github.com/hyperledger-labs/Scorex/pull/397

The error propagation is done by `Try` so there might be some `map` / `flatMap` overhead, I could probably reduce it by throwing and wrapping into `Try` at higher level to spare couple of instantiations per update.