### PR TITLE
Change address fix

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -267,8 +267,10 @@ class ErgoWalletActor(settings: ErgoSettings,
       }
 
     case UnlockWallet(encPass) =>
+      log.info("Unlocking wallet")
       ergoWalletService.unlockWallet(state, encPass, settings.walletSettings.usePreEip3Derivation) match {
         case Success(newState) =>
+          log.info("Wallet successfully unlocked")
           context.become(loadedWallet(newState))
           sender() ! Success(())
         case f@Failure(t) =>
@@ -301,7 +303,10 @@ class ErgoWalletActor(settings: ErgoSettings,
     case GetWalletStatus =>
       val isSecretSet = state.secretIsSet(settings.walletSettings.testMnemonic)
       val isUnlocked = state.walletVars.proverOpt.isDefined
-      val status = WalletStatus(isSecretSet, isUnlocked, state.getChangeAddress, state.getWalletHeight, state.error)
+      val changeAddress = state.getChangeAddress
+      val height = state.getWalletHeight
+      val lastError = state.error
+      val status = WalletStatus(isSecretSet, isUnlocked, changeAddress, height, lastError)
       sender() ! status
 
     case GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -391,11 +391,16 @@ class ErgoWalletActor(settings: ErgoSettings,
       sender() ! ScanRelatedTxsResponse(ergoWalletService.getScanTransactions(scanId, state.registry, state.fullHeight))
 
     case GetFilteredScanTxs(scanIds, minHeight, maxHeight, minConfNum, maxConfNum)  =>
-      getFiltered(state, scanIds, minHeight, maxHeight, minConfNum, maxConfNum)
+      readFiltered(state, scanIds, minHeight, maxHeight, minConfNum, maxConfNum)
 
   }
 
-  def getFiltered(state: ErgoWalletState, scanIds: List[ScanId], minHeight: Int, maxHeight: Int, minConfNum: Int, maxConfNum: Int): Unit = {
+  def readFiltered(state: ErgoWalletState,
+                   scanIds: List[ScanId],
+                   minHeight: Int,
+                   maxHeight: Int,
+                   minConfNum: Int,
+                   maxConfNum: Int): Unit = {
     val heightFrom = if (maxConfNum == Int.MaxValue) {
       minHeight
     } else {
@@ -406,13 +411,13 @@ class ErgoWalletActor(settings: ErgoSettings,
     } else {
       Math.min(maxHeight,  - minConfNum)
     }
-    log.info("Starting to read wallet transactions")
+    log.debug("Starting to read wallet transactions")
     val ts0 = System.currentTimeMillis()
     val txs = scanIds.flatMap(scan => state.registry.walletTxsBetween(scan, heightFrom, heightTo))
       .sortBy(-_.inclusionHeight)
       .map(tx => AugWalletTransaction(tx, state.fullHeight - tx.inclusionHeight))
     val ts = System.currentTimeMillis()
-    log.info(s"Wallet: ${txs.size} read in ${ts-ts0} ms")
+    log.debug(s"Wallet: ${txs.size} read in ${ts-ts0} ms")
     sender() ! txs
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -330,14 +330,16 @@ class ErgoWalletServiceImpl extends ErgoWalletService with ErgoWalletSupport {
     state.copy(walletVars = state.walletVars.resetProver())
   }
 
-  def recreateRegistry(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] =
+  def recreateRegistry(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] = {
+    val registryFolder = WalletRegistry.registryFolder(settings)
+    log.info(s"Removing the registry folder $registryFolder")
+    state.registry.close()
+    FileUtils.deleteRecursive(registryFolder)
+
     WalletRegistry.apply(settings).map { reg =>
-      val registryFolder = WalletRegistry.registryFolder(settings)
-      log.info(s"Removing the registry folder $registryFolder")
-      state.registry.close()
-      FileUtils.deleteRecursive(registryFolder)
       state.copy(registry = reg)
     }
+  }
 
   def recreateStorage(state: ErgoWalletState, settings: ErgoSettings)(implicit addrEncoder: ErgoAddressEncoder): Try[ErgoWalletState] =
     Try {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -228,7 +228,10 @@ trait ErgoWalletService {
 
 class ErgoWalletServiceImpl extends ErgoWalletService with ErgoWalletSupport {
 
-  def readWallet(state: ErgoWalletState, testMnemonic: Option[String], testKeysQty: Option[Int], secretStorageSettings: SecretStorageSettings): ErgoWalletState = {
+  def readWallet(state: ErgoWalletState,
+                 testMnemonic: Option[String],
+                 testKeysQty: Option[Int],
+                 secretStorageSettings: SecretStorageSettings): ErgoWalletState = {
     testMnemonic match {
       case Some(mnemonic) =>
         log.warn("Avoiding wallet reading in test mode by building prover from mnemonic. Switch to secure mode for production usage.")
@@ -257,7 +260,7 @@ class ErgoWalletServiceImpl extends ErgoWalletService with ErgoWalletSupport {
     val walletSettings = settings.walletSettings
     //Read high-quality random bits from Java's SecureRandom
     val entropy = scorex.utils.Random.randomBytes(walletSettings.seedStrengthBits / 8)
-    log.warn("Initializing wallet")
+    log.info("Initializing wallet")
 
     def initStorage(mnemonic: String): Try[JsonSecretStorage] =
       Try(JsonSecretStorage.init(Mnemonic.toSeed(mnemonic, mnemonicPassOpt), walletPass)(walletSettings.secretStorage))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -22,7 +22,7 @@ case class ErgoWalletState(
     offChainRegistry: OffChainRegistry,
     outputsFilter: Option[BloomFilter[Array[Byte]]], // Bloom filter for boxes not being spent to the moment
     walletVars: WalletVars,
-    stateReaderOpt: Option[ErgoStateReader], //todo: temporary 3.2.x collection and readers
+    stateReaderOpt: Option[ErgoStateReader],
     mempoolReaderOpt: Option[ErgoMemPoolReader],
     utxoStateReaderOpt: Option[UtxoStateReader],
     parameters: Parameters,
@@ -79,12 +79,13 @@ case class ErgoWalletState(
     */
   def fullHeight: Int = stateContext.currentHeight
 
-  def getChangeAddress(implicit addrEncoder: ErgoAddressEncoder): Option[P2PKAddress] = walletVars.proverOpt.map { prover =>
-    storage.readChangeAddress
-      .getOrElse {
+  def getChangeAddress(implicit addrEncoder: ErgoAddressEncoder): Option[P2PKAddress] = {
+    walletVars.proverOpt.map { prover =>
+      storage.readChangeAddress.getOrElse {
         log.debug("Change address not specified. Using root address from wallet.")
         P2PKAddress(prover.hdPubKeys.head.key)
       }
+    }
   }
 
   // Read a box from UTXO set if the node has it, otherwise, from the wallet

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -112,7 +112,10 @@ trait ErgoWalletSupport extends ScorexLogging {
           }
         } else {
           // If no usePreEip3Derivation flag is set, add first derived key (for m/44'/429'/0'/0/0) to the db
-          deriveNextKeyForMasterKey(state, masterKey, usePreEip3Derivation).flatMap { case (derivationResult, newState) =>
+          val prover = ErgoProvingInterpreter(IndexedSeq(masterKey), state.parameters)
+          val sp = state.copy(walletVars = state.walletVars.withProver(prover))
+
+          deriveNextKeyForMasterKey(sp, masterKey, usePreEip3Derivation).flatMap { case (derivationResult, newState) =>
             derivationResult.result.flatMap { case (_, _, firstSk) =>
               val firstPk = firstSk.publicKey
               newState.storage.addKey(firstPk).flatMap { _ =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -112,6 +112,9 @@ trait ErgoWalletSupport extends ScorexLogging {
           }
         } else {
           // If no usePreEip3Derivation flag is set, add first derived key (for m/44'/429'/0'/0/0) to the db
+
+          // We set prover to avoid None.get exception in addSecretToStorage
+          // the prover (with derived key added) will be recreated later in updatePublicKeys()
           val prover = ErgoProvingInterpreter(IndexedSeq(masterKey), state.parameters)
           val sp = state.copy(walletVars = state.walletVars.withProver(prover))
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -45,7 +45,9 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
 
   // call nextPath and derive next key from it
-  protected def deriveNextKeyForMasterKey(state: ErgoWalletState, masterKey: ExtendedSecretKey, usePreEip3Derivation: Boolean)
+  protected def deriveNextKeyForMasterKey(state: ErgoWalletState,
+                                          masterKey: ExtendedSecretKey,
+                                          usePreEip3Derivation: Boolean)
                                        (implicit addrEncoder: ErgoAddressEncoder): Try[(DeriveNextKeyResult, ErgoWalletState)] = {
     val secrets = state.walletVars.proverOpt.toIndexedSeq.flatMap(_.hdKeys)
     val derivationResult = DerivationPath.nextPath(secrets, usePreEip3Derivation).map { path =>
@@ -57,7 +59,9 @@ trait ErgoWalletSupport extends ScorexLogging {
       .map( newState => DeriveNextKeyResult(derivationResult) -> newState )
   }
 
-  protected def updatePublicKeys(state: ErgoWalletState, masterKey: ExtendedSecretKey, pks: IndexedSeq[ExtendedPublicKey]): ErgoWalletState = {
+  protected def updatePublicKeys(state: ErgoWalletState,
+                                 masterKey: ExtendedSecretKey,
+                                 pks: IndexedSeq[ExtendedPublicKey]): ErgoWalletState = {
     // Secrets corresponding to public keys
     val sks =
       pks.map { pk =>
@@ -76,7 +80,8 @@ trait ErgoWalletSupport extends ScorexLogging {
   }
 
   private def convertLegacyClientPaths(storage: WalletStorage, masterKey: ExtendedSecretKey): Try[Unit] = Try {
-    // first, we're trying to find in the database paths written by clients prior 3.3.0 and convert them into a new format (pubkeys with paths stored instead of paths)
+    // first, we're trying to find in the database paths written by clients prior 3.3.0 and convert them into
+    // a new format (pubkeys with paths stored instead of paths)
     val oldPaths = storage.readPaths()
     if (oldPaths.nonEmpty) {
       val oldDerivedSecrets = masterKey +: oldPaths.map {
@@ -88,7 +93,10 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
   }
 
-  protected def processUnlock(state: ErgoWalletState, masterKey: ExtendedSecretKey, usePreEip3Derivation: Boolean)(implicit addrEncoder: ErgoAddressEncoder): Try[ErgoWalletState] = {
+  protected def processUnlock(state: ErgoWalletState,
+                              masterKey: ExtendedSecretKey,
+                              usePreEip3Derivation: Boolean)
+                             (implicit addrEncoder: ErgoAddressEncoder): Try[ErgoWalletState] = {
     log.info("Starting wallet unlock")
     convertLegacyClientPaths(state.storage, masterKey).flatMap { _ =>
       // Now we read previously stored, or just stored during the conversion procedure above, public keys
@@ -131,12 +139,11 @@ trait ErgoWalletSupport extends ScorexLogging {
     * @param requests - an input sequence of requests
     * @return sequence of transaction outputs or failure if inputs are incorrect
     */
-  protected def requestsToBoxCandidates(
-                                         requests: Seq[TransactionGenerationRequest],
-                                         assetId: BoxId,
-                                         fullHeight: Int,
-                                         parameters: Parameters,
-                                         publicKeyAddresses: Seq[P2PKAddress]): Try[Seq[ErgoBoxCandidate]] =
+  protected def requestsToBoxCandidates(requests: Seq[TransactionGenerationRequest],
+                                        assetId: BoxId,
+                                        fullHeight: Int,
+                                        parameters: Parameters,
+                                        publicKeyAddresses: Seq[P2PKAddress]): Try[Seq[ErgoBoxCandidate]] = {
     Traverse[List].sequence {
       requests.toList
         .map {
@@ -177,6 +184,7 @@ trait ErgoWalletSupport extends ScorexLogging {
             Failure(new Exception(s"Unknown TransactionRequest type: $other"))
         }
     }
+  }
 
   protected def prepareUnsignedTransaction(payTo: Seq[ErgoBoxCandidate],
                                            walletHeight: Int,
@@ -211,13 +219,12 @@ trait ErgoWalletSupport extends ScorexLogging {
     *                      (to spend the spendable inputs).
     * @return generated transaction along with its inputs and data-inputs, or an error
     */
-  protected def generateUnsignedTransaction(
-                                           state: ErgoWalletState,
-                                           boxSelector: BoxSelector,
-                                           requests: Seq[TransactionGenerationRequest],
-                                           inputsRaw: Seq[String],
-                                           dataInputsRaw: Seq[String]
-                                         )(implicit addrEncoder: ErgoAddressEncoder): Try[(UnsignedErgoTransaction, IndexedSeq[ErgoBox], IndexedSeq[ErgoBox])] = Try {
+  protected def generateUnsignedTransaction(state: ErgoWalletState,
+                                            boxSelector: BoxSelector,
+                                            requests: Seq[TransactionGenerationRequest],
+                                            inputsRaw: Seq[String],
+                                            dataInputsRaw: Seq[String])
+                                           (implicit addrEncoder: ErgoAddressEncoder): Try[(UnsignedErgoTransaction, IndexedSeq[ErgoBox], IndexedSeq[ErgoBox])] = Try {
     require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issuance requests")
 
     val userInputs = ErgoWalletService.stringsToBoxes(inputsRaw)


### PR DESCRIPTION
This PR contains two bugfixes: 

* For wallet which is just initialized (or restored) absence of prover caused None.get error in processUnlock() , which in turn prevented from setting change address (which caused a lot of confusion among users)
* After wallet initialization (restoring) there was a bug unlock due to improper wallet registry database recreation  

The node tries to fix change address for previously created wallets during unlock, if there's one address in the wallet and it corresponds to default derivation path m/44'/429'/0'/0/0 