### PR TITLE
avoid using global LaunchParameters throughout the codebase

### DIFF
--- a/benchmarks/src/test/scala/org/ergoplatform/nodeView/state/TransactionExecutionBenchmark.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/nodeView/state/TransactionExecutionBenchmark.scala
@@ -17,13 +17,11 @@ object TransactionExecutionBenchmark extends HistoryTestHelpers with NVBenchmark
 
   val WarmupRuns = 3
 
-  def stateContextWithMaxCost(manualCost: Int): UpcomingStateContext = {
-    val table2: Map[Byte, Int] = Parameters.DefaultParameters + (MaxBlockCostIncrease -> manualCost)
-    val params2 = new Parameters(height = 0,
-      parametersTable = table2,
-      proposedUpdate = ErgoValidationSettingsUpdate.empty)
-    emptyStateContext.copy(currentParameters = params2)(settings)
-  }
+  override val parameters =
+    new Parameters(height = 0,
+      parametersTable = Parameters.DefaultParameters + (MaxBlockCostIncrease -> Int.MaxValue),
+      proposedUpdate = ErgoValidationSettingsUpdate.empty
+    )
 
   def main(args: Array[String]): Unit = {
 
@@ -41,10 +39,9 @@ object TransactionExecutionBenchmark extends HistoryTestHelpers with NVBenchmark
     }.result()
 
     val boxes = bh.boxes
-    val stateContext = stateContextWithMaxCost(Int.MaxValue)
     def bench: Long =
       Utils.time {
-        assert(ErgoState.execTransactions(txs, stateContext)(id => Try(boxes(ByteArrayWrapper(id)))) == Valid(178665000))
+        assert(ErgoState.execTransactions(txs, emptyStateContext)(id => Try(boxes(ByteArrayWrapper(id)))) == Valid(178665000))
       }.toLong
 
     (0 to WarmupRuns).foreach(_ => bench)

--- a/benchmarks/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateBenchmark.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateBenchmark.scala
@@ -22,7 +22,7 @@ object UtxoStateBenchmark extends HistoryTestHelpers with NVBenchmark {
     val transactionsQty = blocks.flatMap(_.transactions).size
 
     def bench(mods: Seq[ErgoPersistentModifier]): Long = {
-      val state = ErgoState.generateGenesisUtxoState(createTempDir, StateConstants(None, realNetworkSetting))._1
+      val state = ErgoState.generateGenesisUtxoState(createTempDir, StateConstants(None, realNetworkSetting), parameters)._1
       Utils.time {
         mods.foldLeft(state) { case (st, mod) =>
           st.applyModifier(mod).get

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-async" % "0.9.7" % "test",
   "com.storm-enroute" %% "scalameter" % "0.8.+" % "test",
   "org.scalactic" %% "scalactic" % "3.0.3" % "test",
-  "org.scalatest" %% "scalatest" % "3.1.1" % "test,it",
+  "org.scalatest" %% "scalatest" % "3.2.10" % "test,it",
   "org.scalacheck" %% "scalacheck" % "1.14.+" % "test",
   "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test,
 

--- a/src/it/scala/org/ergoplatform/it/WalletSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/WalletSpec.scala
@@ -12,7 +12,7 @@ import org.ergoplatform.it.util.RichEither
 import org.ergoplatform.modifiers.mempool.UnsignedErgoTransaction
 import org.ergoplatform.nodeView.wallet.requests.{PaymentRequest, PaymentRequestEncoder, RequestsHolder, RequestsHolderEncoder}
 import org.ergoplatform.nodeView.wallet.{AugWalletTransaction, ErgoWalletServiceImpl}
-import org.ergoplatform.settings.{Args, ErgoSettings, LaunchParameters}
+import org.ergoplatform.settings.{Args, ErgoSettings}
 import org.ergoplatform.utils.{ErgoTestHelpers, WalletTestOps}
 import org.ergoplatform.wallet.interface4j.SecretString
 import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
@@ -71,7 +71,7 @@ class WalletSpec extends AsyncWordSpec with IntegrationSuite with WalletTestOps 
   "it should generate unsigned transaction" in {
     import sigmastate.eval._
     val mnemonic = SecretString.create(walletAutoInitConfig.getString("ergo.wallet.testMnemonic"))
-    val prover = new ErgoWalletServiceImpl().buildProverFromMnemonic(mnemonic, None, LaunchParameters)
+    val prover = new ErgoWalletServiceImpl().buildProverFromMnemonic(mnemonic, None, parameters)
     val pk = prover.hdPubKeys.head.key
     val ergoTree = ErgoTree.fromProposition(TrueLeaf)
     val transactionId = ModifierId @@ Base16.encode(Array.fill(32)(5: Byte))

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -12,7 +12,7 @@ import org.ergoplatform.mining.ErgoMiner.StartMining
 import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ErgoSyncTracker, ModeFeature}
 import org.ergoplatform.nodeView.history.ErgoSyncInfoMessageSpec
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
-import org.ergoplatform.settings.{Args, ErgoSettings, NetworkType}
+import org.ergoplatform.settings.{Args, ErgoSettings, LaunchParameters, NetworkType}
 import scorex.core.api.http._
 import scorex.core.app.ScorexContext
 import scorex.core.network.NetworkController.ReceivableMessages.ShutdownNetwork
@@ -86,7 +86,9 @@ class ErgoApp(args: Args) extends ScorexLogging {
   private val networkControllerRef: ActorRef = NetworkControllerRef(
     "networkController", scorexSettings.network, peerManagerRef, scorexContext)
 
-  private val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
+  private val parameters = LaunchParameters
+
+  private val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider, parameters)
 
   private val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
@@ -99,7 +101,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
     }
 
   private val statsCollectorRef: ActorRef =
-    ErgoStatsCollectorRef(readersHolderRef, networkControllerRef, ergoSettings, timeProvider)
+    ErgoStatsCollectorRef(readersHolderRef, networkControllerRef, ergoSettings, timeProvider, parameters)
 
   private val syncTracker = ErgoSyncTracker(actorSystem, scorexSettings.network, timeProvider)
 

--- a/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
+++ b/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.state.{ErgoStateReader, StateType}
-import org.ergoplatform.settings.{Algos, ErgoSettings, LaunchParameters, Parameters}
+import org.ergoplatform.settings.{Algos, ErgoSettings, Parameters}
 import scorex.core.network.ConnectedPeer
 import scorex.core.network.NetworkController.ReceivableMessages.{GetConnectedPeers, GetPeersStatus}
 import org.ergoplatform.network.ErgoNodeViewSynchronizer.ReceivableMessages._
@@ -29,7 +29,8 @@ import scala.concurrent.duration._
 class ErgoStatsCollector(readersHolder: ActorRef,
                          networkController: ActorRef,
                          settings: ErgoSettings,
-                         timeProvider: NetworkTimeProvider)
+                         timeProvider: NetworkTimeProvider,
+                         parameters: Parameters)
   extends Actor with ScorexLogging {
 
   override def preStart(): Unit = {
@@ -63,7 +64,7 @@ class ErgoStatsCollector(readersHolder: ActorRef,
     launchTime = networkTime(),
     lastIncomingMessageTime = networkTime(),
     None,
-    LaunchParameters)
+    parameters)
 
   override def receive: Receive =
     onConnectedPeers orElse
@@ -195,11 +196,15 @@ object ErgoStatsCollectorRef {
   def props(readersHolder: ActorRef,
             networkController: ActorRef,
             settings: ErgoSettings,
-            timeProvider: NetworkTimeProvider): Props =
-    Props(new ErgoStatsCollector(readersHolder, networkController, settings, timeProvider))
+            timeProvider: NetworkTimeProvider,
+            parameters: Parameters): Props =
+    Props(new ErgoStatsCollector(readersHolder, networkController, settings, timeProvider, parameters))
 
-  def apply(readersHolder: ActorRef, networkController: ActorRef, settings: ErgoSettings, timeProvider: NetworkTimeProvider)
-           (implicit system: ActorSystem): ActorRef =
-    system.actorOf(props(readersHolder, networkController, settings, timeProvider))
+  def apply(readersHolder: ActorRef,
+            networkController: ActorRef,
+            settings: ErgoSettings,
+            timeProvider: NetworkTimeProvider,
+            parameters: Parameters)(implicit system: ActorSystem): ActorRef =
+    system.actorOf(props(readersHolder, networkController, settings, timeProvider, parameters))
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -16,7 +16,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.mempool.ErgoMemPool.ProcessingOutcome
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.wallet.ErgoWallet
-import org.ergoplatform.settings.{Algos, Constants, ErgoSettings}
+import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, Parameters}
 import scorex.core._
 import org.ergoplatform.network.ErgoNodeViewSynchronizer.ReceivableMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.{CurrentView, DownloadRequest}
@@ -42,7 +42,8 @@ import scala.util.{Failure, Success, Try}
   *
   */
 abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSettings,
-                                                             timeProvider: NetworkTimeProvider)
+                                                             timeProvider: NetworkTimeProvider,
+                                                             parameters: Parameters)
   extends Actor with ScorexLogging with ScorexEncoding with FileUtils {
 
   private implicit lazy val actorSystem: ActorSystem = context.system
@@ -349,7 +350,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
     val wallet = ErgoWallet.readOrGenerate(
       history.getReader.asInstanceOf[ErgoHistoryReader],
-      settings)
+      settings,
+      parameters)
 
     val memPool = ErgoMemPool.empty(settings)
 
@@ -368,12 +370,13 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     log.info("History database read")
     val memPool = ErgoMemPool.empty(settings)
     val constants = StateConstants(Some(self), settings)
