### PR TITLE
Fix for #1644: DefaultBoxSelector should collect needed inputs when needed for change in presence of assets

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -40,10 +40,20 @@ object DefaultBoxSelector extends BoxSelector {
       res += unspentBox
     }
 
-    def balanceMet = currentBalance >= targetBalance
+    def balanceMet: Boolean = {
+      val diff = currentBalance - targetBalance
+      val diffThreshold = if (currentAssets.isEmpty) {
+        0
+      } else {
+        MinBoxValue * (currentAssets.size / MaxAssetsPerBox + 1)
+      }
+      diff >= diffThreshold
+    }
 
-    def assetsMet = targetAssets.forall {
-      case (id, targetAmt) => currentAssets.getOrElse(id, 0L) >= targetAmt
+    def assetsMet: Boolean = {
+      targetAssets.forall {
+        case (id, targetAmt) => currentAssets.getOrElse(id, 0L) >= targetAmt
+      }
     }
 
     @tailrec

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -25,6 +25,17 @@ object DefaultBoxSelector extends BoxSelector {
 
   final case class NotEnoughCoinsForChangeBoxesError(message: String) extends BoxSelectionError
 
+  // helper function which returns count of assets in `initialMap` not fully spent in `subtractor`
+  private def diffCount(initialMap: mutable.Map[ModifierId, Long], subtractor: TokensMap): Int = {
+    initialMap.foldLeft(0){case (cnt, (tokenId, tokenAmt)) =>
+      if (tokenAmt - subtractor.getOrElse(tokenId, 0L) > 0) {
+        cnt + 1
+      } else {
+        cnt
+      }
+    }
+  }
+
   override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
                                           externalFilter: T => Boolean,
                                           targetBalance: Long,
@@ -47,7 +58,7 @@ object DefaultBoxSelector extends BoxSelector {
       val diff = currentBalance - targetBalance
 
       // We estimate how many ERG needed for assets in change boxes
-      val assetsDiff = currentAssets.size - targetAssets.size
+      val assetsDiff = diffCount(currentAssets, targetAssets)
       val diffThreshold = if (assetsDiff <= 0) {
         0
       } else {

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -40,16 +40,26 @@ object DefaultBoxSelector extends BoxSelector {
       res += unspentBox
     }
 
+    /**
+      * Helper functions which checks whether enough ERGs collected
+      */
     def balanceMet: Boolean = {
       val diff = currentBalance - targetBalance
-      val diffThreshold = if (currentAssets.isEmpty) {
+
+      // We estimate how many ERG needed for assets in change boxes
+      val assetsDiff = currentAssets.size - targetAssets.size
+      val diffThreshold = if (assetsDiff <= 0) {
         0
       } else {
-        MinBoxValue * (currentAssets.size / MaxAssetsPerBox + 1)
+        MinBoxValue * (assetsDiff / MaxAssetsPerBox + 1)
       }
+
       diff >= diffThreshold
     }
 
+    /**
+      * Helper functions which checks whether enough assets collected
+      */
     def assetsMet: Boolean = {
       targetAssets.forall {
         case (id, targetAmt) => currentAssets.getOrElse(id, 0L) >= targetAmt

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -221,6 +221,8 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val tokenData = genTokens(3).last
     tokenData._2 shouldBe 2
 
+    val tokenId = ModifierId @@ bytesToId(tokenData._1)
+
     val ergValue = 10 * MinBoxValue
 
     val box1 = testBox(ergValue, TrueLeaf, StartHeight, Seq(tokenData))
@@ -231,15 +233,16 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val s1 = select(Iterator(uBox1, uBox2), noFilter, ergValue, Map.empty)
     s1 shouldBe 'right
     s1.right.get.changeBoxes.size shouldBe 1
+    s1.right.get.changeBoxes.head.tokens(tokenId) shouldBe 2
 
     val box3 = testBox(ergValue, TrueLeaf, StartHeight)
-    val uBox3 = TrackedBox(parentTx, 0, Some(100), box1, Set(PaymentsScanId))
+    val uBox3 = TrackedBox(parentTx, 0, Some(100), box3, Set(PaymentsScanId))
 
     val s2 = select(Iterator(uBox2, uBox3), noFilter, ergValue, Map.empty)
     s2 shouldBe 'right
     s2.right.get.changeBoxes.size shouldBe 0
 
-    val s3 = select(Iterator(uBox1, uBox2), noFilter, ergValue, Map((ModifierId @@ bytesToId(tokenData._1)) -> 1))
+    val s3 = select(Iterator(uBox1, uBox2), noFilter, ergValue, Map(tokenId -> 1))
     s3 shouldBe 'right
     s3.right.get.changeBoxes.size shouldBe 1
 

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -221,7 +221,7 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
   }
 
   property("i1644") {
-    def tokenData = genTokens(1)
+    val tokenData = genTokens(1)
 
     val ergValue = 10 * MinBoxValue
 
@@ -233,6 +233,13 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val s1 = select(Iterator(uBox1, uBox2), noFilter, ergValue, Map.empty)
     s1 shouldBe 'right
     s1.right.get.changeBoxes.size shouldBe 1
+
+    val box3 = testBox(ergValue, TrueLeaf, StartHeight)
+    val uBox3 = TrackedBox(parentTx, 0, Some(100), box1, Set(PaymentsScanId))
+
+    val s2 = select(Iterator(uBox2, uBox3), noFilter, ergValue, Map.empty)
+    s2 shouldBe 'right
+    s2.right.get.changeBoxes.size shouldBe 0
   }
 
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -12,7 +12,6 @@ import scorex.util.{bytesToId, idToBytes}
 import org.scalatest.EitherValues
 import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughErgsError
 import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughTokensError
-import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughCoinsForChangeBoxesError
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 
@@ -167,19 +166,17 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val s1 = select(uBoxes.toIterator, noFilter, 1 * MinBoxValue, Map(assetId3 -> 11))
     s1 shouldBe 'right
 
-    s1.right.get.boxes.size shouldBe 2
-    s1.right.get.boxes should contain theSameElementsAs(Seq(uBox1, uBox3))
+    s1.right.get.boxes.size shouldBe 3
+    s1.right.get.boxes should contain theSameElementsAs(Seq(uBox1, uBox2, uBox3))
 
     s1.right.get.changeBoxes.size shouldBe 1
-    s1.right.get.changeBoxes(0).value shouldBe 100 * MinBoxValue
+    s1.right.get.changeBoxes(0).value shouldBe 110 * MinBoxValue
     s1.right.get.changeBoxes(0).tokens(assetId1) shouldBe 1
     s1.right.get.changeBoxes(0).tokens(assetId2) shouldBe 1
     s1.right.get.changeBoxes(0).tokens(assetId3) shouldBe 90
     s1.right.get.changeBoxes(0).tokens(assetId4) shouldBe 101
-    s1.right.get.changeBoxes(0).tokens(assetId5) shouldBe 100
-    s1.right.get.changeBoxes(0).tokens(assetId6) shouldBe 100
-
-    s1.right.get.boxes shouldBe Seq(uBox1, uBox3)
+    s1.right.get.changeBoxes(0).tokens(assetId5) shouldBe 110
+    s1.right.get.changeBoxes(0).tokens(assetId6) shouldBe 110
 
     val s2 = select(uBoxes.toIterator, noFilter, 10 * MinBoxValue,
       Map(assetId1 -> 1, assetId2 -> 1, assetId3 -> 1, assetId4 -> 1))
@@ -190,8 +187,7 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     s2.right.get.changeBoxes(0).tokens(assetId7) shouldBe 10
     s2.right.get.changeBoxes(0).tokens(assetId8) shouldBe 10
 
-    //todo: should selector fail in this case (if there's no monetary value to create a new box w. assets) ?
-    select(uBoxes.toIterator, noFilter, 1 * MinBoxValue, Map(assetId1 -> 1)).left.value shouldBe a [NotEnoughCoinsForChangeBoxesError]
+    select(uBoxes.toIterator, noFilter, 1 * MinBoxValue, Map(assetId1 -> 1)).isRight shouldBe true
   }
 
   property("Size of a box with MaxAssetsPerBox tokens should not cross MaxBoxSize") {
@@ -204,7 +200,7 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
 
   property("Select boxes such that change boxes are grouped by MaxAssetsPerBox") {
     // make selection such that '2 * MaxAssetsPerBox + 1' tokens generates exactly 2 change boxes with MaxAssetsPerBox tokens
-    val box1 = testBox(3 * MinBoxValue, TrueLeaf, StartHeight, genTokens(2 * MaxAssetsPerBox + 1))
+    val box1 = testBox(4 * MinBoxValue, TrueLeaf, StartHeight, genTokens(2 * MaxAssetsPerBox + 1))
     val uBox1 = TrackedBox(parentTx, 0, Some(100), box1, Set(PaymentsScanId))
     val s1 = select(Iterator(uBox1), noFilter, 1 * MinBoxValue, Map(bytesToId(Blake2b256("1")) -> 1))
     s1 shouldBe 'right
@@ -220,7 +216,8 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     s2.right.get.changeBoxes.exists(_.tokens.size == 1) shouldBe true
   }
 
-  property("i1644") {
+  // test which shows that https://github.com/ergoplatform/ergo/issues/1644 fixed
+  property("i1644: should collect needed inputs when needed for change in presence of assets") {
     val tokenData = genTokens(1)
 
     val ergValue = 10 * MinBoxValue


### PR DESCRIPTION
This PR is fixing impossibility to collect inputs  in presence of assets (#1644)

From the issue : 
"Steps to reproduce:
Call DefaultBoxSelector.select(inputBoxes, amountToSpend, targetAssets) with

    inputBoxes:
    box 1 with amount 1001000000 nanoerg and a token
    box 2 with amount 1000000 nanoerg
    amoundToSpend: 1001000000 (exactly matching box 1)
    targetAssets: empty

Exptected behaviour:
returning both inputboxes (as both are needed for amountToSpent and change box for the token not to be sent)

Actual behaviour:
throwing NotEnoughCoinsForChangeError"
 
 This PR contains test for situation described (failed initially), as well as a fix (and updated in old tests, as sometimes box selector now works differently)