### PR TITLE
add token access cost on signing tx

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,9 +275,8 @@ lazy val ergoWallet = (project in file("ergo-wallet"))
         Seq.empty
       else
         Seq("-release", "8") 
-      ) 
-  
-  )
+      )
+  ).dependsOn(avldb)
 
 lazy val It2Test = config("it2") extend (IntegrationTest, Test)
 configs(It2Test)

--- a/build.sbt
+++ b/build.sbt
@@ -271,13 +271,12 @@ lazy val ergoWallet = (project in file("ergo-wallet"))
       effectiveSigma,
       (effectiveSigma % Test).classifier("tests")
     ),
-    resolvers ++= Seq("Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"),
     scalacOptions in(Compile, compile) ++= (if(scalaBinaryVersion.value == "2.11")
         Seq.empty
       else
         Seq("-release", "8")
       ),
-  ).dependsOn(avldb)
+  )
 
 lazy val It2Test = config("it2") extend (IntegrationTest, Test)
 configs(It2Test)

--- a/build.sbt
+++ b/build.sbt
@@ -271,11 +271,12 @@ lazy val ergoWallet = (project in file("ergo-wallet"))
       effectiveSigma,
       (effectiveSigma % Test).classifier("tests")
     ),
+    resolvers ++= Seq("Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"),
     scalacOptions in(Compile, compile) ++= (if(scalaBinaryVersion.value == "2.11")
         Seq.empty
       else
-        Seq("-release", "8") 
-      )
+        Seq("-release", "8")
+      ),
   ).dependsOn(avldb)
 
 lazy val It2Test = config("it2") extend (IntegrationTest, Test)

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ErgoBoxAssetExtractor.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ErgoBoxAssetExtractor.scala
@@ -1,0 +1,88 @@
+package org.ergoplatform.wallet.boxes
+
+import org.ergoplatform.ErgoBoxCandidate
+import scorex.db.ByteArrayWrapper
+import sigmastate.eval.Extensions._
+import scala.collection.mutable
+import scala.util.Try
+
+object ErgoBoxAssetExtractor {
+  val MaxAssetsPerBox = 255
+
+  /**
+    * Extracts a mapping (assets -> total amount) from a set of boxes passed as a parameter.
+    * That is, the method is checking amounts of assets in the boxes(i.e. that a box contains positive
+    * amount for an asset) and then summarize and group their corresponding amounts.
+    *
+    * @param boxes - boxes to check and extract assets from
+    * @return a mapping from asset id to to balance and total assets number
+    */
+  def extractAssets(
+    boxes: IndexedSeq[ErgoBoxCandidate]
+  ): Try[(Map[ByteArrayWrapper, Long], Int)] = Try {
+    val map: mutable.Map[ByteArrayWrapper, Long] = mutable.Map[ByteArrayWrapper, Long]()
+    val assetsNum = boxes.foldLeft(0) {
+      case (acc, box) =>
+        require(
+          box.additionalTokens.length <= ErgoBoxAssetExtractor.MaxAssetsPerBox,
+          "too many assets in one box"
+        )
+        box.additionalTokens.foreach {
+          case (assetId, amount) =>
+            val aiWrapped = ByteArrayWrapper(assetId)
+            val total     = map.getOrElse(aiWrapped, 0L)
+            map.put(aiWrapped, Math.addExact(total, amount))
+        }
+        acc + box.additionalTokens.size
+    }
+    map.toMap -> assetsNum
+  }
+
+  /**
+    * Cost of assets preservation rules checks.
+    * We iterate through all assets to create a map (cost: `(outAssetsNum + inAssetsNum) * tokenAccessCost)`)
+    * and after that we iterate through unique asset ids to check preservation rules
+    *     (cost: `(inAssets.size + outAssets.size) * tokenAccessCost`)
+    * @param inAssetsNum number of input assets in all boxes
+    * @param inAssetsSize number if unique input asset ids
+    * @param outAssetsNum number of output assets in all boxes
+    * @param outAssetsSize number if unique output asset ids
+    * @param tokenAccessCost access cost for a token
+    * @return total assets access cost
+    */
+  def totalAssetsAccessCost(
+    inAssetsNum: Int,
+    inAssetsSize: Int,
+    outAssetsNum: Int,
+    outAssetsSize: Int,
+    tokenAccessCost: Int
+  ): Int =
+    (outAssetsNum + inAssetsNum) * tokenAccessCost + (inAssetsSize + outAssetsSize) * tokenAccessCost
+
+  /**
+    * Extract total assets access cost from in/out boxes
+    * @param inputBoxes Input boxes
+    * @param outputBoxes Output boxes
+    * @param tokenAccessCost access cost for a token
+    * @return total assets access cost
+    */
+  def extractTotalAssetsAccessCost(
+    inputBoxes: IndexedSeq[ErgoBoxCandidate],
+    outputBoxes: IndexedSeq[ErgoBoxCandidate],
+    tokenAccessCost: Int
+  ): Try[Int] =
+    extractAssets(inputBoxes).flatMap {
+      case (inAssets, inAssetsNum) =>
+        extractAssets(outputBoxes).map {
+          case (outAssets, outAssetsNum) =>
+            totalAssetsAccessCost(
+              inAssetsNum,
+              inAssets.size,
+              outAssetsNum,
+              outAssets.size,
+              tokenAccessCost
+            )
+
+        }
+    }
+}

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ErgoBoxAssetExtractor.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ErgoBoxAssetExtractor.scala
@@ -1,8 +1,9 @@
 package org.ergoplatform.wallet.boxes
 
 import org.ergoplatform.ErgoBoxCandidate
