### PR TITLE
removing unused applied modifiers

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -754,7 +754,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     case ChangedMempool(newMempoolReader: ErgoMemPool) =>
       context.become(initialized(historyReader, newMempoolReader, blockAppliedTxsCache))
 
-    case ModifiersProcessingResult(_: Seq[ErgoPersistentModifier], cleared: Seq[ErgoPersistentModifier]) =>
+    case ModifiersProcessingResult(cleared: Seq[ErgoPersistentModifier]) =>
       // stop processing for cleared modifiers
       // applied modifiers state was already changed at `SyntacticallySuccessfulModifier`
       cleared.foreach(m => deliveryTracker.setUnknown(m.id, m.modifierTypeId))
@@ -906,7 +906,7 @@ object ErgoNodeViewSynchronizer {
       * After application of batch of modifiers from cache to History, NodeViewHolder sends this message,
       * containing all just applied modifiers and cleared from cache
       */
-    case class ModifiersProcessingResult(applied: Seq[ErgoPersistentModifier], cleared: Seq[ErgoPersistentModifier])
+    case class ModifiersProcessingResult(cleared: Seq[ErgoPersistentModifier])
 
     // hierarchy of events regarding modifiers application outcome
     trait ModificationOutcome extends NodeViewHolderEvent

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -303,7 +303,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           applyFromCacheLoop()
 
           val cleared = modifiersCache.cleanOverfull()
-          context.system.eventStream.publish(ModifiersProcessingResult(cleared))
+          context.system.eventStream.publish(ModifiersRemovedFromCache(cleared))
           log.debug(s"Cache size after: ${modifiersCache.size}")
         case _ =>
           mods.foreach(m => modifiersCache.put(m.id, m))
@@ -313,7 +313,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           applyFromCacheLoop()
           val cleared = modifiersCache.cleanOverfull()
 
-          context.system.eventStream.publish(ModifiersProcessingResult(cleared))
+          context.system.eventStream.publish(ModifiersRemovedFromCache(cleared))
           log.debug(s"Cache size after: ${modifiersCache.size}")
       }
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -73,7 +73,7 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
       context.system.eventStream.subscribe(self, classOf[ChangedMempool[ErgoMemPool]])
       context.system.eventStream.subscribe(self, classOf[ModificationOutcome])
       context.system.eventStream.subscribe(self, classOf[DownloadRequest])
-      context.system.eventStream.subscribe(self, classOf[ModifiersProcessingResult])
+      context.system.eventStream.subscribe(self, classOf[ModifiersRemovedFromCache])
 
       // subscribe for history and mempool changes
       viewHolderRef ! GetNodeViewChanges(history = true, state = false, vault = false, mempool = true)

--- a/src/test/scala/scorex/testkit/properties/NodeViewHolderTests.scala
+++ b/src/test/scala/scorex/testkit/properties/NodeViewHolderTests.scala
@@ -60,9 +60,9 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
       import ctx._
       val p = TestProbe()
 
-      system.eventStream.subscribe(eventListener.ref, classOf[ModifiersProcessingResult])
+      system.eventStream.subscribe(eventListener.ref, classOf[ModifiersRemovedFromCache])
       p.send(node, ModifiersFromRemote(Seq(mod)))
-      eventListener.expectMsgType[ModifiersProcessingResult]
+      eventListener.expectMsgType[ModifiersRemovedFromCache]
     }
   }
 


### PR DESCRIPTION
We needlessly keep `applied` modifiers in memory.