### PR TITLE
i1854 additional mempool endpoints

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2879,6 +2879,222 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
+  /transactions/unconfirmed/{txId}:
+    parameters:
+      - in: path
+        name: txId
+        required: true
+        description: ID of a transaction in question
+        schema:
+          type: string
+    head:
+      summary: Check if given transaction is unconfirmed in pool
+      operationId: checkUnconfirmedTransaction
+      tags:
+        - transactions
+      responses:
+        '200':
+          description: Transaction is in pool
+        '404':
+          description: Transaction is not in pool
+
+  /transactions/unconfirmed/byTransactionId/{txId}:
+    parameters:
+      - in: path
+        name: txId
+        required: true
+        description: ID of a transaction in question
+        schema:
+          type: string
+    get:
+      summary: Get unconfirmed transaction from pool
+      operationId: getUnconfirmedTransactionById
+      tags:
+        - transactions
+      responses:
+        '200':
+          description: Ergo transaction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErgoTransaction'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /transactions/unconfirmed/byErgoTree:
+    post:
+      summary: Finds unconfirmed transactions by ErgoTree of one of its output or input boxes (if present in UtxoState)
+      operationId: getUnconfirmedTransactionsByErgoTree
+      tags:
+        - transactions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              example: '"100204a00b08cd021cf943317b0fdb50f60892a46b9132b9ced337c7de79248b104b293d9f1f078eea02d192a39a8cc7a70173007301"'
+      responses:
+        '200':
+          description: Ergo transaction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transactions'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /transactions/unconfirmed/inputs/byBoxId/{boxId}:
+    parameters:
+      - in: path
+        name: boxId
+        required: true
+        description: ID of an input box in question
+        schema:
+          type: string
+    get:
+      summary: Get input box from unconfirmed transactions in pool
+      operationId: getUnconfirmedTransactionInputBoxById
+      tags:
+        - inputs
+      responses:
+        '200':
+          description: Unspent Ergo Box that is to be used as Input in unconfirmed tx
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErgoTransactionOutput'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /transactions/unconfirmed/outputs/byBoxId/{boxId}:
+    parameters:
+      - in: path
+        name: boxId
+        required: true
+        description: ID of an output box in question
+        schema:
+          type: string
+    get:
+      summary: Get output box from unconfirmed transactions in pool
+      operationId: getUnconfirmedTransactionOutputBoxById
+      tags:
+        - outputs
+      responses:
+        '200':
+          description: Unspent Ergo Box that is to be created by unconfirmed tx
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErgoTransactionOutput'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /transactions/unconfirmed/outputs/byErgoTree:
+    post:
+      summary: Finds all output boxes by ErgoTree hex among unconfirmed transactions
+      operationId: getUnconfirmedTransactionOutputBoxesByErgoTree
+      tags:
+        - outputs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              example: '"100204a00b08cd021cf943317b0fdb50f60892a46b9132b9ced337c7de79248b104b293d9f1f078eea02d192a39a8cc7a70173007301"'
+      responses:
+        '200':
+          description: Unconfirmed transaction output boxes that correspond to given ErgoTree hex
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: ErgoBox
+                  $ref: '#/components/schemas/ErgoTransactionOutput'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /transactions/unconfirmed/outputs/byTokenId/{tokenId}:
+    parameters:
+      - in: path
+        name: tokenId
+        required: true
+        description: ID of a token in question
+        schema:
+          type: string
+    get:
+      summary: Get output box from unconfirmed transactions in pool by tokenId
+      operationId: getUnconfirmedTransactionOutputBoxesByTokenId
+      tags:
+        - outputs
+      responses:
+        '200':
+          description: Unspent Ergo Boxes that are to be created by unconfirmed tx and contain given token
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: ErgoBox
+                  $ref: '#/components/schemas/ErgoTransactionOutput'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /transactions/unconfirmed/outputs/byRegisters:
+    post:
+      summary: Finds all output boxes among unconfirmed transactions that contain given registers
+      operationId: getUnconfirmedTransactionOutputBoxesByRegisters
+      tags:
+        - outputs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Registers'
+      responses:
+        '200':
+          description: Unconfirmed transaction output boxes that contain given registers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: ErgoBox
+                  $ref: '#/components/schemas/ErgoTransactionOutput'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
   /transactions/poolHistogram:
     parameters:
       - in: query

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2930,6 +2930,25 @@ paths:
                 $ref: '#/components/schemas/ApiError'
 
   /transactions/unconfirmed/byErgoTree:
