### PR TITLE
Minor fixes for 4.0.23

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.6.1","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/usr/lib/jvm/java-10-oracle/bin/java","-Xms100m","-Xmx100m","-classpath","/home/kushti/.IntelliJIdea2019.1/config/plugins/Scala/launcher/sbt-launch.jar","-Dsbt.script=/usr/bin/sbt","xsbt.boot.Boot","-bsp"]}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ devnet
 
 # IDE/Editor files
 .idea
+.bsp
 .ensime
 .ensime_cache/
 scorex.yaml

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
@@ -58,7 +58,7 @@ class HistoryStorage private(indexStore: LDBKVStore, objectsStore: LDBKVStore, c
       objectsStore.get(idToBytes(id)).flatMap { bytes =>
         HistoryModifierSerializer.parseBytesTry(bytes) match {
           case Success(pm) =>
-            log.info(s"Cache miss for existing modifier $id")
+            log.trace(s"Cache miss for existing modifier $id")
             cacheModifier(pm)
             Some(pm)
           case Failure(_) =>


### PR DESCRIPTION
log.trace(s"Cache miss for existing modifier $id") creates a lot of noise in the log

.bsp junk removed and git-ignores