### PR TITLE
Use correct method in serializer

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoSyncInfo.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoSyncInfo.scala
@@ -64,7 +64,7 @@ object ErgoSyncInfoSerializer extends ScorexSerializer[ErgoSyncInfo] with Scorex
       case v2: ErgoSyncInfoV2 =>
         w.putUShort(0) // to stop sync v1 parser
         w.put(v2HeaderMode) // signal that v2 message started
-        w.put(v2.lastHeaders.length.toByte) // number of headers peer is announcing
+        w.putUByte(v2.lastHeaders.length) // number of headers peer is announcing
         v2.lastHeaders.foreach { h =>
           val headerBytes = h.bytes
           w.putUShort(headerBytes.length)


### PR DESCRIPTION
Since it writes a signed byte it was unclear whether it supports values higher than 127 but the parser below this method uses `getUByte` so it is indeed supported. There is no difference in the binary representation this, it all depends on how you read it which is why this change is fully backwards-compatible and only makes the code cleaner.