### PR TITLE
Randomized pool sorting by transaction size or cost

### DIFF
--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -134,7 +134,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
     val (isCostValid, scriptCost: Long) =
       costTry match {
         case Failure(t) =>
-          log.warn(s"Tx verification failed: ${t.getMessage}")
+          log.warn(s"Tx verification failed: ${t.getMessage}", t)
           log.warn(s"Tx $id verification context: " +
             s"${JsonCodecsWrapper.ergoLikeContextEncoder.apply(ctx)} " +
             s"input context: $inputContext " +

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -147,7 +147,7 @@ class ErgoMemPool private[mempool](pool: OrderedTxPool,
       val poolSizeLimit = nodeSettings.mempoolCapacity
       if (pool.size == poolSizeLimit &&
         weighted(tx, feeFactor).weight <= pool.orderedTransactions.lastKey.weight) {
-        this -> ProcessingOutcome.Declined(new Exception("Transaction is pool outsider"))
+        this -> ProcessingOutcome.Declined(new Exception("Transaction pays less than any other in the pool being full"))
       } else {
         new ErgoMemPool(pool.put(tx, feeFactor), stats, sortingOption) -> ProcessingOutcome.Accepted
       }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -332,6 +332,7 @@ object ErgoMemPool extends ScorexLogging {
   /**
     * Create empty mempool
     * @param settings - node settings (to get mempool settings from)
+    * @param sortingOption - how to sort transactions (by size or execution cost)
     * @return empty mempool
     */
   def empty(settings: ErgoSettings, sortingOption: SortingOption = SortingOption.random()): ErgoMemPool =

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -81,6 +81,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
   /**
     * Method to put a transaction into the memory pool. Validation of the transactions against
     * the state is done in NodeVieHolder. This put() method can check whether a transaction is valid
+    *
     * @param tx
     * @return Success(updatedPool), if transaction successfully added to the pool, Failure(_) otherwise
     */
@@ -176,7 +177,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
               if (tx.inputIds.forall(inputBoxId => utxoWithPool.boxById(inputBoxId).isDefined)) {
                 utxoWithPool.validateWithCost(tx, Some(utxo.stateContext), costLimit, None) match {
                   case Success(cost) => acceptIfNoDoubleSpend(tx, cost)
-                  case Failure(ex) => new ErgoMemPool (pool.invalidate (tx), stats, sortingOption) -> ProcessingOutcome.Invalidated (ex)
+                  case Failure(ex) => new ErgoMemPool(pool.invalidate(tx), stats, sortingOption) -> ProcessingOutcome.Invalidated(ex)
                 }
               } else {
                 this -> ProcessingOutcome.Declined(new Exception("not all utxos in place yet"))
@@ -239,6 +240,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     * Calculate position in mempool corresponding to the specified fee and
     * estimate time of serving this transaction based on average rate of placing
     * transactions in blockchain
+    *
     * @param txFee  - transaction fee
     * @param txSize - size of transaction (in bytes)
     * @return average time for this transaction to be placed in block
@@ -312,6 +314,7 @@ object ErgoMemPool extends ScorexLogging {
     /**
       * Class signalling that a valid transaction was rejected as it is double-spending inputs of mempool transactions
       * and has no bigger weight (fee/byte) than them on average.
+      *
       * @param winnerTxIds - identifiers of transactions won in replace-by-fee auction
       */
     case class DoubleSpendingLoser(winnerTxIds: Set[ModifierId]) extends ProcessingOutcome
@@ -331,6 +334,7 @@ object ErgoMemPool extends ScorexLogging {
 
   /**
     * Create empty mempool
+    *
     * @param settings - node settings (to get mempool settings from)
     * @param sortingOption - how to sort transactions (by size or execution cost)
     * @return empty mempool

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Random, Success, Try}
   *                 information about mempool's state and transactions in it.
   * @param sortingOption - this input sets how transactions are sorted in the pool, by fee-per-byte or fee-per-cycle
   */
-class ErgoMemPool private[mempool](pool: OrderedTxPool,
+class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
                                    private[mempool] val stats : MemPoolStatistics,
                                    private[mempool] val sortingOption: SortingOption)
                                   (implicit settings: ErgoSettings)

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/HistogramStats.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/HistogramStats.scala
@@ -10,7 +10,7 @@ object HistogramStats {
     for (wtx <- wtxs) {
       val waitTime = currTime - wtx.created
       val bin = if (waitTime < maxWaitTimeMsec) (waitTime/interval).toInt else nBins
-      histogram.update(bin, FeeHistogramBin(histogram(bin).nTxns + 1, histogram(bin).totalFee + wtx.feePerKb))
+      histogram.update(bin, FeeHistogramBin(histogram(bin).nTxns + 1, histogram(bin).totalFee + wtx.feePerFactor))
     }
     histogram
   }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/MemPoolStatistics.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/MemPoolStatistics.scala
@@ -39,7 +39,7 @@ case class MemPoolStatistics(startMeasurement: Long,
     val durationMinutes = ((currTime - wtx.created) / (60 * 1000)).toInt
     val newHist =
       if (durationMinutes < MemPoolStatistics.nHistogramBins) {
-        val (histx, hisfee) = (histogram(durationMinutes).nTxns + 1, histogram(durationMinutes).totalFee + wtx.feePerKb)
+        val (histx, hisfee) = (histogram(durationMinutes).nTxns + 1, histogram(durationMinutes).totalFee + wtx.feePerFactor)
         histogram.updated(durationMinutes, FeeHistogramBin(histx, hisfee))
       } else {
         histogram

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -197,6 +197,7 @@ object OrderedTxPool {
   }
 
   /**
+    * Wrap transaction into an entity which is storing its mempool sorting weight also
     *
     * @param tx - transaction
     * @param feeFactor - fee-related factor of the transaction `tx`, so size or cost
@@ -210,7 +211,8 @@ object OrderedTxPool {
       .sum
 
     // We multiply by 1024 for better precision
-    val feePerKb = fee * 1024 / feeFactor
-    WeightedTxId(tx.id, feePerKb, feePerKb, System.currentTimeMillis())
+    val feePerFactor = fee * 1024 / feeFactor
+    // Weight is equal to feePerFactor here, however, it can be modified later when children transactions will arrive
+    WeightedTxId(tx.id, feePerFactor, feePerFactor, System.currentTimeMillis())
   }
 }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.nodeView.mempool
 
 import org.ergoplatform.{ErgoBoxCandidate, Input}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
-import org.ergoplatform.nodeView.mempool.ErgoMemPool.ProcessingOutcome
+import org.ergoplatform.nodeView.mempool.ErgoMemPool.{ProcessingOutcome, SortingOption}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.utils.generators.ErgoGenerators
@@ -80,7 +80,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         val tx1 = ErgoTransaction(tx1Like.inputs, tx1Like.outputCandidates)
         val tx2 = ErgoTransaction(tx2Like.inputs, tx2Like.outputCandidates)
 
-        val pool0 = ErgoMemPool.empty(settings)
+        val pool0 = ErgoMemPool.empty(settings, SortingOption.FeePerByte)
         val (pool, tx1Outcome) = pool0.process(tx1, us)
 
         tx1Outcome shouldBe ProcessingOutcome.Accepted

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -214,8 +214,12 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     pool.size shouldBe (family_depth + 1) * txs.size
     txs.foreach { tx =>
       val sb = tx.outputs.head
-      pool.process(tx.copy(inputs = IndexedSeq(new Input(sb.id, emptyProverResult)),
-        outputCandidates = IndexedSeq(new ErgoBoxCandidate(sb.value+1, sb.ergoTree, sb.creationHeight, sb.additionalTokens, sb.additionalRegisters))), us)._2.isInstanceOf[ProcessingOutcome.Declined] shouldBe true
+      val txToDecline = tx.copy(inputs = IndexedSeq(new Input(sb.id, emptyProverResult)),
+        outputCandidates = IndexedSeq(new ErgoBoxCandidate(sb.value, sb.ergoTree, sb.creationHeight, sb.additionalTokens, sb.additionalRegisters)))
+
+      // some transaction is dropped from the pool during processing
+      pool = pool.process(txToDecline, us)._1
+      pool.size shouldBe (family_depth + 1) * txs.size
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.utils.generators.ErgoGenerators
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import sigmastate.Values.ByteArrayConstant
+import sigmastate.Values.{ByteArrayConstant, TrueLeaf}
 import sigmastate.interpreter.{ContextExtension, ProverResult}
 
 class ErgoMemPoolSpec extends AnyFlatSpec
@@ -83,7 +83,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         val wus = WrappedUtxoState(us, bh, stateConstants, extendedParameters).applyModifier(genesis)(_ => ()).get
 
         val feeProp = settings.chainSettings.monetary.feeProposition
-        val inputBox = wus.takeBoxes(1).head
+        val inputBox = wus.takeBoxes(100).collectFirst{
+          case box if box.ergoTree == TrueLeaf.toSigmaProp.treeWithSegregation => box
+        }.get
         val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
 
         def rndContext(n: Int): ContextExtension = ContextExtension(Map(

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -219,6 +219,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
       val res = pool.process(txToDecline, us)._2
       res.isInstanceOf[ProcessingOutcome.Declined] shouldBe true
       res.asInstanceOf[ProcessingOutcome.Declined].e.getMessage.contains("pays less") shouldBe true
+      pool.size shouldBe (family_depth + 1) * txs.size
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -216,10 +216,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
       val sb = tx.outputs.head
       val txToDecline = tx.copy(inputs = IndexedSeq(new Input(sb.id, emptyProverResult)),
         outputCandidates = IndexedSeq(new ErgoBoxCandidate(sb.value, sb.ergoTree, sb.creationHeight, sb.additionalTokens, sb.additionalRegisters)))
-
-      // some transaction is dropped from the pool during processing
-      pool = pool.process(txToDecline, us)._1
-      pool.size shouldBe (family_depth + 1) * txs.size
+      val res = pool.process(txToDecline, us)._2
+      res.isInstanceOf[ProcessingOutcome.Declined] shouldBe true
+      res.asInstanceOf[ProcessingOutcome.Declined].e.getMessage.contains("pays less") shouldBe true
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -55,7 +55,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val size = tx.size
     poolSize.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, size).weight
 
-    var poolCost = ErgoMemPool.empty(settings, SortingOption.FeePerCostUnit)
+    var poolCost = ErgoMemPool.empty(settings, SortingOption.FeePerCycle)
     poolCost = poolCost.process(tx, wus)._1
     val cost = wus.validateWithCost(tx, Int.MaxValue).get
     poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight


### PR DESCRIPTION
In this pool request, possible pool sorting by fee per cycle (execution cost unit) added. Currently pool sorting is chosen randomly during the node start. In future it makes sense to add a setting for that.  