### PR TITLE
Mempool fixes and improvements

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -158,7 +158,9 @@ class CandidateGenerator(
               _ ! StatusReply.error(s"Candidate generation failed : ${ex.getMessage}")
             )
           case Some(Success((candidate, eliminatedTxs))) =>
-            if (eliminatedTxs.ids.nonEmpty) viewHolderRef ! eliminatedTxs
+            if (eliminatedTxs.ids.nonEmpty) {
+              viewHolderRef ! eliminatedTxs
+            }
             val generationTook = System.currentTimeMillis() - start
             log.info(s"Generated new candidate in $generationTook ms")
             context.become(

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/UnconfirmedTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/UnconfirmedTransaction.scala
@@ -30,6 +30,12 @@ case class UnconfirmedTransaction(transaction: ErgoTransaction,
     copy(lastCost = Some(cost), lastCheckedTime = System.currentTimeMillis())
   }
 
+  override def equals(obj: Any): Boolean = obj match {
+    case that: UnconfirmedTransaction => that.id == id
+    case _ => false
+  }
+
+  override def hashCode(): Int = id.hashCode()
 }
 
 object UnconfirmedTransaction {

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -762,7 +762,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
         if (txAcceptanceFilter) {
           val unknownMods =
-            //todo: filter out transactions invalidated in the mempool?
+            // todo: filter out transactions invalidated in the mempool,
+            // todo: see https://github.com/ergoplatform/ergo/issues/1863
             invData.ids.filter(mid => deliveryTracker.status(mid, modifierTypeId, Seq(mp)) == ModifiersStatus.Unknown)
           // filter out transactions that were already applied to history
           val notApplied = unknownMods.filterNot(blockAppliedTxsCache.mightContain)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -97,7 +97,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     * The node stops to accept transactions if declined table reaches this max size. It prevents spam attacks trying
     * to bloat the table (or exhaust node's CPU)
     */
-  private val MaxDeclined = 400
+  private val MaxDeclined = 1000
 
   /**
     * No more than this number of unparsed transactions can be cached
@@ -968,7 +968,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   // helper method to clear declined transactions after some off, so the node may accept them again
   private def clearDeclined(): Unit = {
-    val clearTimeout = FiniteDuration(10, MINUTES)
+    val clearTimeout = FiniteDuration(20, MINUTES)
     val now = System.currentTimeMillis()
 
     val toRemove = declined.filter { case (_, time) =>

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -109,6 +109,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
   }
 
   def remove(unconfirmedTransaction: UnconfirmedTransaction): ErgoMemPool = {
+    log.debug(s"Removing transaction ${unconfirmedTransaction.id} from the mempool")
     val tx = unconfirmedTransaction.transaction
     val wtx = pool.transactionsRegistry.get(tx.id)
     val updStats = wtx.map(wgtx => stats.add(System.currentTimeMillis(), wgtx))

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -188,7 +188,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     val validationStartTime = System.currentTimeMillis()
 
     val blacklistedTransactions = nodeSettings.blacklistedTransactions
-    if(blacklistedTransactions.nonEmpty && blacklistedTransactions.contains(tx.id)) {
+    if (blacklistedTransactions.nonEmpty && blacklistedTransactions.contains(tx.id)) {
       val exc = new Exception("blacklisted tx")
       this.invalidate(unconfirmedTx) -> new ProcessingOutcome.Invalidated(exc, validationStartTime)
     } else {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -229,7 +229,15 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
               acceptIfNoDoubleSpend(unconfirmedTx, validationStartTime)
           }
         } else {
-          val exc = new Exception(s"Pool can not accept transaction ${tx.id}, it is invalidated earlier or the pool is full")
+          val contains = this.contains(tx.id)
+          val msg = if(contains) {
+            s"Pool can not accept transaction ${tx.id}, it is already in the mempool"
+          } else if(pool.size == settings.nodeSettings.mempoolCapacity) {
+            s"Pool can not accept transaction ${tx.id}, the mempool is full"
+          } else {
+            s"Pool can not accept transaction ${tx.id}"
+          }
+          val exc = new Exception(msg)
           this -> new ProcessingOutcome.Declined(exc, validationStartTime)
         }
       } else {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -185,7 +185,13 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
 
   def process(unconfirmedTx: UnconfirmedTransaction, state: ErgoState[_]): (ErgoMemPool, ProcessingOutcome) = {
     val tx = unconfirmedTx.transaction
+
+    val invalidatedCnt = this.pool.invalidatedTxIds.approximateElementCount
+    val poolSize = this.size
+
     log.info(s"Processing mempool transaction: $tx")
+    log.debug(s"Mempool: invalidated transactions: $invalidatedCnt, pool size: $poolSize")
+
     val validationStartTime = System.currentTimeMillis()
 
     val blacklistedTransactions = nodeSettings.blacklistedTransactions

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -96,7 +96,7 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, UnconfirmedT
           invalidatedTxIds,
           outputs -- tx.outputs.map(_.id),
           inputs -- tx.inputs.map(_.boxId)
-        ).updateFamily(unconfirmedTx, -wtx.weight, System.currentTimeMillis(), 0)
+        ).updateFamily(unconfirmedTx, -wtx.weight, System.currentTimeMillis(), depth = 0)
       case None => this
     }
   }
@@ -111,7 +111,7 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, UnconfirmedT
           invalidatedTxIds.put(tx.id),
           outputs -- tx.outputs.map(_.id),
           inputs -- tx.inputs.map(_.boxId)
-        ).updateFamily(unconfirmedTx, -wtx.weight, System.currentTimeMillis(), 0)
+        ).updateFamily(unconfirmedTx, -wtx.weight, System.currentTimeMillis(), depth = 0)
       case None =>
         OrderedTxPool(orderedTransactions, transactionsRegistry, invalidatedTxIds.put(tx.id), outputs, inputs)
     }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -142,7 +142,7 @@ case class OrderedTxPool(orderedTransactions: TreeMap[WeightedTxId, UnconfirmedT
     * @return - true, if transaction is in the pool or invalidated earlier, false otherwise
     */
   def contains(id: ModifierId): Boolean = {
-    transactionsRegistry.contains(id) || isInvalidated(id)
+    transactionsRegistry.contains(id)
   }
 
   def isInvalidated(id: ModifierId): Boolean = invalidatedTxIds.mightContain(id)


### PR DESCRIPTION
* `equals` and `hashCode` are added to `UnconfirmedTransaction`
* contains now not accounting `invalid`
* better log output for "Pool can not accept transaction" case