-    restoreConsistentState(ErgoState.readOrGenerate(settings, constants).asInstanceOf[State], history) match {
+    restoreConsistentState(ErgoState.readOrGenerate(settings, constants, parameters).asInstanceOf[State], history) match {
       case Success(state) =>
         log.info("State database read, state synchronized")
         val wallet = ErgoWallet.readOrGenerate(
           history.getReader.asInstanceOf[ErgoHistoryReader],
-          settings)
+          settings,
+          parameters)
         log.info("Wallet database read")
         Some((history, state, wallet, memPool))
       case Failure(ex) =>
@@ -444,7 +447,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     deleteRecursive(dir)
 
     val constants = StateConstants(Some(self), settings)
-    ErgoState.readOrGenerate(settings, constants)
+    ErgoState.readOrGenerate(settings, constants, parameters)
       .asInstanceOf[State]
       .ensuring(
         state => java.util.Arrays.equals(state.rootHash, settings.chainSettings.genesisStateDigest),
@@ -505,7 +508,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       .flatMap { ctx =>
         val recoverVersion = idToVersion(lastHeaders.last.id)
         val recoverRoot = bestFullBlock.header.stateRoot
-        DigestState.recover(recoverVersion, recoverRoot, ctx, stateDir(settings), constants)
+        DigestState.recover(recoverVersion, recoverRoot, ctx, stateDir(settings), constants, parameters)
       }
 
     recoveredStateTry match {
@@ -515,7 +518,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       case Failure(exception) => // recover using whole headers chain
         log.warn(s"Failed to recover state from current epoch, using whole chain: ${exception.getMessage}")
         val wholeChain = history.headerChainBack(Int.MaxValue, bestFullBlock.header, _.isGenesis).headers
-        val genesisState = DigestState.create(None, None, stateDir(settings), constants)
+        val genesisState = DigestState.create(None, None, stateDir(settings), constants, parameters)
         wholeChain.foldLeft[Try[DigestState]](Success(genesisState))((acc, m) => acc.flatMap(_.applyModifier(m)))
     }
   }
@@ -606,34 +609,40 @@ object ErgoNodeViewHolder {
 }
 
 private[nodeView] class DigestNodeViewHolder(settings: ErgoSettings,
-                                             timeProvider: NetworkTimeProvider)
-  extends ErgoNodeViewHolder[DigestState](settings, timeProvider)
+                                             timeProvider: NetworkTimeProvider,
+                                             parameters: Parameters)
+  extends ErgoNodeViewHolder[DigestState](settings, timeProvider, parameters)
 
 private[nodeView] class UtxoNodeViewHolder(settings: ErgoSettings,
-                                           timeProvider: NetworkTimeProvider)
-  extends ErgoNodeViewHolder[UtxoState](settings, timeProvider)
+                                           timeProvider: NetworkTimeProvider,
+                                           parameters: Parameters)
+  extends ErgoNodeViewHolder[UtxoState](settings, timeProvider, parameters)
 
 
 
 object ErgoNodeViewRef {
 
   private def digestProps(settings: ErgoSettings,
-                  timeProvider: NetworkTimeProvider): Props =
-    Props.create(classOf[DigestNodeViewHolder], settings, timeProvider)
+                          timeProvider: NetworkTimeProvider,
+                          parameters: Parameters): Props =
+    Props.create(classOf[DigestNodeViewHolder], settings, timeProvider, parameters)
 
   private def utxoProps(settings: ErgoSettings,
-                timeProvider: NetworkTimeProvider): Props =
-    Props.create(classOf[UtxoNodeViewHolder], settings, timeProvider)
+                        timeProvider: NetworkTimeProvider,
+                        parameters: Parameters): Props =
+    Props.create(classOf[UtxoNodeViewHolder], settings, timeProvider, parameters)
 
   def props(settings: ErgoSettings,
-            timeProvider: NetworkTimeProvider): Props =
+            timeProvider: NetworkTimeProvider,
+            parameters: Parameters): Props =
     settings.nodeSettings.stateType match {
-      case StateType.Digest => digestProps(settings, timeProvider)
-      case StateType.Utxo => utxoProps(settings, timeProvider)
+      case StateType.Digest => digestProps(settings, timeProvider, parameters)
+      case StateType.Utxo => utxoProps(settings, timeProvider, parameters)
     }
 
   def apply(settings: ErgoSettings,
-            timeProvider: NetworkTimeProvider)(implicit system: ActorSystem): ActorRef =
-    system.actorOf(props(settings, timeProvider))
+            timeProvider: NetworkTimeProvider,
+            parameters: Parameters)(implicit system: ActorSystem): ActorRef =
+    system.actorOf(props(settings, timeProvider, parameters))
   
 }

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
@@ -296,19 +296,19 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
 
 object ErgoStateContext {
 
-  def empty(constants: StateConstants): ErgoStateContext = {
-    empty(constants.settings.chainSettings.genesisStateDigest, constants.settings)
+  def empty(constants: StateConstants, parameters: Parameters): ErgoStateContext = {
+    empty(constants.settings.chainSettings.genesisStateDigest, constants.settings, parameters)
   }
 
-  def empty(settings: ErgoSettings): ErgoStateContext = {
-    empty(settings.chainSettings.genesisStateDigest, settings)
+  def empty(settings: ErgoSettings, parameters: Parameters): ErgoStateContext = {
+    empty(settings.chainSettings.genesisStateDigest, settings, parameters)
   }
 
   /**
     * Initialize empty state context
     */
-  def empty(genesisStateDigest: ADDigest, settings: ErgoSettings): ErgoStateContext = {
-    new ErgoStateContext(Seq.empty, None, genesisStateDigest, LaunchParameters, ErgoValidationSettings.initial,
+  def empty(genesisStateDigest: ADDigest, settings: ErgoSettings, parameters: Parameters): ErgoStateContext = {
+    new ErgoStateContext(Seq.empty, None, genesisStateDigest, parameters, ErgoValidationSettings.initial,
       VotingData.empty)(settings)
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateReader.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.state
 
 import org.ergoplatform.ErgoBox
-import org.ergoplatform.settings.{Algos, VotingSettings}
+import org.ergoplatform.settings.{Algos, Parameters, VotingSettings}
 import scorex.core.{NodeViewComponent, VersionTag}
 import scorex.crypto.authds.ADDigest
 import scorex.crypto.hash.Digest32
@@ -11,6 +11,7 @@ import scorex.util.ScorexLogging
 trait ErgoStateReader extends NodeViewComponent with ScorexLogging {
 
   def rootHash: ADDigest
+  def parameters: Parameters
   val store: LDBVersionedStore
   val constants: StateConstants
 
@@ -18,7 +19,7 @@ trait ErgoStateReader extends NodeViewComponent with ScorexLogging {
 
   protected lazy val votingSettings: VotingSettings = chainSettings.voting
 
-  def stateContext: ErgoStateContext = ErgoStateReader.storageStateContext(store, constants)
+  def stateContext: ErgoStateContext = ErgoStateReader.storageStateContext(store, constants, parameters)
 
   def genesisBoxes: Seq[ErgoBox] = ErgoState.genesisBoxes(chainSettings)
 
@@ -36,10 +37,10 @@ object ErgoStateReader {
 
   val ContextKey: Digest32 = Algos.hash("current state context")
 
-  def storageStateContext(store: LDBVersionedStore, constants: StateConstants): ErgoStateContext = {
+  def storageStateContext(store: LDBVersionedStore, constants: StateConstants, parameters: Parameters): ErgoStateContext = {
     store.get(ErgoStateReader.ContextKey)
       .flatMap(b => ErgoStateContextSerializer(constants.settings).parseBytesTry(b).toOption)
-      .getOrElse(ErgoStateContext.empty(constants))
+      .getOrElse(ErgoStateContext.empty(constants, parameters))
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
@@ -135,7 +135,7 @@ trait UtxoStateReader extends ErgoStateReader with TransactionValidation {
     * Useful when checking mempool transactions.
     */
   def withTransactions(txns: Seq[ErgoTransaction]): UtxoState = {
-    new UtxoState(persistentProver, version, store, constants) {
+    new UtxoState(persistentProver, version, store, constants, parameters) {
       lazy val createdBoxes: Seq[ErgoBox] = txns.flatMap(_.outputs)
 
       override def boxById(id: ADKey): Option[ErgoBox] = {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.state.ErgoState
 import org.ergoplatform.nodeView.wallet.ErgoWalletActor._
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.boxes.ReplaceCompactCollectBoxSelector
 import scorex.core.VersionTag
 import scorex.core.transaction.wallet.Vault
@@ -14,7 +14,7 @@ import scorex.util.ScorexLogging
 
 import scala.util.{Failure, Success, Try}
 
-class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
+class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings, parameters: Parameters)
                 (implicit val actorSystem: ActorSystem)
   extends Vault[ErgoTransaction, ErgoPersistentModifier, ErgoWallet]
     with ErgoWalletReader
@@ -29,7 +29,7 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
   private val boxSelector = new ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs)
 
   override val walletActor: ActorRef =
-    ErgoWalletActor(settings, new ErgoWalletServiceImpl, boxSelector, historyReader)
+    ErgoWalletActor(settings, parameters, new ErgoWalletServiceImpl, boxSelector, historyReader)
 
   override def scanOffchain(tx: ErgoTransaction): ErgoWallet = {
     walletActor ! ScanOffChain(tx)
@@ -69,8 +69,9 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings)
 object ErgoWallet {
 
   def readOrGenerate(historyReader: ErgoHistoryReader,
-                     settings: ErgoSettings)(implicit actorSystem: ActorSystem): ErgoWallet = {
-    new ErgoWallet(historyReader, settings)
+                     settings: ErgoSettings,
+                     parameters: Parameters)(implicit actorSystem: ActorSystem): ErgoWallet = {
+    new ErgoWallet(historyReader, settings, parameters)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -31,6 +31,7 @@ import scala.util.{Failure, Success, Try}
 
 
 class ErgoWalletActor(settings: ErgoSettings,
+                      parameters: Parameters,
                       ergoWalletService: ErgoWalletService,
                       boxSelector: BoxSelector,
                       historyReader: ErgoHistoryReader)
@@ -68,7 +69,7 @@ class ErgoWalletActor(settings: ErgoSettings,
 
   override def preStart(): Unit = {
     log.info("Initializing wallet actor")
-    ErgoWalletState.initial(settings) match {
+    ErgoWalletState.initial(settings, parameters) match {
       case Success(state) =>
         context.system.eventStream.subscribe(self, classOf[ChangedState])
         context.system.eventStream.subscribe(self, classOf[ChangedMempool[_]])
@@ -445,10 +446,11 @@ object ErgoWalletActor extends ScorexLogging {
 
   /** Start actor and register its proper closing into coordinated shutdown */
   def apply(settings: ErgoSettings,
+            parameters: Parameters,
             service: ErgoWalletService,
             boxSelector: BoxSelector,
             historyReader: ErgoHistoryReader)(implicit actorSystem: ActorSystem): ActorRef = {
-    val props = Props(classOf[ErgoWalletActor], settings, service, boxSelector, historyReader)
+    val props = Props(classOf[ErgoWalletActor], settings, parameters, service, boxSelector, historyReader)
       .withDispatcher(GlobalConstants.ApiDispatcher)
     val walletActorRef = actorSystem.actorOf(props)
     CoordinatedShutdown(actorSystem).addActorTerminationTask(

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoStateContext, ErgoStateReader, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletState.FilterFn
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
-import org.ergoplatform.settings.{ErgoSettings, LaunchParameters, Parameters}
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.boxes.TrackedBox
 import org.ergoplatform.wallet.secrets.JsonSecretStorage
 import scorex.util.ScorexLogging
@@ -67,7 +67,7 @@ case class ErgoWalletState(
   // State context used to sign transactions and check that coins found in the blockchain are indeed belonging
   // to the wallet (by executing testing transactions against them).
   // The state context is being updated by listening to state updates.
-  def stateContext: ErgoStateContext = storage.readStateContext
+  def stateContext: ErgoStateContext = storage.readStateContext(parameters)
 
   /**
     * @return height of the last block scanned by the wallet
@@ -133,7 +133,7 @@ object ErgoWalletState {
     */
   val noWalletFilter: FilterFn = (_: TrackedBox) => true
 
-  def initial(ergoSettings: ErgoSettings): Try[ErgoWalletState] = {
+  def initial(ergoSettings: ErgoSettings, parameters: Parameters): Try[ErgoWalletState] = {
     WalletRegistry.apply(ergoSettings).map { registry =>
       val ergoStorage: WalletStorage = WalletStorage.readOrCreate(ergoSettings)(ergoSettings.addressEncoder)
       val offChainRegistry = OffChainRegistry.init(registry)
@@ -148,7 +148,7 @@ object ErgoWalletState {
         stateReaderOpt = None,
         mempoolReaderOpt = None,
         utxoStateReaderOpt = None,
-        LaunchParameters
+        parameters
       )
     }
   }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
@@ -3,14 +3,14 @@ package org.ergoplatform.nodeView.wallet.persistence
 import com.google.common.primitives.{Ints, Shorts}
 import org.ergoplatform.nodeView.state.{ErgoStateContext, ErgoStateContextSerializer}
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest, ScanSerializer}
-import org.ergoplatform.settings.{Constants, ErgoSettings}
+import org.ergoplatform.settings.{Constants, ErgoSettings, Parameters}
 import org.ergoplatform.wallet.secrets.{DerivationPath, DerivationPathSerializer, ExtendedPublicKey, ExtendedPublicKeySerializer}
 import org.ergoplatform.{ErgoAddressEncoder, P2PKAddress}
 import scorex.crypto.hash.Blake2b256
 import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import scorex.db.{LDBFactory, LDBKVStore}
-import java.io.File
 
+import java.io.File
 import scorex.util.ScorexLogging
 
 import scala.util.{Failure, Success, Try}
@@ -106,10 +106,10 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings)
     * Read state context from the database
     * @return state context read
     */
-  def readStateContext: ErgoStateContext = store
+  def readStateContext(parameters: Parameters): ErgoStateContext = store
     .get(StateContextKey)
     .flatMap(r => ErgoStateContextSerializer(settings).parseBytesTry(r).toOption)
-    .getOrElse(ErgoStateContext.empty(settings))
+    .getOrElse(ErgoStateContext.empty(settings, parameters))
 
   /**
     * Update address used by the wallet for change outputs

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -33,7 +33,7 @@ class BlocksApiRouteSpec extends AnyFlatSpec
   }
 
   it should "post block correctly" in {
-    val (st, bh) = createUtxoState()
+    val (st, bh) = createUtxoState(parameters)
     val block: ErgoFullBlock = validFullBlock(parentOpt = None, st, bh)
     val blockJson: UniversalEntity = HttpEntity(block.asJson.toString).withContentType(ContentTypes.`application/json`)
     Post(prefix, blockJson) ~> route ~> check {

--- a/src/test/scala/org/ergoplatform/http/routes/InfoApiRoutesSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/InfoApiRoutesSpec.scala
@@ -39,7 +39,7 @@ class InfoApiRoutesSpec extends AnyFlatSpec
 
   implicit val actorTimeout: Timeout = Timeout(15.seconds.dilated)
   implicit val routeTimeout: RouteTestTimeout = RouteTestTimeout(15.seconds.dilated)
-  val statsCollector: ActorRef = ErgoStatsCollectorRef(nodeViewRef, networkControllerRef, settings, fakeTimeProvider)
+  val statsCollector: ActorRef = ErgoStatsCollectorRef(nodeViewRef, networkControllerRef, settings, fakeTimeProvider, parameters)
   val route: Route = InfoApiRoute(statsCollector, settings.scorexSettings.restApi, fakeTimeProvider).route
   val requiredDifficulty = BigInt(1)
 

--- a/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
@@ -28,13 +28,13 @@ import sigmastate.serialization.ErgoTreeSerializer
 class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestHelpers {
   implicit lazy val context: IRContext = new RuntimeIRContext
 
-  val cleanupDuration: FiniteDuration = 2.seconds
+  val cleanupDuration: FiniteDuration = 3.seconds
   val settingsToTest: ErgoSettings = settings.copy(
     nodeSettings = settings.nodeSettings.copy(
       mempoolCleanupDuration = cleanupDuration,
       rebroadcastCount = 1
     ))
-  val fixture = new NodeViewFixture(settingsToTest)
+  val fixture = new NodeViewFixture(settingsToTest, parameters)
   val newTx: Class[SuccessfulTransaction] = classOf[SuccessfulTransaction]
 
   it should "remove transactions which become invalid" in {
@@ -43,9 +43,9 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
     val testProbe = new TestProbe(actorSystem)
     actorSystem.eventStream.subscribe(testProbe.ref, newTx)
 
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
 
     applyBlock(genesis) shouldBe 'success
     getRootHash shouldBe Algos.encode(wusAfterGenesis.rootHash)
@@ -88,7 +88,7 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
 
   it should "rebroadcast transactions correctly" in {
 
-    val (us0, bh0) = createUtxoState(None)
+    val (us0, bh0) = createUtxoState(parameters, None)
     val (txs0, bh1) = validTransactionsFromBoxHolder(bh0)
     val b1 = validFullBlock(None, us0, txs0)
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.mining
 import org.ergoplatform.ErgoScriptPredef
 import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.nodeView.history.ErgoHistory
-import org.ergoplatform.settings.{LaunchParameters, MonetarySettings}
+import org.ergoplatform.settings.MonetarySettings
 import org.ergoplatform.utils.{ErgoPropertyTest, RandomWrapper}
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.scalacheck.Gen
@@ -18,7 +18,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
   private def expectedRewardOutputScriptBytes(pk: ProveDlog): Array[Byte] =
     ErgoScriptPredef.rewardOutputScript(delta, pk).bytes
 
-  implicit private val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
+  implicit private val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
 
   property("minersRewardAtHeight test vectors") {
     emission.minersRewardAtHeight(525000) shouldBe 67500000000L
@@ -51,7 +51,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
   }
 
   property("collect reward from emission box only") {
-    val us = createUtxoState()._1
+    val us = createUtxoState(parameters)._1
     us.emissionBoxOpt should not be None
     val expectedReward = emission.minersRewardAtHeight(us.stateContext.currentHeight)
 
@@ -73,7 +73,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
 
   property("collect reward from transaction fees only") {
     val bh     = boxesHolderGen.sample.get
-    val us     = createUtxoState(bh)
+    val us     = createUtxoState(bh, parameters)
     val height = us.stateContext.currentHeight
     val blockTx = validTransactionFromBoxes(
       bh.boxes.take(2).values.toIndexedSeq,
@@ -123,7 +123,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
 
       val bh          = boxesHolderGen.sample.get
       val rnd         = new RandomWrapper
-      val us          = createUtxoState(bh)
+      val us          = createUtxoState(bh, parameters)
       val inputs      = bh.boxes.values.toIndexedSeq.takeRight(100)
       val txsWithFees = inputs.map(i =>
         validTransactionFromBoxes(IndexedSeq(i), rnd, issueNew = withTokens, feeProp)
@@ -183,7 +183,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
     }
 
     // transactions reach computation cost block limit
-    checkCollectTxs(LaunchParameters.maxBlockCost, Int.MaxValue)
+    checkCollectTxs(parameters.maxBlockCost, Int.MaxValue)
 
     // transactions reach block size limit
     checkCollectTxs(Long.MaxValue, 4096)
@@ -200,7 +200,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
     val feeProposition = ErgoScriptPredef.feeProposition(delta)
 
     val bh     = boxesHolderGen.sample.get
-    var us     = createUtxoState(bh)
+    var us     = createUtxoState(bh, parameters)
     val height = ErgoHistory.EmptyHistoryHeight
 
     val emissionRules = new EmissionRules(
@@ -244,7 +244,7 @@ class CandidateGeneratorPropSpec extends ErgoPropertyTest {
   }
 
   property("collect reward from both emission box and fees") {
-    val (us, _) = createUtxoState()
+    val (us, _) = createUtxoState(parameters)
     us.emissionBoxOpt should not be None
     val expectedReward = emission.minersRewardAtHeight(us.stateContext.currentHeight)
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -53,7 +53,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with ErgoTestHelpers with Event
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -76,7 +76,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with ErgoTestHelpers with Event
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -120,7 +120,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with ErgoTestHelpers with Event
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -160,7 +160,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with ErgoTestHelpers with Event
   ) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -67,7 +67,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with ValidBlocksGen
     }
     complexScript.complexity shouldBe 28077
 
-    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
+    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
     val minerRef: ActorRef = ErgoMiner(
@@ -129,13 +129,13 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with ValidBlocksGen
 
   it should "not freeze while mempool is full" in new TestKit(ActorSystem()) {
     // generate amount of transactions, twice more than can fit in one block
-    val desiredSize: Int = ((parameters.maxBlockCost / CostTable.interpreterInitCost) * 2).toInt
+    val desiredSize: Int = Math.ceil((parameters.maxBlockCost / CostTable.interpreterInitCost) * 1.2).toInt
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
+    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
     expectNoMessage(1 second)
     val r: Readers = requestReaders
@@ -210,7 +210,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with ValidBlocksGen
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
 
-    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
+    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
     val minerRef: ActorRef = ErgoMiner(
@@ -286,7 +286,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with ValidBlocksGen
   it should "prepare external candidate" in new TestKit(ActorSystem()) {
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
 
-    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
+    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
     def minerRef: ActorRef = ErgoMiner(
@@ -310,7 +310,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with ValidBlocksGen
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
 
-    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
+    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
     val minerRef: ActorRef = ErgoMiner(
@@ -389,7 +389,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with ValidBlocksGen
       empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings, directory = createTempDir.getAbsolutePath)
     }
 
-    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(forkSettings, timeProvider)
+    val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(forkSettings, timeProvider, parameters)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
     val minerRef: ActorRef = ErgoMiner(

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.modifiers.mempool
 import io.circe.syntax._
 import org.ergoplatform.ErgoBox._
 import org.ergoplatform.nodeView.ErgoContext
-import org.ergoplatform.nodeView.state.{ErgoStateContext, UpcomingStateContext, VotingData}
+import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
 import org.ergoplatform.settings.Parameters.MaxBlockCostIncrease
 import org.ergoplatform.settings.ValidationRules.{bsBlockTransactionsCost, txAssetsInOneBox}
 import org.ergoplatform.settings._
@@ -30,7 +30,7 @@ import scala.util.{Random, Try}
 
 class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
-  private implicit val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
+  private implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
 
   property("serialization vector") {
     // test vectors, that specifies transaction json and bytes representation.
@@ -301,7 +301,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
     tx.statelessValidity().isSuccess shouldBe true
 
     //check that spam transaction is being rejected quickly
-    implicit val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
+    implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
     val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
     validity.isSuccess shouldBe false
     assert(time0 <= Timeout)
@@ -328,13 +328,11 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
   }
 
   property("transaction cost") {
-    def stateContextWithMaxCost(manualCost: Int): UpcomingStateContext = {
-      val table2: Map[Byte, Int] = Parameters.DefaultParameters + (MaxBlockCostIncrease -> manualCost)
-      val params2 = new Parameters(height = 0,
-        parametersTable = table2,
-        proposedUpdate = ErgoValidationSettingsUpdate.empty)
-      emptyStateContext.copy(currentParameters = params2)(settings)
-    }
+    def paramsWith(manualCost: Int) = new Parameters(
+      height = 0,
+      parametersTable = Parameters.DefaultParameters + (MaxBlockCostIncrease -> manualCost),
+      proposedUpdate = ErgoValidationSettingsUpdate.empty
+    )
 
     val gen = validErgoTransactionGenTemplate(0, 0,10, trueLeafGen)
     val (from, tx) = gen.sample.get
@@ -342,26 +340,26 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
     // calculate costs manually
     val initialCost: Long =
-      tx.inputs.size * LaunchParameters.inputCost +
-        tx.dataInputs.size * LaunchParameters.dataInputCost +
-        tx.outputs.size * LaunchParameters.outputCost +
+      tx.inputs.size * parameters.inputCost +
+        tx.dataInputs.size * parameters.dataInputCost +
+        tx.outputs.size * parameters.outputCost +
         CostTable.interpreterInitCost
     val (outAssets, outAssetsNum) = tx.outAssetsTry.get
     val (inAssets, inAssetsNum) = ErgoBoxAssetExtractor.extractAssets(from).get
-    val totalAssetsAccessCost = (outAssetsNum + inAssetsNum) * LaunchParameters.tokenAccessCost +
-      (inAssets.size + outAssets.size) * LaunchParameters.tokenAccessCost
+    val totalAssetsAccessCost = (outAssetsNum + inAssetsNum) * parameters.tokenAccessCost +
+      (inAssets.size + outAssets.size) * parameters.tokenAccessCost
     val scriptsValidationCosts = tx.inputs.size * (CostTable.constCost + CostTable.logicCost + CostTable.logicCost + from.head.ergoTree.complexity)
     val manualCost: Int = (initialCost + totalAssetsAccessCost + scriptsValidationCosts).toInt
 
 
     // check that validation pass if cost limit equals to manually calculated cost
-    val sc = stateContextWithMaxCost(manualCost)
+    val sc = stateContextWith(paramsWith(manualCost))
     sc.currentParameters.maxBlockCost shouldBe manualCost
     val calculatedCost = tx.statefulValidity(from, IndexedSeq(), sc)(ErgoInterpreter(sc.currentParameters)).get
     manualCost shouldBe calculatedCost
 
     // transaction exceeds computations limit
-    val sc2 = stateContextWithMaxCost(manualCost - 1)
+    val sc2 = stateContextWith(paramsWith(manualCost - 1))
     tx.statefulValidity(from, IndexedSeq(), sc2)(ErgoInterpreter(sc2.currentParameters)) shouldBe 'failure
 
     // transaction exceeds computations limit due to non-zero accumulated cost
@@ -417,9 +415,9 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
       signerTxCostWithInitCost shouldBe txCost // signer and verifier costs should be the same
 
       val initialCost: Long =
-        tx.inputs.size * LaunchParameters.inputCost +
-          tx.dataInputs.size * LaunchParameters.dataInputCost +
-          tx.outputs.size * LaunchParameters.outputCost +
+        tx.inputs.size * parameters.inputCost +
+          tx.dataInputs.size * parameters.dataInputCost +
+          tx.outputs.size * parameters.outputCost +
           CostTable.interpreterInitCost +
           assetsCost
 

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.modifiers.mempool
 
 import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
-import org.ergoplatform.settings.{Constants, LaunchParameters}
+import org.ergoplatform.settings.Constants
 import org.ergoplatform.utils.ErgoPropertyTest
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
@@ -15,7 +15,7 @@ class ExpirationSpecification extends ErgoPropertyTest {
 
   type Height = Int
 
-  private implicit val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
+  private implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
 
   def falsify(box: ErgoBox): ErgoBox = {
     testBox(box.value,
@@ -47,7 +47,7 @@ class ExpirationSpecification extends ErgoPropertyTest {
       val fb = fb0.copy(fb0.header.copy(height = h, parentId = fakeHeader.id))
 
       val updContext = {
-        val inContext = new ErgoStateContext(Seq(fakeHeader), None, genesisStateDigest, LaunchParameters, validationSettingsNoIl,
+        val inContext = new ErgoStateContext(Seq(fakeHeader), None, genesisStateDigest, parameters, validationSettingsNoIl,
           VotingData.empty)(settings)
         inContext.appendFullBlock(fb).get
       }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -105,7 +105,7 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
   }
 
   val localStateGen: Gen[WrappedUtxoState] =
-    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, settings))
+    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, parameters, settings))
 
   def semanticallyValidModifier(state: UTXO_ST): PM = {
     statefulyValidFullBlock(state.asInstanceOf[WrappedUtxoState])

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyNonADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyNonADHistorySpecification.scala
@@ -157,7 +157,7 @@ class VerifyNonADHistorySpecification extends HistoryTestHelpers {
   }
 
   property("append header to genesis - 2") {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
 
     val block = validFullBlock(None, us, bh)
 

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -55,9 +55,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   it should "reject double-spending transaction if it is paying no more than one already sitting in the pool" in {
     forAll(smallPositiveInt, smallPositiveInt) { case (n1, n2) =>
       whenever(n1 != n2) {
-        val (us, bh) = createUtxoState(increasedMaxBlockCostParameters)
+        val (us, bh) = createUtxoState(extendedParameters)
         val genesis = validFullBlock(None, us, bh)
-        val wus = WrappedUtxoState(us, bh, stateConstants, increasedMaxBlockCostParameters).applyModifier(genesis).get
+        val wus = WrappedUtxoState(us, bh, stateConstants, extendedParameters).applyModifier(genesis).get
 
         val feeProp = settings.chainSettings.monetary.feeProposition
         val inputBox = wus.takeBoxes(1).head

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -17,9 +17,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   with ScalaCheckPropertyChecks {
 
   it should "accept valid transaction" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     val txs = validTransactionsFromUtxoState(wus)
     val pool0 = ErgoMemPool.empty(settings)
     val poolAfter = txs.foldLeft(pool0) { case (pool, tx) =>
@@ -39,9 +39,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "decline already contained transaction" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     val txs = validTransactionsFromUtxoState(wus)
     var pool = ErgoMemPool.empty(settings)
     txs.foreach { tx =>
@@ -55,9 +55,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   it should "reject double-spending transaction if it is paying no more than one already sitting in the pool" in {
     forAll(smallPositiveInt, smallPositiveInt) { case (n1, n2) =>
       whenever(n1 != n2) {
-        val (us, bh) = createUtxoState()
+        val (us, bh) = createUtxoState(increasedMaxBlockCostParameters)
         val genesis = validFullBlock(None, us, bh)
-        val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+        val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
 
         val feeProp = settings.chainSettings.monetary.feeProposition
         val inputBox = wus.takeBoxes(1).head
@@ -101,7 +101,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "decline transactions invalidated earlier" in {
-    val us = createUtxoState()._1
+    val us = createUtxoState(parameters)._1
     var pool = ErgoMemPool.empty(settings)
     forAll(invalidBlockTransactionsGen) { blockTransactions =>
       blockTransactions.txs.foreach(tx => pool = pool.process(tx, us)._1)
@@ -111,9 +111,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "decline transactions not meeting min fee" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     val txs = validTransactionsFromUtxoState(wus)
 
     val maxSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(minimalFeeAmount = Long.MaxValue))
@@ -134,7 +134,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "invalidate invalid transaction" in {
-    val us = createUtxoState()._1
+    val us = createUtxoState(parameters)._1
     val pool = ErgoMemPool.empty(settings)
     forAll(invalidBlockTransactionsGen) { blockTransactions =>
       blockTransactions.txs.forall(pool.process(_, us)._2.isInstanceOf[ProcessingOutcome.Invalidated]) shouldBe true
@@ -169,9 +169,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "Accept output of pooled transactions" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     val txs = validTransactionsFromUtxoState(wus)
     var pool = ErgoMemPool.empty(settings)
     txs.foreach { tx =>
@@ -187,9 +187,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "consider families for replacement policy" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     var txs = validTransactionsFromUtxoState(wus)
     val family_depth = 10
     val limitedPoolSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(mempoolCapacity = (family_depth + 1) * txs.size))
@@ -217,9 +217,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "correctly remove transaction from pool and rebuild families" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     var txs = validTransactionsFromUtxoState(wus)
     var allTxs = txs
     val family_depth = 10
@@ -250,9 +250,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   it should "return results take / getAll / getAllPrioritized sorted by priority" in {
     val feeProp = settings.chainSettings.monetary.feeProposition
 
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     var txs = validTransactionsFromUtxoState(wus)
     val family_depth = 10
     val limitedPoolSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(mempoolCapacity = (family_depth + 1) * txs.size))
@@ -291,9 +291,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   }
 
   it should "add removed transaction to mempool statistics" in {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     var txs = validTransactionsFromUtxoState(wus)
     var allTxs = txs
     val family_depth = 10

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -57,7 +57,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
       whenever(n1 != n2) {
         val (us, bh) = createUtxoState(increasedMaxBlockCostParameters)
         val genesis = validFullBlock(None, us, bh)
-        val wus = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
+        val wus = WrappedUtxoState(us, bh, stateConstants, increasedMaxBlockCostParameters).applyModifier(genesis).get
 
         val feeProp = settings.chainSettings.monetary.feeProposition
         val inputBox = wus.takeBoxes(1).head

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ScriptsSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ScriptsSpec.scala
@@ -73,7 +73,7 @@ class ScriptsSpec extends ErgoPropertyTest {
   private def applyBlockSpendingScript(script: ErgoTree): Try[UtxoState] = {
     val scriptBox = ergoBoxGen(script, heightGen = 0).sample.get
     val bh = BoxHolder(Seq(fixedBox, scriptBox))
-    val us = UtxoState.fromBoxHolder(bh, None, createTempDir, stateConstants)
+    val us = UtxoState.fromBoxHolder(bh, None, createTempDir, stateConstants, parameters)
     bh.boxes.map(b => us.boxById(b._2.id) shouldBe Some(b._2))
     val tx = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(1)), 201)._1
     tx.size shouldBe 1

--- a/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateSpecification.scala
@@ -18,8 +18,8 @@ class ErgoStateSpecification extends ErgoPropertyTest {
 
   property("applyModifier() - double spending") {
     forAll(boxesHolderGen, Gen.choose(1: Byte, 2: Byte)) { case (bh, version) =>
-      val us = createUtxoState(bh)
-      val ds = createDigestState(bytesToVersion(Array.fill(32)(100: Byte)), us.rootHash)
+      val us = createUtxoState(bh, parameters)
+      val ds = createDigestState(bytesToVersion(Array.fill(32)(100: Byte)), us.rootHash, parameters)
 
       val validBlock = validFullBlock(None, us, bh)
       val dsTxs = validBlock.transactions ++ validBlock.transactions
@@ -52,8 +52,8 @@ class ErgoStateSpecification extends ErgoPropertyTest {
       s1.genesisStateDigest shouldBe s2.genesisStateDigest
     }
 
-    var (us, bh) = createUtxoState()
-    var ds = createDigestState(us.version, us.rootHash)
+    var (us, bh) = createUtxoState(parameters)
+    var ds = createDigestState(us.version, us.rootHash, parameters)
     var lastBlocks: Seq[ErgoFullBlock] = Seq()
     forAll { seed: Int =>
       val blBh = validFullBlockWithBoxHolder(lastBlocks.headOption, us, bh, new RandomWrapper(Some(seed)))
@@ -69,13 +69,13 @@ class ErgoStateSpecification extends ErgoPropertyTest {
   property("generateGenesisUtxoState & generateGenesisDigestState are compliant") {
     val settings = ErgoSettings.read(Args.empty)
     val dir = createTempDir
-    val rootHash = createUtxoState()._1.rootHash
-    val expectedRootHash = ErgoState.generateGenesisDigestState(dir, settings).rootHash
+    val rootHash = createUtxoState(parameters)._1.rootHash
+    val expectedRootHash = ErgoState.generateGenesisDigestState(dir, settings, parameters).rootHash
     rootHash shouldBe expectedRootHash
   }
 
   property("ErgoState.boxChanges() should generate operations in the same order") {
-    var (us, bh) = createUtxoState()
+    var (us, bh) = createUtxoState(parameters)
     var parentOpt: Option[ErgoFullBlock] = None
 
     forAll { seed: Int =>
@@ -93,7 +93,7 @@ class ErgoStateSpecification extends ErgoPropertyTest {
   }
 
   property("ErgoState.boxChanges() double spend attempt") {
-    val (_, bh) = createUtxoState()
+    val (_, bh) = createUtxoState(parameters)
     val emissionBox = genesisBoxes.head
 
     forAll { seed: Int =>
@@ -117,7 +117,7 @@ class ErgoStateSpecification extends ErgoPropertyTest {
   }
 
   property("ErgoState.stateChanges()") {
-    val bh = createUtxoState()._2
+    val bh = createUtxoState(parameters)._2
     val emissionBox = genesisBoxes.head
 
     forAll { seed: Int =>

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -32,7 +32,7 @@ import scala.util.Try
 class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenerators {
 
   property("Founders box workflow") {
-    var (us, bh) = createUtxoState()
+    var (us, bh) = createUtxoState(parameters)
     var foundersBox = genesisBoxes.last
     var lastBlock = validFullBlock(parentOpt = None, us, bh)
     us = us.applyModifier(lastBlock).get
@@ -57,7 +57,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
   }
 
   property("Founders should be able to spend genesis founders box") {
-    var (us, bh) = createUtxoState()
+    var (us, bh) = createUtxoState(parameters)
     val foundersBox = genesisBoxes.last
     var height: Int = ErgoHistory.GenesisHeight
 
@@ -97,7 +97,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
   }
 
   property("Correct genesis state") {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val boxes = bh.boxes.values.toList
     boxes.size shouldBe 3
 
@@ -105,7 +105,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
     genesisBoxes.length shouldBe bh.boxes.size
     genesisBoxes.foreach { b =>
       us.boxById(b.id).isDefined shouldBe true
-      bh.boxes.get(ByteArrayWrapper(b.id)).isDefined shouldBe true
+      bh.boxes.contains(ByteArrayWrapper(b.id)) shouldBe true
     }
 
     // check total supply
@@ -121,7 +121,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
   }
 
   property("extractEmissionBox() should extract correct box") {
-    var (us, bh) = createUtxoState()
+    var (us, bh) = createUtxoState(parameters)
     us.emissionBoxOpt should not be None
     var lastBlockOpt: Option[ErgoFullBlock] = None
     forAll { seed: Int =>
@@ -136,7 +136,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
   property("fromBoxHolder") {
     forAll(boxesHolderGen) { bh =>
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       bh.take(1000)._1.foreach { box =>
         us.boxById(box.id) shouldBe Some(box)
       }
@@ -144,7 +144,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
   }
 
   property("proofsForTransactions") {
-    var (us: UtxoState, bh) = createUtxoState()
+    var (us: UtxoState, bh) = createUtxoState(parameters)
     var height: Int = ErgoHistory.GenesisHeight
     forAll(defaultHeaderGen) { header =>
       val t = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(height)))
@@ -167,7 +167,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
     implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
 
     var bh = BoxHolder(Seq(genesisEmissionBox))
-    var us = createUtxoState(bh)
+    var us = createUtxoState(bh, parameters)
 
     var height: Int = ErgoHistory.GenesisHeight
     // generate chain of correct full blocks
@@ -189,7 +189,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
       fb
     }
     // create new genesis state
-    var us2 = createUtxoState(BoxHolder(Seq(genesisEmissionBox)))
+    var us2 = createUtxoState(BoxHolder(Seq(genesisEmissionBox)), parameters)
     val stateReader = us2.getReader.asInstanceOf[UtxoState]
     // parallel thread that generates proofs
     val f = Future {
@@ -210,7 +210,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
   property("proofsForTransactions() to be deterministic") {
     forAll(boxesHolderGen) { bh =>
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       val txs = validTransactionsFromBoxHolder(bh)._1
 
       val (proof1, digest1) = us.proofsForTransactions(txs).get
@@ -225,7 +225,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
     forAll(boxesHolderGen) { bh =>
       val txsIn = validTransactionsFromBoxHolder(bh)._1
       val headTx = txsIn.head
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       val existingBoxes: IndexedSeq[BoxId] = bh.boxes.takeRight(3).map(_._2.id).toIndexedSeq
 
       // trying to apply transactions with missing data inputs
@@ -250,7 +250,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
   property("applyTransactions() - dataInputs intersect with inputs") {
     forAll(boxesHolderGen) { bh =>
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
 
       // generate 2 independent transactions, that only spend state boxes
       val headTx = validTransactionsFromBoxes(1, bh.boxes.take(10).values.toSeq, new RandomWrapper())._1.head
@@ -315,7 +315,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
       val toRemove = boxIds.filterNot(id => created.contains(id))
       toRemove.foreach(id => bh.get(id) should not be None)
 
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       bh.sortedBoxes.foreach(box => us.boxById(box.id) should not be None)
       val digest = us.proofsForTransactions(txs).get._2
       val wBlock = invalidErgoFullBlockGen.sample.get
@@ -340,7 +340,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
       val txs = txsFromHolder :+ spendingTx
 
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       val digest = us.proofsForTransactions(txs).get._2
 
       val header = invalidHeaderGen.sample.get.copy(stateRoot = digest, height = 1)
@@ -365,14 +365,14 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
       val txs = spendingTx +: txsFromHolder
 
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       us.proofsForTransactions(txs).isSuccess shouldBe false
     }
   }
 
   property("applyModifier() - valid full block") {
     forAll(boxesHolderGen) { bh =>
-      val us = createUtxoState(bh)
+      val us = createUtxoState(bh, parameters)
       bh.sortedBoxes.foreach(box => us.boxById(box.id) should not be None)
 
       val block = validFullBlock(parentOpt = None, us, bh)
@@ -382,13 +382,13 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
   property("applyModifier() - invalid block") {
     forAll(invalidErgoFullBlockGen) { b =>
-      val state = createUtxoState()._1
+      val state = createUtxoState(parameters)._1
       state.applyModifier(b).isFailure shouldBe true
     }
   }
 
   property("applyModifier() - valid full block after invalid one") {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val validBlock = validFullBlock(parentOpt = None, us, bh)
 
     //Different state
@@ -397,7 +397,7 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
       val bh = BoxHolder(initialBoxes)
 
-      createUtxoState(bh) -> bh
+      createUtxoState(bh, parameters) -> bh
     }
     val invalidBlock = validFullBlock(parentOpt = None, us2, bh2)
 
@@ -407,20 +407,20 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
 
   property("2 forks switching") {
-    val (us, bh) = createUtxoState()
+    val (us, bh) = createUtxoState(parameters)
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     val chain1block1 = validFullBlock(Some(genesis), wusAfterGenesis)
     val wusChain1Block1 = wusAfterGenesis.applyModifier(chain1block1).get
     val chain1block2 = validFullBlock(Some(chain1block1), wusChain1Block1)
 
-    val (us2, bh2) = createUtxoState()
-    val wus2AfterGenesis = WrappedUtxoState(us2, bh2, stateConstants).applyModifier(genesis).get
+    val (us2, bh2) = createUtxoState(parameters)
+    val wus2AfterGenesis = WrappedUtxoState(us2, bh2, stateConstants, parameters).applyModifier(genesis).get
     val chain2block1 = validFullBlock(Some(genesis), wus2AfterGenesis)
     val wusChain2Block1 = wus2AfterGenesis.applyModifier(chain2block1).get
     val chain2block2 = validFullBlock(Some(chain2block1), wusChain2Block1)
 
-    var (state, _) = createUtxoState()
+    var (state, _) = createUtxoState(parameters)
     state = state.applyModifier(genesis).get
 
     state = state.applyModifier(chain1block1).get
@@ -438,10 +438,10 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
   property("rollback n blocks and apply again") {
     forAll(boxesHolderGen, smallPositiveInt) { (bh, depth) =>
       whenever(depth > 0 && depth <= 5) {
-        val us = createUtxoState(bh)
+        val us = createUtxoState(bh, parameters)
         bh.sortedBoxes.foreach(box => us.boxById(box.id) should not be None)
         val genesis = validFullBlock(parentOpt = None, us, bh)
-        val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+        val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
         wusAfterGenesis.rootHash shouldEqual genesis.header.stateRoot
 
         val (finalState: WrappedUtxoState, chain: Seq[ErgoFullBlock]) = (0 until depth)

--- a/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedDigestState.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedDigestState.scala
@@ -2,15 +2,16 @@ package org.ergoplatform.nodeView.state.wrapped
 
 import org.ergoplatform.modifiers.ErgoPersistentModifier
 import org.ergoplatform.nodeView.state.DigestState
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import scorex.core.VersionTag
 
 import scala.util.Try
 
 class WrappedDigestState(val digestState: DigestState,
                          val wrappedUtxoState: WrappedUtxoState,
-                         val settings: ErgoSettings)
-  extends DigestState(digestState.version, digestState.rootHash, digestState.store, settings) {
+                         val settings: ErgoSettings,
+                         override val parameters: Parameters)
+  extends DigestState(digestState.version, digestState.rootHash, digestState.store, parameters, settings) {
 
   override def applyModifier(mod: ErgoPersistentModifier): Try[WrappedDigestState] = {
     wrapped(super.applyModifier(mod), wrappedUtxoState.applyModifier(mod))
@@ -21,5 +22,5 @@ class WrappedDigestState(val digestState: DigestState,
   }
 
   private def wrapped(digestT: Try[DigestState], utxoT: Try[WrappedUtxoState]): Try[WrappedDigestState] =
-    digestT.flatMap(digest => utxoT.map(utxo => new WrappedDigestState(digest, utxo, settings)))
+    digestT.flatMap(digest => utxoT.map(utxo => new WrappedDigestState(digest, utxo, settings, parameters)))
 }

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -29,7 +29,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t3 = TestCase("apply valid block header") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val block = validFullBlock(None, us, bh)
 
     getBestHeaderOpt shouldBe None
@@ -49,7 +49,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t4 = TestCase("apply valid block as genesis") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
 
     subscribeEvents(classOf[SyntacticallySuccessfulModifier])
@@ -69,9 +69,9 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t5 = TestCase("apply full blocks after genesis") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     applyBlock(genesis) shouldBe 'success
 
     val block = validFullBlock(Some(genesis), wusAfterGenesis)
@@ -88,7 +88,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t6 = TestCase("add transaction to memory pool") { fixture =>
     import fixture._
     if (stateType == Utxo) {
-      val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+      val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
       val genesis = validFullBlock(parentOpt = None, us, bh)
       applyBlock(genesis) shouldBe 'success
 
@@ -103,11 +103,11 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
     }
   }
 
-  private val t7 = TestCase("apply statefuly invalid full block") { fixture =>
+  private val t7 = TestCase("apply statefully invalid full block") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     // TODO looks like another bug is still present here, see https://github.com/ergoplatform/ergo/issues/309
     if (verifyTransactions) {
       applyBlock(genesis) shouldBe 'success
@@ -157,9 +157,9 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t8 = TestCase("switching for a better chain") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
 
     applyBlock(genesis) shouldBe 'success
     getRootHash shouldBe Algos.encode(wusAfterGenesis.rootHash)
@@ -191,7 +191,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t9 = TestCase("UTXO state should generate adProofs and put them in history") { fixture =>
     import fixture._
     if (stateType == StateType.Utxo) {
-      val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+      val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
       val genesis = validFullBlock(parentOpt = None, us, bh)
 
       nodeViewHolderRef ! LocallyGeneratedModifier(genesis.header)
@@ -205,9 +205,9 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t10 = TestCase("NodeViewHolder start from inconsistent state") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
     applyBlock(genesis) shouldBe 'success
 
     val block1 = validFullBlock(Some(genesis), wusAfterGenesis)
@@ -225,9 +225,9 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t11 = TestCase("apply payload in incorrect order (excluding extension)") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val genesis = validFullBlock(parentOpt = None, us, bh)
-    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants).applyModifier(genesis).get
+    val wusAfterGenesis = WrappedUtxoState(us, bh, stateConstants, parameters).applyModifier(genesis).get
 
     applyBlock(genesis) shouldBe 'success
     getRootHash shouldBe Algos.encode(wusAfterGenesis.rootHash)
@@ -251,7 +251,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t12 = TestCase("Do not apply txs with wrong header id") { fixture =>
     import fixture._
 
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val block = validFullBlock(None, us, bh)
     getBestHeaderOpt shouldBe None
     getHistoryHeight shouldBe ErgoHistory.EmptyHistoryHeight
@@ -303,7 +303,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t13 = TestCase("Do not apply wrong adProofs") { fixture =>
     import fixture._
 
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val block = validFullBlock(None, us, bh)
     getBestHeaderOpt shouldBe None
 
@@ -334,7 +334,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
     "it's not equal to genesisId from config") { fixture =>
     import fixture._
     updateConfig(genesisIdConfig(modifierIdGen.sample))
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val block = validFullBlock(None, us, bh)
 
     getBestHeaderOpt shouldBe None
@@ -352,7 +352,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t15 = TestCase("apply genesis block header if it's equal to genesisId from config") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val block = validFullBlock(None, us, bh)
     updateConfig(genesisIdConfig(Some(block.header.id)))
 
@@ -371,8 +371,8 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t16 = TestCase("apply forks that include genesis block") { fixture =>
     import fixture._
 
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
-    val wusGenesis = WrappedUtxoState(us, bh, stateConstants)
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
+    val wusGenesis = WrappedUtxoState(us, bh, stateConstants, parameters)
 
 
     val chain1block1 = validFullBlock(parentOpt = None, us, bh)
@@ -401,7 +401,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   private val t17 = TestCase("apply invalid genesis header") { fixture =>
     import fixture._
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
     val header = validFullBlock(None, us, bh).header.copy(parentId = bytesToId(Array.fill(32)(9: Byte)))
 
     getBestHeaderOpt shouldBe None
@@ -419,7 +419,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t18 = TestCase("apply syntactically invalid genesis block") { fixture =>
     import fixture._
 
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
 
     val validBlock = validFullBlock(parentOpt = None, us, bh)
     val invalidBlock = validBlock.copy(header = validBlock.header.copy(parentId = bytesToId(Array.fill(32)(9: Byte))))
@@ -432,8 +432,8 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   private val t19 = TestCase("apply semantically invalid genesis block") { fixture =>
     import fixture._
 
-    val (us, bh) = createUtxoState(Some(nodeViewHolderRef))
-    val wusGenesis = WrappedUtxoState(us, bh, stateConstants)
+    val (us, bh) = createUtxoState(parameters, Some(nodeViewHolderRef))
+    val wusGenesis = WrappedUtxoState(us, bh, stateConstants, parameters)
 
     val invalidBlock = generateInvalidFullBlock(None, wusGenesis)
 
@@ -454,7 +454,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   NodeViewTestConfig.allConfigs.foreach { c =>
     cases.foreach { t =>
       property(s"${t.name} - $c") {
-        t.run(c)
+        t.run(parameters, c)
       }
     }
   }
@@ -464,7 +464,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
   NodeViewTestConfig.verifyTxConfigs.foreach { c =>
     verifyingTxCases.foreach { t =>
       property(s"${t.name} - $c") {
-        t.run(c)
+        t.run(parameters, c)
       }
     }
   }
@@ -477,7 +477,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps with 
 
   genesisIdTestCases.foreach { t =>
     property(t.name) {
-      t.run(NodeViewTestConfig(StateType.Digest, verifyTransactions = true, popowBootstrap = true))
+      t.run(parameters, NodeViewTestConfig(StateType.Digest, verifyTransactions = true, popowBootstrap = true))
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/PrunedNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/PrunedNodeViewHolderSpec.scala
@@ -47,8 +47,8 @@ class PrunedNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps wit
   private def testCode(fixture: NodeViewFixture, toSkip: Int, totalBlocks: Int = 20) = {
     import fixture._
 
-    val (us, bh) = createUtxoState(stateConstants)
-    val wus = WrappedUtxoState(us, bh, stateConstants)
+    val (us, bh) = createUtxoState(stateConstants, parameters)
+    val wus = WrappedUtxoState(us, bh, stateConstants, parameters)
 
     val fullChain = genFullChain(wus, totalBlocks)
 
@@ -69,19 +69,19 @@ class PrunedNodeViewHolderSpec extends ErgoPropertyTest with NodeViewTestOps wit
   }
 
   property(s"pruned chain bootstrapping - blocksToKeep = -1 - all the blocks are to be applied to the state") {
-    new NodeViewFixture(prunedSettings(-1)).apply(f => testCode(f, 0))
+    new NodeViewFixture(prunedSettings(-1), parameters).apply(f => testCode(f, 0))
   }
 
   property(s"pruned chain bootstrapping - blocksToKeep = 3 - first 9 blocks out of 20 are not to be applied to the state") {
-    new NodeViewFixture(prunedSettings(3)).apply(f => testCode(f, 9))
+    new NodeViewFixture(prunedSettings(3), parameters).apply(f => testCode(f, 9))
   }
 
   property(s"pruned chain bootstrapping - blocksToKeep = 15 - all the blocks are to be applied to the state") {
-    new NodeViewFixture(prunedSettings(15)).apply(f => testCode(f, 0))
+    new NodeViewFixture(prunedSettings(15), parameters).apply(f => testCode(f, 0))
   }
 
   property(s"pruned chain bootstrapping - total = 30, blocksToKeep = 15 - first 9 blocks are not to be applied to the state") {
-    new NodeViewFixture(prunedSettings(15)).apply(f => testCode(f, 9, 30))
+    new NodeViewFixture(prunedSettings(15), parameters).apply(f => testCode(f, 9, 30))
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -29,7 +29,7 @@ import scala.util.Random
 
 class ErgoWalletServiceSpec extends ErgoPropertyTest with WalletTestOps with ErgoWalletSupport with ErgoTransactionGenerators with DBSpec with BeforeAndAfterAll {
 
-  private implicit val x: WalletFixture = new WalletFixture(settings, getCurrentView(_).vault)
+  private implicit val x: WalletFixture = new WalletFixture(settings, parameters, getCurrentView(_).vault)
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 4, sizeRange = 4)
   private lazy val pks = getPublicKeys.toList
   private val masterKey = ExtendedSecretKey.deriveMasterKey(Mnemonic.toSeed(SecretString.create("edge talent poet tortoise trumpet dose")))

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
 import org.ergoplatform.nodeView.wallet.IdUtils._
 import org.ergoplatform.nodeView.wallet.persistence.{WalletDigest, WalletDigestSerializer}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, ExternalSecret, PaymentRequest}
-import org.ergoplatform.settings.{Algos, Constants, LaunchParameters}
+import org.ergoplatform.settings.{Algos, Constants}
 import org.ergoplatform.utils._
 import org.ergoplatform.wallet.interpreter.{ErgoInterpreter, TransactionHintsBag}
 import scorex.util.encode.Base16
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 
 class ErgoWalletSpec extends ErgoPropertyTest with WalletTestOps with Eventually {
 
-  private implicit val verifier: ErgoInterpreter = ErgoInterpreter(LaunchParameters)
+  private implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
 
   property("assets in WalletDigest are deterministic against serialization") {
     forAll(Gen.listOfN(5, assetGen)) { preAssets =>

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistryBenchmark.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistryBenchmark.scala
@@ -63,7 +63,7 @@ object WalletRegistryBenchmark extends App with ErgoTestConstants {
   println("boxes read: " + boxesRead.size)
   println("boxes read time: " + (bts - bts0) + " ms")
 
-  val stateContext = storage.readStateContext
+  val stateContext = storage.readStateContext(parameters)
 
   val txs = boxes.map { tb =>
     val bx = tb.box

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanityDigest.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanityDigest.scala
@@ -28,9 +28,9 @@ class ErgoSanityDigest extends ErgoSanity[DIGEST_ST] {
     generateHistory(verifyTransactions = true, StateType.Digest, PoPoWBootstrap = false, -1)
 
   override val stateGen: Gen[WrappedDigestState] = {
-    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, settings)).map { wus =>
-      val digestState = DigestState.create(Some(wus.version), Some(wus.rootHash), createTempDir, stateConstants)
-      new WrappedDigestState(digestState, wus, settings)
+    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, parameters, settings)).map { wus =>
+      val digestState = DigestState.create(Some(wus.version), Some(wus.rootHash), createTempDir, stateConstants, parameters)
+      new WrappedDigestState(digestState, wus, settings, parameters)
     }
   }
 

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanityUTXO.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanityUTXO.scala
@@ -28,7 +28,7 @@ class ErgoSanityUTXO extends ErgoSanity[UTXO_ST] with ErgoTestHelpers {
     generateHistory(verifyTransactions = true, StateType.Utxo, PoPoWBootstrap = false, blocksToKeep = -1)
 
   override val stateGen: Gen[WrappedUtxoState] =
-    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, settings))
+    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, parameters, settings))
 
   override def semanticallyValidModifier(state: UTXO_ST): PM = {
     statefulyValidFullBlock(state.asInstanceOf[WrappedUtxoState])

--- a/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
@@ -28,7 +28,7 @@ class JsonSerializationSpec extends ErgoPropertyTest with WalletGenerators with 
 
   property("ErgoFullBlock should be encoded into JSON and decoded back correctly") {
 
-    val (st, bh) = createUtxoState()
+    val (st, bh) = createUtxoState(parameters)
     val block: ErgoFullBlock = validFullBlock(parentOpt = None, st, bh)
 
     val blockJson: Json = block.asJson
@@ -59,7 +59,7 @@ class JsonSerializationSpec extends ErgoPropertyTest with WalletGenerators with 
       val json = request.asJson
       val parsingResult = json.as[PaymentRequest]
       parsingResult.isRight shouldBe true
-      val restored = parsingResult.right.value
+      val restored = parsingResult.value
       restored.address shouldEqual request.address
       restored.value shouldEqual request.value
       restored.registers shouldEqual request.registers
@@ -79,7 +79,7 @@ class JsonSerializationSpec extends ErgoPropertyTest with WalletGenerators with 
       val json = request.asJson
       val parsingResult = json.as[AssetIssueRequest]
       parsingResult.isRight shouldBe true
-      val restored = parsingResult.right.value
+      val restored = parsingResult.value
       restored.addressOpt shouldEqual request.addressOpt
       restored.amount shouldEqual request.amount
       restored.name shouldEqual request.name

--- a/src/test/scala/org/ergoplatform/settings/VotingSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/VotingSpecification.scala
@@ -38,12 +38,12 @@ class VotingSpecification extends ErgoPropertyTest {
     Seq(VR.CheckDeserializedScriptType.id -> DisabledRule, VR.CheckValidOpCode.id -> ReplacedRule((VR.FirstRuleId + 11).toShort)))
   private val proposedUpdate2 = ErgoValidationSettingsUpdate(Seq(ValidationRules.fbOperationFailed), Seq())
   val ctx: ErgoStateContext = {
-    new ErgoStateContext(Seq.empty, None, genesisStateDigest, LaunchParameters, validationSettingsNoIl, VotingData.empty)(updSettings)
+    new ErgoStateContext(Seq.empty, None, genesisStateDigest, parameters, validationSettingsNoIl, VotingData.empty)(updSettings)
       .upcoming(org.ergoplatform.mining.group.generator, 0L, settings.chainSettings.initialNBits, Array.fill(3)(0.toByte), emptyVSUpdate, 0.toByte)
   }
   val initialVs: ErgoValidationSettings = ctx.validationSettings
   val extensionWithAllParams: ExtensionCandidate = {
-    LaunchParameters.toExtensionCandidate ++ initialVs.toExtensionCandidate
+    parameters.toExtensionCandidate ++ initialVs.toExtensionCandidate
   }
 
   val emptyParameters = Parameters(0, Map.empty, ErgoValidationSettingsUpdate.empty)
@@ -84,7 +84,7 @@ class VotingSpecification extends ErgoPropertyTest {
     }
     val invalidExtBlock2 = { // extension contains redundant parameter
       lastBlock.copy(extension = lastBlock.extension.copy(
-        fields = LaunchParameters.toExtensionCandidate.fields :+ Array(0: Byte, 99: Byte) -> Array.fill(4)(2: Byte))
+        fields = parameters.toExtensionCandidate.fields :+ Array(0: Byte, 99: Byte) -> Array.fill(4)(2: Byte))
       )
     }
     val invalidExtBlock3 = { // extension does not contain params at all
@@ -302,7 +302,7 @@ class VotingSpecification extends ErgoPropertyTest {
 
   property("hardfork - v2 - activation") {
     val vr: VotingData = VotingData.empty
-    val esc0 = new ErgoStateContext(Seq(), None, ADDigest @@ Array.fill(33)(0: Byte), LaunchParameters, ErgoValidationSettings.initial, vr)(updSettings)
+    val esc0 = new ErgoStateContext(Seq(), None, ADDigest @@ Array.fill(33)(0: Byte), parameters, ErgoValidationSettings.initial, vr)(updSettings)
     val h1 = defaultHeaderGen.sample.get.copy(votes = Array.empty, version = 1: Byte, height = hfActivationHeight - 1)
     val expectedParameters1 = Parameters(hfActivationHeight - 1, DefaultParameters, ErgoValidationSettingsUpdate.empty)
     val esc1 = process(esc0, expectedParameters1, h1).get

--- a/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/tools/ChainGenerator.scala
@@ -75,7 +75,7 @@ object ChainGenerator extends App with ErgoTestHelpers {
 
   val history = ErgoHistory.readOrGenerate(fullHistorySettings, timeProvider)
   HistoryTestHelpers.allowToApplyOldBlocks(history)
-  val (state, _) = ErgoState.generateGenesisUtxoState(stateDir, StateConstants(None, fullHistorySettings))
+  val (state, _) = ErgoState.generateGenesisUtxoState(stateDir, StateConstants(None, fullHistorySettings), parameters)
   log.info(s"Going to generate a chain at ${dir.getAbsoluteFile} starting from ${history.bestFullBlockOpt}")
 
   val chain = loop(state, None, None, Seq())

--- a/src/test/scala/org/ergoplatform/utils/ErgoTestConstants.scala
+++ b/src/test/scala/org/ergoplatform/utils/ErgoTestConstants.scala
@@ -41,8 +41,8 @@ trait ErgoTestConstants extends ScorexLogging {
   val extendedParameters: Parameters = {
     // Randomness in tests is causing occasional cost overflow in the state context and insufficient box value
     val extension = Map(
-      MaxBlockCostIncrease -> Math.ceil(parameters.parametersTable(MaxBlockCostIncrease) * 1.1).toInt,
-      MinValuePerByteIncrease -> (parameters.parametersTable(MinValuePerByteIncrease) - 20)
+      MaxBlockCostIncrease -> Math.ceil(parameters.parametersTable(MaxBlockCostIncrease) * 1.2).toInt,
+      MinValuePerByteIncrease -> (parameters.parametersTable(MinValuePerByteIncrease) - 30)
     )
     new Parameters(
       height = 0,

--- a/src/test/scala/org/ergoplatform/utils/ErgoTestConstants.scala
+++ b/src/test/scala/org/ergoplatform/utils/ErgoTestConstants.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.modifiers.history.extension.ExtensionCandidate
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateConstants, StateType, UpcomingStateContext}
 import org.ergoplatform.settings.Constants.HashLength
-import org.ergoplatform.settings.Parameters.MaxBlockCostIncrease
+import org.ergoplatform.settings.Parameters.{MaxBlockCostIncrease, MinValuePerByteIncrease}
 import org.ergoplatform.settings.ValidationRules._
 import org.ergoplatform.settings._
 import org.ergoplatform.wallet.interface4j.SecretString
@@ -38,12 +38,15 @@ trait ErgoTestConstants extends ScorexLogging {
 
   val parameters: Parameters = LaunchParameters
 
-  val increasedMaxBlockCostParameters: Parameters = {
-    // Randomness in tests is causing occasional cost overflow in the state context
-    val slightlyIncreasedMaxBlockCost = Math.ceil(parameters.parametersTable(MaxBlockCostIncrease) * 1.1).toInt
+  val extendedParameters: Parameters = {
+    // Randomness in tests is causing occasional cost overflow in the state context and insufficient box value
+    val extension = Map(
+      MaxBlockCostIncrease -> Math.ceil(parameters.parametersTable(MaxBlockCostIncrease) * 1.1).toInt,
+      MinValuePerByteIncrease -> (parameters.parametersTable(MinValuePerByteIncrease) - 20)
+    )
     new Parameters(
       height = 0,
-      parametersTable = Parameters.DefaultParameters + (MaxBlockCostIncrease -> slightlyIncreasedMaxBlockCost),
+      parametersTable = Parameters.DefaultParameters ++ extension,
       proposedUpdate = ErgoValidationSettingsUpdate.empty
     )
   }

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -55,15 +55,15 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
   val history: HT = applyChain(generateHistory(), chain)
 
   val digestState: DigestState = {
-    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, settings)).map { wus =>
-      DigestState.create(Some(wus.version), Some(wus.rootHash), createTempDir, stateConstants)
+    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, parameters, settings)).map { wus =>
+      DigestState.create(Some(wus.version), Some(wus.rootHash), createTempDir, stateConstants, parameters)
     }
   }.sample.value
 
   val utxoSettings: ErgoSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(stateType = StateType.Utxo))
 
   val utxoState: WrappedUtxoState =
-    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, utxoSettings)).sample.value
+    boxesHolderGen.map(WrappedUtxoState(_, createTempDir, None, parameters, utxoSettings)).sample.value
 
   lazy val wallet = new WalletStub
 
@@ -230,9 +230,8 @@ trait Stubs extends ErgoGenerators with ErgoTestHelpers with ChainGenerator with
         sender() ! Success(tx)
 
       case SignTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt) =>
-        val sc = ErgoStateContext.empty(stateConstants)
-        val params = LaunchParameters
-        sender() ! ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, params, sc) { boxId =>
+        val sc = ErgoStateContext.empty(stateConstants, parameters)
+        sender() ! ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, parameters, sc) { boxId =>
           utxoState.versionedBoxHolder.get(ByteArrayWrapper(boxId))
         }
     }

--- a/src/test/scala/org/ergoplatform/utils/TestCase.scala
+++ b/src/test/scala/org/ergoplatform/utils/TestCase.scala
@@ -1,7 +1,9 @@
 package org.ergoplatform.utils
 
+import org.ergoplatform.settings.Parameters
 import org.ergoplatform.utils.fixtures.NodeViewFixture
 
 case class TestCase(name: String)(test: NodeViewFixture => Unit) {
-  def run(c: NodeViewTestConfig): Unit = new NodeViewFixture(c.toSettings).apply(test)
+  def run(parameters: Parameters, c: NodeViewTestConfig): Unit =
+    new NodeViewFixture(c.toSettings, parameters).apply(test)
 }

--- a/src/test/scala/org/ergoplatform/utils/WalletTestOps.scala
+++ b/src/test/scala/org/ergoplatform/utils/WalletTestOps.scala
@@ -27,7 +27,7 @@ trait WalletTestOps extends NodeViewBaseOps {
   def newAssetIdStub: TokenId = Blake2b256.hash("new_asset")
 
   def withFixture[T](test: WalletFixture => T): T =
-    new WalletFixture(settings, getCurrentView(_).vault).apply(test)
+    new WalletFixture(settings, parameters, getCurrentView(_).vault).apply(test)
 
   def wallet(implicit w: WalletFixture): ErgoWallet = w.wallet
 

--- a/src/test/scala/org/ergoplatform/utils/fixtures/NodeViewFixture.scala
+++ b/src/test/scala/org/ergoplatform/utils/fixtures/NodeViewFixture.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.TestProbe
 import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.nodeView.ErgoNodeViewRef
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.utils.{ErgoTestHelpers, NodeViewTestContext}
 import org.ergoplatform.wallet.utils.TestFileUtils
 import scorex.core.utils.NetworkTimeProvider
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 /** This uses TestProbe to receive messages from actor.
   * To make TestProbe work `defaultSender` implicit should be imported
   */
-class NodeViewFixture(protoSettings: ErgoSettings) extends NodeViewTestContext with TestFileUtils { self =>
+class NodeViewFixture(protoSettings: ErgoSettings, parameters: Parameters) extends NodeViewTestContext with TestFileUtils { self =>
 
   implicit val actorSystem: ActorSystem = ActorSystem()
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup("scorex.executionContext")
@@ -24,7 +24,7 @@ class NodeViewFixture(protoSettings: ErgoSettings) extends NodeViewTestContext w
   @volatile var settings: ErgoSettings = protoSettings.copy(directory = nodeViewDir.getAbsolutePath)
   val timeProvider: NetworkTimeProvider = ErgoTestHelpers.defaultTimeProvider
   val emission: EmissionRules = new EmissionRules(settings.chainSettings.monetary)
-  @volatile var nodeViewHolderRef: ActorRef = ErgoNodeViewRef(settings, timeProvider)
+  @volatile var nodeViewHolderRef: ActorRef = ErgoNodeViewRef(settings, timeProvider, parameters)
   val testProbe = new TestProbe(actorSystem)
 
   /** This sender should be imported to make TestProbe work! */
@@ -33,7 +33,7 @@ class NodeViewFixture(protoSettings: ErgoSettings) extends NodeViewTestContext w
   def apply[T](test: self.type => T): T = try test(self) finally stop()
 
   def startNodeViewHolder(): Unit = {
-    nodeViewHolderRef = ErgoNodeViewRef(settings, timeProvider)
+    nodeViewHolderRef = ErgoNodeViewRef(settings, timeProvider, parameters)
   }
 
   def stopNodeViewHolder(): Unit = {
@@ -56,5 +56,6 @@ class NodeViewFixture(protoSettings: ErgoSettings) extends NodeViewTestContext w
 }
 
 object NodeViewFixture {
-  def apply(protoSettings: ErgoSettings): NodeViewFixture = new NodeViewFixture(protoSettings)
+  def apply(protoSettings: ErgoSettings, parameters: Parameters): NodeViewFixture =
+    new NodeViewFixture(protoSettings, parameters)
 }

--- a/src/test/scala/org/ergoplatform/utils/fixtures/WalletFixture.scala
+++ b/src/test/scala/org/ergoplatform/utils/fixtures/WalletFixture.scala
@@ -1,8 +1,12 @@
 package org.ergoplatform.utils.fixtures
 
 import org.ergoplatform.nodeView.wallet.ErgoWallet
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
 
-class WalletFixture(settings: ErgoSettings, getWallet: WalletFixture => ErgoWallet) extends NodeViewFixture(settings) {
+class WalletFixture(
+  settings: ErgoSettings,
+  params: Parameters,
+  getWallet: WalletFixture => ErgoWallet
+) extends NodeViewFixture(settings, params) {
   val wallet: ErgoWallet = getWallet(this)
 }

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
@@ -128,7 +128,7 @@ trait ErgoTransactionGenerators extends ErgoGenerators with Generators {
       assetsMap.put(ByteArrayWrapper(boxesToSpend.head.id), rnd.nextInt(Int.MaxValue))
     }
 
-    val minValue = BoxUtils.sufficientAmount(parameters)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
 
     require(inputSum >= minValue)
     val inputsCount = boxesToSpend.size

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.nodeView.state.{BoxHolder, ErgoStateContext, VotingData}
 import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, TransactionSigningRequest}
 import org.ergoplatform.nodeView.wallet.{AugWalletTransaction, WalletTransaction}
 import org.ergoplatform.settings.Parameters._
-import org.ergoplatform.settings.{Constants, LaunchParameters, Parameters}
+import org.ergoplatform.settings.{Constants, Parameters}
 import org.ergoplatform.utils.{BoxUtils, RandomLike, RandomWrapper}
 import org.ergoplatform.wallet.Constants.{MaxAssetsPerBox, ScanId}
 import org.ergoplatform.wallet.secrets.{DhtSecretKey, DlogSecretKey}
@@ -65,7 +65,7 @@ trait ErgoTransactionGenerators extends ErgoGenerators with Generators {
     ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = ErgoHistory.EmptyHistoryHeight)
   }
 
-  def unspendableErgoBoxGen(minValue: Long = LaunchParameters.minValuePerByte * 200,
+  def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,
                             maxValue: Long = coinsTotal): Gen[ErgoBox] = {
     ergoBoxGen(propGen = falseLeafGen, valueGenOpt = Some(Gen.choose(minValue, maxValue)))
   }
@@ -128,7 +128,7 @@ trait ErgoTransactionGenerators extends ErgoGenerators with Generators {
       assetsMap.put(ByteArrayWrapper(boxesToSpend.head.id), rnd.nextInt(Int.MaxValue))
     }
 
-    val minValue = BoxUtils.sufficientAmount(LaunchParameters)
+    val minValue = BoxUtils.sufficientAmount(parameters)
 
     require(inputSum >= minValue)
     val inputsCount = boxesToSpend.size
@@ -137,7 +137,7 @@ trait ErgoTransactionGenerators extends ErgoGenerators with Generators {
     require(outputsCount > 0, s"outputs count is not positive: $outputsCount")
 
     require(minValue * outputsCount <= inputSum)
-    val outputPreamounts = (1 to outputsCount).map(_ => minValue.toLong).toBuffer
+    val outputPreamounts = (1 to outputsCount).map(_ => minValue).toBuffer
 
     var remainder = inputSum - minValue * outputsCount
     do {
@@ -323,7 +323,7 @@ trait ErgoTransactionGenerators extends ErgoGenerators with Generators {
           c.appendFullBlock(block).get -> (h + 1)
         }._1
       case _ =>
-        ErgoStateContext.empty(stateRoot, settings)
+        ErgoStateContext.empty(stateRoot, settings, parameters)
     }
   }
 


### PR DESCRIPTION
There is a lot of Randomness in tests which causes non-deterministic failures, especially with generators that run a test many times. When we have complete control over `parameters` then we can change it or override it on a single place and troubleshoot all tests together, ie. avoid fixing one and breaking others.

With this change, `parameters` are propagated as an instance wherever it is needed, instead of just calling `LaunchParameters` global object from everywhere.

I tried to change the randomly generated numbers that are used to generate boxes, transactions and blocks, but after day of trying, not being able to make ALL test pass with it, I figured the only way is to increase some limits like `maxBlockCost` or `minValuePerByte` just on a two places.