+    parameters:
+      - in: query
+        name: limit
+        required: false
+        description: The number of items in list to return
+        schema:
+          type: integer
+          format: int32
+          minimum: 10
+          maximum: 100
+          default: 50
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          default: 0
     post:
       summary: Finds unconfirmed transactions by ErgoTree hex of one of its output or input boxes (if present in UtxoState)
       operationId: getUnconfirmedTransactionsByErgoTree
@@ -3011,6 +3030,25 @@ paths:
                 $ref: '#/components/schemas/ApiError'
 
   /transactions/unconfirmed/outputs/byErgoTree:
+    parameters:
+      - in: query
+        name: limit
+        required: false
+        description: The number of items in list to return
+        schema:
+          type: integer
+          format: int32
+          minimum: 10
+          maximum: 100
+          default: 50
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          default: 0
     post:
       summary: Finds all output boxes by ErgoTree hex among unconfirmed transactions
       operationId: getUnconfirmedTransactionOutputBoxesByErgoTree
@@ -3071,6 +3109,25 @@ paths:
                 $ref: '#/components/schemas/ApiError'
 
   /transactions/unconfirmed/outputs/byRegisters:
+    parameters:
+      - in: query
+        name: limit
+        required: false
+        description: The number of items in list to return
+        schema:
+          type: integer
+          format: int32
+          minimum: 10
+          maximum: 100
+          default: 50
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          default: 0
     post:
       summary: Finds all output boxes among unconfirmed transactions that contain given registers
       operationId: getUnconfirmedTransactionOutputBoxesByRegisters

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2927,7 +2927,7 @@ paths:
 
   /transactions/unconfirmed/byErgoTree:
     post:
-      summary: Finds unconfirmed transactions by ErgoTree of one of its output or input boxes (if present in UtxoState)
+      summary: Finds unconfirmed transactions by ErgoTree hex of one of its output or input boxes (if present in UtxoState)
       operationId: getUnconfirmedTransactionsByErgoTree
       tags:
         - transactions

--- a/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
@@ -1,20 +1,29 @@
 package org.ergoplatform.http.api
 
 import akka.actor.{ActorRef, ActorRefFactory}
-import akka.http.scaladsl.server.{Directive, Route}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{Directive, Directive1, Route, ValidationRejection}
 import akka.pattern.ask
 import io.circe.Json
 import io.circe.syntax._
+import org.ergoplatform.ErgoBox.{BoxId, NonMandatoryRegisterId, TokenId}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.mempool.HistogramStats.getFeeHistogram
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
+import org.ergoplatform.settings.{Algos, ErgoSettings}
 import scorex.core.api.http.ApiError.BadRequest
-import scorex.core.api.http.ApiResponse
+import scorex.core.api.http.{ApiError, ApiResponse}
 import scorex.core.settings.RESTApiSettings
+import scorex.crypto.authds.ADKey
+import scorex.crypto.hash.Digest32
+import scorex.util.encode.Base16
+import sigmastate.SType
+import sigmastate.Values.EvaluatedValue
 
 import scala.concurrent.Future
