### PR TITLE
Remove invalid headers on chain repair

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 
 info:
-  version: "4.0.103"
+  version: "4.0.104"
   title: Ergo Node API
   description: API docs for Ergo Node. Models are shared between all Ergo products
   contact:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -400,7 +400,7 @@ scorex {
     nodeName = "ergo-node"
 
     # Network protocol version to be sent in handshakes
-    appVersion = 4.0.103
+    appVersion = 4.0.104
 
     # Network agent name. May contain information about client code
     # stack, starting from core code-base up to the end graphical interface.

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -76,7 +76,7 @@ scorex {
   network {
     magicBytes = [1, 0, 2, 4]
     bindAddress = "0.0.0.0:9030"
-    nodeName = "ergo-mainnet-4.0.103"
+    nodeName = "ergo-mainnet-4.0.104"
     nodeName = ${?NODENAME}
     knownPeers = [
       "213.239.193.208:9030",

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -743,10 +743,9 @@ object ErgoNodeViewHolder {
         history.bestFullBlockOpt
           .filter(_.id != lastMod.id)
           .fold("")(fb => s"\n best full block: $fb")
-      val repairNeeded = ErgoHistory.repairIfNeeded(history)
+      ErgoHistory.repairIfNeeded(history) // todo: do we need to do it?
       ChainIsStuck(s"Chain not modified for $chainUpdateDelay ms, headers-height: $headersHeight, " +
-        s"block-height $blockHeight, chain synced: $chainSynced, repair needed: $repairNeeded, " +
-        s"last modifier applied: $lastMod, " +
+        s"block-height $blockHeight, chain synced: $chainSynced, last modifier applied: $lastMod, " +
         s"possible best full block $bestFullBlockOpt")
     } else {
       ChainIsHealthy

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -7,17 +7,19 @@ import org.ergoplatform.mining.AutolykosPowScheme
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.{Header, PreGenesisHeader}
 import org.ergoplatform.modifiers.state.UTXOSnapshotChunk
-import org.ergoplatform.modifiers.{NonHeaderBlockSection, ErgoFullBlock, BlockSection}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NonHeaderBlockSection}
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.history.storage.modifierprocessors._
 import org.ergoplatform.nodeView.history.storage.modifierprocessors.popow.{EmptyPoPoWProofsProcessor, FullPoPoWProofsProcessor}
 import org.ergoplatform.settings._
 import org.ergoplatform.utils.LoggingUtil
+import scorex.core.consensus.ModifierSemanticValidity.Invalid
 import scorex.core.consensus.ProgressInfo
 import scorex.core.utils.NetworkTimeProvider
 import scorex.core.validation.RecoverableModifierError
 import scorex.util.{ModifierId, ScorexLogging, idToBytes}
 
+import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -219,7 +221,7 @@ trait ErgoHistory
     log.info(s"Result of removing header $headerId: " + hRes)
 
     hOpt.foreach { h =>
-      requiredModifiersForHeader(h).foreach { case (_, mId) =>
+      h.sectionIds.foreach { case (_, mId) =>
         val mRes = historyStorage.remove(
           indicesToRemove = Array(validityKey(mId)),
           idsToRemove = Array(mId)
@@ -259,20 +261,34 @@ object ErgoHistory extends ScorexLogging {
   // check if there is possible database corruption when there is header after
   // recognized blockchain tip marked as invalid
   protected[nodeView] def repairIfNeeded(history: ErgoHistory): Boolean = history.historyStorage.synchronized {
-    val bestHeaderHeight = history.headersHeight
-    val bestFullBlockHeight = history.bestFullBlockOpt.map(_.height).getOrElse(-1)
-    val afterHeaders = history.headerIdsAtHeight(bestHeaderHeight + 1)
+    val RepairDepth = 128
 
-    if (bestHeaderHeight == bestFullBlockHeight && afterHeaders.nonEmpty) {
-      log.warn("Found suspicious continuation, clearing it...")
-      afterHeaders.map { hId =>
-        history.forgetHeader(hId)
+    val bestHeaderHeight = history.headersHeight
+
+    @tailrec
+    def checkHeightsFrom(h: Int): Unit = {
+      val headerIds = history.headerIdsAtHeight(h)
+      if (headerIds.nonEmpty) {
+        val notInvalidHeaders = headerIds.filter { headerId =>
+          if (history.isSemanticallyValid(headerId) == Invalid) {
+            log.warn(s"Clearing invalid header: $headerId at height $h")
+            history.forgetHeader()
+            false
+          } else {
+            true
+          }
+        }
+        val updatedHeightIdsValue = notInvalidHeaders.foldLeft(Array[Byte].empty) { case (acc, id) =>
+          acc ++ idToBytes(id)
+        }
+        history.historyStorage.insert(Array(history.heightIdsKey(h), updatedHeightIdsValue), Nil)
+        checkHeightsFrom(h + 1)
       }
-      history.historyStorage.remove(Array(history.heightIdsKey(bestHeaderHeight + 1)), Nil)
-      true
-    } else {
-      false
     }
+
+    log.info("Checking invalid headers started")
+    checkHeightsFrom(bestHeaderHeight - RepairDepth)
+    log.info("Checking invalid headers finished")
   }
 
   def readOrGenerate(ergoSettings: ErgoSettings, ntp: NetworkTimeProvider): ErgoHistory = {


### PR DESCRIPTION
Unlike previous attempts to repair db of node being stuck, this one is removing invalid blocks in the past (in 128 blocks depth from the tip) and in future (not just the next height).

Could be useful to unstuck with pre 4,0,100 databases stuck after the HF. 