### PR TITLE
Fix for #1746: transaction of too big size invalidated

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -495,6 +495,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                                             remote: ConnectedPeer): Iterable[M] = {
     modifiers.flatMap { case (id, bytes) =>
       if (typeId == Transaction.ModifierTypeId && bytes.length > settings.nodeSettings.maxTransactionSize) {
+        deliveryTracker.setInvalid(id, typeId)
         penalizeMisbehavingPeer(remote)
         log.warn(s"Transaction size ${bytes.length} from ${remote.toString} exceeds limit ${settings.nodeSettings.maxTransactionSize}")
         None


### PR DESCRIPTION
In this PR, we invalidate too big transaction to not download it again