### PR TITLE
fixing logback oversized logfile issue

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -20,18 +20,15 @@
             <level>${logback.file.level:-DEBUG}</level>
         </filter>
         <file>ergo.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover -->
             <fileNamePattern>ergo.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
 
             <!-- keep 30 days' worth of history capped at 1GB total size -->
             <maxHistory>30</maxHistory>
+            <maxFileSize>100MB</maxFileSize>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
-
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
         <encoder>
             <pattern>${default.pattern}</pattern>
         </encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -26,7 +26,8 @@
 
             <!-- keep 30 days' worth of history capped at 1GB total size -->
             <maxHistory>30</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
+            <maxFileSize>1GB</maxFileSize>
+            <totalSizeCap>2GB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -26,10 +26,12 @@
 
             <!-- keep 30 days' worth of history capped at 1GB total size -->
             <maxHistory>30</maxHistory>
-            <maxFileSize>500MB</maxFileSize>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
 
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
         <encoder>
             <pattern>${default.pattern}</pattern>
         </encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -26,8 +26,8 @@
 
             <!-- keep 30 days' worth of history capped at 1GB total size -->
             <maxHistory>30</maxHistory>
-            <maxFileSize>1GB</maxFileSize>
-            <totalSizeCap>2GB</totalSizeCap>
+            <maxFileSize>500MB</maxFileSize>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -22,7 +22,7 @@
         <file>ergo.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>ergo.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <fileNamePattern>ergo-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
 
             <!-- keep 30 days' worth of history capped at 1GB total size -->
             <maxHistory>30</maxHistory>


### PR DESCRIPTION
I followed the docs https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy