### PR TITLE
Wallet profile setting

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -305,6 +305,14 @@ ergo {
     # Enable this setting to handle re-emission tokens in the wallet properly,
     # e.g. doing transfers correctly in the presence of re-emission tokens
     checkEIP27 = false
+
+    # Wallet profile allows to say wallet what kind of load it should expect,
+    # and so spend memory on caches and Bloom filters accordingly.
+    # There are three options: user, exchange, appServer
+    # User profile is about ordinary planned usage.
+    # Exchange consumes ~20 MB of RAM for high-load ready Bloom filters
+    # AppServer is in between
+    profile = "user"
   }
 
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -554,8 +554,16 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
     }
 
   override def scanBlockUpdate(state: ErgoWalletState, block: ErgoFullBlock, dustLimit: Option[Long]): Try[ErgoWalletState] =
-      WalletScanLogic.scanBlockTransactions(state.registry, state.offChainRegistry, state.walletVars, block, state.outputsFilter, dustLimit)
-        .map { case (reg, offReg, updatedOutputsFilter) => state.copy(registry = reg, offChainRegistry = offReg, outputsFilter = Some(updatedOutputsFilter)) }
+      WalletScanLogic.scanBlockTransactions(
+        state.registry,
+        state.offChainRegistry,
+        state.walletVars,
+        block,
+        state.outputsFilter,
+        dustLimit,
+        ergoSettings.walletSettings.walletProfile).map { case (reg, offReg, updatedOutputsFilter) =>
+        state.copy(registry = reg, offChainRegistry = offReg, outputsFilter = Some(updatedOutputsFilter))
+      }
 
   override def updateUtxoState(state: ErgoWalletState): ErgoWalletState = {
     (state.mempoolReaderOpt, state.stateReaderOpt) match {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletCache.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 final case class WalletCache(publicKeyAddresses: Seq[P2PKAddress],
                              trackedPubKeys: Seq[ExtendedPublicKey],
                              trackedBytes: Seq[Array[Byte]],
-                             pkFilter: BloomFilter[Array[Byte]])(implicit val settings: ErgoSettings) {
+                             scriptsFilter: BloomFilter[Array[Byte]])(implicit val settings: ErgoSettings) {
 
   implicit val addressEncoder: ErgoAddressEncoder = settings.addressEncoder
 
@@ -37,9 +37,9 @@ final case class WalletCache(publicKeyAddresses: Seq[P2PKAddress],
     val updTrackedBytes: Seq[Array[Byte]] = trackedBytes :+ newPkBytes
 
     // update filter
-    pkFilter.put(newPkBytes)
+    scriptsFilter.put(newPkBytes)
 
-    WalletCache(updAddresses, updTrackedPubKeys, updTrackedBytes, pkFilter)
+    WalletCache(updAddresses, updTrackedPubKeys, updTrackedBytes, scriptsFilter)
   }
 
 }
@@ -94,10 +94,10 @@ object WalletCache {
   def apply(trackedPubKeys: Seq[ExtendedPublicKey], settings: ErgoSettings): WalletCache = {
     val tbs = trackedBytes(trackedPubKeys)
     val msBytes = miningScripts(trackedPubKeys, settings).map(_.bytes)
-    val pkFilter = createScriptsFilter(tbs, msBytes, settings.walletSettings.walletProfile)
+    val scriptsFilter = createScriptsFilter(tbs, msBytes, settings.walletSettings.walletProfile)
     val pka = publicKeyAddresses(trackedPubKeys, settings.addressEncoder)
 
-    WalletCache(pka, trackedPubKeys, tbs, pkFilter)(settings)
+    WalletCache(pka, trackedPubKeys, tbs, scriptsFilter)(settings)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletCache.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 final case class WalletCache(publicKeyAddresses: Seq[P2PKAddress],
                              trackedPubKeys: Seq[ExtendedPublicKey],
                              trackedBytes: Seq[Array[Byte]],
-                             filter: BloomFilter[Array[Byte]])(implicit val settings: ErgoSettings) {
+                             pkFilter: BloomFilter[Array[Byte]])(implicit val settings: ErgoSettings) {
 
   implicit val addressEncoder: ErgoAddressEncoder = settings.addressEncoder
 
@@ -37,9 +37,9 @@ final case class WalletCache(publicKeyAddresses: Seq[P2PKAddress],
     val updTrackedBytes: Seq[Array[Byte]] = trackedBytes :+ newPkBytes
 
     // update filter
-    filter.put(newPkBytes)
+    pkFilter.put(newPkBytes)
 
-    WalletCache(updAddresses, updTrackedPubKeys, updTrackedBytes, filter)
+    WalletCache(updAddresses, updTrackedPubKeys, updTrackedBytes, pkFilter)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletProfile.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletProfile.scala
@@ -1,0 +1,46 @@
+package org.ergoplatform.nodeView.wallet
+
+import scorex.util.ScorexLogging
+
+
+sealed trait WalletProfile {
+  def label: String
+
+  def scriptsFilterSize: Int
+
+  def outputsFilterSize: Int
+}
+
+object WalletProfile extends ScorexLogging {
+
+  case object User extends WalletProfile {
+    override val label = "user"
+    override def scriptsFilterSize: Int = 1000
+    override def outputsFilterSize: Int = 10000
+  }
+
+  case object Exchange extends WalletProfile {
+    override val label = "exchange"
+    override def scriptsFilterSize: Int = 1000000
+    override def outputsFilterSize: Int = 10000000
+  }
+
+  case object AppServer extends WalletProfile {
+    override val label = "appServer"
+    override def scriptsFilterSize: Int = 200000
+    override def outputsFilterSize: Int = 2000000
+  }
+
+  def fromLabel(label: String): WalletProfile = {
+    label match {
+      case s: String if s == User.label => User
+      case s: String if s == Exchange.label => Exchange
+      case s: String if s == AppServer.label => AppServer
+      case a =>
+        log.error(s"For wallet profiles, only ${User.label}, ${Exchange.label}, ${AppServer.label} are expected, $a given")
+        ???
+    }
+  }
+}
+
+

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletProfile.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletProfile.scala
@@ -2,32 +2,55 @@ package org.ergoplatform.nodeView.wallet
 
 import scorex.util.ScorexLogging
 
-
+/**
+  * Hierarchy of possible wallet profile options. Wallet profile indicates intended use case for the node wallet
+  */
 sealed trait WalletProfile {
+
+  /**
+    * @return name of the wallet profile
+    */
   def label: String
 
+  /**
+    * @return size of wallet scripts (P2PK and mining) Bloom filter. If wallet is going to use more scripts, efficiency
+    *         of the filter sharply decreasing
+    */
   def scriptsFilterSize: Int
 
+  /**
+    * @return size of Bloom filter on top of unspent wallet outputs. With outputs above the limit, efficiency
+    *         of the filter sharply decreasing
+    */
   def outputsFilterSize: Int
 }
 
 object WalletProfile extends ScorexLogging {
 
+  /**
+    * Wallet profile for ordinary single-user use case, consumes minimum RAM
+    */
   case object User extends WalletProfile {
     override val label = "user"
     override def scriptsFilterSize: Int = 1000
     override def outputsFilterSize: Int = 10000
   }
 
+  /**
+    * Wallet profile for exchange with a lot of users, consumes ~20 MB RAM for Bloom filters only
+    */
   case object Exchange extends WalletProfile {
     override val label = "exchange"
     override def scriptsFilterSize: Int = 1000000
     override def outputsFilterSize: Int = 10000000
   }
 
+  /**
+    * Wallet profile for serving applications, caches and filers sizes are between User and Exchange profiles values
+    */
   case object AppServer extends WalletProfile {
     override val label = "appServer"
-    override def scriptsFilterSize: Int = 200000
+    override def scriptsFilterSize: Int = 50000
     override def outputsFilterSize: Int = 2000000
   }
 
@@ -41,6 +64,5 @@ object WalletProfile extends ScorexLogging {
         ???
     }
   }
+
 }
-
-

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletScanLogic.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletScanLogic.scala
@@ -76,8 +76,6 @@ object WalletScanLogic extends ScorexLogging {
     // Take unspent wallet outputs Bloom Filter from cache
     // or recreate it from unspent outputs stored in the database
     val outputsFilter = cachedOutputsFilter.getOrElse {
-      // todo: currently here and other places hardcoded values are used for Bloom filter parameters
-      // todo: consider different profiles for the config, such as "user", "wallet", "app hub"
       val bf = WalletCache.emptyFilter(walletProfile.outputsFilterSize)
 
       registry.allUnspentBoxes().foreach { tb =>
@@ -200,7 +198,7 @@ object WalletScanLogic extends ScorexLogging {
       val boxScript = bx.propositionBytes
 
       // then check whether Bloom filter built on top of payment & mining scripts of the p2pk-wallet
-      val statuses: Set[ScanId] = if (walletVars.pkFilter.mightContain(boxScript)) {
+      val statuses: Set[ScanId] = if (walletVars.scriptsFilter.mightContain(boxScript)) {
 
         // first, we are checking mining script
         val miningIncomeTriggered = miningScriptsBytes.exists(ms => boxScript.sameElements(ms))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletScanLogic.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletScanLogic.scala
@@ -44,11 +44,11 @@ object WalletScanLogic extends ScorexLogging {
                             walletVars: WalletVars,
                             block: ErgoFullBlock,
                             cachedOutputsFilter: Option[BloomFilter[Array[Byte]]],
-                            dustLimit: Option[Long]
-                           ): Try[(WalletRegistry, OffChainRegistry, BloomFilter[Array[Byte]])] = {
+                            dustLimit: Option[Long],
+                            walletProfile: WalletProfile): Try[(WalletRegistry, OffChainRegistry, BloomFilter[Array[Byte]])] = {
     scanBlockTransactions(
       registry, offChainRegistry, walletVars,
-      block.height, block.id, block.transactions, cachedOutputsFilter, dustLimit)
+      block.height, block.id, block.transactions, cachedOutputsFilter, dustLimit, walletProfile)
   }
 
   /**
@@ -70,15 +70,15 @@ object WalletScanLogic extends ScorexLogging {
                             blockId: ModifierId,
                             transactions: Seq[ErgoTransaction],
                             cachedOutputsFilter: Option[BloomFilter[Array[Byte]]],
-                            dustLimit: Option[Long]
-                           ): Try[(WalletRegistry, OffChainRegistry, BloomFilter[Array[Byte]])] = {
+                            dustLimit: Option[Long],
+                            walletProfile: WalletProfile): Try[(WalletRegistry, OffChainRegistry, BloomFilter[Array[Byte]])] = {
 
     // Take unspent wallet outputs Bloom Filter from cache
     // or recreate it from unspent outputs stored in the database
     val outputsFilter = cachedOutputsFilter.getOrElse {
       // todo: currently here and other places hardcoded values are used for Bloom filter parameters
       // todo: consider different profiles for the config, such as "user", "wallet", "app hub"
-      val bf = WalletCache.emptyFilter(expectedKeys = 20000)
+      val bf = WalletCache.emptyFilter(walletProfile.outputsFilterSize)
 
       registry.allUnspentBoxes().foreach { tb =>
         bf.put(tb.box.id)
@@ -200,7 +200,7 @@ object WalletScanLogic extends ScorexLogging {
       val boxScript = bx.propositionBytes
 
       // then check whether Bloom filter built on top of payment & mining scripts of the p2pk-wallet
-      val statuses: Set[ScanId] = if (walletVars.filter.mightContain(boxScript)) {
+      val statuses: Set[ScanId] = if (walletVars.pkFilter.mightContain(boxScript)) {
 
         // first, we are checking mining script
         val miningIncomeTriggered = miningScriptsBytes.exists(ms => boxScript.sameElements(ms))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -41,7 +41,7 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
   val miningScriptsBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.miningScriptsBytes).getOrElse(Seq.empty)
 
   val filter: BloomFilter[Array[Byte]] =
-    stateCacheOpt.map(_.filter).getOrElse(WalletCache.emptyFilter())
+    stateCacheOpt.map(_.pkFilter).getOrElse(WalletCache.emptyFilter())
 
   def removeScan(scanId: ScanId): WalletVars = {
     this.copy(externalScans = this.externalScans.filter(_.scanId != scanId))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -40,8 +40,10 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
 
   val miningScriptsBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.miningScriptsBytes).getOrElse(Seq.empty)
 
-  val filter: BloomFilter[Array[Byte]] =
-    stateCacheOpt.map(_.pkFilter).getOrElse(WalletCache.emptyFilter())
+  val pkFilter: BloomFilter[Array[Byte]] =
+    stateCacheOpt
+      .map(_.pkFilter)
+      .getOrElse(WalletCache.emptyFilter(settings.walletSettings.walletProfile.outputsFilterSize))
 
   def removeScan(scanId: ScanId): WalletVars = {
     this.copy(externalScans = this.externalScans.filter(_.scanId != scanId))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -40,10 +40,10 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
 
   val miningScriptsBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.miningScriptsBytes).getOrElse(Seq.empty)
 
-  val pkFilter: BloomFilter[Array[Byte]] =
+  val scriptsFilter: BloomFilter[Array[Byte]] =
     stateCacheOpt
-      .map(_.pkFilter)
-      .getOrElse(WalletCache.emptyFilter(settings.walletSettings.walletProfile.outputsFilterSize))
+      .map(_.scriptsFilter)
+      .getOrElse(WalletCache.emptyFilter(settings.walletSettings.walletProfile.scriptsFilterSize))
 
   def removeScan(scanId: ScanId): WalletVars = {
     this.copy(externalScans = this.externalScans.filter(_.scanId != scanId))

--- a/src/main/scala/org/ergoplatform/settings/WalletSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/WalletSettings.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.settings
 
+import org.ergoplatform.nodeView.wallet.WalletProfile
 import org.ergoplatform.wallet.settings.SecretStorageSettings
 
 case class WalletSettings(secretStorage: SecretStorageSettings,
@@ -15,4 +16,9 @@ case class WalletSettings(secretStorage: SecretStorageSettings,
                           testKeysQty: Option[Int] = None,
                           // Some(Seq(x)) burns all except x, Some(Seq.empty) burns all, None ignores that feature
                           tokensWhitelist: Option[Seq[String]] = None,
-                          checkEIP27: Boolean = false)
+                          checkEIP27: Boolean = false,
+                          profile: String = WalletProfile.User.label) {
+
+  val walletProfile: WalletProfile = WalletProfile.fromLabel(profile)
+
+}

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletProfileSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletProfileSpec.scala
@@ -1,0 +1,20 @@
+package org.ergoplatform.nodeView.wallet
+
+import org.ergoplatform.utils.ErgoPropertyTest
+
+import scala.util.Try
+
+class WalletProfileSpec extends ErgoPropertyTest {
+  property("fromLabel getting profiles properly") {
+    WalletProfile.fromLabel("user").outputsFilterSize shouldBe WalletProfile.User.outputsFilterSize
+    WalletProfile.fromLabel("user").scriptsFilterSize shouldBe WalletProfile.User.scriptsFilterSize
+
+    WalletProfile.fromLabel("exchange").scriptsFilterSize should not be WalletProfile.User.scriptsFilterSize
+    WalletProfile.fromLabel("exchange").outputsFilterSize shouldBe WalletProfile.Exchange.outputsFilterSize
+    WalletProfile.fromLabel("exchange").scriptsFilterSize shouldBe WalletProfile.Exchange.scriptsFilterSize
+
+    Try(WalletProfile.fromLabel("appserver")).isFailure shouldBe true
+    WalletProfile.fromLabel("appServer").outputsFilterSize shouldBe WalletProfile.AppServer.outputsFilterSize
+    WalletProfile.fromLabel("appServer").scriptsFilterSize shouldBe WalletProfile.AppServer.scriptsFilterSize
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletScanLogicSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletScanLogicSpec.scala
@@ -128,7 +128,8 @@ class WalletScanLogicSpec extends ErgoPropertyTest with DBSpec with WalletTestOp
       val height0 = 5
       //simplest case - we're scanning an empty block
       val (r0, o0, f0) =
-        scanBlockTransactions(emptyReg, emptyOff, walletVars, height0, blockId, Seq.empty, None, None).get
+        scanBlockTransactions(emptyReg, emptyOff, walletVars, height0, blockId,
+                              Seq.empty, None, None, WalletProfile.User).get
       val r0digest = r0.fetchDigest()
       r0digest.walletBalance shouldBe 0
       r0digest.walletAssetBalances.size shouldBe 0
@@ -152,7 +153,8 @@ class WalletScanLogicSpec extends ErgoPropertyTest with DBSpec with WalletTestOp
         val offDigestBefore = off.digest.walletBalance
 
         val (r1, o1, f1) =
-          scanBlockTransactions(registry, off, walletVars, height1, blockId, txs, Some(f0), None).get
+          scanBlockTransactions(registry, off, walletVars, height1, blockId,
+                                txs, Some(f0), None, WalletProfile.User).get
         val r1digest = r1.fetchDigest()
         r1digest.walletBalance shouldBe (regDigestBefore + trackedTransaction.paymentValues.sum)
         r1digest.walletAssetBalances.size shouldBe 0
@@ -172,7 +174,8 @@ class WalletScanLogicSpec extends ErgoPropertyTest with DBSpec with WalletTestOp
         val spendingTx = ErgoTransaction(inputs, IndexedSeq.empty, tx.outputCandidates)
 
         val (r2, o2, f2) =
-          scanBlockTransactions(registry, off, walletVars, height1 + 1, blockId, Seq(spendingTx), Some(f1), None).get
+          scanBlockTransactions(registry, off, walletVars, height1 + 1, blockId,
+                                Seq(spendingTx), Some(f1), None, WalletProfile.User).get
 
         val r2digest = r2.fetchDigest()
         r2digest.walletBalance shouldBe (regDigestBefore + trackedTransaction.paymentValues.sum)
@@ -193,7 +196,8 @@ class WalletScanLogicSpec extends ErgoPropertyTest with DBSpec with WalletTestOp
         val spendingTx2 = new ErgoTransaction(inputs2, IndexedSeq.empty, outputs2)
 
         val (r3, o3, f3) =
-          scanBlockTransactions(registry, off, walletVars, height1 + 2, blockId, Seq(spendingTx2), Some(f2), None).get
+          scanBlockTransactions(registry, off, walletVars, height1 + 2, blockId,
+                                Seq(spendingTx2), Some(f2), None, WalletProfile.User).get
 
         val r3digest = r3.fetchDigest()
         r3digest.walletBalance shouldBe regDigestBefore
@@ -212,7 +216,8 @@ class WalletScanLogicSpec extends ErgoPropertyTest with DBSpec with WalletTestOp
         val threeTxs = Seq(creatingTx, spendingTx, spendingTx2)
 
         val (r4, o4, _) =
-          scanBlockTransactions(registry, off, walletVars, height1 + 3, blockId, threeTxs, Some(f3), None).get
+          scanBlockTransactions(registry, off, walletVars, height1 + 3, blockId,
+                                threeTxs, Some(f3), None, WalletProfile.User).get
 
         val r4digest = r4.fetchDigest()
         r4digest.walletBalance shouldBe regDigestBefore


### PR DESCRIPTION
In this PR, wallet profile setting is introduced. It allows to spend RAM is wallet is used for ordinary single-user use cases, and also to handle high-load with spending more RAM on Bloom filters and other caches.

Possible wallet profiles: user, exchange, appServer