### PR TITLE
i1827 improve node repairing when node is stuck

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -623,14 +623,17 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
   }
 
   protected def handleHealthCheck: Receive = {
-    case IsChainHealthy if chainProgress.isEmpty =>
-      val repairNeeded = ErgoHistory.repairIfNeeded(history())
-      val error = s"Trying to repair node that is stuck already from the start, repair needed : $repairNeeded"
-      log.warn(error)
-      sender() ! ChainIsStuck(error)
     case IsChainHealthy =>
-      log.info(s"Checking that chain is healthy, progress is ${chainProgress.get}")
-      sender() ! ErgoNodeViewHolder.checkChainIsHealthy(chainProgress.get, history(), timeProvider, settings)
+      chainProgress match {
+        case Some(progress) =>
+          log.info(s"Checking that chain is healthy, progress is $progress")
+          sender() ! ErgoNodeViewHolder.checkChainIsHealthy(progress, history(), timeProvider, settings)
+        case None =>
+          val repairNeeded = ErgoHistory.repairIfNeeded(history())
+          val error = s"Trying to repair node that is stuck already from the start, repair needed : $repairNeeded"
+          log.warn(error)
+          sender() ! ChainIsStuck(error)
+      }
   }
 
   override def receive: Receive =


### PR DESCRIPTION
Closes https://github.com/ergoplatform/ergo/issues/1827

So far I just improved it so we try to repair history in case the node is stuck already after start.

But IDK how to improve the repair algorithm so we unstuck the case that happened in https://github.com/ergoplatform/ergo/issues/1824

@kushti Do you know how to do it?