### PR TITLE
Candidate for 4.0.102

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 
 info:
-  version: "4.0.101"
+  version: "4.0.102"
   title: Ergo Node API
   description: API docs for Ergo Node. Models are shared between all Ergo products
   contact:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -400,7 +400,7 @@ scorex {
     nodeName = "ergo-node"
 
     # Network protocol version to be sent in handshakes
-    appVersion = 4.0.101
+    appVersion = 4.0.102
 
     # Network agent name. May contain information about client code
     # stack, starting from core code-base up to the end graphical interface.

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -75,7 +75,7 @@ scorex {
   network {
     magicBytes = [1, 0, 2, 4]
     bindAddress = "0.0.0.0:9030"
-    nodeName = "ergo-mainnet-4.0.101"
+    nodeName = "ergo-mainnet-4.0.102"
     nodeName = ${?NODENAME}
     knownPeers = [
       "213.239.193.208:9030",

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -66,9 +66,6 @@ ergo {
     maxTransactionCost = 4900000
   }
 
-  voting {
-    6 = 2400 #vote for EIP-37
-  }
 }
 
 scorex {


### PR DESCRIPTION
Candidate for 4.0.102. In contains:

* #1850 -  time limit for block sections processing in `ModifiersFromRemote` handling removed. That limit created temporary sync stop near blockchain tip, which is during slow blocks makes people think that sync is stuck.


This version is *NOT* auto-voting for EIP-37. For auto-voting, please use 4.0.103. 