### PR TITLE
Candidate for 4.0.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To run specific Ergo version `<VERSION>` as a service with custom config `/path/
         -e MAX_HEAP=3G \
         ergoplatform/ergo:<VERSION> --<networkId> -c /etc/myergo.conf
 
-Available versions can be found on [Ergo Docker image page](https://hub.docker.com/r/ergoplatform/ergo/tags), for example, `v4.0.37`.
+Available versions can be found on [Ergo Docker image page](https://hub.docker.com/r/ergoplatform/ergo/tags), for example, `v4.0.38`.
 
 This will connect to the Ergo mainnet or testnet following your configuration passed in `myergo.conf` and network flag `--<networkId>`. Every default config value would be overwritten with corresponding value in `myergo.conf`. `MAX_HEAP` variable can be used to control how much memory can the node consume.
 

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 
 info:
-  version: "4.0.37"
+  version: "4.0.38"
   title: Ergo Node API
   description: API docs for Ergo Node. Models are shared between all Ergo products
   contact:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -396,7 +396,7 @@ scorex {
     nodeName = "ergo-node"
 
     # Network protocol version to be sent in handshakes
-    appVersion = 4.0.37
+    appVersion = 4.0.38
 
     # Network agent name. May contain information about client code
     # stack, starting from core code-base up to the end graphical interface.

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -65,7 +65,7 @@ scorex {
   network {
     magicBytes = [1, 0, 2, 4]
     bindAddress = "0.0.0.0:9030"
-    nodeName = "ergo-mainnet-4.0.37"
+    nodeName = "ergo-mainnet-4.0.38"
     nodeName = ${?NODENAME}
     knownPeers = [
       "213.239.193.208:9030",

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -411,7 +411,7 @@ object CandidateGenerator extends ScorexLogging {
 
     betterVersion &&
       forkVotingAllowed &&
-      (ergoSettings.votingTargets.softFork != 0 && nextHeightCondition)
+      nextHeightCondition
   }
 
   /**


### PR DESCRIPTION
This version is auto-voting for 5.0 soft-fork, thus there's no need to set `120=1` in `ergo.voting` config section with it. 4.0.39 and follow-up version will not include auto-voting