### PR TITLE
Fix misspelling in openapi.yaml

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2799,7 +2799,7 @@ paths:
 
   /peers/status:
     get:
-      summary: Get last incomming message timestamp and current network time
+      summary: Get last incoming message timestamp and current network time
       operationId: getPeersStatus
       tags:
         - peers


### PR DESCRIPTION
Fixes a minor misspelling in the openapi.yaml.  "Incomming" was used instead of "incoming".