### PR TITLE
Avoid using reduceToCrypto in ScriptApiRoute

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ScriptApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScriptApiRoute.scala
@@ -20,6 +20,7 @@ import sigmastate._
 import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.eval.{CompiletimeIRContext, IRContext, RuntimeIRContext}
 import sigmastate.lang.{CompilerSettings, SigmaCompiler, TransformingSigmaBuilder}
+import sigmastate.interpreter.Interpreter
 import sigmastate.serialization.ValueSerializer
 
 import scala.concurrent.Future
@@ -102,8 +103,7 @@ case class ScriptApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
         tree => {
           implicit val irc: IRContext = new RuntimeIRContext()
           val interpreter: ErgoLikeInterpreter = new ErgoLikeInterpreter()
-          val prop = interpreter.propositionFromErgoTree(tree, req.ctx.asInstanceOf[interpreter.CTX])
-          val res = interpreter.reduceToCrypto(req.ctx.asInstanceOf[interpreter.CTX], prop)
+          val res = Try(interpreter.fullReduction(tree, req.ctx.asInstanceOf[interpreter.CTX], Interpreter.emptyEnv))
           res.fold(
             e => BadRequest(e.getMessage),
             s => ApiResponse(CryptoResult(s.value, s.cost).asJson)

--- a/src/test/scala/org/ergoplatform/http/routes/ScriptApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ScriptApiRouteSpec.scala
@@ -56,7 +56,7 @@ class ScriptApiRouteSpec extends AnyFlatSpec
       val cost = json.hcursor.downField("cost").as[Int].right.get
       value shouldEqual -45
       condition shouldEqual true
-      cost shouldEqual 40
+      cost shouldEqual 50
     }
     val json = io.circe.parser.parse(req)
     Post(prefix + suffix, json) ~> route ~> check(assertion(responseAs[Json]))


### PR DESCRIPTION
The new implementation uses passed ErgoTree and interpret it the same way as TX validation and candidate assembly code.

In particulare, caching and optimized evaluation is performed.