### PR TITLE
Networking layer optimizations for 4.0.20

### DIFF
--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -62,7 +62,7 @@ scorex {
 
     # Max number of delivery checks. Stop expecting modifier (and penalize peer) if it was not delivered after that
     # number of delivery attempts
-    maxDeliveryChecks = 4
+    maxDeliveryChecks = 3
   }
   restApi {
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -82,8 +82,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
   protected val deliveryTracker: DeliveryTracker =
     DeliveryTracker.empty(context.system, deliveryTimeout, maxDeliveryChecks, self, settings)
 
-  private val minModifiersPerBucket = 5 // minimum of persistent modifiers (excl. headers) to download by single peer
-  private val maxModifiersPerBucket = 20 // maximum of persistent modifiers (excl. headers) to download by single peer
+  private val minModifiersPerBucket = 20 // minimum of persistent modifiers (excl. headers) to download by single peer
+  private val maxModifiersPerBucket = 50 // maximum of persistent modifiers (excl. headers) to download by single peer
 
   private val minHeadersPerBucket = 50 // minimum of headers to download by single peer
   private val maxHeadersPerBucket = 400 // maximum of headers to download by single peer
@@ -514,7 +514,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         if (!settings.nodeSettings.stateType.requireProofs &&
           hr.isHeadersChainSynced &&
           hr.fullBlockHeight == hr.headersHeight) {
-          log.info(s"Processing ${invData.ids.length} tx invs")
+          log.info(s"Processing ${invData.ids.length} tx invs frpm $peer")
           val unknownMods =
             invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(mp)) == ModifiersStatus.Unknown)
           // filter out transactions that were already applied to history
@@ -523,7 +523,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
           Seq.empty
         }
       case _ =>
-        log.info(s"Processing ${invData.ids.length} non-tx invs")
+        log.info(s"Processing ${invData.ids.length} non-tx invs frpm $peer")
         invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(hr)) == ModifiersStatus.Unknown)
     }
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -514,6 +514,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         if (!settings.nodeSettings.stateType.requireProofs &&
           hr.isHeadersChainSynced &&
           hr.fullBlockHeight == hr.headersHeight) {
+          log.info(s"Processing ${invData.ids.length} tx invs")
           val unknownMods =
             invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(mp)) == ModifiersStatus.Unknown)
           // filter out transactions that were already applied to history
@@ -522,6 +523,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
           Seq.empty
         }
       case _ =>
+        log.info(s"Processing ${invData.ids.length} non-tx invs")
         invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(hr)) == ModifiersStatus.Unknown)
     }
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -142,15 +142,6 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     remote.peerInfo.exists(_.peerSpec.protocolVersion >= syncV2Version)
   }
 
-  def blockDownloadingSupported(remote: ConnectedPeer): Boolean = {
-    val mostRecentOldVersion = Version(4, 0, 16)
-    val oldestNewVersion = Version(4, 0, 19)
-    remote.peerInfo.exists { pi =>
-      pi.peerSpec.protocolVersion <= mostRecentOldVersion || pi.peerSpec.protocolVersion >= oldestNewVersion
-    }
-  }
-
-
   /**
     * Send synchronization statuses to neighbour peers
     *
@@ -523,7 +514,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
           Seq.empty
         }
       case _ =>
-        log.info(s"Processing ${invData.ids.length} non-tx invs frpm $peer")
+        log.info(s"Processing ${invData.ids.length} non-tx invs (of type $modifierTypeId) frpm $peer")
         invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(hr)) == ModifiersStatus.Unknown)
     }
 

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -414,7 +414,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                   vault().rollback(idToVersion(progressInfo.branchPoint.get)).get
                 } else vault()
 
-                if(newHistory.fullBlockHeight == newHistory.headersHeight) {
+                if((newHistory.headersHeight - newHistory.fullBlockHeight) < 20) {
                   blocksApplied.foreach(newVault.scanPersistent)
                 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -409,16 +409,18 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                 val newMemPool = updateMemPool(progressInfo.toRemove, blocksApplied, memoryPool(), newMinState)
 
                 @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+                val v = vault()
                 val newVault = if (progressInfo.chainSwitchingNeeded) {
-                  val v = vault()
                   v.rollback(idToVersion(progressInfo.branchPoint.get)) match {
                     case Success(nv) => nv
                     case Failure(e) => log.warn("Wallet rollback failed: ", e); v
                   }
                 } else {
-                  vault()
+                  v
                 }
 
+                // we assume that wallet scan may be started if fullblocks-chain is no more
+                // than 20 blocks behind headers-chain
                 val almostSyncedGap = 20
 
                 if((newHistory.headersHeight - newHistory.fullBlockHeight) < almostSyncedGap) {

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -413,7 +413,10 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                 val newVault = if (progressInfo.chainSwitchingNeeded) {
                   vault().rollback(idToVersion(progressInfo.branchPoint.get)).get
                 } else vault()
-                blocksApplied.foreach(newVault.scanPersistent)
+
+                if(newHistory.fullBlockHeight == newHistory.headersHeight) {
+                  blocksApplied.foreach(newVault.scanPersistent)
+                }
 
                 log.info(s"Persistent modifier ${pmod.encodedId} applied successfully")
                 updateNodeView(Some(newHistory), Some(newMinState), Some(newVault), Some(newMemPool))

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -66,7 +66,7 @@ trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
 
     bestFullBlockOpt match {
       case _ if (nodeSettings.blocksToKeep != -1 && !isHeadersChainSynced) || !nodeSettings.verifyTransactions =>
-        // do not download full blocks if no headers-chain synced yet or SPV mode
+        // do not download full blocks if no headers-chain synced yet and suffix enabled or SPV mode
         Map.empty
       case Some(fb) =>
         // download children blocks of last 100 full blocks applied to the best chain

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -65,7 +65,7 @@ trait ToDownloadProcessor extends BasicReaders with ScorexLogging {
     }
 
     bestFullBlockOpt match {
-      case _ if !isHeadersChainSynced || !nodeSettings.verifyTransactions =>
+      case _ if (nodeSettings.blocksToKeep != -1 && !isHeadersChainSynced) || !nodeSettings.verifyTransactions =>
         // do not download full blocks if no headers-chain synced yet or SPV mode
         Map.empty
       case Some(fb) =>

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -246,6 +246,7 @@ class NetworkController(settings: NetworkSettings,
      () =>
        val connectedPeers = connections.values.filter(_.peerInfo.nonEmpty).toSeq
        if (connectedPeers.length >= evictionThreshold) {
+         // if we hava at least `evictionThreshold` connection, we drop a random one
          val victim = Random.nextInt(connectedPeers.size)
          val cp = connectedPeers(victim)
          log.info(s"Evict connection to ${cp.peerInfo}")

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -241,10 +241,11 @@ class NetworkController(settings: NetworkSettings,
     * It is needed to prevent eclipsing (https://www.usenix.org/system/files/conference/usenixsecurity15/sec15-paper-heilman.pdf)
     */
   private def scheduleEvictRandomConnections(): Unit = {
+   val evictionThreshold = 5
    context.system.scheduler.scheduleWithFixedDelay(settings.peerEvictionInterval, settings.peerEvictionInterval) {
      () =>
        val connectedPeers = connections.values.filter(_.peerInfo.nonEmpty).toSeq
-       if (!connectedPeers.isEmpty) {
+       if (connectedPeers.length >= evictionThreshold) {
          val victim = Random.nextInt(connectedPeers.size)
          val cp = connectedPeers(victim)
          log.info(s"Evict connection to ${cp.peerInfo}")

--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -192,7 +192,7 @@ class PeerConnectionHandler(val settings: NetworkSettings,
       def process(): Unit = {
         messageSerializer.deserialize(chunksBuffer, selfPeer) match {
           case Success(Some(message)) =>
-            log.info("Received message " + message.spec + " from " + connectionId)
+            log.debug("Received message " + message.spec + " from " + connectionId)
             networkControllerRef ! message
             chunksBuffer = chunksBuffer.drop(message.messageLength)
             process()


### PR DESCRIPTION
* minModifiersPerBucket & maxModifiersPerBucket values increased for better bandwidth utilization 
* maxDeliveryChecks decreased for the mainnet (to ignore nodes failing to deliver quicker)
* less INFO output
* if node is storing all the full blocks (blocksToKeep = -1), downloading to be started immediately now, not after headers synchronization
* `.get` removed in ErgoNodeViewHolder on `vault().rollback(idToVersion(progressInfo.branchPoint.get)).get`
* wallet scan to be started only when chain is about to sync
* peer eviction happens now only if there are 5 connections at least