+import scala.util.Success
 
 case class TransactionsApiRoute(readersHolder: ActorRef,
                                 nodeViewActorRef: ActorRef,
@@ -25,9 +34,39 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
 
   val txPaging: Directive[(Int, Int)] = parameters("offset".as[Int] ? 0, "limit".as[Int] ? 50)
 
+  val boxId: Directive1[BoxId] = pathPrefix(Segment).flatMap(handleBoxId)
+
+  private def handleBoxId(value: String): Directive1[BoxId] = {
+    ADKey @@ Base16.decode(value) match {
+      case Success(boxId) =>
+        provide(boxId)
+      case _ =>
+        reject(ValidationRejection("Wrong boxId format, it should be hex string"))
+    }
+  }
+
+  val tokenId: Directive1[TokenId] = pathPrefix(Segment).flatMap(handleTokenId)
+
+  private def handleTokenId(value: String): Directive1[TokenId] = {
+    Digest32 @@ Algos.decode(value) match {
+      case Success(tokenId) =>
+        provide(tokenId)
+      case _ =>
+        reject(ValidationRejection("Wrong tokenId format, it should be hex string"))
+    }
+  }
+
   override val route: Route = pathPrefix("transactions") {
     checkTransactionR ~
+      getUnconfirmedOutputByRegistersR ~
+      getUnconfirmedOutputByTokenIdR ~
+      getUnconfirmedOutputByErgoTreeR ~
+      getUnconfirmedOutputByBoxIdR ~
+      getUnconfirmedInputByBoxIdR ~
+      getUnconfirmedTxByErgoTreeR ~
+      getUnconfirmedTxByIdR ~
       getUnconfirmedTransactionsR ~
+      unconfirmedContainsR ~
       sendTransactionR ~
       getFeeHistogramR ~
       getRecommendedFeeR ~
@@ -35,6 +74,8 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
   }
 
   private def getMemPool: Future[ErgoMemPoolReader] = (readersHolder ? GetReaders).mapTo[Readers].map(_.m)
+
+  private def getState: Future[ErgoStateReader] = (readersHolder ? GetReaders).mapTo[Readers].map(_.s)
 
   private def getUnconfirmedTransactions(offset: Int, limit: Int): Future[Json] = getMemPool.map { p =>
     p.getAll.slice(offset, offset + limit).map(_.transaction.asJson).asJson
@@ -65,10 +106,6 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
     validateTransactionAndProcess(tx)(validTx => ApiResponse(validTx.transaction.id))
   }
 
-  def getUnconfirmedTransactionsR: Route = (path("unconfirmed") & get & txPaging) { (offset, limit) =>
-    ApiResponse(getUnconfirmedTransactions(offset, limit))
-  }
-
   val feeHistogramParameters: Directive[(Int, Long)] = parameters("bins".as[Int] ? 10, "maxtime".as[Long] ? (60*1000L))
 
   def getFeeHistogramR: Route = (path("poolHistogram") & get & feeHistogramParameters) { (bins, maxtime) =>
@@ -86,5 +123,121 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
   def getExpectedWaitTimeR: Route = (path("waitTime") & get & waitTimeRequestParameters) { (fee, txSize) =>
     ApiResponse(getMemPool.map(_.getExpectedWaitTime(fee,txSize).asJson))
   }
+
+  /** Unconfirmed Txs */
+
+  /** Check whether given transaction is present in mempool without returning it */
+  def unconfirmedContainsR: Route = (pathPrefix("unconfirmed") & head & modifierId) { modifierId =>
+    ApiResponse(getMemPool.map(_.modifierById(modifierId)))
+  }
+
+  /** Get unconfirmed transactions at given offset and limit*/
+  def getUnconfirmedTransactionsR: Route = (path("unconfirmed") & get & txPaging) { (offset, limit) =>
+    ApiResponse(getUnconfirmedTransactions(offset, limit))
+  }
+
+  /** Get unconfirmed transaction by its id */
+  def getUnconfirmedTxByIdR: Route =
+    (pathPrefix("unconfirmed" / "byTransactionId") & get & modifierId) { modifierId =>
+      ApiResponse(getMemPool.map(_.modifierById(modifierId)))
+    }
+
+  /** Collect all transactions which inputs or outputs contain given ErgoTree hex */
+  def getUnconfirmedTxByErgoTreeR: Route =
+    (pathPrefix("unconfirmed" / "byErgoTree") & post & entity(as[Json])) { body =>
+      body.as[String] match {
+        case Left(ex) =>
+          ApiError(StatusCodes.BadRequest, ex.getMessage())
+        case Right(ergoTree) =>
+          ApiResponse(
+            getMemPool.flatMap { pool =>
+              val allTxs = pool.getAll
+              val txsWithOutputMatch =
+                allTxs
+                  .collect { case tx if tx.transaction.outputs.exists(_.ergoTree.bytesHex == ergoTree) =>
+                    tx.transaction
+                  }.toSet
+
+              getState.map {
+                case state: UtxoStateReader =>
+                  val txWithInputMatch =
+                    allTxs
+                      .collect { case tx if
+                          tx.transaction.inputs.exists(i => state.boxById(i.boxId).exists(_.ergoTree.bytesHex == ergoTree)) =>
+                        tx.transaction
+                      }
+                  txsWithOutputMatch ++ txWithInputMatch
+                case _ =>
+                  txsWithOutputMatch
+              }
+            }
+          )
+      }
+  }
+
+  /** Get input box by box id from unconfirmed transactions */
+  def getUnconfirmedInputByBoxIdR: Route =
+    (pathPrefix("unconfirmed" / "inputs" / "byBoxId") & get & boxId) { boxId =>
+      ApiResponse(
+        getMemPool.flatMap { pool =>
+          getState.map {
+            case state: UtxoStateReader =>
+              pool.getAll
+                .flatMap(_.transaction.inputs.filter(_.boxId.sameElements(boxId)).flatMap(i => state.boxById(i.boxId).toList))
+                .headOption
+            case _ =>
+              Option.empty
+          }
+        }
+      )
+    }
+
+  /** Get output box by box id from unconfirmed transactions */
+  def getUnconfirmedOutputByBoxIdR: Route =
+    (pathPrefix("unconfirmed" / "outputs" / "byBoxId") & get & boxId) { boxId =>
+      ApiResponse(
+        getMemPool.map(_.getAll.flatMap(_.transaction.outputs.filter(_.id.sameElements(boxId))).headOption)
+      )
+    }
+
+  /** Collect all tx outputs which contain given ErgoTree hex */
+  def getUnconfirmedOutputByErgoTreeR: Route =
+    (pathPrefix("unconfirmed" / "outputs" / "byErgoTree") & post & entity(as[Json])) { body =>
+      body.as[String] match {
+        case Left(ex) =>
+          ApiError(StatusCodes.BadRequest, ex.getMessage())
+        case Right(ergoTree) =>
+          ApiResponse(
+            getMemPool.map(_.getAll.flatMap(_.transaction.outputs.filter(_.ergoTree.bytesHex == ergoTree)))
+          )
+      }
+    }
+
+  /** Collect all tx outputs which contain given TokenId hex */
+  def getUnconfirmedOutputByTokenIdR: Route =
+    (pathPrefix("unconfirmed" / "outputs" / "byTokenId") & get & tokenId) { tokenId =>
+      ApiResponse(
+        getMemPool.map(_.getAll.flatMap(_.transaction.outputs.filter(_.additionalTokens.exists(_._1.sameElements(tokenId)))))
+      )
+    }
+
+  /** Collect all tx outputs which contain all given Registers */
+  def getUnconfirmedOutputByRegistersR: Route =
+    (pathPrefix("unconfirmed" / "outputs" / "byRegisters") & post & entity(as[Json])) { body =>
+      body.as[Map[NonMandatoryRegisterId, EvaluatedValue[SType]]] match {
+        case Left(ex) =>
+          ApiError(StatusCodes.BadRequest, ex.getMessage())
+        case Right(registers) if registers.isEmpty =>
+          ApiError(StatusCodes.BadRequest, "Registers filter cannot be empty")
+        case Right(registers) =>
+          ApiResponse(
+            getMemPool.map { pool =>
+              pool
+                .getAll
+                .flatMap(_.transaction.outputs.filter(o => registers.toSet.diff(o.additionalRegisters.toSet).isEmpty))
+            }
+          )
+      }
+    }
 
 }

--- a/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
@@ -151,7 +151,7 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
         case Right(ergoTree) =>
           ApiResponse(
             getMemPool.flatMap { pool =>
-              val allTxs = pool.getAll.slice(offset, offset + limit)
+              val allTxs = pool.getAll
               val txsWithOutputMatch =
                 allTxs
                   .collect { case tx if tx.transaction.outputs.exists(_.ergoTree.bytesHex == ergoTree) =>
@@ -169,7 +169,7 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
                   txsWithOutputMatch ++ txWithInputMatch
                 case _ =>
                   txsWithOutputMatch
-              }
+              }.map(_.slice(offset, offset + limit))
             }
           )
       }
