### PR TITLE
Performance optimizations in checking tree operations

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
@@ -93,7 +93,7 @@ class UtxoState(override val persistentProver: PersistentBatchAVLProver[Digest32
             persistentProver.performOneOperation(op) match {
               case Success(_) =>
               case Failure(t) =>
-                log.error(s"Operation $op failed during $headerId transactions validation in")
+                log.error(s"Operation $op failed during $headerId transactions validation")
                 opsResult = Failure(t)
             }
           }


### PR DESCRIPTION
In this PR, Traverse.sequence is removed when we are checking tree operations during block application, to improve efficiency and readability