### PR TITLE
Dockerfile/Workflow: add support for aarch64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        
+      - name: qemu
+        uses: docker/setup-qemu-action@v1
+        
+      - uses: docker/setup-buildx-action@v1
 
       - name: Docker Login
         uses: docker/login-action@v1.10.0
@@ -29,5 +34,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/sbt:11.0.8_1.3.13 as builder
+FROM mozilla/sbt:11.0.13_1.6.2 as builder
 WORKDIR /mnt
 COPY build.sbt findbugs-exclude.xml ./
 COPY project/ project/
@@ -11,16 +11,17 @@ RUN sbt update
 COPY . ./
 RUN sbt assembly
 RUN mv `find target/scala-*/stripped/ -name ergo-*.jar` ergo.jar
-
-FROM openjdk:11-jre-slim
-RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
-RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatform" ergo && \
+FROM openjdk:11-oraclelinux8
+RUN microdnf --nodocs -y upgrade
+RUN microdnf --nodocs -y install --setopt=install_weak_deps=0 jq curl
+RUN microdnf clean all
+RUN adduser --home-dir /home/ergo --uid 9052 ergo && \
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
 USER ergo
-EXPOSE 9020 9052 9030 9053
+EXPOSE 9020 9021 9052 9030 9053
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G
-ENV _JAVA_OPTIONS "-Xmx${MAX_HEAP}"
+ENV _JAVA_OPTIONS "-Xms${MAX_HEAP} -Xmx${MAX_HEAP}"
 COPY --from=builder /mnt/ergo.jar /home/ergo/ergo.jar
 ENTRYPOINT ["java", "-jar", "/home/ergo/ergo.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/sbt:11.0.13_1.6.2 as builder
+FROM sbtscala/scala-sbt:eclipse-temurin-11.0.15_1.6.2_2.12.16 as builder
 WORKDIR /mnt
 COPY build.sbt findbugs-exclude.xml ./
 COPY project/ project/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,10 @@ RUN sbt update
 COPY . ./
 RUN sbt assembly
 RUN mv `find target/scala-*/stripped/ -name ergo-*.jar` ergo.jar
-FROM openjdk:11-oraclelinux8
-RUN microdnf --nodocs -y upgrade
-RUN microdnf --nodocs -y install --setopt=install_weak_deps=0 jq curl
-RUN microdnf clean all
-RUN adduser --home-dir /home/ergo --uid 9052 ergo && \
+
+FROM eclipse-temurin:11-jre-jammy
+RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatform" ergo && \
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
 USER ergo
 EXPOSE 9020 9021 9052 9030 9053

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
 RUN adduser --disabled-password --home /home/ergo --uid 9052 --gecos "ErgoPlatform" ergo && \
     install -m 0750 -o ergo -g ergo -d /home/ergo/.ergo
 USER ergo
-EXPOSE 9020 9021 9052 9030 9053
+EXPOSE 9020 9021 9022 9052 9030 9053
 WORKDIR /home/ergo
 VOLUME ["/home/ergo/.ergo"]
 ENV MAX_HEAP 3G


### PR DESCRIPTION
Similar to PR #1829 

- Changed to SBT version that has support for aarch64.

- Added port 9021 as it's being used in the new testnet.
 
- RE: openjdk docker image change: As per openjdk docker repo, starting with version 12, oraclelinux will be the default image. 
I'm using oracle image with version 11 here, because I found issues running this on RHEL-based systems with the other image.  Changed adduser command + jq/curl install commands since previous do not work with RHEL-based image.
 
- Added docker workflow to build/publish aarch64
 
- ( optional ) Changed min heap same as max for potential performance improvement as per:
https://blog.ycrash.io/2022/03/22/benefits-of-setting-initial-and-maximum-memory-size-to-the-same-value/

Inspiration for this PR:
ARM is a first-class citizen now, and provides increased performance for less cost at many datacentres, not to mention people can use this to run on Raspberry Pi / New Apple silicon systems.