### PR TITLE
Add networkType to /info call

### DIFF
--- a/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
+++ b/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
@@ -49,6 +49,7 @@ class ErgoStatsCollector(readersHolder: ActorRef,
   private var nodeInfo = NodeInfo(
     settings.scorexSettings.network.nodeName,
     Version.VersionString,
+    settings.networkType.verboseName,
     0,
     0,
     None,
@@ -142,6 +143,7 @@ object ErgoStatsCollector {
 
   case class NodeInfo(nodeName: String,
                       appVersion: String,
+                      network: String,
                       unconfirmedCount: Int,
                       peersCount: Int,
                       stateRoot: Option[String],
@@ -164,6 +166,7 @@ object ErgoStatsCollector {
       Map(
         "name" -> ni.nodeName.asJson,
         "appVersion" -> Version.VersionString.asJson,
+        "network" -> ni.network.asJson,
         "headersHeight" -> ni.bestHeaderOpt.map(_.height).asJson,
         "fullHeight" -> ni.bestFullBlockOpt.map(_.header.height).asJson,
         "bestHeaderId" -> ni.bestHeaderOpt.map(_.encodedId).asJson,


### PR DESCRIPTION
Regarding https://github.com/ergoplatform/ergo/issues/1410

I want to add a `networkType` lookup on the [ergo-node-interface](https://github.com/ergoplatform/ergo-node-interface/issues) project so that panel hyperlinks point to the correct explorer.  I didn't see any existing way to check the node's `networkType` via API, so I figured a good place to add it is in `GET /info`.

This change would be used in a subsequent PR in the [ergo-node-interface](https://github.com/ergoplatform/ergo-node-interface/issues) repository.