### PR TITLE
Candidate for 4.0.20.2: Memory pool improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To run specific Ergo version `<VERSION>` as a service with custom config `/path/
         -e MAX_HEAP=3G \
         ergoplatform/ergo:<VERSION> --<networkId> -c /etc/myergo.conf
 
-Available versions can be found on [Ergo Docker image page](https://hub.docker.com/r/ergoplatform/ergo/tags), for example, `v4.0.20.1`.
+Available versions can be found on [Ergo Docker image page](https://hub.docker.com/r/ergoplatform/ergo/tags), for example, `v4.0.20.2`.
 
 This will connect to the Ergo mainnet or testnet following your configuration passed in `myergo.conf` and network flag `--<networkId>`. Every default config value would be overwritten with corresponding value in `myergo.conf`. `MAX_HEAP` variable can be used to control how much memory can the node consume.
 

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 
 info:
-  version: "4.0.20.1"
+  version: "4.0.20.2"
   title: Ergo Node API
   description: API docs for Ergo Node. Models are shared between all Ergo products
   contact:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -338,7 +338,7 @@ scorex {
     nodeName = "ergo-node"
 
     # Network protocol version to be sent in handshakes
-    appVersion = 4.0.20.1
+    appVersion = 4.0.20.2
 
     # Network agent name. May contain information about client code
     # stack, starting from core code-base up to the end graphical interface.

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -41,7 +41,7 @@ scorex {
   network {
     magicBytes = [1, 0, 2, 4]
     bindAddress = "0.0.0.0:9030"
-    nodeName = "ergo-mainnet-4.0.20.1"
+    nodeName = "ergo-mainnet-4.0.20.2"
     nodeName = ${?NODENAME}
     knownPeers = [
       "213.239.193.208:9030",

--- a/src/main/resources/testnet.conf
+++ b/src/main/resources/testnet.conf
@@ -56,7 +56,7 @@ scorex {
   network {
     magicBytes = [2, 0, 0, 2]
     bindAddress = "0.0.0.0:9020"
-    nodeName = "ergo-testnet-4.0.20.1"
+    nodeName = "ergo-testnet-4.0.20.2"
     nodeName = ${?NODENAME}
     knownPeers = [
       "213.239.193.208:9020",

--- a/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
+++ b/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
@@ -6,12 +6,14 @@ import org.ergoplatform.local.CleanupWorker.RunCleanup
 import org.ergoplatform.local.MempoolAuditor.CleanupDone
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import scorex.core.network.Broadcast
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.ErgoNodeViewSynchronizer.ReceivableMessages.{ChangedMempool, ChangedState, SemanticallySuccessfulModifier}
+import org.ergoplatform.nodeView.state.UtxoStateReader
 import scorex.core.network.message.{InvData, InvSpec, Message}
 import scorex.core.transaction.Transaction
 import scorex.core.transaction.state.TransactionValidation
@@ -98,21 +100,33 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
     context become working // ignore other triggers until work is done
   }
 
+  private def broadcastTx(tx: ErgoTransaction): Unit = {
+    val msg = Message(
+      new InvSpec(settings.scorexSettings.network.maxInvObjects),
+      Right(InvData(Transaction.ModifierTypeId, Seq(tx.id))),
+      None
+    )
+    networkControllerRef ! SendToNetwork(msg, Broadcast)
+  }
+
   private def rebroadcastTransactions(): Unit = {
     log.debug("Rebroadcasting transactions")
     poolReaderOpt.foreach { pr =>
-      pr.take(settings.nodeSettings.rebroadcastCount).foreach { tx =>
-        log.info(s"Rebroadcasting $tx")
-        val msg = Message(
-          new InvSpec(settings.scorexSettings.network.maxInvObjects),
-          Right(InvData(Transaction.ModifierTypeId, Seq(tx.id))),
-          None
-        )
-        networkControllerRef ! SendToNetwork(msg, Broadcast)
+      pr.random(settings.nodeSettings.rebroadcastCount).foreach { tx =>
+        stateReaderOpt match {
+          case Some(utxoState: UtxoStateReader) =>
+            if (tx.inputIds.forall(inputBoxId => utxoState.boxById(inputBoxId).isDefined)) {
+              log.info(s"Rebroadcasting $tx")
+              broadcastTx(tx)
+            } else {
+              log.info(s"Not rebroadcasting $tx as not all the inputs are in place")
+            }
+          case _ =>
+            log.warn(s"Rebroadcasting $tx while state is not ready or not UTXO set")
+            broadcastTx(tx)
+        }
       }
-
     }
-
   }
 }
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -506,11 +506,13 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         if (!settings.nodeSettings.stateType.requireProofs &&
           hr.isHeadersChainSynced &&
           hr.fullBlockHeight == hr.headersHeight) {
-          log.info(s"Processing ${invData.ids.length} tx invs frpm $peer")
           val unknownMods =
             invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(mp)) == ModifiersStatus.Unknown)
           // filter out transactions that were already applied to history
-          unknownMods.filterNot(blockAppliedTxsCache.mightContain)
+          val notApplied = unknownMods.filterNot(blockAppliedTxsCache.mightContain)
+          log.info(s"Processing ${invData.ids.length} tx invs frpm $peer, " +
+            s"${unknownMods.size} of them are unknown, requesting $notApplied")
+          notApplied
         } else {
           Seq.empty
         }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -52,7 +52,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
       scala.util.Random.nextInt(max)
     }
 
-    cfor(start)(_ < start + limit, _ + 1) { idx =>
+    cfor(start)(_ < Math.min(start + limit, total), _ + 1) { idx =>
       val tx = txSeq.apply(idx)
       result += tx
     }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -10,8 +10,10 @@ import scorex.core.transaction.MemoryPool
 import scorex.core.transaction.state.TransactionValidation
 import scorex.util.{ModifierId, bytesToId}
 import OrderedTxPool.weighted
+import spire.syntax.all.cfor
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.util.Try
 
 
@@ -38,6 +40,25 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
   override def modifierById(modifierId: ModifierId): Option[ErgoTransaction] = pool.get(modifierId)
 
   override def take(limit: Int): Iterable[ErgoTransaction] = pool.orderedTransactions.values.take(limit)
+
+  def random(limit: Int): Iterable[ErgoTransaction] = {
+    val result = mutable.ArrayBuffer[ErgoTransaction]()
+    val txSeq = pool.orderedTransactions.values.toSeq
+    val total = txSeq.size
+    val start = if(total < limit) {
+      0
+    } else {
+      val max = total - limit
+      scala.util.Random.nextInt(max)
+    }
+
+    cfor(start)(_ < start + limit, _ + 1) { idx =>
+      val tx = txSeq.apply(idx)
+      result += tx
+    }
+
+    result
+  }
 
   override def getAll: Seq[ErgoTransaction] = pool.orderedTransactions.values.toSeq
 
@@ -109,7 +130,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
   def process(tx: ErgoTransaction, state: ErgoState[_]): (ErgoMemPool, ProcessingOutcome) = {
     val blacklistedTransactions = nodeSettings.blacklistedTransactions
     if(blacklistedTransactions.nonEmpty && blacklistedTransactions.contains(tx.id)) {
-      new ErgoMemPool(pool.invalidate(tx), stats) -> ProcessingOutcome.Declined(new Exception("blacklisted tx"))
+      new ErgoMemPool(pool.invalidate(tx), stats) -> ProcessingOutcome.Invalidated(new Exception("blacklisted tx"))
     } else {
       val fee = extractFee(tx)
       val minFee = settings.nodeSettings.minimalFeeAmount
@@ -120,10 +141,15 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
           state match {
             case utxo: UtxoState =>
               // Allow proceeded transaction to spend outputs of pooled transactions.
-              utxo.withTransactions(getAll).validate(tx).fold(
-                ex => new ErgoMemPool(pool.invalidate(tx), stats) -> ProcessingOutcome.Invalidated(ex),
-                _ => acceptIfNoDoubleSpend(tx)
-              )
+              val utxoWithPool = utxo.withTransactions(getAll)
+              if (tx.inputIds.forall(inputBoxId => utxoWithPool.boxById(inputBoxId).isDefined)) {
+                utxoWithPool.validate(tx).fold(
+                  ex => new ErgoMemPool(pool.invalidate(tx), stats) -> ProcessingOutcome.Invalidated(ex),
+                  _ => acceptIfNoDoubleSpend(tx)
+                )
+              } else {
+                this -> ProcessingOutcome.Declined(new Exception("not all utxos in place yet"))
+              }
             case validator: TransactionValidation =>
               // transaction validation currently works only for UtxoState, so this branch currently
               // will not be triggered probably

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -42,8 +42,8 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
   override def take(limit: Int): Iterable[ErgoTransaction] = pool.orderedTransactions.values.take(limit)
 
   def random(limit: Int): Iterable[ErgoTransaction] = {
-    val result = mutable.ArrayBuffer[ErgoTransaction]()
-    val txSeq = pool.orderedTransactions.values.toSeq
+    val result = mutable.WrappedArray.newBuilder[ErgoTransaction]
+    val txSeq = pool.orderedTransactions.values.to[Vector]
     val total = txSeq.size
     val start = if(total < limit) {
       0
@@ -57,7 +57,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
       result += tx
     }
 
-    result
+    result.result()
   }
 
   override def getAll: Seq[ErgoTransaction] = pool.orderedTransactions.values.toSeq

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -49,6 +49,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
       0
     } else {
       val max = total - limit
+      // max > 0 always
       scala.util.Random.nextInt(max)
     }
 

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -45,7 +45,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool, private[mempool] val sta
     val result = mutable.WrappedArray.newBuilder[ErgoTransaction]
     val txSeq = pool.orderedTransactions.values.to[Vector]
     val total = txSeq.size
-    val start = if(total < limit) {
+    val start = if (total <= limit) {
       0
     } else {
       val max = total - limit

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolReader.scala
@@ -32,6 +32,11 @@ trait ErgoMemPoolReader extends MempoolReader[ErgoTransaction] {
     */
   def take(limit: Int): Iterable[ErgoTransaction]
 
+  /**
+    * Returns up to given number of transactions randomly
+    */
+  def random(limit: Int): Iterable[ErgoTransaction]
+
   def modifierById(modifierId: ModifierId): Option[ErgoTransaction]
 
   /**

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -52,7 +52,8 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, ErgoTransact
     val wtx = weighted(tx)
     val newPool = OrderedTxPool(
       orderedTransactions.updated(wtx, tx),
-      transactionsRegistry.updated(wtx.id, wtx), invalidatedTxIds,
+      transactionsRegistry.updated(wtx.id, wtx),
+      invalidatedTxIds,
       outputs ++ tx.outputs.map(_.id -> wtx),
       inputs ++ tx.inputs.map(_.boxId -> wtx)
     ).updateFamily(tx, wtx.weight)

--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -138,6 +138,15 @@ class DeliveryTracker(system: ActorSystem,
   def setRequested(ids: Seq[ModifierId], typeId: ModifierTypeId, cp: Option[ConnectedPeer])
                   (implicit ec: ExecutionContext): Unit = ids.foreach(setRequested(_, typeId, cp))
 
+  /** Get peer we're communicating with in regards with modifier `id` **/
+  def getSource(id: ModifierId, modifierTypeId: ModifierTypeId): Option[ConnectedPeer] = {
+    status(id, modifierTypeId, Seq.empty) match {
+      case Requested => requested.get(modifierTypeId).flatMap(_.get(id)).flatMap(_.peer)
+      case Received => received.get(modifierTypeId).flatMap(_.get(id))
+      case _ => None
+    }
+  }
+
   /**
     * Modified with id `id` is permanently invalid - set its status to `Invalid`
     * and return [[ConnectedPeer]] which sent bad modifier.

--- a/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
@@ -115,6 +115,8 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
 
       override def take(limit: Int): Iterable[ErgoTransaction] = txs.take(limit)
 
+      override def random(limit: Int): Iterable[ErgoTransaction] = take(limit)
+
       override def spentInputs: Iterator[BoxId] = txs.flatMap(_.inputs).map(_.boxId).toIterator
 
       override def getRecommendedFee(expectedWaitTimeMinutes: Int, txSize: Int) : Long = 0

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -140,7 +140,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
       blockTransactions.txs.forall{tx =>
         val valRes = pool.process(tx, us)._2
         valRes.isInstanceOf[ProcessingOutcome.Invalidated] ||
-          valRes.isInstanceOf[ProcessingOutcome.Invalidated]} shouldBe true
+          valRes.isInstanceOf[ProcessingOutcome.Declined]} shouldBe true
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -133,11 +133,14 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     }
   }
 
-  it should "invalidate invalid transaction" in {
+  it should "invalidate or reject invalid transaction" in {
     val us = createUtxoState()._1
     val pool = ErgoMemPool.empty(settings)
     forAll(invalidBlockTransactionsGen) { blockTransactions =>
-      blockTransactions.txs.forall(pool.process(_, us)._2.isInstanceOf[ProcessingOutcome.Invalidated]) shouldBe true
+      blockTransactions.txs.forall{tx =>
+        val valRes = pool.process(tx, us)._2
+        valRes.isInstanceOf[ProcessingOutcome.Invalidated] ||
+          valRes.isInstanceOf[ProcessingOutcome.Invalidated]} shouldBe true
     }
   }
 


### PR DESCRIPTION
This PR covering following issues: 

1) broadcasting is not randomized, always broadcasting the same transactions set. also it is not checking whether inputs of transactions are in utxo set
2) transaction got invalidated if no inputs in the mempool or utxo set. but then due to (1) chained transactions can come out-of-order and be invalidated


In this PR, transaction with no inputs presented in the utxo set or pool only declined, not invalidated.

Also, only transactions with inputs in the utxo set broadcasted. And broadcast now randomized