### PR TITLE
Faster tx box processing

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -621,10 +621,8 @@ object CandidateGenerator extends ScorexLogging {
 
     val inputs = txs.flatMap(_.inputs)
     val feeBoxes: Seq[ErgoBox] = ErgoState
-      .boxChanges(txs)
-      ._2
-      .filter(b => java.util.Arrays.equals(b.propositionBytes, propositionBytes))
-      .filter(b => !inputs.exists(i => java.util.Arrays.equals(i.boxId, b.id)))
+      .newBoxes(txs)
+      .filter(b => java.util.Arrays.equals(b.propositionBytes, propositionBytes) && !inputs.exists(i => java.util.Arrays.equals(i.boxId, b.id)))
     val nextHeight = currentHeight + 1
     val minerProp =
       ErgoScriptPredef.rewardOutputScript(emission.settings.minerRewardDelay, minerPk)

--- a/src/main/scala/org/ergoplatform/modifiers/state/StateChanges.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/state/StateChanges.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.modifiers.state
 import scorex.crypto.authds.avltree.batch.{Insert, Lookup, Operation, Remove}
 
 
-case class StateChanges(toRemove: Seq[Remove], toAppend: Seq[Insert], toLookup: Seq[Lookup]) {
+case class StateChanges(toRemove: IndexedSeq[Remove], toAppend: IndexedSeq[Insert], toLookup: IndexedSeq[Lookup]) {
 
   /**
     * First lookup for all leafs required by data inputs (never fails, but may return proof-of-non-existence),

--- a/src/main/scala/org/ergoplatform/nodeView/state/DigestState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/DigestState.scala
@@ -44,13 +44,19 @@ class DigestState protected(override val version: VersionTag,
                                           proofs: ADProofs,
                                           currentStateContext: ErgoStateContext): Try[Unit] = {
     // Check modifications, returning sequence of old values
-    val boxesFromProofs: Seq[ErgoBox] = proofs.verify(ErgoState.stateChanges(transactions), rootHash, expectedHash)
-      .get.map(v => ErgoBoxSerializer.parseBytes(v))
-    val knownBoxes = (transactions.flatMap(_.outputs) ++ boxesFromProofs).map(o => (ByteArrayWrapper(o.id), o)).toMap
+    val knownBoxesTry =
+      ErgoState.stateChanges(transactions).map { stateChanges =>
+        val boxesFromProofs: Seq[ErgoBox] =
+          proofs.verify(stateChanges, rootHash, expectedHash).get.map(v => ErgoBoxSerializer.parseBytes(v))
+        (transactions.flatMap(_.outputs) ++ boxesFromProofs).map(o => (ByteArrayWrapper(o.id), o)).toMap
+      }
 
-    def checkBoxExistence(id: ErgoBox.BoxId): Try[ErgoBox] = knownBoxes
-      .get(ByteArrayWrapper(id))
-      .fold[Try[ErgoBox]](Failure(new Exception(s"Box with id ${Algos.encode(id)} not found")))(Success(_))
+    def checkBoxExistence(id: ErgoBox.BoxId): Try[ErgoBox] =
+      knownBoxesTry.flatMap { knownBoxes =>
+        knownBoxes
+        .get(ByteArrayWrapper(id))
+        .fold[Try[ErgoBox]](Failure(new Exception(s"Box with id ${Algos.encode(id)} not found")))(Success(_))
+      }
 
     ErgoState.execTransactions(transactions, currentStateContext)(checkBoxExistence)
       .toTry

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
@@ -1,7 +1,6 @@
 package org.ergoplatform.nodeView.state
 
 import java.io.File
-
 import org.ergoplatform.ErgoBox.{AdditionalRegisters, R4, TokenId}
 import org.ergoplatform._
 import org.ergoplatform.mining.emission.EmissionRules
@@ -19,18 +18,20 @@ import scorex.core.validation.ValidationResult.Valid
 import scorex.core.validation.{ModifierValidator, ValidationResult}
 import scorex.core.{VersionTag, idToVersion}
 import scorex.crypto.authds.avltree.batch.{Insert, Lookup, Remove}
-import scorex.crypto.authds.{ADDigest, ADKey, ADValue}
+import scorex.crypto.authds.{ADDigest, ADValue}
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import sigmastate.AtLeast
 import sigmastate.Values.{ByteArrayConstant, ErgoTree, IntConstant, SigmaPropConstant}
 import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.serialization.ValueSerializer
+import spire.syntax.all.cfor
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
+import scala.collection.breakOut
 
 /**
   * Implementation of minimal state concept in Scorex. Minimal state (or just state from now) is some data structure
@@ -75,12 +76,11 @@ object ErgoState extends ScorexLogging {
     *         if some box was created and later spent in this sequence - it is not included in the result at all
     *         if box was first spent and created after that - it is in both toInsert and toRemove
     */
-  def stateChanges(txs: Seq[ErgoTransaction]): StateChanges = {
-    val (toRemove, toInsert) = boxChanges(txs)
-    val toRemoveChanges = toRemove.map(id => Remove(id))
-    val toInsertChanges = toInsert.map(b => Insert(b.id, ADValue @@ b.bytes))
-    val toLookup = txs.flatMap(_.dataInputs).map(b => Lookup(b.boxId))
-    StateChanges(toRemoveChanges, toInsertChanges, toLookup)
+  def stateChanges(txs: Seq[ErgoTransaction]): Try[StateChanges] = {
+    boxChanges(txs).map { case (toRemoveChanges, toInsertChanges) =>
+      val toLookup: IndexedSeq[Lookup] = txs.flatMap(_.dataInputs).map(b => Lookup(b.boxId))(breakOut)
+      StateChanges(toRemoveChanges, toInsertChanges, toLookup)
+    }
   }
 
   /**
@@ -152,20 +152,38 @@ object ErgoState extends ScorexLogging {
     *         if box was first spend and created after that - it is in both toInsert and toRemove,
     *         and an error will be thrown further during tree modification
     */
-  def boxChanges(txs: Seq[ErgoTransaction]): (Seq[ADKey], Seq[ErgoBox]) = {
-    val toInsert: mutable.HashMap[ModifierId, ErgoBox] = mutable.HashMap.empty
-    val toRemove: mutable.ArrayBuffer[(ModifierId, ADKey)] = mutable.ArrayBuffer()
-    txs.foreach { tx =>
+  def boxChanges(txs: Seq[ErgoTransaction]): Try[(Vector[Remove], Vector[Insert])] = Try {
+    val toInsert: mutable.TreeMap[ModifierId, Insert] = mutable.TreeMap.empty
+    val toRemove: mutable.TreeMap[ModifierId, Remove] = mutable.TreeMap.empty
+
+    cfor(0)(_ < txs.length, _ + 1) { i =>
+      val tx = txs(i)
       tx.inputs.foreach { i =>
-        val wrapped = bytesToId(i.boxId)
-        toInsert.remove(wrapped) match {
-          case None => toRemove.append((wrapped, i.boxId))
+        val wrappedBoxId = bytesToId(i.boxId)
+        toInsert.remove(wrappedBoxId) match {
+          case None =>
+            if (toRemove.put(wrappedBoxId, Remove(i.boxId)).nonEmpty) {
+              throw new IllegalArgumentException(s"Tx : ${tx.id} is double-spending input id : $wrappedBoxId")
+            }
           case _ => // old value removed, do nothing
         }
       }
-      tx.outputs.foreach(o => toInsert += bytesToId(o.id) -> o)
+      tx.outputs.foreach(o => toInsert += bytesToId(o.id) -> Insert(o.id, ADValue @@ o.bytes))
     }
-    (toRemove.sortBy(_._1).map(_._2), toInsert.toSeq.sortBy(_._1).map(_._2))
+    (toRemove.map(_._2)(breakOut), toInsert.map(_._2)(breakOut))
+  }
+
+  /**
+    * @param txs - sequence of transactions
+    * @return new ErgoBoxes produced by the transactions
+    */
+  def newBoxes(txs: Seq[ErgoTransaction]): Vector[ErgoBox] = {
+    val newBoxes: mutable.TreeMap[ModifierId, ErgoBox] = mutable.TreeMap.empty
+    txs.foreach { tx =>
+      tx.inputs.foreach(i => newBoxes.remove(bytesToId(i.boxId)))
+      tx.outputs.foreach(o => newBoxes += bytesToId(o.id) -> o)
+    }
+    newBoxes.map(_._2)(breakOut)
   }
 
   /**

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
@@ -135,7 +135,9 @@ trait UtxoStateReader extends ErgoStateReader with TransactionValidation {
       Failure(new Error(s"Incorrect storage: ${storage.version.map(Algos.encode)} != ${Algos.encode(rootHash)}. " +
         "Possible reason - state update is in process."))
     } else {
-      persistentProver.avlProver.generateProofForOperations(ErgoState.stateChanges(txs).operations)
+      ErgoState.stateChanges(txs).flatMap { stateChanges =>
+        persistentProver.avlProver.generateProofForOperations(stateChanges.operations)
+      }
     }
   }
 

--- a/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
@@ -53,7 +53,7 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
     applyBlock(genesis) shouldBe 'success
     getRootHash shouldBe Algos.encode(wusAfterGenesis.rootHash)
 
-    val boxes = ErgoState.boxChanges(genesis.transactions)._2.find(_.ergoTree == Constants.TrueLeaf)
+    val boxes = ErgoState.newBoxes(genesis.transactions).find(_.ergoTree == Constants.TrueLeaf)
     boxes.nonEmpty shouldBe true
 
     val script = s"{sigmaProp(HEIGHT == ${genesis.height})}"

--- a/src/test/scala/org/ergoplatform/modifiers/history/AdProofSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/AdProofSpec.scala
@@ -27,7 +27,7 @@ class AdProofSpec extends ErgoPropertyTest {
   private def insert(box: ErgoBox) = Insert(box.id, ADValue @@ box.bytes)
 
   private def createEnv(howMany: Int = 10):
-  (Seq[Insert], PrevDigest, NewDigest, Proof) = {
+  (IndexedSeq[Insert], PrevDigest, NewDigest, Proof) = {
 
     val prover = new BatchAVLProver[Digest32, HF](KL, None)
     val zeroBox = testBox(0, Constants.TrueLeaf, startHeight, Seq(), Map(), Array.fill(32)(0: Byte).toModifierId)
@@ -40,7 +40,7 @@ class AdProofSpec extends ErgoPropertyTest {
     val pf = prover.generateProof()
 
     val newDigest = prover.digest
-    val operations: Seq[Insert] = boxes.map(box => Insert(box.id, ADValue @@ box.bytes))
+    val operations: IndexedSeq[Insert] = boxes.map(box => Insert(box.id, ADValue @@ box.bytes))
     (operations, prevDigest, newDigest, pf)
   }
 
@@ -49,7 +49,7 @@ class AdProofSpec extends ErgoPropertyTest {
       whenever(s >= 0) {
         val (operations, prevDigest, newDigest, pf) = createEnv(s)
         val proof = ADProofs(emptyModifierId, pf)
-        proof.verify(StateChanges(Seq(), operations, Seq()), prevDigest, newDigest) shouldBe 'success
+        proof.verify(StateChanges(IndexedSeq.empty, operations, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'success
       }
     }
   }
@@ -57,54 +57,54 @@ class AdProofSpec extends ErgoPropertyTest {
   property("verify should be failed if first operation is missed") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, pf)
-    proof.verify(StateChanges(Seq(), operations.tail, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, operations.tail, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("verify should be failed if last operation is missed") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, pf)
-    proof.verify(StateChanges(Seq(), operations.init, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, operations.init, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("verify should be failed if there are more operations than expected") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, pf)
     val moreInsertions = operations :+ insert(testBox(10, Constants.TrueLeaf, creationHeight = startHeight))
-    proof.verify(StateChanges(Seq(), moreInsertions, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, moreInsertions, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("verify should be failed if there are illegal operation") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, pf)
     val differentInsertions = operations.init :+ insert(testBox(10, Constants.TrueLeaf, creationHeight = startHeight))
-    proof.verify(StateChanges(Seq(), differentInsertions, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, differentInsertions, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("verify should be failed if there are operations in different order") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, pf)
     val operationsInDifferentOrder = operations.last +: operations.init
-    proof.verify(StateChanges(Seq(), operationsInDifferentOrder, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, operationsInDifferentOrder, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   //todo: what to do with that?
   ignore("verify should be failed if there are more proof bytes that needed") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, SerializedAdProof @@ (pf :+ 't'.toByte))
-    proof.verify(StateChanges(Seq(), operations, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, operations, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("verify should be failed if there are less proof bytes that needed") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, SerializedAdProof @@ pf.init)
-    proof.verify(StateChanges(Seq(), operations, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, operations, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("verify should be failed if there are different proof bytes") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     pf.update(4, 6.toByte)
     val proof = ADProofs(emptyModifierId, pf)
-    proof.verify(StateChanges(Seq(), operations, Seq()), prevDigest, newDigest) shouldBe 'failure
+    proof.verify(StateChanges(IndexedSeq.empty, operations, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
   property("proof is deterministic") {

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ScriptsSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ScriptsSpec.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.{ErgoBox, ErgoScriptPredef, Height, Self}
 import org.ergoplatform.nodeView.state.{BoxHolder, ErgoState, UtxoState}
 import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils.{ErgoPropertyTest, RandomWrapper}
-import scorex.crypto.authds.ADKey
+import scorex.crypto.authds.avltree.batch.Remove
 import sigmastate._
 import sigmastate.Values._
 import sigmastate.lang.Terms._
@@ -72,7 +72,7 @@ class ScriptsSpec extends ErgoPropertyTest {
     val tx = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(1)), 201)._1
     tx.size shouldBe 1
     tx.head.inputs.size shouldBe 2
-    ErgoState.boxChanges(tx)._1.foreach { boxId: ADKey =>
+    ErgoState.boxChanges(tx).get._1.foreach { case Remove(boxId) =>
       assert(us.boxById(boxId).isDefined, s"Box ${Algos.encode(boxId)} missed")
     }
     val block = validFullBlock(None, us, tx, Some(1234L))

--- a/src/test/scala/org/ergoplatform/nodeView/state/DigestStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/DigestStateSpecification.scala
@@ -9,8 +9,6 @@ import scorex.core._
 import scorex.crypto.authds.ADDigest
 import sigmastate.interpreter.ProverResult
 
-import scala.util.Try
-
 class DigestStateSpecification extends ErgoPropertyTest {
 
   private val emptyVersion: VersionTag = bytesToVersion(Array.fill(32)(0: Byte))
@@ -121,15 +119,15 @@ class DigestStateSpecification extends ErgoPropertyTest {
       val txs1 = IndexedSeq(headTx, nextTx, txWithDataInputs)
       val (proofBytes1, digest1) = us.proofsForTransactions(txs1).get
       val proof1 = ADProofs(defaultHeaderGen.sample.get.id, proofBytes1)
-      Try(ds.validateTransactions(txs1, digest1, proof1, emptyStateContext)) shouldBe 'success
+      ds.validateTransactions(txs1, digest1, proof1, emptyStateContext) shouldBe 'success
 
       val txs2 = IndexedSeq(headTx, txWithDataInputs, nextTx)
       val (proofBytes2, digest2) = us.proofsForTransactions(txs2).get
       val proof2 = ADProofs(defaultHeaderGen.sample.get.id, proofBytes2)
-      Try(ds.validateTransactions(txs2, digest2, proof2, emptyStateContext)) shouldBe 'success
+      ds.validateTransactions(txs2, digest2, proof2, emptyStateContext) shouldBe 'success
 
       val txs3 = IndexedSeq(txWithDataInputs, headTx, nextTx)
-      Try(ds.validateTransactions(txs3, digest2, proof2, emptyStateContext)) shouldBe 'failure
+      ds.validateTransactions(txs3, digest2, proof2, emptyStateContext) shouldBe 'failure
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateSpecification.scala
@@ -24,9 +24,8 @@ class ErgoStateSpecification extends ErgoPropertyTest {
 
       val validBlock = validFullBlock(None, us, bh)
       val dsTxs = validBlock.transactions ++ validBlock.transactions
-      val changes = ErgoState.stateChanges(dsTxs)
-      val toRemove = changes.toRemove.map(_.key)
-      toRemove.count(boxId => java.util.Arrays.equals(toRemove.head, boxId)) shouldBe 2
+      val changes = ErgoState.stateChanges(dsTxs).get
+      changes.toRemove.map(_.key).toSet.size shouldBe 1
 
       val dsRoot = BlockTransactions.transactionsRoot(dsTxs, version)
       val dsHeader = validBlock.header.copy(transactionsRoot = dsRoot)
@@ -86,8 +85,8 @@ class ErgoStateSpecification extends ErgoPropertyTest {
       bh = blBh._2
       us = us.applyModifier(block)(_ => ()).get
 
-      val changes1 = ErgoState.boxChanges(block.transactions)
-      val changes2 = ErgoState.boxChanges(block.transactions)
+      val changes1 = ErgoState.boxChanges(block.transactions).get
+      val changes2 = ErgoState.boxChanges(block.transactions).get
       changes1._1 shouldBe changes2._1
       changes1._2 shouldBe changes2._2
     }
@@ -101,8 +100,8 @@ class ErgoStateSpecification extends ErgoPropertyTest {
       val txs = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(seed)))._1
       whenever(txs.lengthCompare(2) > 0) {
         // valid transaction should spend the only existing genesis box
-        ErgoState.boxChanges(txs)._1.length shouldBe 1
-        ErgoState.boxChanges(txs)._1.head shouldBe emissionBox.id
+        ErgoState.boxChanges(txs).get._1.length shouldBe 1
+        ErgoState.boxChanges(txs).get._1.head.key shouldBe emissionBox.id
 
         // second transaction input should be an input created by the first transaction
         val inputToDoubleSpend = txs(1).inputs.head
@@ -112,7 +111,7 @@ class ErgoStateSpecification extends ErgoPropertyTest {
         invalidTxs.length shouldBe txs.length
         invalidTxs.count(_.inputs.contains(inputToDoubleSpend)) shouldBe 2
 
-        ErgoState.boxChanges(invalidTxs)._1.length shouldBe 2
+        ErgoState.boxChanges(invalidTxs).get._1.length shouldBe 2
       }
     }
   }
@@ -124,7 +123,7 @@ class ErgoStateSpecification extends ErgoPropertyTest {
     forAll { seed: Int =>
       val txs = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(seed)))._1
       whenever(txs.lengthCompare(1) > 0) {
-        val changes = ErgoState.stateChanges(txs)
+        val changes = ErgoState.stateChanges(txs).get
         val removals = changes.toRemove
         // should remove the only genesis box from the state
         removals.length shouldBe 1
@@ -137,7 +136,7 @@ class ErgoStateSpecification extends ErgoPropertyTest {
         insertions.map(_.value).map(ErgoBoxSerializer.parseBytes).map(_.value).sum shouldBe emissionBox.value
 
         // if output was spend and then created - it is in both toInsert and toRemove
-        val changesRev = ErgoState.stateChanges(txs.reverse)
+        val changesRev = ErgoState.stateChanges(txs.reverse).get
         val removalsRev = changesRev.toRemove
         val insertionsRev = changesRev.toAppend
         removalsRev.length should be > removals.length

--- a/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateSpecification.scala
@@ -24,8 +24,7 @@ class ErgoStateSpecification extends ErgoPropertyTest {
 
       val validBlock = validFullBlock(None, us, bh)
       val dsTxs = validBlock.transactions ++ validBlock.transactions
-      val changes = ErgoState.stateChanges(dsTxs).get
-      changes.toRemove.map(_.key).toSet.size shouldBe 1
+      ErgoState.stateChanges(dsTxs) shouldBe 'failure
 
       val dsRoot = BlockTransactions.transactionsRoot(dsTxs, version)
       val dsHeader = validBlock.header.copy(transactionsRoot = dsRoot)

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -275,8 +275,8 @@ class UtxoStateSpecification extends ErgoPropertyTest with ErgoTransactionGenera
 
       val txs1 = IndexedSeq(headTx, nextTx)
       val txs2 = IndexedSeq(txWithDataInputs, nextTx)
-      val sc1 = ErgoState.stateChanges(txs1)
-      val sc2 = ErgoState.stateChanges(IndexedSeq(txWithDataInputs, nextTx))
+      val sc1 = ErgoState.stateChanges(txs1).get
+      val sc2 = ErgoState.stateChanges(IndexedSeq(txWithDataInputs, nextTx)).get
       // check that the only difference between txs1 and txs2 are dataInputs and Lookup tree operations
       txs1.flatMap(_.inputs) shouldBe txs2.flatMap(_.inputs)
       txs1.flatMap(_.outputCandidates) shouldBe txs2.flatMap(_.outputCandidates)

--- a/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedUtxoState.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedUtxoState.scala
@@ -43,7 +43,7 @@ class WrappedUtxoState(prover: PersistentBatchAVLProver[Digest32, HF],
           case ct: TransactionsCarryingPersistentNodeViewModifier =>
             // You can not get block with transactions not being of ErgoTransaction type so no type checks here.
 
-            val changes = ErgoState.stateChanges(ct.transactions)
+            val changes = ErgoState.stateChanges(ct.transactions).get
             val updHolder = versionedBoxHolder.applyChanges(
               us.version,
               changes.toRemove.map(_.key).map(ByteArrayWrapper.apply),

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -115,7 +115,7 @@ class ErgoNodeViewHolderSpec extends ErgoPropertyTest with HistoryTestHelpers wi
       val genesis = validFullBlock(parentOpt = None, us, bh)
       applyBlock(genesis) shouldBe 'success
 
-      val boxes = ErgoState.boxChanges(genesis.transactions)._2.find(_.ergoTree == Constants.TrueLeaf)
+      val boxes = ErgoState.newBoxes(genesis.transactions).find(_.ergoTree == Constants.TrueLeaf)
       boxes.nonEmpty shouldBe true
 
       val tx = validTransactionFromBoxes(boxes.toIndexedSeq)

--- a/src/test/scala/org/ergoplatform/utils/generators/ValidBlocksGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ValidBlocksGenerators.scala
@@ -14,7 +14,8 @@ import org.ergoplatform.utils.{LoggingUtil, RandomLike, RandomWrapper}
 import org.ergoplatform.wallet.utils.TestFileUtils
 import org.scalatest.matchers.should.Matchers
 import scorex.core.VersionTag
-import scorex.crypto.authds.{ADDigest, ADKey}
+import scorex.crypto.authds.avltree.batch.Remove
+import scorex.crypto.authds.ADDigest
 import scorex.db.ByteArrayWrapper
 import scorex.testkit.TestkitHelpers
 
@@ -242,7 +243,7 @@ trait ValidBlocksGenerators
   private def checkPayload(transactions: Seq[ErgoTransaction], us: UtxoState): Unit = {
     transactions.foreach(_.statelessValidity() shouldBe 'success)
     transactions.nonEmpty shouldBe true
-    ErgoState.boxChanges(transactions)._1.foreach { boxId: ADKey =>
+    ErgoState.boxChanges(transactions).get._1.foreach { case Remove(boxId) =>
       assert(us.boxById(boxId).isDefined, s"Box ${Algos.encode(boxId)} missed")
     }
   }


### PR DESCRIPTION
I found slow tx processing fragment in ErgoState, there is needless multiple O(n) concat operations, collection copying and sorting. CandidateGenerator performance improved too.