### PR TITLE
limit headerChainBack

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -229,7 +229,7 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
       }
     }
 
-    if (bestHeaderIdOpt.isEmpty || (limit == 0)) {
+    if (bestHeaderIdOpt.isEmpty || (limit == 0) || (limit > startHeader.height)) {
       HeaderChain(ArrayBuffer.empty)
     } else {
       HeaderChain(loop(startHeader, ArrayBuffer.empty += startHeader).reverse)


### PR DESCRIPTION
Stop API/node crash caused by requesting /blocks/lastHeaders/ with count > height