### PR TITLE
Make uninitialized keystore log less pronounced

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
@@ -1,9 +1,8 @@
 package org.ergoplatform.wallet.secrets
 
-import java.io.{File, PrintWriter}
+import java.io.{File, FileNotFoundException, PrintWriter}
 import java.util
 import java.util.UUID
-
 import io.circe.parser._
 import io.circe.syntax._
 import org.ergoplatform.wallet.crypto
@@ -137,7 +136,7 @@ object JsonSecretStorage {
           Failure(new Exception(s"Cannot readSecretStorage: Secret file not found in dir '$dir'"))
       }
     } else {
-      Failure(new Exception(s"Cannot readSecretStorage: dir '$dir' doesn't exist"))
+      Failure(new FileNotFoundException(s"Cannot readSecretStorage: dir '$dir' doesn't exist"))
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -24,6 +24,7 @@ import scorex.util.encode.Base16
 import scorex.util.{ModifierId, bytesToId}
 import sigmastate.Values.SigmaBoolean
 
+import java.io.FileNotFoundException
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -243,7 +244,12 @@ class ErgoWalletServiceImpl extends ErgoWalletService with ErgoWalletSupport wit
         log.info("Trying to read wallet in secure mode ..")
         JsonSecretStorage.readFile(secretStorageSettings).fold(
           e => {
-            log.warn(s"Failed to read wallet. Manual initialization is required. Details: ", e)
+            e match {
+              case e: FileNotFoundException =>
+                log.info(s"Wallet secret storage not found. Details: {}", e.getMessage)
+              case _ =>
+                log.warn(s"Failed to read wallet. Manual initialization is required. Details: ", e)
+            }
             state
           },
           secretStorage => {


### PR DESCRIPTION
Make the missing keystore log (see below) less pronounced by only displaying the message as an `info` log level instead of `warning` with a stacktrace.

I've seen questions asked about this a number of times in discord and again in #1675 , it's not a problem, just means the wallet isn't initialized.

```
11:27:28.269 WARN  [ergoref-api-dispatcher-8] o.e.n.w.ErgoWalletServiceImpl - Failed to read wallet. Manual initialization is required. Details: 
java.lang.Exception: Cannot readSecretStorage: dir 'D:\Development\crypto\ergo\.mainnet\wallet\keystore' doesn't exist
	at org.ergoplatform.wallet.secrets.JsonSecretStorage$.readFile(JsonSecretStorage.scala:140)
	at org.ergoplatform.nodeView.wallet.ErgoWalletServiceImpl.readWallet(ErgoWalletService.scala:244)
	at org.ergoplatform.nodeView.wallet.ErgoWalletActor$$anonfun$emptyWallet$1.applyOrElse(ErgoWalletActor.scala:87)
	at akka.actor.Actor.aroundReceive(Actor.scala:537)
	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
	at org.ergoplatform.nodeView.wallet.ErgoWalletActor.aroundReceive(ErgoWalletActor.scala:33)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:577)
	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```