### PR TITLE
Comparing pay-to-reemission trees by proposition

### DIFF
--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -300,7 +300,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
           log.debug(s"Reemission tokens to burn: $toBurn")
           val reemissionOutputs = outputCandidates.filter { out =>
             require(!out.tokens.contains(reemissionTokenId), "outputs contain reemission token")
-            out.ergoTree == payToReemissionContract
+            out.ergoTree.toProposition(true) == payToReemissionContract.toProposition(true)
           }
           val sentToReemission = reemissionOutputs.map(_.value).sum
           require(sentToReemission == toBurn, "Burning condition violated")

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -300,6 +300,9 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
           log.debug(s"Reemission tokens to burn: $toBurn")
           val reemissionOutputs = outputCandidates.filter { out =>
             require(!out.tokens.contains(reemissionTokenId), "outputs contain reemission token")
+            // we compare by trees in the mainnet (to avoid disagreement with versions 4.0.29-31 doing that),
+            // and by propositions in the testnet (as there are v0 & v1 transactions paying to pay-to-reemission there)
+            // see https://github.com/ergoplatform/ergo/pull/1728 for details.
             if (chainSettings.isMainnet) {
               out.ergoTree == payToReemissionContract
             } else {

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -300,7 +300,11 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
           log.debug(s"Reemission tokens to burn: $toBurn")
           val reemissionOutputs = outputCandidates.filter { out =>
             require(!out.tokens.contains(reemissionTokenId), "outputs contain reemission token")
-            out.ergoTree.toProposition(true) == payToReemissionContract.toProposition(true)
+            if (chainSettings.isMainnet) {
+              out.ergoTree == payToReemissionContract
+            } else {
+              out.ergoTree.toProposition(true) == payToReemissionContract.toProposition(true)
+            }
           }
           val sentToReemission = reemissionOutputs.map(_.value).sum
           require(sentToReemission == toBurn, "Burning condition violated")


### PR DESCRIPTION
This PR fixes #1726 : 

There's a consensus-level disagreement affecting testnet (only). As pay-to-reemission tree is switched to v1 in https://github.com/ergoplatform/ergo/commit/78a8bfc80be4901715bdb72f4f7c9ee0d48c981e (merged into 4.0.29), and comparison is done over the trees during transaction validation, 4.0.29+ and prior versions currently disagree on transactions burning re-emission tokens (while paying to pay-to-reemission outputs).

As a solution, we now compare trees by propositions. Done for the testnet only, in the mainnet, to avoid disagreement with older versions, we compare trees as before. 