### PR TITLE
Voting for 5.0 soft-fork 

### DIFF
--- a/src/main/resources/testnet.conf
+++ b/src/main/resources/testnet.conf
@@ -31,10 +31,12 @@ ergo {
     # Length of an epoch in difficulty recalculation. 1 means difficulty recalculation every block
     epochLength = 128
 
+    blockInterval = 5s
+
     # Monetary config for chain
     monetary {
       # delay between the block mined and time when the reward can be spend
-      minerRewardDelay = 72
+      minerRewardDelay = 720
     }
 
     voting {
@@ -54,7 +56,7 @@ ergo {
     }
 
     reemission {
-      checkReemissionRules = true
+      checkReemissionRules = false
 
       emissionNftId = "06f29034fb69b23d519f84c4811a19694b8cdc2ce076147aaa050276f0b840f4"
 
@@ -62,15 +64,15 @@ ergo {
 
       reemissionNftId = "06f2c3adfe52304543f7b623cc3fccddc0174a7db52452fef8e589adacdfdfee"
 
-      activationHeight = 188001
+      activationHeight = 1880001
 
-      reemissionStartHeight = 186400
+      reemissionStartHeight = 1860400
 
       injectionBoxBytesEncoded = "a0f9e1b5fb011003040005808098f4e9b5ca6a0402d1ed91c1b2a4730000730193c5a7c5b2a4730200f6ac0b0201345f0ed87b74008d1c46aefd3e7ad6ee5909a2324f2899031cdfee3cc1e02280808cfaf49aa53506f29034fb69b23d519f84c4811a19694b8cdc2ce076147aaa050276f0b840f40100325c3679e7e0e2f683e4a382aa74c2c1cb989bb6ad6a1d4b1c5a021d7b410d0f00"
     }
 
     # Base16 representation of genesis state roothash
-    genesisStateDigestHex = "21660785f08767ef2b5f311827e896a4b59c9d39b8f036d71af1e9c7f02120de02"
+    genesisStateDigestHex = "cb63aa99a3060f341781d8662b58bf18b9ad258db4fe88d09f8f71cb668cad4502"
   }
 
   wallet.secretStorage.secretDir = ${ergo.directory}"/wallet/keystore"
@@ -78,16 +80,19 @@ ergo {
 
 scorex {
   network {
-    magicBytes = [2, 0, 0, 2]
-    bindAddress = "0.0.0.0:9020"
-    nodeName = "ergo-testnet-4.0.37"
+    magicBytes = [2, 0, 0, 3]
+    bindAddress = "0.0.0.0:9021"
+    nodeName = "ergo-testnet-5.0"
     nodeName = ${?NODENAME}
     knownPeers = [
-      "213.239.193.208:9020",
-      "176.9.15.237:9020"
+      "213.239.193.208:9021",
+      "176.9.15.237:9021"
     ]
   }
   restApi {
-    apiKeyHash = null
+    # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
+    # Below is the hash of "hello" string.
+    # Change it!
+    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
   }
 }

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -404,7 +404,7 @@ object CandidateGenerator extends ScorexLogging {
     val forkVotingAllowed = votingFinishHeight.forall(fh => nextHeight < fh)
 
     val nextHeightCondition = if(ergoSettings.networkType.isMainNet) {
-      nextHeight >= 819201 // mainnet voting start height
+      nextHeight >= 819201 // mainnet voting start height, first block of epoch #800
     } else {
       nextHeight >= 4096
     }

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -19,7 +19,7 @@ import org.ergoplatform.nodeView.history.ErgoHistory.Height
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateType, UtxoStateReader}
-import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate}
+import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
 import org.ergoplatform.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoScriptPredef, Input}
@@ -379,6 +379,30 @@ object CandidateGenerator extends ScorexLogging {
   }
 
   /**
+    * Private method which suggests to vote for soft-fork (or not)
+    *
+    * @param ergoSettings - constant settings
+    * @param currentParams - network parameters after last block mined
+    * @param header - last mined header
+    * @return `true` if the node should vote for soft-fork
+    */
+  private def forkOrdered(ergoSettings: ErgoSettings, currentParams: Parameters, header: Header): Boolean = {
+    val nextHeight = header.height + 1
+
+    val protocolVersion = ergoSettings.chainSettings.protocolVersion
+    val betterVersion = protocolVersion > header.version
+
+    val votingSettings = ergoSettings.chainSettings.voting
+    val votingFinishHeight: Option[Height] = currentParams.softForkStartingHeight
+      .map(_ + votingSettings.votingLength * votingSettings.softForkEpochs)
+    val forkVotingAllowed = votingFinishHeight.forall(fh => nextHeight < fh)
+
+    betterVersion &&
+     forkVotingAllowed &&
+      (ergoSettings.votingTargets.softFork != 0 && nextHeight >= 4096)
+  }
+
+  /**
     * Assemble correct block candidate based on
     *
     * @param minerPk                 - public key of the miner
@@ -431,26 +455,20 @@ object CandidateGenerator extends ScorexLogging {
         .map { header =>
           val newHeight     = header.height + 1
           val currentParams = stateContext.currentParameters
-          val betterVersion = ergoSettings.chainSettings.protocolVersion > header.version
-          val votingFinishHeight: Option[Height] = currentParams.softForkStartingHeight
-            .map(_ + votingSettings.votingLength * votingSettings.softForkEpochs)
-          val forkVotingAllowed = votingFinishHeight.forall(fh => newHeight < fh)
-          val forkOrdered       = ergoSettings.votingTargets.softFork != 0
-          val voteForFork       = betterVersion && forkOrdered && forkVotingAllowed
+          val voteForSoftFork = forkOrdered(ergoSettings, currentParams, header)
 
           if (newHeight % votingSettings.votingLength == 0 && newHeight > 0) {
             val (newParams, activatedUpdate) = currentParams.update(
               newHeight,
-              voteForFork,
+              voteForSoftFork,
               stateContext.votingData.epochVotes,
               proposedUpdate,
               votingSettings
             )
-            val newValidationSettings =
-              stateContext.validationSettings.updated(activatedUpdate)
+            val newValidationSettings = stateContext.validationSettings.updated(activatedUpdate)
             (
               newParams.toExtensionCandidate ++ interlinksExtension ++ newValidationSettings.toExtensionCandidate,
-              newParams.suggestVotes(ergoSettings.votingTargets.targets, voteForFork),
+              newParams.suggestVotes(ergoSettings.votingTargets.targets, voteForSoftFork),
               newParams.blockVersion
             )
           } else {
@@ -459,7 +477,7 @@ object CandidateGenerator extends ScorexLogging {
               currentParams.vote(
                 ergoSettings.votingTargets.targets,
                 stateContext.votingData.epochVotes,
-                voteForFork
+                voteForSoftFork
               ),
               currentParams.blockVersion
             )


### PR DESCRIPTION
With this PR , the 4.x node may vote for 5.0 soft-fork. The voting will be started from block #819,201 if vote for soft-fork is ordered via config as : 

```
ergo {
  ...
  voting {
    120 = 1 // vote for 5.0 soft-fork, the vote will not be given before block 4,096
  }
}
```