### PR TITLE
i1609 cache sync messages

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -76,11 +76,11 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private val syncInfoV1CacheByHeadersHeight = CacheBuilder.newBuilder()
     .maximumSize(10)
-    .build[Int, ErgoSyncInfoV1]
+    .build[Integer, ErgoSyncInfoV1]
 
   private val syncInfoV2CacheByHeadersHeight = CacheBuilder.newBuilder()
     .maximumSize(10)
-    .build[Int, ErgoSyncInfoV2]
+    .build[Integer, ErgoSyncInfoV2]
 
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -316,7 +316,7 @@ trait ErgoHistoryReader
     *
     * @return
     */
-  def syncInfoV1: ErgoSyncInfo = {
+  def syncInfoV1: ErgoSyncInfoV1 = {
     /**
       * Return last count headers from best headers chain if exist or chain up to genesis otherwise
       */


### PR DESCRIPTION
Solves https://github.com/ergoplatform/ergo/issues/1609 ... We simply cache last syncV1 and syncV2 messages by headers height, as there are multiple very expensive history queries executed for the same height.

We only need to cache sync Msg for the last HeaderHeight and we cache new one when height progresses and drop the old one.