### PR TITLE
Fixed socket address parsing for IPv6

### DIFF
--- a/src/main/scala/scorex/core/settings/SettingsReaders.scala
+++ b/src/main/scala/scorex/core/settings/SettingsReaders.scala
@@ -9,7 +9,8 @@ trait SettingsReaders {
   implicit val fileReader: ValueReader[File] = (cfg, path) => new File(cfg.getString(path))
   implicit val byteValueReader: ValueReader[Byte] = (cfg, path) => cfg.getInt(path).toByte
   implicit val inetSocketAddressReader: ValueReader[InetSocketAddress] = { (config: Config, path: String) =>
-    val split = config.getString(path).split(":")
-    new InetSocketAddress(split(0), split(1).toInt)
+    val string = config.getString(path)
+    val index = string.lastIndexOf(':')
+    new InetSocketAddress(string.substring(0, index), string.substring(index + 1).toInt)
   }
 }


### PR DESCRIPTION
The previous code was splitting the declaredAddress based on colons. This works with IPv4 socket addresses, but IPv6 socket addresses are formatted like this: `[2345:0425:2CA1:0000:0000:0567:5673:23b5]:9030`.

There are colons in the IP itself. I changed the code to cut the string based on the last colon.

(No wonder there are no IPv6 nodes found on ergonodes.net, you could not even declare one before this fix..)