### PR TITLE
EIP-27 implementation: edits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.10" % "test,it",
   "org.scalacheck" %% "scalacheck" % "1.14.+" % "test",
   "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test,
+  "com.lihaoyi" %% "pprint" % "0.5.4" % Test,  // the last version with Scala 2.11 support
 
   "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion,
   "io.circe" %% "circe-core" % circeVersion,

--- a/ergo-wallet/src/main/scala/org/ergoplatform/contracts/ReemissionContracts.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/contracts/ReemissionContracts.scala
@@ -1,12 +1,12 @@
 package org.ergoplatform.contracts
 
-import org.ergoplatform.ErgoBox.R2
+import org.ergoplatform.ErgoBox.{R2, STokensRegType}
 import org.ergoplatform.ErgoScriptPredef.{boxCreationHeight, expectedMinerOutScriptBytesVal}
-import org.ergoplatform.{Height, MinerPubkey, Outputs, Self}
+import org.ergoplatform.{MinerPubkey, Outputs, Height, Self}
 import org.ergoplatform.settings.MonetarySettings
-import sigmastate.{AND, EQ, GE, GT, LE, Minus, OR, SByte, SCollection, SLong, STuple}
-import sigmastate.Values.{ByteArrayConstant, ErgoTree, IntConstant, LongConstant}
-import sigmastate.utxo.{ByIndex, ExtractAmount, ExtractRegisterAs, ExtractScriptBytes, OptionGet, SelectField, SizeOf}
+import sigmastate.{OR, SByte, STuple, GT, SBox, AND, Minus, SLong, EQ, LE, SCollection, GE}
+import sigmastate.Values.{LongConstant, Value, ByteArrayConstant, IntConstant, ErgoTree}
+import sigmastate.utxo.{OptionGet, ExtractRegisterAs, ExtractScriptBytes, SelectField, ExtractAmount, ByIndex, SizeOf}
 
 /**
   * Container for re-emission related contracts. Contains re-emission contract and pay-to-reemission contract.
@@ -28,6 +28,12 @@ trait ReemissionContracts {
     */
   def reemissionStartHeight: Int
 
+  /** Helper method to extract tokens from a box. */
+  private def extractTokens(box: Value[SBox.type]): OptionGet[SCollection[STuple]] = {
+    val rOutTokens = OptionGet(ExtractRegisterAs(box, R2)(STokensRegType))
+    rOutTokens
+  }
+
   /**
     * Contract for boxes miners paying to remission contract according to EIP-27.
     * Anyone can merge multiple boxes locked by this contract with reemission box
@@ -35,8 +41,7 @@ trait ReemissionContracts {
   lazy val payToReemission: ErgoTree = {
     // output of the reemission contract
     val reemissionOut = ByIndex(Outputs, IntConstant(0))
-
-    val rOutTokens = OptionGet(ExtractRegisterAs(reemissionOut, R2)(SCollection(STuple(SCollection(SByte), SLong))))
+    val rOutTokens = extractTokens(reemissionOut)
 
     val firstTokenId = SelectField(ByIndex(rOutTokens, IntConstant(0)), 1.toByte)
 
@@ -54,7 +59,7 @@ trait ReemissionContracts {
     // output to pay miner
     val minerOut = ByIndex(Outputs, IntConstant(1))
 
-    val rOutTokens = OptionGet(ExtractRegisterAs(reemissionOut, R2)(SCollection(STuple(SCollection(SByte), SLong))))
+    val rOutTokens = extractTokens(reemissionOut)
 
     val firstTokenId = SelectField(ByIndex(rOutTokens, IntConstant(0)), 1.toByte)
 
@@ -84,7 +89,7 @@ trait ReemissionContracts {
 
     // when reemission contract box got merged with other boxes
     val sponsored = {
-      val feeOut = ByIndex(Outputs, IntConstant(1))
+      val feeOut = ByIndex(Outputs, IntConstant(1)) // TODO: is it the same as minerOut?
       AND(
         GT(ExtractAmount(reemissionOut), ExtractAmount(Self)),
         LE(ExtractAmount(feeOut), LongConstant(10000000)), // 0.01 ERG

--- a/src/test/scala/org/ergoplatform/reemission/ReemissionRulesSpec.scala
+++ b/src/test/scala/org/ergoplatform/reemission/ReemissionRulesSpec.scala
@@ -213,27 +213,37 @@ class ReemissionRulesSpec extends ErgoPropertyTest with ErgoTestConstants {
   }
 
   def compareSizes(tree: ErgoTree, name: String) = {
-    println(s"Original size of $name: ${tree.bytes.length}")
+    println(s"\n\n====  original $name  ================================")
+    println(s"size of $name: ${tree.bytes.length}")
+//    SigmaPPrint.pprintln(tree, 150, 250)
+
     val IR.Pair(calcF, _) = IR.doCosting(Interpreter.emptyEnv, tree.toProposition(true), true)
     val compiledProp = IR.buildTree(calcF).toSigmaProp
     val version: Byte = 1
     val headerFlags = ErgoTree.headerWithVersion(version)
     val compiledTree = ErgoTree.fromProposition(headerFlags, compiledProp)
-    println(s"Compiled size of $name: ${compiledTree.bytes.length}")
+
+    println(s"====  compiled $name  ================================")
+    println(s"size of $name: ${compiledTree.bytes.length}")
 //    SigmaPPrint.pprintln(compiledTree, 150, 250)
   }
 
   property("compile reemission scripts") {
-//    val compiler = SigmaCompiler(CompilerSettings(ErgoAddressEncoder.MainnetNetworkPrefix, TransformingSigmaBuilder, lowerMethodCalls = true))
-
     val p2r = rr.payToReemission
     compareSizes(p2r, "pay2Reemission")
     compareSizes(prop, "reemissionBoxProp")
 
 //  Output:
-//  Original size of pay2Reemission: 61
-//  Compiled size of pay2Reemission: 62
-//  Original size of reemissionBoxProp: 262
-//  Compiled size of reemissionBoxProp: 254
+//  ====  original pay2Reemission  ================================
+//  size of pay2Reemission: 61
+//  ====  compiled pay2Reemission  ================================
+//  size of pay2Reemission: 62
+//
+//
+//  ====  original reemissionBoxProp  ================================
+//  size of reemissionBoxProp: 262
+//  ====  compiled reemissionBoxProp  ================================
+//  size of reemissionBoxProp: 254
+
   }
 }


### PR DESCRIPTION
- changed contracts code a bit
- added test case which compares tree sizes and do pretty printing (compiled tree is smaller)