### PR TITLE
sbt-dynver requires .git folder - removing from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git/
 **/.gitignore
 **/.gitkeep
 **/.dockerignore


### PR DESCRIPTION
@Luivatra on Discord reported that the node panel was showing an incorrect version in the docker build.
![image](https://user-images.githubusercontent.com/12741277/138200401-e940ee73-1d42-48c3-aa39-d8853fec620c.png)

I narrowed it down to [this](https://github.com/ergoplatform/ergo/pull/1431/commits/d81eb51c7b5560b75946b88a97e2db88f186141b) change where we started using the `sbt-dynver` plugin to set the project version.

This plugin uses git tags to construct the version, and since the `.git` folder was excluded by the `.dockerignore` file, it was reverting to the [fallback](https://github.com/dwijnand/sbt-dynver/blob/624276301fdab6807242854d824dc3399ac6407b/dynver/src/main/scala/sbtdynver/DynVer.scala#L135) version.

After this change, the version should match the non-docker node, as below.
![image](https://user-images.githubusercontent.com/12741277/138199899-cbfc424d-e463-4c07-af2d-c62ac89d5e4a.png)

I'm not aware of any specific issues with including the `.git` folder other than perhaps increasing the build time/docker context size?