### PR TITLE
i1620 reset delivery tracker

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -122,8 +122,9 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     val interval = networkSettings.syncInterval
     context.system.scheduler.scheduleWithFixedDelay(2.seconds, interval, self, SendLocalSyncInfo)
 
+    val healthCheckDelay = settings.nodeSettings.acceptableChainUpdateDelay
     val healthCheckRate = settings.nodeSettings.acceptableChainUpdateDelay / 3
-    context.system.scheduler.scheduleAtFixedRate(healthCheckRate, healthCheckRate, viewHolderRef, IsChainHealthy)(ex, self)
+    context.system.scheduler.scheduleAtFixedRate(healthCheckDelay, healthCheckRate, viewHolderRef, IsChainHealthy)(ex, self)
   }
 
   protected def broadcastModifierInv(m: NodeViewModifier): Unit = {

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -783,6 +783,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
     case ChainIsStuck(error) =>
       log.warn(s"Chain is stuck! $error\nDelivery tracker State:\n$deliveryTracker\nSync tracker state:\n$syncTracker")
+      deliveryTracker.reset()
   }
 
   /** get handlers of messages coming from peers */

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -578,10 +578,10 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
   protected def handleHealthCheck: Receive = {
     case IsChainHealthy =>
-      log.debug(s"Check that chain is healthy, progress is $chainProgress")
+      log.info(s"Check that chain is healthy, progress is $chainProgress")
       val healthCheckReply = chainProgress.map { progress =>
         ErgoNodeViewHolder.checkChainIsHealthy(progress, history(), timeProvider, settings)
-      }.getOrElse(ChainIsHealthy)
+      }.getOrElse(ChainIsStuck("Node already stuck when started"))
       sender() ! healthCheckReply
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -653,24 +653,15 @@ object ErgoNodeViewHolder {
     val chainUpdateDelay = timeProvider.time() - lastUpdate
     val acceptableChainUpdateDelay = settings.nodeSettings.acceptableChainUpdateDelay
     def chainUpdateDelayed = chainUpdateDelay > acceptableChainUpdateDelay.toMillis
-    def blockUpdateDelayed =
-      history.bestFullBlockOpt
-        .map(b => timeProvider.time() - b.header.timestamp)
-        .exists(blockUpdateDelay => blockUpdateDelay > acceptableChainUpdateDelay.toMillis)
-
     def chainSynced =
       history.bestFullBlockOpt.map(_.id) == history.bestHeaderOpt.map(_.id)
 
-    if (chainUpdateDelayed || blockUpdateDelayed) {
+    if (chainUpdateDelayed) {
       val bestFullBlockOpt =
         history.bestFullBlockOpt
           .filter(_.id != lastMod.id)
           .fold("")(fb => s"\n best full block: $fb")
-      val repairNeeded = if(blockUpdateDelayed) {
-        ErgoHistory.repairIfNeeded(history)
-      } else {
-        false
-      }
+      val repairNeeded = ErgoHistory.repairIfNeeded(history)
       ChainIsStuck(s"Chain not modified for $chainUpdateDelay ms, headers-height: $headersHeight, " +
         s"block-height $blockHeight, chain synced: $chainSynced, repair needed: $repairNeeded, " +
         s"last modifier applied: $lastMod, " +

--- a/src/test/scala/scorex/core/network/DeliveryTrackerSpec.scala
+++ b/src/test/scala/scorex/core/network/DeliveryTrackerSpec.scala
@@ -54,6 +54,12 @@ class DeliveryTrackerSpec extends ErgoPropertyTest with ObjectGenerators {
           "104" -> Json.obj()
         )
       )
+
+      tracker.reset()
+      val fullInfoAfterReset = tracker.fullInfo
+      fullInfoAfterReset.invalidModifierApproxSize shouldBe 0
+      fullInfoAfterReset.requested.size shouldBe 0
+      fullInfoAfterReset.received.size shouldBe 0
     }
   }
 


### PR DESCRIPTION
To my understanding, it is not necessary to restart the actor. As `CheckModifiersToDownload` is repeatedly executed but returns No Modifiers with current `DeliveryTracker` state, we just need to `reset` the state and try to re-download missing modifiers.