### PR TITLE
ErgoNodeViewSynchronizer refactoring

### DIFF
--- a/avldb/build.sbt
+++ b/avldb/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
 )
 
 testOptions in Test := Seq(Tests.Filter(t => !t.matches(".*Benchmark$")))
-javaOptions in run += "-Xmx12G"
+javaOptions in run += "-Xmx6G"
 
 //scalacOptions ++= Seq("-Xdisable-assertions")
 

--- a/benchmarks/src/test/scala/org/ergoplatform/Utils.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/Utils.scala
@@ -5,7 +5,7 @@ import java.net.URL
 
 import com.google.common.primitives.Ints
 import javax.net.ssl.HttpsURLConnection
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.HistoryModifierSerializer
 
 object Utils {
@@ -31,7 +31,7 @@ object Utils {
   def readBytes(length: Int)(implicit fis: InputStream): Option[Array[Byte]] =
     Some(Stream.continually(fis.read().toByte).take(length).toArray)
 
-  def readModifier[M <: ErgoPersistentModifier](implicit fis: InputStream): Option[M] = {
+  def readModifier[M <: BlockSection](implicit fis: InputStream): Option[M] = {
     for {
       length <- readLength
       bytes <- readBytes(length)

--- a/benchmarks/src/test/scala/org/ergoplatform/bench/BenchRunner.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/bench/BenchRunner.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.bench
 
 import akka.actor.{ActorRef, ActorSystem}
 import org.ergoplatform.bench.misc.TempDir
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.history.storage.modifierprocessors.{FullBlockPruningProcessor, ToDownloadProcessor}
 import org.ergoplatform.nodeView.state.{ErgoState, StateType}
@@ -71,7 +71,7 @@ object BenchRunner extends ScorexLogging with NVBenchmark {
     ()
   }
 
-  private def runBench(benchRef: ActorRef, nodeRef: ActorRef, modifiers: Vector[ErgoPersistentModifier]): Unit = {
+  private def runBench(benchRef: ActorRef, nodeRef: ActorRef, modifiers: Vector[BlockSection]): Unit = {
     benchRef ! BenchActor.Start
     modifiers.foreach { m => nodeRef ! LocallyGeneratedModifier(m) }
   }

--- a/benchmarks/src/test/scala/org/ergoplatform/bench/CrawlerRunner.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/bench/CrawlerRunner.scala
@@ -49,7 +49,7 @@ class CrawlerRunner(args: Array[String]) extends Application {
 
   val minerRef: ActorRef = ErgoMiner(ergoSettings, nodeViewHolderRef, readersHolderRef, timeProvider)
 
-  private val syncTracker = ErgoSyncTracker(actorSystem, settings.network, timeProvider)
+  private val syncTracker = ErgoSyncTracker(settings.network, timeProvider)
 
   val statsCollectorRef: ActorRef =
     ErgoStatsCollectorRef(nodeViewHolderRef, networkControllerRef, syncTracker, ergoSettings, timeProvider)

--- a/benchmarks/src/test/scala/org/ergoplatform/bench/misc/ModifierWriter.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/bench/misc/ModifierWriter.scala
@@ -4,7 +4,7 @@ import java.io.{InputStream, OutputStream}
 
 import com.google.common.primitives.Ints
 import org.ergoplatform.Utils._
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import scorex.core.serialization.ScorexSerializer
@@ -12,7 +12,7 @@ import scorex.core.{ModifierTypeId, NodeViewModifier}
 
 object ModifierWriter {
 
-  val modifierSerializers: Map[ModifierTypeId, ScorexSerializer[_ <: ErgoPersistentModifier]] =
+  val modifierSerializers: Map[ModifierTypeId, ScorexSerializer[_ <: BlockSection]] =
     Map(Header.modifierTypeId -> HeaderSerializer,
       BlockTransactions.modifierTypeId -> BlockTransactionsSerializer,
       ADProofs.modifierTypeId -> ADProofsSerializer)
@@ -27,7 +27,7 @@ object ModifierWriter {
     fos.flush()
   }
 
-  def read(implicit fis: InputStream): Option[ErgoPersistentModifier] = for {
+  def read(implicit fis: InputStream): Option[BlockSection] = for {
     typeId <- readModId
     length <- readLength
     bytes <- readBytes(length)

--- a/benchmarks/src/test/scala/org/ergoplatform/nodeView/NVBenchmark.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/nodeView/NVBenchmark.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView
 import org.ergoplatform.Utils
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.modifiers.history.BlockTransactions
 
 trait NVBenchmark {
@@ -16,7 +16,7 @@ trait NVBenchmark {
   def readBlocks: Seq[ErgoFullBlock] = readHeaders.zip(readPayloads).zip(readExtensions)
     .map { case ((h, txs), ext) => ErgoFullBlock(h, txs, ext, None) }
 
-  def readModifiers[M <: ErgoPersistentModifier](path: String): Seq[M] = {
+  def readModifiers[M <: BlockSection](path: String): Seq[M] = {
     val is = Utils.getUrlInputStream(path)
     Stream
       .continually {

--- a/benchmarks/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateBenchmark.scala
+++ b/benchmarks/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateBenchmark.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.nodeView.state
 
 import org.ergoplatform.Utils
 import org.ergoplatform.Utils.BenchReport
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.NVBenchmark
 import org.ergoplatform.settings.{Args, ErgoSettings}
 import org.ergoplatform.utils.HistoryTestHelpers
@@ -21,7 +21,7 @@ object UtxoStateBenchmark extends HistoryTestHelpers with NVBenchmark {
 
     val transactionsQty = blocks.flatMap(_.transactions).size
 
-    def bench(mods: Seq[ErgoPersistentModifier]): Long = {
+    def bench(mods: Seq[BlockSection]): Long = {
       val state = ErgoState.generateGenesisUtxoState(createTempDir, StateConstants(realNetworkSetting))._1
       Utils.time {
         mods.foldLeft(state) { case (st, mod) =>

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -104,7 +104,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
     }
 
 
-  private val syncTracker = ErgoSyncTracker(actorSystem, scorexSettings.network, timeProvider)
+  private val syncTracker = ErgoSyncTracker(scorexSettings.network, timeProvider)
   private val statsCollectorRef: ActorRef = ErgoStatsCollectorRef(readersHolderRef, networkControllerRef, syncTracker, ergoSettings, timeProvider)
   private val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(ergoSettings)
 

--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -7,7 +7,7 @@ import io.circe.Json
 import io.circe.syntax._
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.BlockTransactions
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.ErgoReadersHolder.GetDataFromHistory
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.settings.{Algos, ErgoSettings}
@@ -69,13 +69,13 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
       history.typedModifierById[Header](headerId).flatMap(history.getFullBlock)
     }
 
-  private def getModifierById(modifierId: ModifierId): Future[Option[ErgoPersistentModifier]] =
+  private def getModifierById(modifierId: ModifierId): Future[Option[BlockSection]] =
     getHistory.map(_.modifierById(modifierId))
 
   private def getProofForTx(headerId: ModifierId, txId: ModifierId): Future[Option[MerkleProof[Digest32]]] =
     getModifierById(headerId).flatMap {
       case Some(header: Header) =>
-        val blockTxsId = BlockSection.computeId(
+        val blockTxsId = NonHeaderBlockSection.computeId(
           BlockTransactions.modifierTypeId,
           headerId,
           header.transactionsRoot.asInstanceOf[Array[Byte]]

--- a/src/main/scala/org/ergoplatform/modifiers/BlockSection.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/BlockSection.scala
@@ -1,30 +1,21 @@
 package org.ergoplatform.modifiers
 
-import org.ergoplatform.settings.Algos
-import scorex.core.ModifierTypeId
-import scorex.crypto.hash.Digest32
-import scorex.util.{ModifierId, bytesToId, idToBytes}
+import io.circe.Encoder
+import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions}
+import scorex.core.PersistentNodeViewModifier
 
-/**
-  * An interface for Ergo block section which contains corresponding header id and a digest of its payload.
-  */
-trait BlockSection extends ErgoPersistentModifier {
-
-  override lazy val serializedId: Array[Byte] = BlockSection.computeIdBytes(modifierTypeId, headerId, digest)
-
-  override lazy val id: ModifierId = bytesToId(serializedId)
-
-  def digest: Digest32
-
-  def headerId: ModifierId
-
-  override def parentId: ModifierId = headerId
-}
+trait BlockSection extends PersistentNodeViewModifier with ErgoNodeViewModifier
 
 object BlockSection {
-  def computeId(modifierType: ModifierTypeId, headerId: ModifierId, digest: Array[Byte]): ModifierId =
-    bytesToId(computeIdBytes(modifierType, headerId, digest))
 
-  def computeIdBytes(modifierType: ModifierTypeId, headerId: ModifierId, digest: Array[Byte]): Array[Byte] =
-      Algos.hash.prefixedHash(modifierType, idToBytes(headerId), digest)
+  implicit val jsonEncoder: Encoder[BlockSection] = {
+    case h: Header => Header.jsonEncoder(h)
+    case bt: BlockTransactions => BlockTransactions.jsonEncoder(bt)
+    case adp: ADProofs => ADProofs.jsonEncoder(adp)
+    case ext: Extension => Extension.jsonEncoder(ext)
+    case other => throw new Exception(s"Unknown persistent modifier type: $other")
+  }
+
 }

--- a/src/main/scala/org/ergoplatform/modifiers/ErgoFullBlock.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/ErgoFullBlock.scala
@@ -15,7 +15,7 @@ case class ErgoFullBlock(header: Header,
                          blockTransactions: BlockTransactions,
                          extension: Extension,
                          adProofs: Option[ADProofs])
-  extends ErgoPersistentModifier
+  extends BlockSection
     with TransactionsCarryingPersistentNodeViewModifier {
 
   override type M = ErgoFullBlock
@@ -28,11 +28,11 @@ case class ErgoFullBlock(header: Header,
 
   override def parentId: ModifierId = header.parentId
 
-  lazy val mandatoryBlockSections: Seq[BlockSection] = Seq(blockTransactions, extension)
+  lazy val mandatoryBlockSections: Seq[NonHeaderBlockSection] = Seq(blockTransactions, extension)
 
-  lazy val blockSections: Seq[BlockSection] = adProofs.toSeq ++ mandatoryBlockSections
+  lazy val blockSections: Seq[NonHeaderBlockSection] = adProofs.toSeq ++ mandatoryBlockSections
 
-  lazy val toSeq: Seq[ErgoPersistentModifier] = header +: blockSections
+  lazy val toSeq: Seq[BlockSection] = header +: blockSections
 
   override lazy val transactions: Seq[ErgoTransaction] = blockTransactions.txs
 

--- a/src/main/scala/org/ergoplatform/modifiers/NonHeaderBlockSection.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/NonHeaderBlockSection.scala
@@ -1,0 +1,30 @@
+package org.ergoplatform.modifiers
+
+import org.ergoplatform.settings.Algos
+import scorex.core.ModifierTypeId
+import scorex.crypto.hash.Digest32
+import scorex.util.{ModifierId, bytesToId, idToBytes}
+
+/**
+  * An interface for Ergo block section which contains corresponding header id and a digest of its payload.
+  */
+trait NonHeaderBlockSection extends BlockSection {
+
+  override lazy val serializedId: Array[Byte] = NonHeaderBlockSection.computeIdBytes(modifierTypeId, headerId, digest)
+
+  override lazy val id: ModifierId = bytesToId(serializedId)
+
+  def digest: Digest32
+
+  def headerId: ModifierId
+
+  override def parentId: ModifierId = headerId
+}
+
+object NonHeaderBlockSection {
+  def computeId(modifierType: ModifierTypeId, headerId: ModifierId, digest: Array[Byte]): ModifierId =
+    bytesToId(computeIdBytes(modifierType, headerId, digest))
+
+  def computeIdBytes(modifierType: ModifierTypeId, headerId: ModifierId, digest: Array[Byte]): Array[Byte] =
+      Algos.hash.prefixedHash(modifierType, idToBytes(headerId), digest)
+}

--- a/src/main/scala/org/ergoplatform/modifiers/history/ADProofs.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/ADProofs.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.modifiers.history
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 import org.ergoplatform.http.api.ApiCodecs
-import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.modifiers.NonHeaderBlockSection
 import org.ergoplatform.modifiers.state._
 import org.ergoplatform.settings.Algos.HF
 import org.ergoplatform.settings.{Algos, Constants}
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success, Try}
 
 case class ADProofs(headerId: ModifierId,
                     proofBytes: SerializedAdProof,
-                    override val sizeOpt: Option[Int] = None) extends BlockSection {
+                    override val sizeOpt: Option[Int] = None) extends NonHeaderBlockSection {
 
   override def digest: Digest32 = ADProofs.proofDigest(proofBytes)
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.modifiers.history
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 import org.ergoplatform.http.api.ApiCodecs
-import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.modifiers.NonHeaderBlockSection
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer}
 import org.ergoplatform.nodeView.mempool.TransactionMembershipProof
@@ -33,7 +33,7 @@ case class BlockTransactions(headerId: ModifierId,
                              blockVersion: Version,
                              txs: Seq[ErgoTransaction],
                              override val sizeOpt: Option[Int] = None)
-  extends BlockSection with TransactionsCarryingPersistentNodeViewModifier {
+  extends NonHeaderBlockSection with TransactionsCarryingPersistentNodeViewModifier {
 
   assert(txs.nonEmpty, "Block should always contain at least 1 coinbase-like transaction")
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/HistoryModifierSerializer.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/HistoryModifierSerializer.scala
@@ -1,14 +1,14 @@
 package org.ergoplatform.modifiers.history
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSerializer}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import scorex.core.serialization.ScorexSerializer
 import scorex.util.serialization.{Reader, Writer}
 
-object HistoryModifierSerializer extends ScorexSerializer[ErgoPersistentModifier] {
+object HistoryModifierSerializer extends ScorexSerializer[BlockSection] {
 
-  override def serialize(obj: ErgoPersistentModifier, w: Writer): Unit = {
+  override def serialize(obj: BlockSection, w: Writer): Unit = {
     obj match {
       case m: Header =>
         w.put(Header.modifierTypeId)
@@ -27,7 +27,7 @@ object HistoryModifierSerializer extends ScorexSerializer[ErgoPersistentModifier
     }
   }
 
-  override def parse(r: Reader): ErgoPersistentModifier = {
+  override def parse(r: Reader): BlockSection = {
     r.getByte() match {
       case Header.`modifierTypeId` =>
         HeaderSerializer.parse(r)

--- a/src/main/scala/org/ergoplatform/modifiers/history/NipopowProofModifier.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/NipopowProofModifier.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.modifiers.history
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.popow.NipopowProof
 import org.ergoplatform.settings.Algos
 import scorex.core.ModifierTypeId
@@ -16,7 +16,7 @@ import scorex.util.{ModifierId, bytesToId}
   * @param sizeOpt - optionally, serialized network message size
   */
 case class NipopowProofModifier(proof: NipopowProof, override val sizeOpt: Option[Int] = None)
-  extends Comparable[NipopowProofModifier] with Ordered[NipopowProofModifier] with ErgoPersistentModifier {
+  extends Comparable[NipopowProofModifier] with Ordered[NipopowProofModifier] with BlockSection {
 
   override val modifierTypeId: ModifierTypeId = NipopowProofModifier.modifierTypeId
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala
@@ -4,7 +4,7 @@ import com.google.common.primitives.Bytes
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor}
 import org.ergoplatform.http.api.ApiCodecs
-import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.modifiers.NonHeaderBlockSection
 import org.ergoplatform.settings.Algos
 import scorex.core.ModifierTypeId
 import scorex.core.serialization.ScorexSerializer
@@ -23,7 +23,7 @@ import scorex.util.ModifierId
 case class Extension(headerId: ModifierId,
                      override val fields: Seq[(Array[Byte], Array[Byte])],
                      override val sizeOpt: Option[Int] = None)
-  extends ExtensionCandidate(fields) with BlockSection {
+  extends ExtensionCandidate(fields) with NonHeaderBlockSection {
 
   override val modifierTypeId: ModifierTypeId = Extension.modifierTypeId
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.mining.difficulty.RequiredDifficulty
 import org.ergoplatform.mining.AutolykosSolution
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions, PreHeader}
-import org.ergoplatform.modifiers.{BlockSection, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, BlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.history.ErgoHistory.Difficulty
 import org.ergoplatform.settings.{Algos, Constants}
@@ -54,7 +54,7 @@ case class Header(override val version: Header.Version,
                   powSolution: AutolykosSolution,
                   override val votes: Array[Byte], //3 bytes
                   override val sizeOpt: Option[Int] = None) extends HeaderWithoutPow(version, parentId, ADProofsRoot, stateRoot, transactionsRoot, timestamp,
-  nBits, height, extensionRoot, votes) with PreHeader with ErgoPersistentModifier {
+  nBits, height, extensionRoot, votes) with PreHeader with BlockSection {
 
   override def serializedId: Array[Header.Version] = Algos.hash(bytes)
 
@@ -64,11 +64,11 @@ case class Header(override val version: Header.Version,
 
   lazy val requiredDifficulty: Difficulty = RequiredDifficulty.decodeCompactBits(nBits)
 
-  lazy val ADProofsId: ModifierId = BlockSection.computeId(ADProofs.modifierTypeId, id, ADProofsRoot)
+  lazy val ADProofsId: ModifierId = NonHeaderBlockSection.computeId(ADProofs.modifierTypeId, id, ADProofsRoot)
 
-  lazy val transactionsId: ModifierId = BlockSection.computeId(BlockTransactions.modifierTypeId, id, transactionsRoot)
+  lazy val transactionsId: ModifierId = NonHeaderBlockSection.computeId(BlockTransactions.modifierTypeId, id, transactionsRoot)
 
-  lazy val extensionId: ModifierId = BlockSection.computeId(Extension.modifierTypeId, id, extensionRoot)
+  lazy val extensionId: ModifierId = NonHeaderBlockSection.computeId(Extension.modifierTypeId, id, extensionRoot)
 
   override def minerPk: EcPointType = powSolution.pk
 
@@ -89,7 +89,7 @@ case class Header(override val version: Header.Version,
   /**
     * Checks that modifier m corresponds to this header
     */
-  def isCorrespondingModifier(m: ErgoPersistentModifier): Boolean = sectionIds.exists(_._2 == m.id)
+  def isCorrespondingModifier(m: BlockSection): Boolean = sectionIds.exists(_._2 == m.id)
 
   /**
     * Estimate that this header is recent enough to possibly be the best header

--- a/src/main/scala/org/ergoplatform/modifiers/state/UTXOSnapshotChunk.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/state/UTXOSnapshotChunk.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.modifiers.state
 
 import org.ergoplatform.ErgoBox
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.state.UTXOSnapshotChunk.StateElement
 import org.ergoplatform.settings.Algos
 import scorex.core.ModifierTypeId
@@ -12,7 +12,7 @@ import scorex.util.{ModifierId, bytesToId}
 import scorex.utils.Random
 
 case class UTXOSnapshotChunk(stateElements: Seq[StateElement],
-                             index: Short) extends ErgoPersistentModifier {
+                             index: Short) extends BlockSection {
   override val modifierTypeId: ModifierTypeId = UTXOSnapshotChunk.modifierTypeId
 
   //TODO implement correctly

--- a/src/main/scala/org/ergoplatform/modifiers/state/UTXOSnapshotManifest.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/state/UTXOSnapshotManifest.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.modifiers.state
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.settings.Algos
 import scorex.core.ModifierTypeId
@@ -12,7 +12,7 @@ import scorex.util.{ModifierId, bytesToId, idToBytes}
 
 import scala.util.Try
 
-case class UTXOSnapshotManifest(chunkRootHashes: Seq[Array[Byte]], blockId: ModifierId) extends ErgoPersistentModifier {
+case class UTXOSnapshotManifest(chunkRootHashes: Seq[Array[Byte]], blockId: ModifierId) extends BlockSection {
   override val modifierTypeId: ModifierTypeId = UTXOSnapshotManifest.modifierTypeId
 
   override def serializedId: Array[Byte] = Algos.hash(concatBytes(chunkRootHashes :+ idToBytes(blockId)))

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -938,16 +938,6 @@ object ErgoNodeViewSynchronizer {
 
   case object CheckModifiersToDownload
 
-  object Events {
-
-    trait NodeViewSynchronizerEvent
-
-    case object NoBetterNeighbour extends NodeViewSynchronizerEvent
-
-    case object BetterNeighbourAppeared extends NodeViewSynchronizerEvent
-
-  }
-
   object ReceivableMessages {
 
     // getLocalSyncInfo messages

--- a/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
@@ -2,7 +2,6 @@ package org.ergoplatform.network
 
 import java.net.InetSocketAddress
 
-import org.ergoplatform.network.ErgoSyncTracker.{NeighboursStatus, NeighboursStatusUnknown}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.history.ErgoHistory.Height
 import scorex.core.consensus.{Fork, HistoryComparisonResult, Older, Unknown}

--- a/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
@@ -20,10 +20,9 @@ final case class ErgoSyncTracker(networkSettings: NetworkSettings, timeProvider:
   private val MinSyncInterval: FiniteDuration = 20.seconds
   private val SyncThreshold: FiniteDuration = 1.minute
 
-  val heights: mutable.Map[ConnectedPeer, Height] = mutable.Map[ConnectedPeer, Height]()
+  private val heights = mutable.Map[ConnectedPeer, Height]()
 
-  protected[network] val statuses: mutable.Map[ConnectedPeer, ErgoPeerStatus] =
-    mutable.Map[ConnectedPeer, ErgoPeerStatus]()
+  private val statuses = mutable.Map[ConnectedPeer, ErgoPeerStatus]()
 
   def fullInfo(): Iterable[ErgoPeerStatus] = statuses.values
 

--- a/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
@@ -46,7 +46,7 @@ final case class ErgoSyncTracker(networkSettings: NetworkSettings, timeProvider:
 
   def updateStatus(peer: ConnectedPeer,
                    status: HistoryComparisonResult,
-                   height: Option[Height]): NeighboursStatus = {
+                   height: Option[Height]): Unit = {
     val seniorsBefore = numOfSeniors()
     statuses.adjust(peer){
       case None =>
@@ -65,8 +65,6 @@ final case class ErgoSyncTracker(networkSettings: NetworkSettings, timeProvider:
     if (seniorsBefore == 0 && seniorsAfter > 0) {
       // todo: update neighbours status?
     }
-
-    NeighboursStatusUnknown
   }
 
   /**
@@ -149,9 +147,4 @@ final case class ErgoSyncTracker(networkSettings: NetworkSettings, timeProvider:
     }.mkString("\n")
   }
 
-}
-
-object ErgoSyncTracker {
-  sealed trait NeighboursStatus
-  case object NeighboursStatusUnknown extends NeighboursStatus
 }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistory
 import scorex.core.DefaultModifiersCache
@@ -12,7 +12,7 @@ class ErgoModifiersCache(override val maxSize: Int)
   extends DefaultModifiersCache(maxSize) {
 
   override def findCandidateKey(history: ErgoHistory): Option[K] = {
-    def tryToApply(k: K, v: ErgoPersistentModifier): Boolean = {
+    def tryToApply(k: K, v: BlockSection): Boolean = {
       history.applicableTry(v) match {
         case Failure(e) if e.isInstanceOf[MalformedModifierError] =>
           log.warn(s"Modifier ${v.encodedId} is permanently invalid and will be removed from cache", e)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
@@ -8,8 +8,7 @@ import scorex.core.validation.MalformedModifierError
 
 import scala.util.Failure
 
-class ErgoModifiersCache(override val maxSize: Int)
-  extends DefaultModifiersCache(maxSize) {
+class ErgoModifiersCache(override val maxSize: Int) extends DefaultModifiersCache(maxSize) {
 
   override def findCandidateKey(history: ErgoHistory): Option[K] = {
     def tryToApply(k: K, v: BlockSection): Boolean = {
@@ -43,4 +42,5 @@ class ErgoModifiersCache(override val maxSize: Int)
       }.map(_._1)
     }
   }
+
 }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -7,7 +7,8 @@ import org.ergoplatform.ErgoApp.CriticalSystemException
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.BlockAppliedTransactions
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.mempool.ErgoMemPool.ProcessingOutcome
@@ -53,9 +54,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
   case class UpdateInformation(history: ErgoHistory,
                                state: State,
-                               failedMod: Option[ErgoPersistentModifier],
-                               alternativeProgressInfo: Option[ProgressInfo[ErgoPersistentModifier]],
-                               suffix: IndexedSeq[ErgoPersistentModifier])
+                               failedMod: Option[BlockSection],
+                               alternativeProgressInfo: Option[ProgressInfo[BlockSection]],
+                               suffix: IndexedSeq[BlockSection])
 
   val scorexSettings: ScorexSettings = settings.scorexSettings
 
@@ -128,19 +129,19 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     nodeView = newNodeView
   }
 
-  protected def extractTransactions(mod: ErgoPersistentModifier): Seq[ErgoTransaction] = mod match {
+  protected def extractTransactions(mod: BlockSection): Seq[ErgoTransaction] = mod match {
     case tcm: TransactionsCarryingPersistentNodeViewModifier => tcm.transactions
     case _ => Seq.empty
   }
 
 
-  protected def requestDownloads(pi: ProgressInfo[ErgoPersistentModifier]): Unit =
+  protected def requestDownloads(pi: ProgressInfo[BlockSection]): Unit =
     pi.toDownload.foreach { case (tid, id) =>
       context.system.eventStream.publish(DownloadRequest(tid, id))
     }
 
-  private def trimChainSuffix(suffix: IndexedSeq[ErgoPersistentModifier],
-                              rollbackPoint: scorex.util.ModifierId): IndexedSeq[ErgoPersistentModifier] = {
+  private def trimChainSuffix(suffix: IndexedSeq[BlockSection],
+                              rollbackPoint: scorex.util.ModifierId): IndexedSeq[BlockSection] = {
     val idx = suffix.indexWhere(_.id == rollbackPoint)
     if (idx == -1) IndexedSeq.empty else suffix.drop(idx)
   }
@@ -180,11 +181,11 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
   @tailrec
   protected final def updateState(history: ErgoHistory,
                                   state: State,
-                                  progressInfo: ProgressInfo[ErgoPersistentModifier],
-                                  suffixApplied: IndexedSeq[ErgoPersistentModifier]): (ErgoHistory, Try[State], Seq[ErgoPersistentModifier]) = {
+                                  progressInfo: ProgressInfo[BlockSection],
+                                  suffixApplied: IndexedSeq[BlockSection]): (ErgoHistory, Try[State], Seq[BlockSection]) = {
     requestDownloads(progressInfo)
 
-    val (stateToApplyTry: Try[State], suffixTrimmed: IndexedSeq[ErgoPersistentModifier]) = if (progressInfo.chainSwitchingNeeded) {
+    val (stateToApplyTry: Try[State], suffixTrimmed: IndexedSeq[BlockSection]) = if (progressInfo.chainSwitchingNeeded) {
       @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
       val branchingPoint = progressInfo.branchPoint.get //todo: .get
       if (state.version != branchingPoint) {
@@ -231,8 +232,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
   private def applyState(history: ErgoHistory,
                          stateToApply: State,
-                         suffixTrimmed: IndexedSeq[ErgoPersistentModifier],
-                         progressInfo: ProgressInfo[ErgoPersistentModifier]): Try[UpdateInformation] = {
+                         suffixTrimmed: IndexedSeq[BlockSection],
+                         progressInfo: ProgressInfo[BlockSection]): Try[UpdateInformation] = {
     val updateInfoSample = UpdateInformation(history, stateToApply, None, None, suffixTrimmed)
     progressInfo.toApply.foldLeft[Try[UpdateInformation]](Success(updateInfoSample)) {
       case (f@Failure(ex), _) =>
@@ -281,7 +282,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     * Publish `ModifiersProcessingResult` message with all just applied and removed from cache modifiers.
     */
   protected def processRemoteModifiers: Receive = {
-    case ModifiersFromRemote(mods: Seq[ErgoPersistentModifier]@unchecked) =>
+    case ModifiersFromRemote(mods: Seq[BlockSection]@unchecked) =>
       @tailrec
       def applyFromCacheLoop(): Unit = {
         modifiersCache.popCandidate(history()) match {
@@ -340,10 +341,10 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     * from rolled back block are to be returned to the pool, and transactions
     * included in applied block are to be removed.
     */
-  protected def updateMemPool(blocksRemoved: Seq[ErgoPersistentModifier],
-                                       blocksApplied: Seq[ErgoPersistentModifier],
-                                       memPool: ErgoMemPool,
-                                       state: State): ErgoMemPool = {
+  protected def updateMemPool(blocksRemoved: Seq[BlockSection],
+                              blocksApplied: Seq[BlockSection],
+                              memPool: ErgoMemPool,
+                              state: State): ErgoMemPool = {
     val rolledBackTxs = blocksRemoved.flatMap(extractTransactions)
     val appliedTxs = blocksApplied.flatMap(extractTransactions)
     context.system.eventStream.publish(BlockAppliedTransactions(appliedTxs.map(_.id)))
@@ -404,7 +405,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     * @param pmod Remote or local persistent modifier
     * @param local whether the modifier was generated locally or not
     */
-  protected def pmodModify(pmod: ErgoPersistentModifier, local: Boolean): Unit = {
+  protected def pmodModify(pmod: BlockSection, local: Boolean): Unit = {
     if (!history().contains(pmod.id)) { // todo: .contains reads modifier pmod fully here if in db
 
       // if ADProofs block section generated locally, just dump it into the database
@@ -523,7 +524,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
             .fold(throw new Error(s"Failed to get full block for header $h"))(fb => fb)
         }
         toApply.foldLeft[Try[State]](Success(initState)) { case (acc, m) =>
-          log.info(s"Applying modifier during node start-up to restore consistent state: ${m.id}")
+          log.info(s"Applying block ${m.height} during node start-up to restore consistent state: ${m.id}")
           acc.flatMap(_.applyModifier(m, estimatedTip())(lm => self ! lm))
         }
     }
@@ -632,7 +633,7 @@ object ErgoNodeViewHolder {
 
   object ReceivableMessages {
     // Tracking last modifier and header & block heights in time, being periodically checked for possible stuck
-    case class ChainProgress(lastMod: ErgoPersistentModifier, headersHeight: Int, blockHeight: Int, lastUpdate: Long)
+    case class ChainProgress(lastMod: BlockSection, headersHeight: Int, blockHeight: Int, lastUpdate: Long)
 
     // Explicit request of NodeViewChange events of certain types.
     case class GetNodeViewChanges(history: Boolean, state: Boolean, vault: Boolean, mempool: Boolean)
@@ -640,7 +641,7 @@ object ErgoNodeViewHolder {
     case class GetDataFromCurrentView[State, A](f: CurrentView[State] => A)
 
     // Modifiers received from the remote peer with new elements in it
-    case class ModifiersFromRemote(modifiers: Iterable[ErgoPersistentModifier])
+    case class ModifiersFromRemote(modifiers: Iterable[BlockSection])
 
     sealed trait NewTransactions{
       val txs: Iterable[ErgoTransaction]
@@ -652,7 +653,7 @@ object ErgoNodeViewHolder {
 
     case class TransactionsFromRemote(override val txs: Iterable[ErgoTransaction]) extends NewTransactions
 
-    case class LocallyGeneratedModifier(pmod: ErgoPersistentModifier)
+    case class LocallyGeneratedModifier(pmod: BlockSection)
 
     case class EliminateTransactions(ids: Seq[scorex.util.ModifierId])
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -5,7 +5,7 @@ import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.{Header, PreGenesisHeader}
 import org.ergoplatform.modifiers.history.popow.{NipopowAlgos, NipopowProof, PoPowHeader, PoPowParams}
 import org.ergoplatform.modifiers.state.UTXOSnapshotChunk
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistory.Height
 import org.ergoplatform.nodeView.history.storage._
 import org.ergoplatform.nodeView.history.storage.modifierprocessors._
@@ -26,7 +26,7 @@ import scala.util.{Failure, Try}
   */
 trait ErgoHistoryReader
   extends NodeViewComponent
-    with ContainsModifiers[ErgoPersistentModifier]
+    with ContainsModifiers[BlockSection]
     with HeadersProcessor
     with PoPoWProofsProcessor
     with UTXOSnapshotChunkProcessor
@@ -77,7 +77,7 @@ trait ErgoHistoryReader
     * @param id - modifier id
     * @return semantically valid ErgoPersistentModifier with the given id it is in history
     */
-  override def modifierById(id: ModifierId): Option[ErgoPersistentModifier] =
+  override def modifierById(id: ModifierId): Option[BlockSection] =
     if (isSemanticallyValid(id) != ModifierSemanticValidity.Invalid) {
       historyStorage.modifierById(id)
     } else {
@@ -90,7 +90,7 @@ trait ErgoHistoryReader
     * @tparam T - expected Type
     * @return semantically valid ErgoPersistentModifier of type T with the given id it is in history
     */
-  def typedModifierById[T <: ErgoPersistentModifier : ClassTag](id: ModifierId): Option[T] = modifierById(id) match {
+  def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T] = modifierById(id) match {
     case Some(m: T) => Some(m)
     case _ => None
   }
@@ -100,7 +100,7 @@ trait ErgoHistoryReader
   /**
     * Check, that it's possible to apply modifier to history
     */
-  def applicable(modifier: ErgoPersistentModifier): Boolean = applicableTry(modifier).isSuccess
+  def applicable(modifier: BlockSection): Boolean = applicableTry(modifier).isSuccess
 
   /**
     * For given headers (sorted in reverse chronological order), find first one (most recent one) which is known
@@ -405,11 +405,11 @@ trait ErgoHistoryReader
     * @param modifier  - modifier to apply
     * @return `Success` if modifier can be applied, `Failure(ModifierError)` if can not
     */
-  def applicableTry(modifier: ErgoPersistentModifier): Try[Unit] = {
+  def applicableTry(modifier: BlockSection): Try[Unit] = {
     modifier match {
       case header: Header =>
         validate(header)
-      case m: BlockSection =>
+      case m: NonHeaderBlockSection =>
         validate(m)
       case m: NipopowProofModifier =>
         validate(m)

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -389,8 +389,11 @@ trait ErgoHistoryReader
   /**
     * Return last count headers from best headers chain if exist or chain up to genesis otherwise
     */
-  def lastHeaders(count: Int, offset: Int = 0): HeaderChain = bestHeaderOpt
-    .map(bestHeader => headerChainBack(count, bestHeader, _ => false).drop(offset)).getOrElse(HeaderChain.empty)
+  def lastHeaders(count: Int, offset: Int = 0): HeaderChain = {
+    bestHeaderOpt
+      .map(bestHeader => headerChainBack(count, bestHeader, _ => false).drop(offset))
+      .getOrElse(HeaderChain.empty)
+  }
 
   /**
     * @return ids of headers (max. limit) starting from offset

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.history.storage
 
 import com.google.common.cache.CacheBuilder
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.HistoryModifierSerializer
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.settings.{Algos, CacheSettings, ErgoSettings}
@@ -26,22 +26,22 @@ class HistoryStorage private(indexStore: LDBKVStore, objectsStore: LDBKVStore, c
 
   private val headersCache = CacheBuilder.newBuilder()
     .maximumSize(config.history.headersCacheSize)
-    .build[String, ErgoPersistentModifier]
+    .build[String, BlockSection]
 
   private val blockSectionsCache = CacheBuilder.newBuilder()
     .maximumSize(config.history.blockSectionsCacheSize)
-    .build[String, ErgoPersistentModifier]
+    .build[String, BlockSection]
 
   private val indexCache = CacheBuilder.newBuilder()
     .maximumSize(config.history.indexesCacheSize)
     .build[ByteArrayWrapper, Array[Byte]]
 
-  private def cacheModifier(mod: ErgoPersistentModifier): Unit = mod.modifierTypeId match {
+  private def cacheModifier(mod: BlockSection): Unit = mod.modifierTypeId match {
     case Header.modifierTypeId => headersCache.put(mod.id, mod)
     case _ => blockSectionsCache.put(mod.id, mod)
   }
 
-  private def lookupModifier(id: ModifierId): Option[ErgoPersistentModifier] =
+  private def lookupModifier(id: ModifierId): Option[BlockSection] =
     Option(headersCache.getIfPresent(id)) orElse Option(blockSectionsCache.getIfPresent(id))
 
   private def removeModifier(id: ModifierId): Unit = {
@@ -53,7 +53,7 @@ class HistoryStorage private(indexStore: LDBKVStore, objectsStore: LDBKVStore, c
     objectsStore.get(idToBytes(id)).map(_.tail) // removing modifier type byte with .tail
   }
 
-  def modifierById(id: ModifierId): Option[ErgoPersistentModifier] =
+  def modifierById(id: ModifierId): Option[BlockSection] =
     lookupModifier(id) orElse
       objectsStore.get(idToBytes(id)).flatMap { bytes =>
         HistoryModifierSerializer.parseBytesTry(bytes) match {
@@ -80,7 +80,7 @@ class HistoryStorage private(indexStore: LDBKVStore, objectsStore: LDBKVStore, c
   def contains(id: ModifierId): Boolean = objectsStore.get(idToBytes(id)).isDefined
 
   def insert(indexesToInsert: Seq[(ByteArrayWrapper, Array[Byte])],
-             objectsToInsert: Seq[ErgoPersistentModifier]): Try[Unit] = {
+             objectsToInsert: Seq[BlockSection]): Try[Unit] = {
     objectsStore.insert(
       objectsToInsert.map(m => idToBytes(m.id) -> HistoryModifierSerializer.toBytes(m))
     ).flatMap { _ =>

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/BasicReaders.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/BasicReaders.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import scorex.util.ModifierId
 
 import scala.reflect.ClassTag
@@ -10,7 +10,7 @@ trait BasicReaders {
 
   def headerIdsAtHeight(height: Int): Seq[ModifierId]
 
-  def typedModifierById[T <: ErgoPersistentModifier : ClassTag](id: ModifierId): Option[T]
+  def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T]
 
   def contains(id: ModifierId): Boolean
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/BlockSectionProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/BlockSectionProcessor.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
-import org.ergoplatform.modifiers.{BlockSection, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, BlockSection}
 import scorex.core.consensus.ProgressInfo
 import scorex.core.utils.ScorexEncoding
 
@@ -21,12 +21,12 @@ trait BlockSectionProcessor extends ScorexEncoding {
     * @param m - modifier to process
     * @return ProgressInfo - info required for State to be consistent with History
     */
-  protected def process(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]]
+  protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]]
 
   /**
     * @param m - modifier to validate
     * @return Success() if modifier is valid from History point of view, Failure(error) otherwise
     */
-  protected def validate(m: BlockSection): Try[Unit]
+  protected def validate(m: NonHeaderBlockSection): Try[Unit]
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/EmptyBlockSectionProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/EmptyBlockSectionProcessor.scala
@@ -1,20 +1,20 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
-import org.ergoplatform.modifiers.{BlockSection, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, BlockSection}
 import scorex.core.consensus.ProgressInfo
 
 import scala.util.{Failure, Success, Try}
 
 /**
-  * Trait that implements BlockSectionProcessor interfaces for a regime where the node only
-  * downloads block headers
+  * Trait that implements BlockSectionProcessor interfaces for a regime where the node is only
+  * downloading block headers
   */
 trait EmptyBlockSectionProcessor extends BlockSectionProcessor {
 
-  override protected def process(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]] =
-    Success(ProgressInfo[ErgoPersistentModifier](None, Seq.empty, Seq.empty, Seq.empty))
+  override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+    Success(ProgressInfo[BlockSection](None, Seq.empty, Seq.empty, Seq.empty))
 
-  override protected def validate(m: BlockSection): Try[Unit] =
+  override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
     Failure(new Error("Regime that does not support block sections processing"))
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.Header
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.settings.Algos
 import scorex.core.consensus.ProgressInfo
@@ -47,7 +47,7 @@ trait FullBlockProcessor extends HeadersProcessor {
     * @return ProgressInfo required for State to process to be consistent with the history
     */
   protected def processFullBlock(fullBlock: ErgoFullBlock,
-                                 newMod: ErgoPersistentModifier): Try[ProgressInfo[ErgoPersistentModifier]] = {
+                                 newMod: BlockSection): Try[ProgressInfo[BlockSection]] = {
     val bestFullChainAfter = calculateBestChain(fullBlock.header)
     val newBestBlockHeader = typedModifierById[Header](bestFullChainAfter.last).ensuring(_.isDefined)
     processing(ToProcess(fullBlock, newMod, newBestBlockHeader, bestFullChainAfter))
@@ -236,7 +236,7 @@ trait FullBlockProcessor extends HeadersProcessor {
     historyStorage.remove(mutable.WrappedArray.empty, toRemove)
   }
 
-  private def updateStorage(newModRow: ErgoPersistentModifier,
+  private def updateStorage(newModRow: BlockSection,
                             bestFullHeaderId: ModifierId,
                             additionalIndexes: Seq[(ByteArrayWrapper, Array[Byte])]): Try[Unit] = {
     val indicesToInsert = Seq(BestFullBlockKey -> idToBytes(bestFullHeaderId)) ++ additionalIndexes
@@ -253,10 +253,10 @@ trait FullBlockProcessor extends HeadersProcessor {
 
 object FullBlockProcessor {
 
-  type BlockProcessing = PartialFunction[ToProcess, Try[ProgressInfo[ErgoPersistentModifier]]]
+  type BlockProcessing = PartialFunction[ToProcess, Try[ProgressInfo[BlockSection]]]
 
   case class ToProcess(fullBlock: ErgoFullBlock,
-                       newModRow: ErgoPersistentModifier,
+                       newModRow: BlockSection,
                        newBestBlockHeaderOpt: Option[Header],
                        newBestChain: Seq[ModifierId])
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockSectionProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockSectionProcessor.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.history.storage.modifierprocessors
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, ErgoFullBlock, BlockSection}
 import org.ergoplatform.settings.ValidationRules._
 import org.ergoplatform.settings.{Algos, ErgoValidationSettings}
 import scorex.core.consensus.ProgressInfo
@@ -28,7 +28,7 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     * Otherwise - try to construct full block with this block section, if possible - process this new full block,
     * if not - just put new block section to storage.
     */
-  override protected def process(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]] = {
+  override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] = {
     m match {
       case _: ADProofs if !requireProofs =>
         // got proofs in UTXO mode. Don't need to try to update better chain
@@ -43,7 +43,7 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     }
   }
 
-  override protected def validate(m: BlockSection): Try[Unit] = {
+  override protected def validate(m: NonHeaderBlockSection): Try[Unit] = {
     typedModifierById[Header](m.headerId).map(header =>
       new PayloadValidator().validate(m, header)
     ).getOrElse(
@@ -60,8 +60,8 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     * @param m - new modifier
     * @return Some(ErgoFullBlock) if block construction is possible, None otherwise
     */
-  private def getFullBlockByBlockSection(m: BlockSection): Option[ErgoFullBlock] = {
-    def getOrRead[T <: ErgoPersistentModifier : ClassTag](id: ModifierId): Option[T] = m match {
+  private def getFullBlockByBlockSection(m: NonHeaderBlockSection): Option[ErgoFullBlock] = {
+    def getOrRead[T <: BlockSection : ClassTag](id: ModifierId): Option[T] = m match {
       case mod: T if m.id == id => Some(mod)
       case _ => typedModifierById[T](id)
     }
@@ -81,7 +81,7 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     }
   }
 
-  private def justPutToHistory(m: BlockSection): Try[ProgressInfo[ErgoPersistentModifier]] = {
+  private def justPutToHistory(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] = {
     historyStorage.insert(Seq.empty, Seq(m)).map { _ =>
       ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
     }
@@ -92,7 +92,7 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
     */
   class PayloadValidator extends ScorexEncoding {
 
-    def validate(m: BlockSection, header: Header): ValidationResult[Unit] = {
+    def validate(m: NonHeaderBlockSection, header: Header): ValidationResult[Unit] = {
       initialValidationState
         .validate(alreadyApplied, !historyStorage.contains(m.id), s"${m.encodedId}")
         .validate(bsCorrespondsToHeader, header.isCorrespondingModifier(m), s"header=${header.encodedId}, id=${m.encodedId}")
@@ -103,7 +103,7 @@ trait FullBlockSectionProcessor extends BlockSectionProcessor with FullBlockProc
         .result
     }
 
-    private def isHistoryADProof(m: BlockSection, header: Header): Boolean = m match {
+    private def isHistoryADProof(m: NonHeaderBlockSection, header: Header): Boolean = m match {
       // ADProofs for block transactions that are already in history. Do not validate whether ADProofs are too old
       case _: ADProofs if contains(header.transactionsId) => true
       case _ => false

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -2,9 +2,10 @@ package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
 import com.google.common.primitives.Ints
 import org.ergoplatform.ErgoApp.CriticalSystemException
+import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.mining.AutolykosPowScheme
 import org.ergoplatform.mining.difficulty.LinearDifficultyControl
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
@@ -65,12 +66,12 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
   /**
     * @return height of best header
     */
-  def headersHeight: Int = bestHeaderIdOpt.flatMap(id => heightOf(id)).getOrElse(ErgoHistory.EmptyHistoryHeight)
+  def headersHeight: Height = bestHeaderIdOpt.flatMap(id => heightOf(id)).getOrElse(ErgoHistory.EmptyHistoryHeight)
 
   /**
     * @return height of best header with all block sections
     */
-  def fullBlockHeight: Int = bestFullBlockIdOpt.flatMap(id => heightOf(id)).getOrElse(ErgoHistory.EmptyHistoryHeight)
+  def fullBlockHeight: Height = bestFullBlockIdOpt.flatMap(id => heightOf(id)).getOrElse(ErgoHistory.EmptyHistoryHeight)
 
   /**
     * @param id - id of ErgoPersistentModifier
@@ -87,8 +88,8 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     * @param h - header to process
     * @return ProgressInfo - info required for State to be consistent with History
     */
-  protected def process(h: Header): Try[ProgressInfo[ErgoPersistentModifier]] = synchronized {
-    val dataToInsert: (Seq[(ByteArrayWrapper, Array[Byte])], Seq[ErgoPersistentModifier]) = toInsert(h)
+  protected def process(h: Header): Try[ProgressInfo[BlockSection]] = synchronized {
+    val dataToInsert: (Seq[(ByteArrayWrapper, Array[Byte])], Seq[BlockSection]) = toInsert(h)
 
     historyStorage.insert(dataToInsert._1, dataToInsert._2).flatMap { _ =>
       bestHeaderIdOpt match {
@@ -106,7 +107,7 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
   /**
     * Data to add to and remove from the storage to process this modifier
     */
-  private def toInsert(h: Header): (Seq[(ByteArrayWrapper, Array[Byte])], Seq[ErgoPersistentModifier]) = {
+  private def toInsert(h: Header): (Seq[(ByteArrayWrapper, Array[Byte])], Seq[BlockSection]) = {
     val requiredDifficulty: Difficulty = h.requiredDifficulty
     val score = scoreOf(h.parentId).getOrElse(BigInt(0)) + requiredDifficulty
     val bestRow: Seq[(ByteArrayWrapper, Array[Byte])] =

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UTXOSnapshotChunkProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UTXOSnapshotChunkProcessor.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.state.UTXOSnapshotChunk
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import scorex.core.consensus.ProgressInfo
@@ -16,7 +16,7 @@ trait UTXOSnapshotChunkProcessor extends ScorexLogging with ScorexEncoding {
 
   protected val historyStorage: HistoryStorage
 
-  def process(m: UTXOSnapshotChunk): Try[ProgressInfo[ErgoPersistentModifier]] = ???
+  def process(m: UTXOSnapshotChunk): Try[ProgressInfo[BlockSection]] = ???
 /*
     {
       //TODO

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/EmptyPoPoWProofsProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/EmptyPoPoWProofsProcessor.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors.popow
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.NipopowProofModifier
 import scorex.core.consensus.ProgressInfo
 
@@ -13,7 +13,7 @@ trait EmptyPoPoWProofsProcessor extends PoPoWProofsProcessor {
 
   def validate(m: NipopowProofModifier): Try[Unit] = Failure(new Error("Regime that do not process PoPoWProof"))
 
-  def process(m: NipopowProofModifier): Try[ProgressInfo[ErgoPersistentModifier]] =
+  def process(m: NipopowProofModifier): Try[ProgressInfo[BlockSection]] =
     Success(ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty))
 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/FullPoPoWProofsProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/FullPoPoWProofsProcessor.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors.popow
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.NipopowProofModifier
 import org.ergoplatform.nodeView.history.storage.modifierprocessors.HeadersProcessor
 import scorex.core.consensus.ProgressInfo
@@ -14,7 +14,7 @@ trait FullPoPoWProofsProcessor extends PoPoWProofsProcessor with HeadersProcesso
 
   def validate(m: NipopowProofModifier): Try[Unit] = throw new Error("PoPow not yet supported")
 
-  def process(m: NipopowProofModifier): Try[ProgressInfo[ErgoPersistentModifier]] =
+  def process(m: NipopowProofModifier): Try[ProgressInfo[BlockSection]] =
     Success(ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty))
 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/PoPoWProofsProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/popow/PoPoWProofsProcessor.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors.popow
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.{HeaderChain, NipopowProofModifier}
 import org.ergoplatform.nodeView.history.storage.modifierprocessors.HeadersProcessor
 import scorex.core.consensus.ProgressInfo
@@ -15,7 +15,7 @@ trait PoPoWProofsProcessor extends HeadersProcessor with ScorexLogging {
 
   def validate(m: NipopowProofModifier): Try[Unit]
 
-  def process(m: NipopowProofModifier): Try[ProgressInfo[ErgoPersistentModifier]]
+  def process(m: NipopowProofModifier): Try[ProgressInfo[BlockSection]]
 
   def lastHeaders(count: Int, offset: Int = 0): HeaderChain
 }

--- a/src/main/scala/org/ergoplatform/nodeView/state/DigestState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/DigestState.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.modifiers.history.ADProofs
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.LocallyGeneratedModifier
 import org.ergoplatform.nodeView.state.ErgoState.ModifierProcessing
 import org.ergoplatform.settings._
@@ -64,7 +64,7 @@ class DigestState protected(override val version: VersionTag,
       .map(_ => ())
   }
 
-  def validate(mod: ErgoPersistentModifier): Try[Unit] = mod match {
+  def validate(mod: BlockSection): Try[Unit] = mod match {
     case fb: ErgoFullBlock =>
       fb.adProofs match {
         case None =>
@@ -85,7 +85,7 @@ class DigestState protected(override val version: VersionTag,
       Failure(new Exception(s"Modifier not validated: $a"))
   }
 
-  override def applyModifier(mod: ErgoPersistentModifier, estimatedTip: Option[Height])(generate: LocallyGeneratedModifier => Unit): Try[DigestState] =
+  override def applyModifier(mod: BlockSection, estimatedTip: Option[Height])(generate: LocallyGeneratedModifier => Unit): Try[DigestState] =
     (processFullBlock orElse processHeader orElse processOther) (mod)
 
   @SuppressWarnings(Array("OptionGet"))

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform._
 import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.mining.groupElemFromBytes
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.modifiers.state.StateChanges
@@ -54,7 +54,7 @@ trait ErgoState[IState <: ErgoState[IState]] extends ErgoStateReader {
     * @param generate function that handles newly created modifier as a result of application the current one
     * @return new State
     */
-  def applyModifier(mod: ErgoPersistentModifier, estimatedTip: Option[Height])(generate: LocallyGeneratedModifier => Unit): Try[IState]
+  def applyModifier(mod: BlockSection, estimatedTip: Option[Height])(generate: LocallyGeneratedModifier => Unit): Try[IState]
 
   def rollbackTo(version: VersionTag): Try[IState]
 
@@ -69,7 +69,7 @@ trait ErgoState[IState <: ErgoState[IState]] extends ErgoStateReader {
 
 object ErgoState extends ScorexLogging {
 
-  type ModifierProcessing[T <: ErgoState[T]] = PartialFunction[ErgoPersistentModifier, Try[T]]
+  type ModifierProcessing[T <: ErgoState[T]] = PartialFunction[BlockSection, Try[T]]
 
   def stateDir(settings: ErgoSettings): File = new File(s"${settings.directory}/state")
 

--- a/src/main/scala/org/ergoplatform/nodeView/state/StateConstants.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/StateConstants.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.settings.{ErgoSettings, VotingSettings}
 import scorex.crypto.authds.ADDigest
 
 /**
-  * Constants that do not change with state version changes
+  * Constants that do not change when state version changes
   *
   * @param settings          - node settings
   */

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.ADProofs
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.settings.Algos.HF
 import org.ergoplatform.settings.ValidationRules.{fbDigestIncorrect, fbOperationFailed}
 import org.ergoplatform.settings.{Algos, Parameters}
@@ -91,7 +91,7 @@ class UtxoState(override val persistentProver: PersistentBatchAVLProver[Digest32
     }
   }
 
-  override def applyModifier(mod: ErgoPersistentModifier, estimatedTip: Option[Height])
+  override def applyModifier(mod: BlockSection, estimatedTip: Option[Height])
                             (generate: LocallyGeneratedModifier => Unit): Try[UtxoState] = mod match {
     case fb: ErgoFullBlock =>
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.nodeView.wallet
 
 import akka.actor.{ActorRef, ActorSystem}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.state.ErgoState
 import org.ergoplatform.nodeView.wallet.ErgoWalletActor._
@@ -46,7 +46,7 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings, param
     this
   }
 
-  def scanPersistent(modifier: ErgoPersistentModifier): ErgoWallet = {
+  def scanPersistent(modifier: BlockSection): ErgoWallet = {
     modifier match {
       case fb: ErgoFullBlock =>
         walletActor ! ScanOnChain(fb)
@@ -57,7 +57,7 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings, param
     this
   }
 
-  def scanPersistent(modifiers: Option[ErgoPersistentModifier]): ErgoWallet = {
+  def scanPersistent(modifiers: Option[BlockSection]): ErgoWallet = {
     modifiers.foldLeft(this) { case (v, mod) =>
       v.scanPersistent(mod)
     }

--- a/src/main/scala/scorex/core/ModifiersCache.scala
+++ b/src/main/scala/scorex/core/ModifiersCache.scala
@@ -1,6 +1,6 @@
 package scorex.core
 
-import org.ergoplatform.modifiers.{ErgoNodeViewModifier, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{BlockSection, ErgoNodeViewModifier}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import scorex.core.consensus.ContainsModifiers
 import scorex.core.validation.RecoverableModifierError
@@ -21,7 +21,7 @@ trait ModifiersCache extends ContainsModifiers[ErgoNodeViewModifier] {
   require(maxSize >= 1)
 
   type K = scorex.util.ModifierId
-  type V = ErgoPersistentModifier
+  type V = BlockSection
 
   protected val cache: mutable.Map[K, V] = mutable.LinkedHashMap[K, V]()
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -137,7 +137,7 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val eventListener = TestProbe("EventListener")
-    val syncTracker = ErgoSyncTracker(system, settings.scorexSettings.network, timeProvider)
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network, timeProvider)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
     // each test should always start with empty history
@@ -181,7 +181,7 @@ class ErgoNodeViewSynchronizerSpecification extends HistoryTestHelpers with Matc
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
-    val syncTracker = ErgoSyncTracker(system, settings.scorexSettings.network, timeProvider)
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network, timeProvider)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
     // each test should always start with empty history

--- a/src/test/scala/org/ergoplatform/network/ErgoSyncTrackerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoSyncTrackerSpecification.scala
@@ -1,6 +1,5 @@
 package org.ergoplatform.network
 
-import akka.actor.ActorSystem
 import org.ergoplatform.utils.ErgoPropertyTest
 import scorex.core.consensus.{Older, Younger}
 import scorex.core.network.{ConnectedPeer, ConnectionId, Incoming}
@@ -12,7 +11,7 @@ class ErgoSyncTrackerSpecification extends ErgoPropertyTest {
     val peerInfo = PeerInfo(defaultPeerSpec, time, Some(Incoming))
     val cid = ConnectionId(inetAddr1, inetAddr2, Incoming)
     val connectedPeer = ConnectedPeer(cid, handlerRef = null, lastMessage = 5L, Some(peerInfo))
-    val syncTracker = ErgoSyncTracker(ActorSystem(), settings.scorexSettings.network, timeProvider)
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network, timeProvider)
 
     val height = 1000
     // add peer to sync

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.history
 
-import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.modifiers.NonHeaderBlockSection
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
@@ -65,7 +65,7 @@ class BlockSectionValidationSpecification extends HistoryTestHelpers {
     (history, chain.last)
   }
 
-  private def commonChecks(history: ErgoHistory, section: BlockSection, header: Header) = {
+  private def commonChecks(history: ErgoHistory, section: NonHeaderBlockSection, header: Header) = {
     history.applicableTry(section) shouldBe 'success
     // header should contain correct digest
     history.applicableTry(withUpdatedHeaderId(section, section.id)) shouldBe 'failure
@@ -93,7 +93,7 @@ class BlockSectionValidationSpecification extends HistoryTestHelpers {
   private def genHistory() =
     generateHistory(verifyTransactions = true, StateType.Utxo, PoPoWBootstrap = false, BlocksToKeep)
 
-  private def withUpdatedHeaderId[T <: BlockSection](section: T, newId: ModifierId): T = section match {
+  private def withUpdatedHeaderId[T <: NonHeaderBlockSection](section: T, newId: ModifierId): T = section match {
     case s: Extension => s.copy(headerId = newId).asInstanceOf[T]
     case s: BlockTransactions => s.copy(headerId = newId).asInstanceOf[T]
     case s: ADProofs => s.copy(headerId = newId).asInstanceOf[T]

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.history
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.HeaderChain
 import org.ergoplatform.modifiers.history.header.Header
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.ErgoModifiersCache
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.utils.HistoryTestHelpers
@@ -16,7 +16,7 @@ import scala.util.Random
 
 class VerifyADHistorySpecification extends HistoryTestHelpers with NoShrink {
 
-  type PM = ErgoPersistentModifier
+  type PM = BlockSection
 
   private def genHistory(blocksNum: Int = 0,
                          minFullHeight: Option[Int] = Some(ErgoHistory.GenesisHeight)): (ErgoHistory, Seq[ErgoFullBlock]) = {

--- a/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedDigestState.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedDigestState.scala
@@ -1,8 +1,8 @@
 package org.ergoplatform.nodeView.state.wrapped
 
-import org.ergoplatform.ErgoLikeContext.Height
-import org.ergoplatform.modifiers.ErgoPersistentModifier
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.LocallyGeneratedModifier
+import org.ergoplatform.ErgoLikeContext.Height
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.state.DigestState
 import org.ergoplatform.settings.ErgoSettings
 import scorex.core.VersionTag
@@ -14,7 +14,7 @@ class WrappedDigestState(val digestState: DigestState,
                          val settings: ErgoSettings)
   extends DigestState(digestState.version, digestState.rootHash, digestState.store, settings) {
 
-  override def applyModifier(mod: ErgoPersistentModifier, estimatedTip: Option[Height])
+  override def applyModifier(mod: BlockSection, estimatedTip: Option[Height])
                             (generate: LocallyGeneratedModifier => Unit): Try[WrappedDigestState] = {
     wrapped(super.applyModifier(mod, estimatedTip)(_ => ()), wrappedUtxoState.applyModifier(mod, estimatedTip)(_ => ()))
   }

--- a/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedUtxoState.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/wrapped/WrappedUtxoState.scala
@@ -4,9 +4,9 @@ import java.io.File
 
 import akka.actor.ActorRef
 import org.ergoplatform.ErgoBox
-import org.ergoplatform.ErgoLikeContext.Height
-import org.ergoplatform.modifiers.ErgoPersistentModifier
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.LocallyGeneratedModifier
+import org.ergoplatform.ErgoLikeContext.Height
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.settings.Algos.HF
@@ -36,7 +36,7 @@ class WrappedUtxoState(prover: PersistentBatchAVLProver[Digest32, HF],
     case Failure(e) => Failure(e)
   }
 
-  override def applyModifier(mod: ErgoPersistentModifier, estimatedTip: Option[Height] = None)
+  override def applyModifier(mod: BlockSection, estimatedTip: Option[Height] = None)
                             (generate: LocallyGeneratedModifier => Unit): Try[WrappedUtxoState] =
     super.applyModifier(mod, estimatedTip)(generate) match {
       case Success(us) =>

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanity.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanity.scala
@@ -5,7 +5,7 @@ import org.ergoplatform.ErgoBox
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ErgoSyncTracker}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoSyncInfo, ErgoSyncInfoMessageSpec}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
@@ -118,7 +118,7 @@ trait ErgoSanity[ST <: ErgoState[ST]] extends HistoryTests
 object ErgoSanity {
   type TX = ErgoTransaction
   type B = ErgoBox
-  type PM = ErgoPersistentModifier
+  type PM = BlockSection
   type CTM = BlockTransactions
   type SI = ErgoSyncInfo
   type HT = ErgoHistory

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanityDigest.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanityDigest.scala
@@ -69,7 +69,7 @@ class ErgoSanityDigest extends ErgoSanity[DIGEST_ST] {
     val vhProbe = TestProbe("ViewHolderProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val eventListener = TestProbe("EventListener")
-    val syncTracker = ErgoSyncTracker(system, settings.scorexSettings.network, timeProvider)
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network, timeProvider)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
     val ref = system.actorOf(Props(
       new SyncronizerMock(

--- a/src/test/scala/org/ergoplatform/sanity/ErgoSanityUTXO.scala
+++ b/src/test/scala/org/ergoplatform/sanity/ErgoSanityUTXO.scala
@@ -64,7 +64,7 @@ class ErgoSanityUTXO extends ErgoSanity[UTXO_ST] with ErgoTestHelpers {
     val vhProbe = TestProbe("ViewHolderProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val eventListener = TestProbe("EventListener")
-    val syncTracker = ErgoSyncTracker(system, settings.scorexSettings.network, timeProvider)
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network, timeProvider)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
     val ref = system.actorOf(Props(
       new SyncronizerMock(

--- a/src/test/scala/org/ergoplatform/utils/NodeViewTestOps.scala
+++ b/src/test/scala/org/ergoplatform/utils/NodeViewTestOps.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.state.{ErgoState, StateType, UtxoState}
 import org.ergoplatform.settings.Algos
@@ -76,7 +76,7 @@ trait NodeViewBaseOps extends ErgoTestHelpers {
     subscribeEvents(classOf[SyntacticallyFailedModification])
   }
 
-  def expectModificationOutcome(section: ErgoPersistentModifier)(implicit ctx: Ctx): Try[Unit] = {
+  def expectModificationOutcome(section: BlockSection)(implicit ctx: Ctx): Try[Unit] = {
     expectMsgType[ModificationOutcome] match {
       case SyntacticallySuccessfulModifier(mod) if mod.id == section.id =>
         Success(())
@@ -147,7 +147,7 @@ trait NodeViewTestOps extends NodeViewBaseOps {
 
   def getLastHeadersLength(count: Int)(implicit ctx: Ctx): Int = getHistory.lastHeaders(count).size
 
-  def getModifierById(id: ModifierId)(implicit ctx: Ctx): Option[ErgoPersistentModifier] = getHistory.modifierById(id)
+  def getModifierById(id: ModifierId)(implicit ctx: Ctx): Option[BlockSection] = getHistory.modifierById(id)
 
   def getGenesisStateDigest(implicit ctx: Ctx): Array[Byte] =
     ctx.settings.chainSettings.genesisStateDigest

--- a/src/test/scala/org/ergoplatform/utils/generators/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ChainGenerator.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionCandida
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.popow.{NipopowAlgos, PoPowHeader}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ErgoPersistentModifier}
+import org.ergoplatform.modifiers.{NonHeaderBlockSection, ErgoFullBlock, BlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.settings.Constants
 import org.ergoplatform.utils.{BoxUtils, ErgoTestConstants}
@@ -179,7 +179,7 @@ trait ChainGenerator extends ErgoTestConstants {
   }
 
   def applyChain(historyIn: ErgoHistory, blocks: Seq[ErgoFullBlock]): ErgoHistory = {
-    def appendOrPass(mod: ErgoPersistentModifier, history: ErgoHistory) =
+    def appendOrPass(mod: BlockSection, history: ErgoHistory) =
       if (history.contains(mod)) history else history.append(mod).get._1
     blocks.foldLeft(historyIn) { (history, block) =>
       val historyWithBlockHeader = appendOrPass(block.header, history)
@@ -191,6 +191,6 @@ trait ChainGenerator extends ErgoTestConstants {
 
   def applyBlock(historyIn: ErgoHistory, block: ErgoFullBlock): ErgoHistory = applyChain(historyIn, Seq(block))
 
-  def applySection(historyIn: ErgoHistory, section: BlockSection): ErgoHistory = historyIn.append(section).get._1
+  def applySection(historyIn: ErgoHistory, section: NonHeaderBlockSection): ErgoHistory = historyIn.append(section).get._1
 
 }

--- a/src/test/scala/scorex/testkit/generators/CustomModifierProducer.scala
+++ b/src/test/scala/scorex/testkit/generators/CustomModifierProducer.scala
@@ -1,6 +1,6 @@
 package scorex.testkit.generators
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.state.ErgoState
 
@@ -13,5 +13,5 @@ trait CustomModifierProducer[ST <: ErgoState[ST]] {
 
   def customModifiers(history: ErgoHistory,
                       state: ST,
-                      template: Seq[ModifierProducerTemplateItem]): Seq[ErgoPersistentModifier]
+                      template: Seq[ModifierProducerTemplateItem]): Seq[BlockSection]
 }

--- a/src/test/scala/scorex/testkit/generators/SemanticallyInvalidModifierProducer.scala
+++ b/src/test/scala/scorex/testkit/generators/SemanticallyInvalidModifierProducer.scala
@@ -1,9 +1,9 @@
 package scorex.testkit.generators
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.state.ErgoState
 
 
 trait SemanticallyInvalidModifierProducer[ST <: ErgoState[ST]] {
-  def semanticallyInvalidModifier(state: ST): ErgoPersistentModifier
+  def semanticallyInvalidModifier(state: ST): BlockSection
 }

--- a/src/test/scala/scorex/testkit/generators/SemanticallyValidModifierProducer.scala
+++ b/src/test/scala/scorex/testkit/generators/SemanticallyValidModifierProducer.scala
@@ -1,10 +1,10 @@
 package scorex.testkit.generators
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.state.ErgoState
 
 trait SemanticallyValidModifierProducer[ST <: ErgoState[ST]] {
-  def semanticallyValidModifier(state: ST): ErgoPersistentModifier
+  def semanticallyValidModifier(state: ST): BlockSection
 }
 
 

--- a/src/test/scala/scorex/testkit/generators/SyntacticallyTargetedModifierProducer.scala
+++ b/src/test/scala/scorex/testkit/generators/SyntacticallyTargetedModifierProducer.scala
@@ -1,11 +1,11 @@
 package scorex.testkit.generators
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.history.ErgoHistory
 
 
 trait SyntacticallyTargetedModifierProducer {
-  def syntacticallyValidModifier(history: ErgoHistory): ErgoPersistentModifier
+  def syntacticallyValidModifier(history: ErgoHistory): BlockSection
 
-  def syntacticallyInvalidModifier(history: ErgoHistory): ErgoPersistentModifier
+  def syntacticallyInvalidModifier(history: ErgoHistory): BlockSection
 }

--- a/src/test/scala/scorex/testkit/generators/TotallyValidModifierProducer.scala
+++ b/src/test/scala/scorex/testkit/generators/TotallyValidModifierProducer.scala
@@ -1,13 +1,13 @@
 package scorex.testkit.generators
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.state.ErgoState
 
 
 trait TotallyValidModifierProducer[ST <: ErgoState[ST]] {
 
-  def totallyValidModifier(history: ErgoHistory, state: ST): ErgoPersistentModifier
+  def totallyValidModifier(history: ErgoHistory, state: ST): BlockSection
 
-  def totallyValidModifiers(history: ErgoHistory, state: ST, count: Int): Seq[ErgoPersistentModifier]
+  def totallyValidModifiers(history: ErgoHistory, state: ST, count: Int): Seq[BlockSection]
 }

--- a/src/test/scala/scorex/testkit/properties/HistoryTests.scala
+++ b/src/test/scala/scorex/testkit/properties/HistoryTests.scala
@@ -1,6 +1,6 @@
 package scorex.testkit.properties
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
@@ -22,11 +22,11 @@ trait HistoryTests
 
   val historyGen: Gen[ErgoHistory]
 
-  lazy val generatorWithValidModifier: Gen[(ErgoHistory, ErgoPersistentModifier)] = {
+  lazy val generatorWithValidModifier: Gen[(ErgoHistory, BlockSection)] = {
     historyGen.map { h => (h, syntacticallyValidModifier(h))}
   }
 
-  lazy val generatorWithInvalidModifier: Gen[(ErgoHistory, ErgoPersistentModifier)] = {
+  lazy val generatorWithInvalidModifier: Gen[(ErgoHistory, BlockSection)] = {
     historyGen.map { h => (h, syntacticallyInvalidModifier(h))}
   }
 

--- a/src/test/scala/scorex/testkit/properties/NodeViewHolderTests.scala
+++ b/src/test/scala/scorex/testkit/properties/NodeViewHolderTests.scala
@@ -2,7 +2,7 @@ package scorex.testkit.properties
 
 import akka.actor._
 import akka.testkit.TestProbe
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
@@ -28,7 +28,7 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
     with CustomModifierProducer[ST]
     with ObjectGenerators {
 
-  def nodeViewHolder(implicit system: ActorSystem): (ActorRef, TestProbe, ErgoPersistentModifier, ST, ErgoHistory)
+  def nodeViewHolder(implicit system: ActorSystem): (ActorRef, TestProbe, BlockSection, ST, ErgoHistory)
 
   class HolderFixture extends AkkaFixture {
     @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
@@ -72,8 +72,8 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
       val p = TestProbe()
 
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallySuccessfulModifier])
-      p.send(node, GetDataFromCurrentView[ST, ErgoPersistentModifier] { v => totallyValidModifiers(v.history, v.state, 2).head })
-      val mod = p.expectMsgClass(classOf[ErgoPersistentModifier])
+      p.send(node, GetDataFromCurrentView[ST, BlockSection] { v => totallyValidModifiers(v.history, v.state, 2).head })
+      val mod = p.expectMsgClass(classOf[BlockSection])
       p.send(node, LocallyGeneratedModifier(mod))
       eventListener.expectMsgType[SyntacticallySuccessfulModifier]
     }
@@ -98,8 +98,8 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
 
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallySuccessfulModifier])
       system.eventStream.subscribe(eventListener.ref, classOf[SemanticallySuccessfulModifier])
-      p.send(node, GetDataFromCurrentView[ST, ErgoPersistentModifier] { v => totallyValidModifiers(v.history, v.state, 2).head })
-      val mod = p.expectMsgClass(classOf[ErgoPersistentModifier])
+      p.send(node, GetDataFromCurrentView[ST, BlockSection] { v => totallyValidModifiers(v.history, v.state, 2).head })
+      val mod = p.expectMsgClass(classOf[BlockSection])
       p.send(node, LocallyGeneratedModifier(mod))
       eventListener.expectMsgType[SyntacticallySuccessfulModifier]
       eventListener.expectMsgType[SemanticallySuccessfulModifier]
@@ -113,8 +113,8 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
 
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallySuccessfulModifier])
       system.eventStream.subscribe(eventListener.ref, classOf[SemanticallyFailedModification])
-      p.send(node, GetDataFromCurrentView[ST, ErgoPersistentModifier] { v => semanticallyInvalidModifier(v.state) })
-      val invalid = p.expectMsgClass(classOf[ErgoPersistentModifier])
+      p.send(node, GetDataFromCurrentView[ST, BlockSection] { v => semanticallyInvalidModifier(v.state) })
+      val invalid = p.expectMsgClass(classOf[BlockSection])
       p.send(node, LocallyGeneratedModifier(invalid))
       eventListener.expectMsgType[SyntacticallySuccessfulModifier]
       eventListener.expectMsgType[SemanticallyFailedModification]
@@ -128,8 +128,8 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
 
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallySuccessfulModifier])
       system.eventStream.subscribe(eventListener.ref, classOf[SemanticallySuccessfulModifier])
-      p.send(node, GetDataFromCurrentView[ST, ErgoPersistentModifier] { v => totallyValidModifiers(v.history, v.state, 2).head })
-      val mod = p.expectMsgClass(classOf[ErgoPersistentModifier])
+      p.send(node, GetDataFromCurrentView[ST, BlockSection] { v => totallyValidModifiers(v.history, v.state, 2).head })
+      val mod = p.expectMsgClass(classOf[BlockSection])
       p.send(node, LocallyGeneratedModifier(mod))
       eventListener.expectMsgType[SyntacticallySuccessfulModifier]
       eventListener.expectMsgType[SemanticallySuccessfulModifier]
@@ -167,10 +167,10 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
 
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallySuccessfulModifier])
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallyFailedModification])
-      p.send(node, GetDataFromCurrentView[ST, Seq[ErgoPersistentModifier]] { v =>
+      p.send(node, GetDataFromCurrentView[ST, Seq[BlockSection]] { v =>
         totallyValidModifiers(v.history, v.state, 10) //todo: fix magic number
       })
-      val mods = p.expectMsgClass(classOf[Seq[ErgoPersistentModifier]])
+      val mods = p.expectMsgClass(classOf[Seq[BlockSection]])
 
       mods.foreach { mod =>
         p.send(node, LocallyGeneratedModifier(mod))
@@ -216,22 +216,22 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallySuccessfulModifier])
       system.eventStream.subscribe(eventListener.ref, classOf[SyntacticallyFailedModification])
 
-      p.send(node, GetDataFromCurrentView[ST, Seq[ErgoPersistentModifier]] { v => totallyValidModifiers(v.history, v.state, 2) })
-      val initMods = p.expectMsgClass(waitDuration, classOf[Seq[ErgoPersistentModifier]])
+      p.send(node, GetDataFromCurrentView[ST, Seq[BlockSection]] { v => totallyValidModifiers(v.history, v.state, 2) })
+      val initMods = p.expectMsgClass(waitDuration, classOf[Seq[BlockSection]])
       initMods.foreach { mod =>
         p.send(node, LocallyGeneratedModifier(mod))
         eventListener.expectMsgType[SyntacticallySuccessfulModifier]
       }
 
-      p.send(node, GetDataFromCurrentView[ST, ErgoPersistentModifier] { v =>
+      p.send(node, GetDataFromCurrentView[ST, BlockSection] { v =>
         totallyValidModifiers(v.history, v.state, 2).head
       })
-      val fork1Mod = p.expectMsgClass(waitDuration, classOf[ErgoPersistentModifier])
+      val fork1Mod = p.expectMsgClass(waitDuration, classOf[BlockSection])
 
-      p.send(node, GetDataFromCurrentView[ST, ErgoPersistentModifier] { v =>
+      p.send(node, GetDataFromCurrentView[ST, BlockSection] { v =>
         totallyValidModifiers(v.history, v.state, 2).head
       })
-      val fork2Mod = p.expectMsgClass(waitDuration, classOf[ErgoPersistentModifier])
+      val fork2Mod = p.expectMsgClass(waitDuration, classOf[BlockSection])
 
       p.send(node, LocallyGeneratedModifier(fork1Mod))
       p.send(node, LocallyGeneratedModifier(fork2Mod))
@@ -264,23 +264,23 @@ trait NodeViewHolderTests[ST <: ErgoState[ST]]
       val waitDuration = 10.seconds
 
       //some base operations, we don't wanna have fork right from genesis
-      p.send(node, GetDataFromCurrentView[ST, Seq[ErgoPersistentModifier]] { v =>
+      p.send(node, GetDataFromCurrentView[ST, Seq[BlockSection]] { v =>
         totallyValidModifiers(v.history, v.state, opCountBeforeFork)
       })
-      val plainMods = p.expectMsgClass(waitDuration, classOf[Seq[ErgoPersistentModifier]])
+      val plainMods = p.expectMsgClass(waitDuration, classOf[Seq[BlockSection]])
       plainMods.foreach { mod => p.send(node, LocallyGeneratedModifier(mod)) }
 
-      p.send(node, GetDataFromCurrentView[ST, Seq[ErgoPersistentModifier]] { v =>
+      p.send(node, GetDataFromCurrentView[ST, Seq[BlockSection]] { v =>
         val mods = totallyValidModifiers(v.history, v.state, fork1OpCount)
         assert(mods.head.parentId == v.history.bestFullBlockIdOpt.orElse(v.history.bestHeaderIdOpt).get)
         mods
       })
-      val fork1Mods = p.expectMsgClass(waitDuration, classOf[Seq[ErgoPersistentModifier]])
+      val fork1Mods = p.expectMsgClass(waitDuration, classOf[Seq[BlockSection]])
 
-      p.send(node, GetDataFromCurrentView[ST, Seq[ErgoPersistentModifier]] { v =>
+      p.send(node, GetDataFromCurrentView[ST, Seq[BlockSection]] { v =>
         totallyValidModifiers(v.history, v.state, fork2OpCount)
       })
-      val fork2Mods = p.expectMsgClass(waitDuration, classOf[Seq[ErgoPersistentModifier]])
+      val fork2Mods = p.expectMsgClass(waitDuration, classOf[Seq[BlockSection]])
 
       fork1Mods.foreach { mod => p.send(node, LocallyGeneratedModifier(mod)) }
       fork2Mods.foreach { mod => p.send(node, LocallyGeneratedModifier(mod)) }

--- a/src/test/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
+++ b/src/test/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
@@ -2,7 +2,7 @@ package scorex.testkit.properties
 
 import akka.actor._
 import akka.testkit.TestProbe
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoSyncInfo}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
@@ -39,7 +39,7 @@ trait NodeViewSynchronizerTests[ST <: ErgoState[ST]] extends AnyPropSpec
   val memPool: ErgoMemPool
 
   def nodeViewSynchronizer(implicit system: ActorSystem):
-    (ActorRef, ErgoSyncInfo, ErgoPersistentModifier, ErgoTransaction, ConnectedPeer, TestProbe, TestProbe, TestProbe, TestProbe, ScorexSerializer[ErgoPersistentModifier])
+    (ActorRef, ErgoSyncInfo, BlockSection, ErgoTransaction, ConnectedPeer, TestProbe, TestProbe, TestProbe, TestProbe, ScorexSerializer[BlockSection])
 
   class SynchronizerFixture extends AkkaFixture {
     @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))

--- a/src/test/scala/scorex/testkit/properties/state/StateApplicationTest.scala
+++ b/src/test/scala/scorex/testkit/properties/state/StateApplicationTest.scala
@@ -1,6 +1,6 @@
 package scorex.testkit.properties.state
 
-import org.ergoplatform.modifiers.ErgoPersistentModifier
+import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.nodeView.state.{DigestState, ErgoState}
 import org.scalacheck.Gen
 import scala.collection.mutable.ListBuffer
@@ -8,11 +8,11 @@ import scala.collection.mutable.ListBuffer
 
 trait StateApplicationTest[ST <: ErgoState[ST]] extends StateTests[ST] {
 
-  lazy val stateGenWithValidModifier: Gen[(ST, ErgoPersistentModifier)] = {
+  lazy val stateGenWithValidModifier: Gen[(ST, BlockSection)] = {
     stateGen.map { s => (s, semanticallyValidModifier(s)) }
   }
 
-  lazy val stateGenWithInvalidModifier: Gen[(ST, ErgoPersistentModifier)] = {
+  lazy val stateGenWithInvalidModifier: Gen[(ST, BlockSection)] = {
     stateGen.map { s => (s, semanticallyInvalidModifier(s))}
   }
 
@@ -77,7 +77,7 @@ trait StateApplicationTest[ST <: ErgoState[ST]] extends StateTests[ST] {
       }
       @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
       val rollbackDepth = Gen.chooseNum(1, maxRollbackDepth).sample.get
-      val buf = new ListBuffer[ErgoPersistentModifier]()
+      val buf = new ListBuffer[BlockSection]()
       val ver = s.version
 
       val s2 = (0 until rollbackDepth).foldLeft(s) { case (state, _) =>


### PR DESCRIPTION
This is refactoring PR: 

* BlockSection renamed to NonHeaderBlockSection, ErgoPersistentModifier to BlockSection
* Unused NoBetterNeighbour / BetterNeighbourAppeared signals removed
* `heights` map in ErgoSyncTracker eliminated (as heights are available in `statuses` map)
* global sync message lock removed (only per-peer left)