@@ -209,7 +209,7 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
         case Right(ergoTree) =>
           ApiResponse(
             getMemPool
-              .map(_.getAll.slice(offset, offset + limit).flatMap(_.transaction.outputs.filter(_.ergoTree.bytesHex == ergoTree)))
+              .map(_.getAll.flatMap(_.transaction.outputs.filter(_.ergoTree.bytesHex == ergoTree)).slice(offset, offset + limit))
           )
       }
     }
@@ -234,8 +234,9 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
           ApiResponse(
             getMemPool.map { pool =>
               pool
-                .getAll.slice(offset, offset + limit)
+                .getAll
                 .flatMap(_.transaction.outputs.filter(o => registers.toSet.diff(o.additionalRegisters.toSet).isEmpty))
+                .slice(offset, offset + limit)
             }
           )
       }

--- a/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
@@ -1,13 +1,14 @@
 package org.ergoplatform.http.routes
 
-import java.net.InetSocketAddress
 import akka.actor.{Actor, Props}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.Json
 import io.circe.syntax._
-import org.ergoplatform.http.api.TransactionsApiRoute
+import org.ergoplatform.ErgoBox.{NonMandatoryRegisterId, TokenId}
+import org.ergoplatform.http.api.{ApiCodecs, TransactionsApiRoute}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetDataFromHistory, GetReaders, Readers}
 import org.ergoplatform.settings.Constants
