### PR TITLE
Fix for #1714: slow headers application

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -34,7 +34,7 @@ import scorex.core.serialization.ScorexSerializer
 import scorex.core.settings.NetworkSettings
 import scorex.core.transaction.{MempoolReader, Transaction}
 import scorex.core.utils.{NetworkTimeProvider, ScorexEncoding}
-import scorex.core.validation.{MalformedModifierError, RecoverableModifierError}
+import scorex.core.validation.MalformedModifierError
 import scorex.util.{ModifierId, ScorexLogging}
 import scorex.core.network.DeliveryTracker
 import scorex.core.network.peer.PenaltyType
@@ -655,9 +655,6 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         log.warn(s"Modifier ${pmod.encodedId} is permanently invalid", e)
         deliveryTracker.setInvalid(pmod.id, pmod.modifierTypeId)
         penalizeMisbehavingPeer(remote)
-        false
-      case Failure(e) if e.isInstanceOf[RecoverableModifierError] =>
-        context.system.eventStream.publish(RecoverableFailedModification(pmod, e))
         false
       case _ =>
         deliveryTracker.setReceived(pmod.id, pmod.modifierTypeId, remote)

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -260,6 +260,8 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
 
       deliveryTracker.reset()
 
+      // we generate fork of two headers, starting from the parent of the best header
+      // so the depth of the rollback is 1, and the fork bypasses the best chain by 1 header
       val hhistory = ErgoHistory.readOrGenerate(settings, timeProvider)
       val parent = hhistory.lastHeaders(2).head
       val smallFork = genHeaderChain(_.size > 2, Some(parent), hhistory.difficultyCalculator, None, false)
@@ -267,7 +269,8 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
       val secondForkHeader = smallFork.apply(2)
 
       sendHeader(synchronizerMockRef, secondForkHeader)
-      // desired state of submitting headers out of order is Unknown, they need to be downloaded again
+      // we submit header at best height + 1, but with parent not known, the status should  be unknown,
+      // so after some time the header could be downloaded again (when the parent may be known)
       eventually {
         deliveryTracker.status(secondForkHeader.id, Header.modifierTypeId, Seq.empty) shouldBe Unknown
       }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -175,7 +175,6 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
   }
 
   class Synchronizer2Fixture extends AkkaFixture {
-      val pool = ErgoMemPool.empty(settings)
       implicit val ec: ExecutionContextExecutor = system.dispatcher
       val ncProbe = TestProbe("NetworkControllerProbe")
       val pchProbe = TestProbe("PeerHandlerProbe")
@@ -203,7 +202,6 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
         lastMessage = 0,
         Some(peerInfo)
       )
-      synchronizerMockRef ! ChangedMempool(pool)
   }
 
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - younger peer") {


### PR DESCRIPTION
In this PR, fail-fast condition in ErgoNodeViewSynchronizer which was added in #1704 : 

``
case Failure(e) if e.isInstanceOf[RecoverableModifierError] =>
        context.system.eventStream.publish(RecoverableFailedModification(pmod, e))
        false
```

now removed. This condition prevents headers from being placed into cache stored in a NodeViewHolder instance. 

`receiving out-of-order header should request it again` test fixed. See comments there on how the test works now. 