### PR TITLE
Use relative URL for default server in openapi spec

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://raw.githubusercontent.com/ergoplatform/ergo/master/LICENSE
 
 servers:
-  - url: http://127.0.0.1:9053
+  - url: /
     description: Local full node
   - url: http://213.239.193.208:9053
     description: Known public node


### PR DESCRIPTION
If `servers` is missing a default of `/` is used: https://swagger.io/specification/ (`specification` -> `schema` section)

This should match the default behavior before my change in #1655 

closes #1672 