@@ -16,13 +17,21 @@ import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, Input}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scorex.core.settings.RESTApiSettings
+import scorex.crypto.hash.Digest32
+import scorex.util.encode.Base16
+import sigmastate.SType
+import sigmastate.Values.{ByteArrayConstant, EvaluatedValue}
+import sigmastate.eval.Extensions._
+import sigmastate.eval._
 
+import java.net.InetSocketAddress
 import scala.concurrent.duration._
 
 class TransactionApiRouteSpec extends AnyFlatSpec
   with Matchers
   with ScalatestRouteTest
   with Stubs
+  with ApiCodecs
   with FailFastCirceSupport {
 
   val prefix = "/transactions"
@@ -34,7 +43,16 @@ class TransactionApiRouteSpec extends AnyFlatSpec
   val input = Input(inputBox.id, emptyProverResult)
   val dataInput = DataInput(input.boxId)
 
-  val output: ErgoBoxCandidate = new ErgoBoxCandidate(inputBox.value, Constants.TrueLeaf, creationHeight = 0)
+  val absentModifierId = "0000000000000000000000000000000000000000000000000000000000000000"
+  val tokens = List[(TokenId, Long)](Digest32 @@ inputBox.id -> 10)
+  val registers =
+    Map(
+      ErgoBox.R4 -> ByteArrayConstant("name".getBytes("UTF-8")),
+      ErgoBox.R5 -> ByteArrayConstant("4".getBytes("UTF-8")),
+    )
+
+  val output: ErgoBoxCandidate =
+     new ErgoBoxCandidate(inputBox.value, Constants.TrueLeaf, creationHeight = 0, tokens.toColl, registers)
   val tx: ErgoTransaction = ErgoTransaction(IndexedSeq(input), IndexedSeq(dataInput), IndexedSeq(output))
 
   val chainedInput = Input(tx.outputs.head.id, emptyProverResult)
@@ -106,7 +124,7 @@ class TransactionApiRouteSpec extends AnyFlatSpec
       }
   }
 
