### PR TITLE
publish ergo-wallet snapshot only in internal PRs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} ergoWallet/test
 
       - name: Publish a wallet snapshot ${{ github.ref }}
+        if: env.HAS_SECRETS == 'true'
         run: sbt ++${{ matrix.scala }} ergoWallet/publish
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
Since repo secrets are not set in GA running for external(forked repo) PRs don't publish snapshot version in those PRs.  