### PR TITLE
Prioritize blocks downloading

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -551,6 +551,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         // (so having UTXO set, and the chain is synced
         if (!settings.nodeSettings.stateType.requireProofs &&
           hr.isHeadersChainSynced &&
+          hr.headersHeight >= syncTracker.maxHeight().getOrElse(0) &&
           hr.fullBlockHeight == hr.headersHeight) {
           val unknownMods =
             invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(mp)) == ModifiersStatus.Unknown)
@@ -584,7 +585,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     */
   protected def requestMoreModifiers(historyReader: ErgoHistory): Unit = {
     if (historyReader.isHeadersChainSynced) {
-      // our requested list is is half empty - request more missed modifiers
+      // our requested list is half empty - request more missed modifiers
       self ! CheckModifiersToDownload
     } else {
       // headers chain is not synced yet, but our requested list is half empty - ask for more headers
@@ -742,7 +743,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       syncTracker.clearStatus(remote)
   }
 
-  protected def getLocalSyncInfo(historyReader: ErgoHistory): Receive = {
+  protected def sendLocalSyncInfo(historyReader: ErgoHistory): Receive = {
     case SendLocalSyncInfo =>
       sendSync(historyReader)
   }
@@ -847,7 +848,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
   def initialized(hr: ErgoHistory, mp: ErgoMemPool, blockAppliedTxsCache: FixedSizeApproximateCacheQueue): PartialFunction[Any, Unit] = {
     processDataFromPeer(msgHandlers(hr, mp, blockAppliedTxsCache)) orElse
       onDownloadRequest(hr) orElse
-      getLocalSyncInfo(hr) orElse
+      sendLocalSyncInfo(hr) orElse
       viewHolderEvents(hr, mp, blockAppliedTxsCache) orElse
       peerManagerEvents orElse
       checkDelivery orElse {

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -330,7 +330,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           applyFromCacheLoop()
           val cleared = modifiersCache.cleanOverfull()
 
-          context.system.eventStream.publish(ModifiersRemovedFromCache(cleared))
+          if (cleared.nonEmpty) {
+            context.system.eventStream.publish(ModifiersRemovedFromCache(cleared))
+          }
           log.debug(s"Cache size after: ${modifiersCache.size}")
       }
   }


### PR DESCRIPTION
In this PR, we introduce new rule for downloading transactions, so we do not downloading transactions if some peer around has a better chain tip. This prioritizes blocks downloading and so helping with getting synced again quicker.