-  it should "get unconfirmed from mempool" in {
+  it should "get unconfirmed txs from mempool" in {
     Get(prefix + "/unconfirmed") ~> route ~> check {
       status shouldBe StatusCodes.OK
       memPool.take(50).map(_.transaction).toSeq shouldBe responseAs[Seq[ErgoTransaction]]
@@ -121,4 +139,165 @@ class TransactionApiRouteSpec extends AnyFlatSpec
       memPool.getAll.slice(offset, offset + limit).map(_.transaction) shouldBe responseAs[Seq[ErgoTransaction]]
     }
   }
+
+  it should "return unconfirmed tx by output ergoTree from mempool" in {
+    val searchedBox = txs.head.outputs.head.ergoTree.bytesHex
+    Post(prefix + s"/unconfirmed/byErgoTree", searchedBox) ~> route ~> check {
+      val expectedTxs = memPool.getAll.toSet.filter(_.transaction.outputs.exists(_.ergoTree.bytesHex == searchedBox))
+      val actualTxs = responseAs[Set[ErgoTransaction]]
+      status shouldBe StatusCodes.OK
+      expectedTxs.map(_.id) shouldBe actualTxs.map(_.id)
+      actualTxs.forall(tx => tx.outputs.map(_.ergoTree.bytesHex).contains(searchedBox)) shouldBe true
+    }
+  }
+
+  it should "return unconfirmed tx by input ergoTree from mempool" in {
+    val searchedBox = inputBox.ergoTree.bytesHex
+    Post(prefix + s"/unconfirmed/byErgoTree", searchedBox) ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val txs = responseAs[Set[ErgoTransaction]]
+      txs.forall { tx =>
+        tx.inputs.map(_.boxId).exists(_.sameElements(inputBox.id)) ||
+          tx.outputs.map(_.ergoTree.bytesHex).contains(searchedBox)
+      } shouldBe true
+    }
+  }
+
+  it should "return unconfirmed tx by absent ergoTree from mempool" in {
+    Post(prefix + s"/unconfirmed/byErgoTree", absentModifierId) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Seq[ErgoTransaction]] shouldBe List.empty
+    }
+  }
+
+  it should "return unconfirmed tx by id from mempool" in {
+    Get(prefix + s"/unconfirmed/byTransactionId/${txs.head.id}") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      memPool.modifierById(txs.head.id).get shouldBe responseAs[ErgoTransaction]
+    }
+  }
+
+  it should "return unconfirmed tx by absent id from mempool" in {
+    Get(prefix + s"/unconfirmed/byTransactionId/$absentModifierId") ~> route ~> check {
+      status shouldBe StatusCodes.NotFound
+    }
+  }
+
+  it should "return 200 if unconfirmed tx is present" in {
+    Head(prefix + s"/unconfirmed/${txs.head.id}") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  it should "return 404 if unconfirmed absent tx is present" in {
+    Head(prefix + s"/unconfirmed/$absentModifierId") ~> route ~> check {
+      status shouldBe StatusCodes.NotFound
+    }
+  }
+
+  it should "return unconfirmed input by boxId from mempool" in {
+    val searchedBox = inputBox.id
+    val searchedBoxEncoded = Base16.encode(searchedBox)
+    Get(prefix + s"/unconfirmed/inputs/byBoxId/$searchedBoxEncoded") ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("boxId").as[String] shouldEqual Right(searchedBoxEncoded)
+    }
+  }
+
+  it should "return unconfirmed output by boxId from mempool" in {
+    val searchedBox = txs.head.outputs.head.id
+    val searchedBoxEncoded = Base16.encode(searchedBox)
+    Get(prefix + s"/unconfirmed/outputs/byBoxId/$searchedBoxEncoded") ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("boxId").as[String] shouldEqual Right(searchedBoxEncoded)
+    }
+  }
+
+  it should "return unconfirmed output by ergoTree from mempool" in {
+    val searchedBox = txs.head.outputs.head
+    val searchedTree = searchedBox.ergoTree.bytesHex
+    Post(prefix + s"/unconfirmed/outputs/byErgoTree", searchedTree) ~> route ~> check {
+      val expectedOutputIds =
+        memPool.getAll
+          .flatMap(_.transaction.outputs)
+          .filter(_.ergoTree.bytesHex == searchedTree)
+          .map(b => Base16.encode(b.id)).toList
+      status shouldBe StatusCodes.OK
+      val actualOutputIds = responseAs[List[Json]].map(_.hcursor.downField("boxId").as[String].right.get)
+      actualOutputIds shouldEqual expectedOutputIds
+    }
+  }
+
+  it should "return unconfirmed output by tokenId from mempool" in {
+    val searchedToken = Base16.encode(tokens.head._1)
+    Get(prefix + s"/unconfirmed/outputs/byTokenId/$searchedToken") ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val actualOutputIds = responseAs[List[Json]].map(_.hcursor.downField("boxId").as[String].right.get)
+      actualOutputIds.nonEmpty shouldBe true
+      actualOutputIds shouldEqual List(Base16.encode(tx.outputs.head.id))
+    }
+  }
+
+  it should "return unconfirmed outputs by exact same registers" in {
+    val searchedRegs =
+      Map(
+        ErgoBox.R4 -> ByteArrayConstant("name".getBytes("UTF-8")),
+        ErgoBox.R5 -> ByteArrayConstant("4".getBytes("UTF-8")),
+      ).asJson
+
+    Post(prefix + s"/unconfirmed/outputs/byRegisters", searchedRegs) ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val actualBoxes = responseAs[List[Json]].flatMap(_.hcursor.downField("boxId").as[String].toOption)
+      actualBoxes.head shouldEqual Base16.encode(tx.outputs.head.id)
+    }
+  }
+
+  it should "return unconfirmed outputs by subset of registers" in {
+    val searchedRegs =
+      Map[NonMandatoryRegisterId, EvaluatedValue[_ <: SType]](
+        ErgoBox.R4 -> ByteArrayConstant("name".getBytes("UTF-8"))
+      ).asJson
+
+    Post(prefix + s"/unconfirmed/outputs/byRegisters", searchedRegs) ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val actualBoxes = responseAs[List[Json]].flatMap(_.hcursor.downField("boxId").as[String].toOption)
+      actualBoxes.head shouldEqual Base16.encode(tx.outputs.head.id)
+    }
+  }
+
+  it should "not return unconfirmed output by registers when one missing" in {
+    val searchedRegs =
+      Map(
+        ErgoBox.R4 -> ByteArrayConstant("name".getBytes("UTF-8")),
+        ErgoBox.R5 -> ByteArrayConstant("4".getBytes("UTF-8")),
+        ErgoBox.R6 -> ByteArrayConstant("description".getBytes("UTF-8")),
+      ).asJson
+
+    Post(prefix + s"/unconfirmed/outputs/byRegisters", searchedRegs) ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val actualBoxes = responseAs[List[Json]].flatMap(_.hcursor.downField("boxId").as[String].toOption)
+      actualBoxes shouldEqual List.empty
+    }
+  }
+
+  it should "not return unconfirmed outputs by registers with only key match" in {
+    val searchedRegs =
+      Map[NonMandatoryRegisterId, EvaluatedValue[_ <: SType]](
+        ErgoBox.R4 -> ByteArrayConstant("foo".getBytes("UTF-8"))
+      ).asJson
+
+    Post(prefix + s"/unconfirmed/outputs/byRegisters", searchedRegs) ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val actualBoxes = responseAs[List[Json]].flatMap(_.hcursor.downField("boxId").as[String].toOption)
+      actualBoxes shouldEqual List.empty
+    }
+  }
+
+  it should "not return unconfirmed outputs by empty registers" in {
+    val searchedRegs = Map.empty[NonMandatoryRegisterId, EvaluatedValue[_ <: SType]].asJson
+    Post(prefix + s"/unconfirmed/outputs/byRegisters", searchedRegs) ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
@@ -221,7 +221,7 @@ class TransactionApiRouteSpec extends AnyFlatSpec
         memPool.getAll
           .flatMap(_.transaction.outputs)
           .filter(_.ergoTree.bytesHex == searchedTree)
-          .map(b => Base16.encode(b.id)).toList
+          .map(b => Base16.encode(b.id)).take(50).toList
       status shouldBe StatusCodes.OK
       val actualOutputIds = responseAs[List[Json]].map(_.hcursor.downField("boxId").as[String].right.get)
       actualOutputIds shouldEqual expectedOutputIds


### PR DESCRIPTION
Closes #https://github.com/ergoplatform/ergo/issues/1854

I added the new endpoints under existing `/transactions/unconfirmed/` endpoint as it is all searching through unconfirmed transactions ... probably better than involving the new word `mempool`.

@MrStahlfelge I implemented it all besides :
```
POST: mempool/transactions/inputs/?check={true|false}
POST: mempool/transactions/outputs/?check={true|false}
```
As they seem hard to reason about, the description : 
>> Batch get a list of inputs filtered by multiple boxIds. If check=true it must check if boxIds list elements are present on mempool as inputs and only return a list of boxId of included ones.

says : "Either return Boxes Or only BoxIds if `check=true` and they are present in mempool. I'd be happy to implement something like this but imho it should be easier to reason about.