### PR TITLE
EIP-39: monotonic creation height rule

### DIFF
--- a/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
@@ -112,10 +112,21 @@ object Header extends ApiCodecs {
   type Timestamp = Long
   type Version = Byte
 
+  /**
+    * Block version during mainnet launch
+    */
   val InitialVersion: Byte = 1
 
+  /**
+    * Block version after the Hardening hard-fork
+    * Autolykos v2 PoW, witnesses in transactions Merkle tree
+    */
   val HardeningVersion: Byte = 2
 
+  /**
+    * Block version after the 5.0 soft-fork
+    * 5.0 interpreter with JITC, monotonic height rule
+    */
   val Interpreter50Version: Byte = 3
 
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
@@ -112,6 +112,13 @@ object Header extends ApiCodecs {
   type Timestamp = Long
   type Version = Byte
 
+  val InitialVersion: Byte = 1
+
+  val HardeningVersion: Byte = 2
+
+  val Interpreter50Version: Byte = 3
+
+
   def toSigma(header: Header): special.sigma.Header =
     CHeader(
       id = header.id.toBytes.toColl,
@@ -130,8 +137,6 @@ object Header extends ApiCodecs {
       powDistance = CBigInt(header.powSolution.d.bigInteger),
       votes = header.votes.toColl
     )
-
-  val InitialVersion: Byte = 1
 
   val modifierTypeId: ModifierTypeId = ModifierTypeId @@ (101: Byte)
 

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -376,6 +376,9 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
 
     val blockVersion = stateContext.blockVersion
 
+    // Before 5.0 soft-fork (v3 block version), we are checking only that
+    // creation height in outputs is not non-negative
+    // After, we are checking that it is not less that max creation height in inputs
     val maxCreationHeightInInputs = if (blockVersion <= Header.HardeningVersion) {
       0
     } else {

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -6,6 +6,7 @@ import org.ergoplatform._
 import org.ergoplatform.http.api.ApiCodecs
 import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.modifiers.ErgoNodeViewModifier
+import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.ErgoContext
 import org.ergoplatform.nodeView.state.ErgoStateContext
 import org.ergoplatform.utils.ArithUtils._
@@ -157,7 +158,8 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
 
   private def verifyOutput(validationBefore: ValidationState[Long],
                            out: ErgoBox,
-                           stateContext: ErgoStateContext): ValidationResult[Long] = {
+                           stateContext: ErgoStateContext,
+                           maxCreationHeightInInputs: Int): ValidationResult[Long] = {
 
     val blockVersion = stateContext.blockVersion
 
@@ -165,6 +167,7 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
       .validate(txDust, out.value >= BoxUtils.minimalErgoAmount(out, stateContext.currentParameters), InvalidModifier(s"$id, output ${Algos.encode(out.id)}, ${out.value} >= ${BoxUtils.minimalErgoAmount(out, stateContext.currentParameters)}", id, modifierTypeId))
       .validate(txFuture, out.creationHeight <= stateContext.currentHeight, InvalidModifier(s" ${out.creationHeight} <= ${stateContext.currentHeight} is not true, output id: $id: output $out", id, modifierTypeId))
       .validate(txNegHeight, (blockVersion == 1) || out.creationHeight >= 0, InvalidModifier(s" ${out.creationHeight} >= 0 is not true, output id: $id: output $out", id, modifierTypeId))
+      .validate(txMonotonicHeight, out.creationHeight >= maxCreationHeightInInputs, InvalidModifier(s" ${out.creationHeight} is less than max creation height in inputs($maxCreationHeightInInputs), output id: $id: output $out", id, modifierTypeId))
       .validate(txBoxSize, out.bytes.length <= MaxBoxSize.value, InvalidModifier(s"$id: output $out", id, modifierTypeId))
       .validate(txBoxPropositionSize, out.propositionBytes.length <= MaxPropositionBytes.value, InvalidModifier(s"$id: output $out", id, modifierTypeId))
   }
@@ -371,6 +374,14 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
     // Cost limit per block
     val maxCost = stateContext.currentParameters.maxBlockCost.toLong
 
+    val blockVersion = stateContext.blockVersion
+
+    val maxCreationHeightInInputs = if (blockVersion <= Header.HardeningVersion) {
+      0
+    } else {
+      boxesToSpend.map(_.creationHeight).max
+    }
+
     // We sum up previously accumulated cost and transaction initialization cost
     val startCost = addExact(initialCost, accumulatedCost)
     ModifierValidator(stateContext.validationSettings)
@@ -384,7 +395,9 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
         outputCandidates.forall(_.additionalTokens.forall(_._2 > 0)),
         InvalidModifier(s"$id: ${outputCandidates.map(_.additionalTokens)}", id, modifierTypeId))
       // Check that outputs are not dust, and not created in future
-      .validateSeq(outputs) { case (validationState, out) => verifyOutput(validationState, out, stateContext) }
+      .validateSeq(outputs) { case (validationState, out) =>
+        verifyOutput(validationState, out, stateContext, maxCreationHeightInInputs)
+      }
       // Just to be sure, check that all the input boxes to spend (and to read) are presented.
       // Normally, this check should always pass, if the client is implemented properly
       // so it is not part of the protocol really.

--- a/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
+++ b/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
@@ -97,6 +97,9 @@ object ValidationRules {
     txReemission -> RuleStatus(im => fatal(s"Transaction should conform EIP-27 rules ${im.error}", im.modifierId, im.modifierTypeId),
       Seq(classOf[ErgoTransaction]),
       mayBeDisabled = true),
+    txMonotonicHeight -> RuleStatus(im => fatal(s"Creation height of any output should be not less than  ${im.error}", im.modifierId, im.modifierTypeId),
+      Seq(classOf[ErgoTransaction]),
+      mayBeDisabled = true),
 
     // header validation
     hdrGenesisParent -> RuleStatus(im => fatal(s"Genesis header should have genesis parent id. ${im.error}", im.modifierId, im.modifierTypeId),
@@ -250,8 +253,9 @@ object ValidationRules {
   val txScriptValidation: Short = 119
   val txBoxSize: Short = 120
   val txBoxPropositionSize: Short = 121
-  val txNegHeight: Short = 122
-  val txReemission: Short = 123
+  val txNegHeight: Short = 122 // introduced in v2 blocks
+  val txReemission: Short = 123 // introduced in EIP-27 (soft-fork)
+  val txMonotonicHeight: Short = 124 // introduced in v3 blocks
 
   // header validation
   val hdrGenesisParent: Short = 200

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -490,6 +490,9 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
                   box.transactionId, box.index, creationHeight)
     }
 
+    // retuns random transaction along with inputs,
+    // and a boolean flag, if the latter is true, monotonic creation height rule holds,
+    // otherwise, it does not hold
     val txGen = boxesGenTemplate(minAssets = 0, maxAssets = 5, minInputs = 5, maxInputs = 10, propositionGen = trueLeafGen).map { case (boxes, _) =>
       boxes.map(updateInputHeight)
     }.map{ boxes =>

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -36,6 +36,52 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
   private val emptyModifierId: ModifierId = bytesToId(Array.fill(32)(0.toByte))
 
+
+  private def updateAnAsset(tx: ErgoTransaction, from: IndexedSeq[ErgoBox], deltaFn: Long => Long) = {
+    val updCandidates = tx.outputCandidates.foldLeft(IndexedSeq[ErgoBoxCandidate]() -> false) { case ((seq, modified), ebc) =>
+      if (modified) {
+        (seq :+ ebc) -> true
+      } else {
+        if (ebc.additionalTokens.nonEmpty && ebc.additionalTokens.exists(t => !java.util.Arrays.equals(t._1, from.head.id))) {
+          (seq :+ modifyAsset(ebc, deltaFn, Digest32 @@ from.head.id)) -> true
+        } else {
+          (seq :+ ebc) -> false
+        }
+      }
+    }._1
+    tx.copy(outputCandidates = updCandidates)
+  }
+
+  private def modifyValue(boxCandidate: ErgoBoxCandidate, delta: Long): ErgoBoxCandidate = {
+    new ErgoBoxCandidate(
+      boxCandidate.value + delta,
+      boxCandidate.ergoTree,
+      boxCandidate.creationHeight,
+      boxCandidate.additionalTokens,
+      boxCandidate.additionalRegisters)
+  }
+
+  private def modifyAsset(boxCandidate: ErgoBoxCandidate,
+                          deltaFn: Long => Long,
+                          idToskip: TokenId): ErgoBoxCandidate = {
+    val assetId = boxCandidate.additionalTokens.find(t => !java.util.Arrays.equals(t._1, idToskip)).get._1
+
+    val tokens = boxCandidate.additionalTokens.map { case (id, amount) =>
+      if (java.util.Arrays.equals(id, assetId)) assetId -> deltaFn(amount) else assetId -> amount
+    }
+
+    new ErgoBoxCandidate(
+      boxCandidate.value,
+      boxCandidate.ergoTree,
+      boxCandidate.creationHeight,
+      tokens,
+      boxCandidate.additionalRegisters)
+  }
+
+  private def checkTx(from: IndexedSeq[ErgoBox], wrongTx: ErgoTransaction): Try[Int] = {
+    wrongTx.statelessValidity().flatMap(_ => wrongTx.statefulValidity(from, emptyDataBoxes, emptyStateContext))
+  }
+
   property("serialization vector") {
     // test vectors, that specifies transaction json and bytes representation.
     // ensures that bytes transaction representation was not changed
@@ -138,21 +184,6 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
       wrongTx.statelessValidity().isSuccess shouldBe false
       wrongTx.statefulValidity(from, emptyDataBoxes, emptyStateContext).isSuccess shouldBe false
     }
-  }
-
-  private def updateAnAsset(tx: ErgoTransaction, from: IndexedSeq[ErgoBox], deltaFn: Long => Long) = {
-    val updCandidates = tx.outputCandidates.foldLeft(IndexedSeq[ErgoBoxCandidate]() -> false) { case ((seq, modified), ebc) =>
-      if (modified) {
-        (seq :+ ebc) -> true
-      } else {
-        if (ebc.additionalTokens.nonEmpty && ebc.additionalTokens.exists(t => !java.util.Arrays.equals(t._1, from.head.id))) {
-          (seq :+ modifyAsset(ebc, deltaFn, Digest32 @@ from.head.id)) -> true
-        } else {
-          (seq :+ ebc) -> false
-        }
-      }
-    }._1
-    tx.copy(outputCandidates = updCandidates)
   }
 
   property("assets preservation law holds") {
@@ -435,34 +466,73 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
     }
   }
 
-  private def modifyValue(boxCandidate: ErgoBoxCandidate, delta: Long): ErgoBoxCandidate = {
-    new ErgoBoxCandidate(
-      boxCandidate.value + delta,
-      boxCandidate.ergoTree,
-      boxCandidate.creationHeight,
-      boxCandidate.additionalTokens,
-      boxCandidate.additionalRegisters)
-  }
-
-  private def modifyAsset(boxCandidate: ErgoBoxCandidate,
-                          deltaFn: Long => Long,
-                          idToskip: TokenId): ErgoBoxCandidate = {
-    val assetId = boxCandidate.additionalTokens.find(t => !java.util.Arrays.equals(t._1, idToskip)).get._1
-
-    val tokens = boxCandidate.additionalTokens.map { case (id, amount) =>
-      if (java.util.Arrays.equals(id, assetId)) assetId -> deltaFn(amount) else assetId -> amount
+  property("monotonic creation height") {
+    def stateContext(height: Int, blockVersion: Byte): ErgoStateContext = {
+      val header = defaultHeaderGen.sample.get.copy(version = blockVersion, height = height)
+      val params = Parameters(LaunchParameters.height,
+                              LaunchParameters.parametersTable.updated(Parameters.BlockVersion, blockVersion),
+                              LaunchParameters.proposedUpdate)
+      new ErgoStateContext(Seq(header), None, genesisStateDigest, params, ErgoValidationSettings.initial,
+        VotingData.empty)(settings)
     }
 
-    new ErgoBoxCandidate(
-      boxCandidate.value,
-      boxCandidate.ergoTree,
-      boxCandidate.creationHeight,
-      tokens,
-      boxCandidate.additionalRegisters)
-  }
+    def stateContextForTx(tx: ErgoTransaction, blockVersion: Byte): ErgoStateContext = {
+      stateContext(tx.outputs.map(_.creationHeight).max, blockVersion)
+    }
 
-  private def checkTx(from: IndexedSeq[ErgoBox], wrongTx: ErgoTransaction): Try[Int] = {
-    wrongTx.statelessValidity().flatMap(_ => wrongTx.statefulValidity(from, emptyDataBoxes, emptyStateContext))
+    def updateOutputHeight(box: ErgoBoxCandidate, value: Int): ErgoBoxCandidate = {
+      new ErgoBoxCandidate(box.value, box.ergoTree, value, box.additionalTokens, box.additionalRegisters)
+    }
+
+    def updateInputHeight(box: ErgoBox): ErgoBox = {
+      val creationHeight = scala.util.Random.nextInt(1000) + 1
+      new ErgoBox(box.value, box.ergoTree, box.additionalTokens, box.additionalRegisters,
+                  box.transactionId, box.index, creationHeight)
+    }
+
+    val txGen = boxesGenTemplate(minAssets = 0, maxAssets = 5, minInputs = 5, maxInputs = 10, propositionGen = trueLeafGen).map { case (boxes, _) =>
+      boxes.map(updateInputHeight)
+    }.map{ boxes =>
+      val fixed = Random.nextBoolean()
+      val maxHeight = boxes.map(_.creationHeight).max
+      val preUnsignedTx = validUnsignedTransactionFromBoxes(boxes)
+      val unsignedTx = if(fixed) {
+        preUnsignedTx.copy(outputCandidates = preUnsignedTx.outputCandidates.map{out =>
+          val creationHeight = maxHeight + Random.nextInt(3)
+          updateOutputHeight(out, creationHeight)
+        })
+      } else {
+        preUnsignedTx.copy(outputCandidates = preUnsignedTx.outputCandidates.map{out =>
+          val creationHeight = maxHeight - (Random.nextInt(maxHeight) + 1)
+          updateOutputHeight(out, creationHeight)
+        })
+      }
+      val tx = defaultProver.sign(unsignedTx, boxes, IndexedSeq.empty, emptyStateContext)
+        .map(ErgoTransaction.apply)
+        .get
+      (boxes, tx, fixed)
+    }
+
+    forAll(txGen){ case (boxes, tx, fixed) =>
+      // with initial block version == 1, monotonic rule does not work
+      tx.statefulValidity(boxes, IndexedSeq.empty, stateContextForTx(tx, blockVersion = 1)).isSuccess shouldBe true
+
+      // with pre-5.0 block version == 2, monotonic rule does not work as well
+      tx.statefulValidity(boxes, IndexedSeq.empty, stateContextForTx(tx, blockVersion = 2)).isSuccess shouldBe true
+
+      // starting from block version == 3, monotonic rule works,
+      // so validation fails if transaction is not following the rule (fixed == false)
+      val ctx3 = stateContextForTx(tx, blockVersion = 3)
+      if (fixed) {
+        tx.statefulValidity(boxes, IndexedSeq.empty, ctx3).isSuccess shouldBe true
+      } else {
+        val txFailure = tx.statefulValidity(boxes, IndexedSeq.empty, ctx3)
+        txFailure.isSuccess shouldBe false
+        val cause = txFailure.toEither.left.get.getMessage
+        val expectedMessage = ValidationRules.errorMessage(ValidationRules.txMonotonicHeight, "", emptyModifierId, Transaction.ModifierTypeId)
+        cause should startWith(expectedMessage)
+      }
+    }
   }
 
 }

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoTransactionGenerators.scala
@@ -232,11 +232,11 @@ trait ErgoTransactionGenerators extends ErgoGenerators with Generators {
     tokensDistribution.ensuring(_.forall(_.forall(_._2 > 0)))
   }
 
-  private def boxesGenTemplate(minAssets: Int,
-                               maxAssets: Int,
-                               minInputs: Int,
-                               maxInputs: Int,
-                               propositionGen: Gen[ErgoTree]): Gen[(IndexedSeq[ErgoBox], ErgoTree)] = for {
+  def boxesGenTemplate(minAssets: Int,
+                       maxAssets: Int,
+                       minInputs: Int,
+                       maxInputs: Int,
+                       propositionGen: Gen[ErgoTree]): Gen[(IndexedSeq[ErgoBox], ErgoTree)] = for {
     inputsCount <- Gen.choose(minInputs, maxInputs)
     tokensCount <- Gen.choose(
       minAssets,


### PR DESCRIPTION
In this PR, EIP-39 (https://github.com/ergoplatform/eips/pull/80) is implemented as follows:

* starting from block version #3 (5.0 soft-fork and after), the client is checking that for every output of a transaction, its creation height is not less than max creation height in inputs
* note, only inputs are considered, data inputs are not
* this rule is about soft-fork, as old nodes will continue to validate new blocks. So it will be activated in 5.0 soft-fork (can be merged with existing code even now). Also, the new rule is soft-forkable, so can be switched off (and so, replaced with another rule) via a soft-fork. 