### PR TITLE
Dockerfile: add support for aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/sbt:11.0.8_1.3.13 as builder
+FROM mozilla/sbt:11.0.13_1.6.2 as builder
 WORKDIR /mnt
 COPY build.sbt findbugs-exclude.xml ./
 COPY project/ project/
@@ -12,11 +12,11 @@ COPY . ./
 RUN sbt assembly
 RUN mv `find target/scala-*/stripped/ -name ergo-*.jar` ergo.jar
 
-FROM openjdk:11-jre-slim
-RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatform" ergo && \
+FROM openjdk:11-oraclelinux8
+RUN adduser --home-dir /home/ergo --uid 9052 ergo && \
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
 USER ergo
-EXPOSE 9020 9052 9030 9053
+EXPOSE 9020 9021 9052 9030 9053
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G


### PR DESCRIPTION
-  Changed to SBT version that has support for aarch64.

-  Added port 9021 as it's being used in the new testnet.

-  RE: openjdk docker image change: As per openjdk docker repo, starting with version 12, oraclelinux will be the default image. I'm using oracle image with version 11 here, because I found issues running this on RHEL-based systems with the other image. Please test this with Debian-based systems to confirm the oraclelinux8 image is compatible for both. Also changed adduser command since previous command does not work with RHEL-based image.

- TODO: Modify github workflows to also build aarch64 images as well ( using self-hosted runner or using qemu with GitHub runner? ), this way multi-arch images are provided for users. ARM is a first-class citizen now, and provides increased performance for less cost at many datacentres, not to mention people can use this to run on Raspberry Pi / New Apple silicon systems.