### PR TITLE
GitHub Action to build & publish Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker Metadata action
+        uses: docker/metadata-action@v3.5.0
+        id: meta
+        with:
+          images: ergoplatform/ergo
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
For https://github.com/ergoplatform/ergo/issues/1466

A couple notes:

- I am pointing to this repository: https://hub.docker.com/r/ergoplatform/ergo
- We have to configure DOCKER_USERNAME and DOCKER_PASSWORD secrets in the repo using the docker hub credentials
- I am triggering on release-published events only
