### PR TITLE
fix: increase akka max uri length

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -288,6 +288,9 @@ akka {
     server {
       request-timeout = 1 minute
     }
+    parsing {
+      max-uri-length = 8192
+    }
   }
 }
 


### PR DESCRIPTION
Large ergo trees are unable to be converted to addresses using the default uri limit of 2k via `utils/ergoTreeToAddress`.