-import scorex.db.ByteArrayWrapper
 import sigmastate.eval.Extensions._
+
+import java.nio.ByteBuffer
 import scala.collection.mutable
 import scala.util.Try
 
@@ -19,8 +20,8 @@ object ErgoBoxAssetExtractor {
     */
   def extractAssets(
     boxes: IndexedSeq[ErgoBoxCandidate]
-  ): Try[(Map[ByteArrayWrapper, Long], Int)] = Try {
-    val map: mutable.Map[ByteArrayWrapper, Long] = mutable.Map[ByteArrayWrapper, Long]()
+  ): Try[(Map[ByteBuffer, Long], Int)] = Try {
+    val map: mutable.Map[ByteBuffer, Long] = mutable.Map[ByteBuffer, Long]()
     val assetsNum = boxes.foldLeft(0) {
       case (acc, box) =>
         require(
@@ -29,7 +30,7 @@ object ErgoBoxAssetExtractor {
         )
         box.additionalTokens.foreach {
           case (assetId, amount) =>
-            val aiWrapped = ByteArrayWrapper(assetId)
+            val aiWrapped = ByteBuffer.wrap(assetId)
             val total     = map.getOrElse(aiWrapped, 0L)
             map.put(aiWrapped, Math.addExact(total, amount))
         }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
@@ -9,17 +9,18 @@ import sigmastate.AvlTreeData
 import sigmastate.Values.SigmaBoolean
 import sigmastate.interpreter.{ContextExtension, ProverInterpreter}
 import org.ergoplatform.validation.ValidationRules
+import org.ergoplatform.wallet.boxes.ErgoBoxAssetExtractor
 import org.ergoplatform.wallet.protocol.context.{ErgoLikeParameters, ErgoLikeStateContext}
 import org.ergoplatform.wallet.secrets.SecretKey
 import sigmastate.basics.SigmaProtocolPrivateInput
 import org.ergoplatform.wallet.secrets.{ExtendedPublicKey, ExtendedSecretKey}
 import scorex.util.encode.Base16
-import sigmastate.eval.{RuntimeIRContext, IRContext}
+import sigmastate.eval.{IRContext, RuntimeIRContext}
 import sigmastate.utxo.CostTable
 import special.collection.Coll
-import special.sigma.{PreHeader, Header}
+import special.sigma.{Header, PreHeader}
 
-import scala.util.{Success, Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
   * A class which is holding secrets and signing transactions.
@@ -116,49 +117,53 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
     } else if (unsignedTx.dataInputs.length != dataBoxes.length) {
       Failure(new Exception("Not enough data boxes"))
     } else {
+      ErgoBoxAssetExtractor.extractTotalAssetsAccessCost(boxesToSpend, unsignedTx.outputCandidates, params.tokenAccessCost)
+        .flatMap { totalAssetsAccessCost =>
 
-      // Cost of transaction initialization: we should read and parse all inputs and data inputs,
-      // and also iterate through all outputs to check rules, also we add some constant for interpreter initialization
-      val initialCost: Long = addExact(
-        CostTable.interpreterInitCost,
-        multiplyExact(boxesToSpend.size, params.inputCost),
-        multiplyExact(dataBoxes.size, params.dataInputCost),
-        multiplyExact(unsignedTx.outputCandidates.size, params.outputCost)
-      )
+          // Cost of transaction initialization: we should read and parse all inputs and data inputs,
+          // and also iterate through all outputs to check rules, also we add some constant for interpreter initialization
+          val initialCost: Long = addExact(
+            CostTable.interpreterInitCost,
+            multiplyExact(boxesToSpend.size, params.inputCost),
+            multiplyExact(dataBoxes.size, params.dataInputCost),
+            multiplyExact(unsignedTx.outputCandidates.size, params.outputCost),
+            totalAssetsAccessCost
+          )
 
-      boxesToSpend
-        .zipWithIndex
-        .foldLeft(Try(IndexedSeq[Input]() -> initialCost)) { case (inputsCostTry, (inputBox, boxIdx)) =>
-          val unsignedInput = unsignedTx.inputs(boxIdx)
-          require(util.Arrays.equals(unsignedInput.boxId, inputBox.id))
+          boxesToSpend
+            .zipWithIndex
+            .foldLeft(Try(IndexedSeq[Input]() -> initialCost)) { case (inputsCostTry, (inputBox, boxIdx)) =>
+              val unsignedInput = unsignedTx.inputs(boxIdx)
+              require(util.Arrays.equals(unsignedInput.boxId, inputBox.id))
 
-          inputsCostTry.flatMap { case (ins, totalCost) =>
-            val context = new ErgoLikeContext(
-              ErgoInterpreter.avlTreeFromDigest(stateContext.previousStateDigest),
-              stateContext.sigmaLastHeaders,
-              stateContext.sigmaPreHeader,
-              dataBoxes,
-              boxesToSpend,
-              unsignedTx,
-              boxIdx.toShort,
-              unsignedInput.extension,
-              ValidationRules.currentSettings,
-              params.maxBlockCost,
-              totalCost,
-              activatedScriptVersion
-            )
+              inputsCostTry.flatMap { case (ins, totalCost) =>
+                val context = new ErgoLikeContext(
+                  ErgoInterpreter.avlTreeFromDigest(stateContext.previousStateDigest),
+                  stateContext.sigmaLastHeaders,
+                  stateContext.sigmaPreHeader,
+                  dataBoxes,
+                  boxesToSpend,
+                  unsignedTx,
+                  boxIdx.toShort,
+                  unsignedInput.extension,
+                  ValidationRules.currentSettings,
+                  params.maxBlockCost,
+                  totalCost,
+                  activatedScriptVersion
+                )
 
-            val hints = txHints.allHintsForInput(boxIdx)
-            prove(inputBox.ergoTree, context, unsignedTx.messageToSign, hints).flatMap { proverResult =>
-              //prove is accumulating cost under the hood, so proverResult.cost = totalCost + input check cost
-              val newTC = proverResult.cost
-              if (newTC > context.costLimit) {
-                Failure(new Exception(s"Cost of transaction $unsignedTx exceeds limit ${context.costLimit}"))
-              } else {
-                Success((ins :+ Input(unsignedInput.boxId, proverResult)) -> newTC)
+                val hints = txHints.allHintsForInput(boxIdx)
+                prove(inputBox.ergoTree, context, unsignedTx.messageToSign, hints).flatMap { proverResult =>
+                  //prove is accumulating cost under the hood, so proverResult.cost = totalCost + input check cost
+                  val newTC = proverResult.cost
+                  if (newTC > context.costLimit) {
+                    Failure(new Exception(s"Cost of transaction $unsignedTx exceeds limit ${context.costLimit}"))
+                  } else {
+                    Success((ins :+ Input(unsignedInput.boxId, proverResult)) -> newTC)
+                  }
+                }
               }
             }
-          }
         }
     }
   }

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -11,6 +11,7 @@ import org.ergoplatform.utils.ArithUtils._
 import org.ergoplatform.settings.ValidationRules._
 import org.ergoplatform.settings.{Algos, ErgoValidationSettings}
 import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.wallet.boxes.ErgoBoxAssetExtractor
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import scorex.core.EphemerealNodeViewModifier
 import org.ergoplatform.wallet.protocol.context.{InputContext, TransactionContext}
@@ -22,12 +23,10 @@ import scorex.core.validation.{ModifierValidator, ValidationState}
 import scorex.db.{ByteArrayUtils, ByteArrayWrapper}
 import scorex.util.serialization.{Reader, Writer}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
-import sigmastate.eval.Extensions._
 import sigmastate.serialization.ConstantStore
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import sigmastate.utxo.CostTable
 
-import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -71,7 +70,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
     Algos.hash(ByteArrayUtils.mergeByteArrays(inputs.map(_.spendingProof.proof))).tail
 
 
-  lazy val outAssetsTry: Try[(Map[ByteArrayWrapper, Long], Int)] = ErgoTransaction.extractAssets(outputCandidates)
+  lazy val outAssetsTry: Try[(Map[ByteArrayWrapper, Long], Int)] = ErgoBoxAssetExtractor.extractAssets(outputCandidates)
 
   lazy val outputsSumTry: Try[Long] = Try(outputCandidates.map(_.value).reduce(Math.addExact(_, _)))
 
@@ -171,17 +170,14 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
       // Check that transaction is not creating money out of thin air.
       .validate(txErgPreservation, inputSumTry == outputsSumTry, s"$id: $inputSumTry == $outputsSumTry")
       .validateTry(outAssetsTry, e => ModifierValidator.fatal("Incorrect assets", e)) { case (validation, (outAssets, outAssetsNum)) =>
-        ErgoTransaction.extractAssets(boxesToSpend) match {
+        ErgoBoxAssetExtractor.extractAssets(boxesToSpend) match {
           case Success((inAssets, inAssetsNum)) =>
             lazy val newAssetId = ByteArrayWrapper(inputs.head.boxId)
             val tokenAccessCost = stateContext.currentParameters.tokenAccessCost
             val currentTxCost = validation.result.payload.get
 
-            // Cost of assets preservation rules checks.
-            // We iterate through all assets to create a map (cost: `(outAssetsNum + inAssetsNum) * tokenAccessCost)`)
-            // and after that we iterate through unique asset ids to check preservation rules (cost: `(inAssets.size + outAssets.size) * tokenAccessCost`)
-            val totalAssetsAccessCost = (outAssetsNum + inAssetsNum) * tokenAccessCost +
-              (inAssets.size + outAssets.size) * tokenAccessCost
+            val totalAssetsAccessCost =
+              ErgoBoxAssetExtractor.totalAssetsAccessCost(inAssetsNum, inAssets.size, outAssetsNum, outAssets.size, tokenAccessCost)
             val newCost = addExact(currentTxCost, totalAssetsAccessCost)
 
             validation
@@ -274,30 +270,6 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
 }
 
 object ErgoTransaction extends ApiCodecs with ScorexLogging with ScorexEncoding {
-
-  val MaxAssetsPerBox = 255
-
-  /**
-    * Extracts a mapping (assets -> total amount) from a set of boxes passed as a parameter.
-    * That is, the method is checking amounts of assets in the boxes(i.e. that a box contains positive
-    * amount for an asset) and then summarize and group their corresponding amounts.
-    *
-    * @param boxes - boxes to check and extract assets from
-    * @return a mapping from asset id to to balance and total assets number
-    */
-  def extractAssets(boxes: IndexedSeq[ErgoBoxCandidate]): Try[(Map[ByteArrayWrapper, Long], Int)] = Try {
-    val map: mutable.Map[ByteArrayWrapper, Long] = mutable.Map[ByteArrayWrapper, Long]()
-    val assetsNum = boxes.foldLeft(0) { case (acc, box) =>
-      require(box.additionalTokens.length <= ErgoTransaction.MaxAssetsPerBox, "too many assets in one box")
-      box.additionalTokens.foreach { case (assetId, amount) =>
-        val aiWrapped = ByteArrayWrapper(assetId)
-        val total = map.getOrElse(aiWrapped, 0L)
-        map.put(aiWrapped, Math.addExact(total, amount))
-      }
-      acc + box.additionalTokens.size
-    }
-    map.toMap -> assetsNum
-  }
 
   def apply(inputs: IndexedSeq[Input], outputCandidates: IndexedSeq[ErgoBoxCandidate]): ErgoTransaction =
     ErgoTransaction(inputs, IndexedSeq(), outputCandidates, None)

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -20,13 +20,14 @@ import scorex.core.transaction.Transaction
 import scorex.core.utils.ScorexEncoding
 import scorex.core.validation.ValidationResult.fromValidationState
 import scorex.core.validation.{ModifierValidator, ValidationState}
-import scorex.db.{ByteArrayUtils, ByteArrayWrapper}
+import scorex.db.ByteArrayUtils
 import scorex.util.serialization.{Reader, Writer}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import sigmastate.serialization.ConstantStore
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import sigmastate.utxo.CostTable
 
+import java.nio.ByteBuffer
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -70,7 +71,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
     Algos.hash(ByteArrayUtils.mergeByteArrays(inputs.map(_.spendingProof.proof))).tail
 
 
-  lazy val outAssetsTry: Try[(Map[ByteArrayWrapper, Long], Int)] = ErgoBoxAssetExtractor.extractAssets(outputCandidates)
+  lazy val outAssetsTry: Try[(Map[ByteBuffer, Long], Int)] = ErgoBoxAssetExtractor.extractAssets(outputCandidates)
 
   lazy val outputsSumTry: Try[Long] = Try(outputCandidates.map(_.value).reduce(Math.addExact(_, _)))
 
@@ -172,7 +173,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
       .validateTry(outAssetsTry, e => ModifierValidator.fatal("Incorrect assets", e)) { case (validation, (outAssets, outAssetsNum)) =>
         ErgoBoxAssetExtractor.extractAssets(boxesToSpend) match {
           case Success((inAssets, inAssetsNum)) =>
-            lazy val newAssetId = ByteArrayWrapper(inputs.head.boxId)
+            lazy val newAssetId = ByteBuffer.wrap(inputs.head.boxId)
             val tokenAccessCost = stateContext.currentParameters.tokenAccessCost
             val currentTxCost = validation.result.payload.get
 

--- a/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
+++ b/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
@@ -7,6 +7,7 @@ import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.history.ErgoHistory
+import org.ergoplatform.wallet.boxes.ErgoBoxAssetExtractor
 import scorex.core.validation.ModifierValidator
 import scorex.core.validation.ValidationResult.Invalid
 
@@ -48,7 +49,7 @@ object ValidationRules {
     txInputsUnique -> RuleStatus(s => fatal(s"There should be no duplicate inputs. $s"),
       Seq(classOf[ErgoTransaction]),
       mayBeDisabled = false),
-    txAssetsInOneBox -> RuleStatus(s => fatal(s"A number of tokens within a box should not exceed ${ErgoTransaction.MaxAssetsPerBox}" +
+    txAssetsInOneBox -> RuleStatus(s => fatal(s"A number of tokens within a box should not exceed ${ErgoBoxAssetExtractor.MaxAssetsPerBox}" +
       s" and sum of assets of one type should not exceed ${Long.MaxValue}. $s"),
       Seq(classOf[ErgoTransaction]),
       mayBeDisabled = false),

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -26,6 +26,7 @@ import sigmastate.interpreter.{ContextExtension, CryptoConstants, ProverResult}
 import sigmastate.utxo.CostTable
 import sigmastate.helpers.TestingHelpers._
 
+import java.nio.ByteBuffer
 import scala.util.{Random, Try}
 
 class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
@@ -403,8 +404,8 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
       val txCost = tx.statefulValidity(from, IndexedSeq(), emptyStateContext, accInitCost).get
 
-      val (inAssets, inAssetsNum): (Map[ByteArrayWrapper, Long], Int) = ErgoBoxAssetExtractor.extractAssets(from).get
-      val (outAssets, outAssetsNum): (Map[ByteArrayWrapper, Long], Int) = ErgoBoxAssetExtractor.extractAssets(tx.outputs).get
+      val (inAssets, inAssetsNum): (Map[ByteBuffer, Long], Int) = ErgoBoxAssetExtractor.extractAssets(from).get
+      val (outAssets, outAssetsNum): (Map[ByteBuffer, Long], Int) = ErgoBoxAssetExtractor.extractAssets(tx.outputs).get
 
       val assetsCost = inAssetsNum * tokenAccessCost + inAssets.size * tokenAccessCost +
         outAssetsNum * tokenAccessCost + outAssets.size * tokenAccessCost

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -7,8 +7,9 @@ import org.ergoplatform.nodeView.state.{ErgoStateContext, UpcomingStateContext, 
 import org.ergoplatform.settings.Parameters.MaxBlockCostIncrease
 import org.ergoplatform.settings.ValidationRules.{bsBlockTransactionsCost, txAssetsInOneBox}
 import org.ergoplatform.settings._
-import org.ergoplatform.utils.ErgoPropertyTest
-import org.ergoplatform.wallet.interpreter.ErgoInterpreter
+import org.ergoplatform.utils.{ErgoPropertyTest, ErgoTestConstants}
+import org.ergoplatform.wallet.boxes.ErgoBoxAssetExtractor
+import org.ergoplatform.wallet.interpreter.{ErgoInterpreter, TransactionHintsBag}
 import org.ergoplatform.wallet.protocol.context.{InputContext, TransactionContext}
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
 import org.scalacheck.Gen
@@ -27,7 +28,7 @@ import sigmastate.helpers.TestingHelpers._
 
 import scala.util.{Random, Try}
 
-class ErgoTransactionSpec extends ErgoPropertyTest {
+class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
   private implicit val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
 
@@ -346,7 +347,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest {
         tx.outputs.size * LaunchParameters.outputCost +
         CostTable.interpreterInitCost
     val (outAssets, outAssetsNum) = tx.outAssetsTry.get
-    val (inAssets, inAssetsNum) = ErgoTransaction.extractAssets(from).get
+    val (inAssets, inAssetsNum) = ErgoBoxAssetExtractor.extractAssets(from).get
     val totalAssetsAccessCost = (outAssetsNum + inAssetsNum) * LaunchParameters.tokenAccessCost +
       (inAssets.size + outAssets.size) * LaunchParameters.tokenAccessCost
     val scriptsValidationCosts = tx.inputs.size * (CostTable.constCost + CostTable.logicCost + CostTable.logicCost + from.head.ergoTree.complexity)
@@ -402,11 +403,18 @@ class ErgoTransactionSpec extends ErgoPropertyTest {
 
       val txCost = tx.statefulValidity(from, IndexedSeq(), emptyStateContext, accInitCost).get
 
-      val (inAssets, inAssetsNum): (Map[ByteArrayWrapper, Long], Int) = ErgoTransaction.extractAssets(from).get
-      val (outAssets, outAssetsNum): (Map[ByteArrayWrapper, Long], Int) = ErgoTransaction.extractAssets(tx.outputs).get
+      val (inAssets, inAssetsNum): (Map[ByteArrayWrapper, Long], Int) = ErgoBoxAssetExtractor.extractAssets(from).get
+      val (outAssets, outAssetsNum): (Map[ByteArrayWrapper, Long], Int) = ErgoBoxAssetExtractor.extractAssets(tx.outputs).get
 
       val assetsCost = inAssetsNum * tokenAccessCost + inAssets.size * tokenAccessCost +
         outAssetsNum * tokenAccessCost + outAssets.size * tokenAccessCost
+
+      val unsignedTx = UnsignedErgoTransaction(tx.inputs, tx.dataInputs, tx.outputCandidates)
+      val signerTxCost =
+        defaultProver.signInputs(unsignedTx, from, Vector.empty, emptyStateContext, TransactionHintsBag.empty).get._2
+
+      val signerTxCostWithInitCost = signerTxCost + accInitCost
+      signerTxCostWithInitCost shouldBe txCost // signer and verifier costs should be the same
 
       val initialCost: Long =
         tx.inputs.size * LaunchParameters.inputCost +


### PR DESCRIPTION
Token access cost is not considered during tx signing, only during tx verification ... see https://github.com/ergoplatform/ergo/issues/1133

@kushti pls check the last commit separately to see the `ByteArrayWrapper -> ByteBuffer` change