### PR TITLE
Do not disconnect from peer in case of block section non-delivery

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -18,7 +18,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder._
 import scorex.core.consensus.{Equal, Fork, Nonsense, Older, Unknown, Younger}
 import scorex.core.network.ModifiersStatus.Requested
 import scorex.core.{ModifierTypeId, NodeViewModifier, PersistentNodeViewModifier, idsToString}
-import scorex.core.network.NetworkController.ReceivableMessages.{DisconnectFrom, PenalizePeer, RegisterMessageSpecs, SendToNetwork}
+import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
 import org.ergoplatform.network.ErgoNodeViewSynchronizer.ReceivableMessages._
 import org.ergoplatform.nodeView.state.ErgoStateReader
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -742,9 +742,6 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                    s"$modifierTypeId : ${encoder.encodeId(modifierId)} on time, status tracker: $syncTracker")
 
           penalizeNonDeliveringPeer(peer)
-          // For now, we drop connection to the peer, as we do not ban it, connection will be likely established
-          // again after some time (but not soon if connections limit reached)
-          networkControllerRef ! DisconnectFrom(peer)
 
           val checksDone = deliveryTracker.requestsMade(modifierTypeId, modifierId) + 1
           val maxDeliveryChecks = networkSettings.maxDeliveryChecks

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -88,7 +88,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
   // no more than `PerPeerSyncLockTime` milliseconds ago.
   private val PerPeerSyncLockTime = 100
 
-  private var lastModifierGotTime = 0
+  private var lastModifierGotTime: Long = 0
 
   /**
     * Register periodic events
@@ -514,7 +514,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     log.info(s"Got ${modifiers.size} modifiers of type $typeId from remote connected peer: ${remote.connectionId}")
     log.debug("Modifier ids: " + modifiers.keys)
 
-    lastModificheckerGotTime = System.currentTimeMillis()
+    lastModifierGotTime = System.currentTimeMillis()
 
     // filter out non-requested modifiers
     val requestedModifiers = processSpam(remote, typeId, modifiers, blockAppliedTxsCache)
@@ -743,7 +743,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
           // A block section is not delivered on time.
           log.info(s"Peer ${peer.toString} has not delivered modifier " +
                    s"$modifierTypeId : ${encoder.encodeId(modifierId)} on time, status tracker: $syncTracker")
-          
+
+          // Number of block section delivery checks increased
           val checksDone = deliveryTracker.getRequestedInfo(modifierTypeId, modifierId) match {
             case Some(ri) if ri.requestTime < lastModifierGotTime =>
               ri.checks

--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -112,13 +112,6 @@ class DeliveryTracker(cacheSettings: NetworkCacheSettings,
   }
 
   /**
-    * @return how many times modifier was requested before
-    */
-  def requestsMade(modifierTypeId: ModifierTypeId, modifierId: ModifierId): Int = {
-    requested.get(modifierTypeId).flatMap(_.get(modifierId)).map(_.checks).getOrElse(0)
-  }
-
-  /**
     * Set status of modifier with id `id` to `Requested`
     */
   def setRequested(typeId: ModifierTypeId,
@@ -129,9 +122,14 @@ class DeliveryTracker(cacheSettings: NetworkCacheSettings,
     tryWithLogging {
       checkStatusTransition(status(id, typeId, Seq.empty), Requested)
       val cancellable = schedule(CheckDelivery(supplier, typeId, id))
-      val requestedInfo = RequestedInfo(supplier, cancellable, checksDone)
+      val now = System.currentTimeMillis()
+      val requestedInfo = RequestedInfo(supplier, cancellable, checksDone, now)
       requested.adjust(typeId)(_.fold(Map(id -> requestedInfo))(_.updated(id, requestedInfo)))
     }
+
+  def getRequestedInfo(typeId: ModifierTypeId, id: ModifierId): Option[RequestedInfo] = {
+    requested.get(typeId).flatMap(_.get(id))
+  }
 
   /** Get peer we're communicating with in regards with modifier `id` **/
   def getSource(id: ModifierId, modifierTypeId: ModifierTypeId): Option[ConnectedPeer] = {
@@ -308,7 +306,7 @@ class DeliveryTracker(cacheSettings: NetworkCacheSettings,
 
 object DeliveryTracker {
 
-  case class RequestedInfo(peer: ConnectedPeer, cancellable: Cancellable, checks: Int)
+  case class RequestedInfo(peer: ConnectedPeer, cancellable: Cancellable, checks: Int, requestTime: Long)
 
   object RequestedInfo {
     import io.circe.syntax._

--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -127,6 +127,9 @@ class DeliveryTracker(cacheSettings: NetworkCacheSettings,
       requested.adjust(typeId)(_.fold(Map(id -> requestedInfo))(_.updated(id, requestedInfo)))
     }
 
+  /**
+    * @return - information on requested modifier delivery tracker potentially has
+    */
   def getRequestedInfo(typeId: ModifierTypeId, id: ModifierId): Option[RequestedInfo] = {
     requested.get(typeId).flatMap(_.get(id))
   }


### PR DESCRIPTION
In this PR:

* we do not disconnect from a peer not delivering a block section anymore
* we invalidate header not-delivered after max number of attempts (for other block sections, the node will automatically stop for block section in the past after some time)
* we do not increase attempts counter in case of possible loss of connectivity 