### PR TITLE
Publish docker image for `sigma-rust` integration tests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,3 +31,17 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Docker Metadata action for sigma-rust integration test node
+        uses: docker/metadata-action@v3.5.0
+        id: meta
+        with:
+          images: ergoplatform/ergo-integration-test
+
+      - name: Build and push Docker images for integration-test node
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: "{{defaultContext}}:sigma-rust-integration-test" 
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/sigma-rust-integration-test/Dockerfile
+++ b/sigma-rust-integration-test/Dockerfile
@@ -1,0 +1,3 @@
+FROM ergoplatform/ergo:latest
+COPY ergo.conf /etc/myergo.conf
+ENTRYPOINT ["java", "-jar", "/home/ergo/ergo.jar", "--devnet", "-c", "/etc/myergo.conf"]

--- a/sigma-rust-integration-test/ergo.conf
+++ b/sigma-rust-integration-test/ergo.conf
@@ -1,0 +1,104 @@
+ergo {
+  # Settings for node view holder regime. See papers.yellow.ModifiersProcessing.md
+  node {
+    # State type.  Possible options are:
+    # "utxo" - keep full utxo set, that allows to validate arbitrary block and generate ADProofs
+    # "digest" - keep state root hash only and validate transactions via ADProofs
+    stateType = "utxo"
+
+    # Download block transactions and verify them (requires BlocksToKeep == 0 if disabled)
+    verifyTransactions = true
+
+    # Number of last blocks to keep with transactions and ADproofs, for all other blocks only header will be stored.
+    # Keep all blocks from genesis if negative
+    blocksToKeep = -1
+
+    # Download PoPoW proof on node bootstrap
+    PoPoWBootstrap = false
+
+    # Minimal suffix size for PoPoW proof (may be pre-defined constant or settings parameter)
+    minimalSuffix = 10
+
+    # Is the node is doing mining
+    mining = true
+
+    # Use external miner, native miner is used if set to `false`
+    useExternalMiner = false
+
+    # If true, a node generate blocks being offline. The only really useful case for it probably is to start a new
+    # blockchain
+    offlineGeneration = true
+
+    # internal miner's interval of polling for a candidate
+    internalMinerPollingInterval = 5s
+
+    mempoolCapacity = 10000
+  }
+
+  chain {
+    # Difficulty network start with
+    initialDifficultyHex = "01"
+
+    powScheme {
+      powType = "autolykos"
+      k = 32
+      n = 26
+    }
+
+  }
+
+  wallet {
+
+    secretStorage {
+
+      secretDir = ${ergo.directory}"/wallet/keystore"
+
+      encryption {
+
+        # Pseudo-random function with output of length `dkLen` (PBKDF2 param)
+        prf = "HmacSHA256"
+
+        # Number of PBKDF2 iterations (PBKDF2 param)
+        c = 128000
+
+        # Desired bit-length of the derived key (PBKDF2 param)
+        dkLen = 256
+      }
+
+    }
+
+    # Generating seed length in bits
+    # Options: 128, 160, 192, 224, 256
+    seedStrengthBits = 160
+
+    # Language to be used in mnemonic seed
+    # Options: "chinese_simplified", "chinese_traditional", "english", "french", "italian", "japanese", "korean", "spanish"
+    mnemonicPhraseLanguage = "english"
+
+    defaultTransactionFee = 10000
+
+    # Save used boxes (may consume additinal disk space) or delete them immediately
+    keepSpentBoxes = false
+
+    # Mnemonic seed used in wallet for tests
+    testMnemonic = "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic"
+
+    # Number of keys to be generated for tests
+    testKeysQty = 5
+  }
+}
+
+scorex {
+  network {
+    maxPacketSize = 2048576
+    maxInvObjects = 400
+    bindAddress = "0.0.0.0:9001"
+    knownPeers = []
+    agentName = "ergo-integration-test"
+  }
+  restApi {
+    bindAddress = "0.0.0.0:9053"
+    # Hash of "hello", taken from mainnet config
+    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+  }
+}


### PR DESCRIPTION
`sigma-rust` needs to do integration testing for P2P and REST APIs (https://github.com/ergoplatform/sigma-rust/issues/480), which can be done by creating an `ergo` node instance in `devnet` mode. Due to limitations with Github Actions, this PR adds to the docker publishing step on each release by creating a new `ergo-integration-test` image.