### PR TITLE
#1778 Remove RegisterMessageSpecs

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -20,6 +20,7 @@ import scorex.core.api.http._
 import scorex.core.app.ScorexContext
 import scorex.core.network.NetworkController.ReceivableMessages.ShutdownNetwork
 import scorex.core.network._
+import scorex.core.network.message.Message.MessageCode
 import scorex.core.network.message._
 import scorex.core.network.peer.PeerManagerRef
 import scorex.core.settings.ScorexSettings
@@ -36,7 +37,10 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   private val ergoSettings: ErgoSettings = ErgoSettings.read(args)
 
-  require(ergoSettings.scorexSettings.restApi.apiKeyHash.isDefined, "API key hash must be set")
+  require(
+    ergoSettings.scorexSettings.restApi.apiKeyHash.isDefined,
+    "API key hash must be set"
+  )
 
   log.info(s"Working directory: ${ergoSettings.directory}")
   log.info(s"Secret directory: ${ergoSettings.walletSettings.secretStorage.secretDir}")
@@ -45,20 +49,25 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   overrideLogLevel()
 
-  implicit private val actorSystem: ActorSystem = ActorSystem(scorexSettings.network.agentName)
+  implicit private val actorSystem: ActorSystem = ActorSystem(
+    scorexSettings.network.agentName
+  )
   implicit private val executionContext: ExecutionContext = actorSystem.dispatcher
 
   private val timeProvider = new NetworkTimeProvider(scorexSettings.ntp)
 
   private val upnpGateway: Option[UPnPGateway] =
-    if (scorexSettings.network.upnpEnabled) UPnP.getValidGateway(scorexSettings.network) else None
+    if (scorexSettings.network.upnpEnabled) UPnP.getValidGateway(scorexSettings.network)
+    else None
   upnpGateway.foreach(_.addPort(scorexSettings.network.bindAddress.getPort))
 
   //an address to send to peers
   private val externalSocketAddress: Option[InetSocketAddress] =
-    scorexSettings.network.declaredAddress orElse {
-      upnpGateway.map(u => new InetSocketAddress(u.externalAddress, scorexSettings.network.bindAddress.getPort))
-    }
+  scorexSettings.network.declaredAddress orElse {
+    upnpGateway.map(u =>
+      new InetSocketAddress(u.externalAddress, scorexSettings.network.bindAddress.getPort)
+    )
+  }
 
   private val basicSpecs = {
     Seq(
@@ -70,19 +79,49 @@ class ErgoApp(args: Args) extends ScorexLogging {
     )
   }
 
+  // touch it to run preStart method of the actor which is in turn running schedulers
+  val ergoNodeViewSynchronizerRef = ErgoNodeViewSynchronizer(
+    networkControllerRef,
+    nodeViewHolderRef,
+    ErgoSyncInfoMessageSpec,
+    ergoSettings,
+    timeProvider,
+    syncTracker,
+    deliveryTracker
+  )
+
+  val messageHandlers: Map[MessageCode, ActorRef] = {
+    var map: Map[MessageCode, ActorRef] = Map(
+      InvSpec.messageCode                 -> ergoNodeViewSynchronizerRef,
+      RequestModifierSpec.messageCode     -> ergoNodeViewSynchronizerRef,
+      ModifiersSpec.messageCode           -> ergoNodeViewSynchronizerRef,
+      ErgoSyncInfoMessageSpec.messageCode -> ergoNodeViewSynchronizerRef
+    )
+    if (ergoSettings.scorexSettings.network.peerDiscovery) {
+      // Launching PeerSynchronizer actor which is then registering itself at network controller
+      map += PeersSpec.messageCode -> PeerSynchronizerRef(
+        "PeerSynchronizer",
+        networkControllerRef,
+        peerManagerRef,
+        scorexSettings.network
+      )
+    }
+    map
+  }
+
   private val additionalMessageSpecs: Seq[MessageSpec[_]] = Seq(ErgoSyncInfoMessageSpec)
 
   private val scorexContext = ScorexContext(
-    messageSpecs = basicSpecs ++ additionalMessageSpecs,
-    upnpGateway = upnpGateway,
-    timeProvider = timeProvider,
+    messageSpecs        = basicSpecs ++ additionalMessageSpecs,
+    upnpGateway         = upnpGateway,
+    timeProvider        = timeProvider,
     externalNodeAddress = externalSocketAddress
   )
 
   private val peerManagerRef = PeerManagerRef(ergoSettings, scorexContext)
 
-  private val networkControllerRef: ActorRef = NetworkControllerRef(
-    "networkController", ergoSettings, peerManagerRef, scorexContext)
+  private val networkControllerRef: ActorRef =
+    NetworkControllerRef("networkController", ergoSettings, peerManagerRef, scorexContext, messageHandlers)
 
   private val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, timeProvider)
 
@@ -96,45 +135,40 @@ class ErgoApp(args: Args) extends ScorexLogging {
       None
     }
 
-
   private val syncTracker = ErgoSyncTracker(scorexSettings.network, timeProvider)
-  private val statsCollectorRef: ActorRef = ErgoStatsCollectorRef(readersHolderRef, networkControllerRef, syncTracker, ergoSettings, timeProvider)
+
+  private val statsCollectorRef: ActorRef = ErgoStatsCollectorRef(
+    readersHolderRef,
+    networkControllerRef,
+    syncTracker,
+    ergoSettings,
+    timeProvider
+  )
   private val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(ergoSettings)
 
-  // touch it to run preStart method of the actor which is in turn running schedulers
-  ErgoNodeViewSynchronizer(
-    networkControllerRef,
-    nodeViewHolderRef,
-    ErgoSyncInfoMessageSpec,
-    ergoSettings,
-    timeProvider,
-    syncTracker,
-    deliveryTracker
-  )
-
-  if (ergoSettings.scorexSettings.network.peerDiscovery) {
-    // Launching PeerSynchronizer actor which is then registering itself at network controller
-    PeerSynchronizerRef("PeerSynchronizer", networkControllerRef, peerManagerRef, scorexSettings.network)
-  }
-
   private val apiRoutes: Seq[ApiRoute] = Seq(
-    EmissionApiRoute(ergoSettings),
-    ErgoUtilsApiRoute(ergoSettings),
-    ErgoPeersApiRoute(peerManagerRef, networkControllerRef, syncTracker, deliveryTracker, scorexSettings.restApi),
-    InfoApiRoute(statsCollectorRef, scorexSettings.restApi, timeProvider),
-    BlocksApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
-    NipopowApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
-    TransactionsApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
-    WalletApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
-    UtxoApiRoute(readersHolderRef, scorexSettings.restApi),
-    ScriptApiRoute(readersHolderRef, ergoSettings),
-    ScanApiRoute(readersHolderRef, ergoSettings),
-    NodeApiRoute(ergoSettings)
-  ) ++ minerRefOpt.map(minerRef => MiningApiRoute(minerRef, ergoSettings)).toSeq
-
+      EmissionApiRoute(ergoSettings),
+      ErgoUtilsApiRoute(ergoSettings),
+      ErgoPeersApiRoute(
+        peerManagerRef,
+        networkControllerRef,
+        syncTracker,
+        deliveryTracker,
+        scorexSettings.restApi
+      ),
+      InfoApiRoute(statsCollectorRef, scorexSettings.restApi, timeProvider),
+      BlocksApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
+      NipopowApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
+      TransactionsApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
+      WalletApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
+      UtxoApiRoute(readersHolderRef, scorexSettings.restApi),
+      ScriptApiRoute(readersHolderRef, ergoSettings),
+      ScanApiRoute(readersHolderRef, ergoSettings),
+      NodeApiRoute(ergoSettings)
+    ) ++ minerRefOpt.map(minerRef => MiningApiRoute(minerRef, ergoSettings)).toSeq
 
   private val swaggerRoute = SwaggerRoute(scorexSettings.restApi, swaggerConfig)
-  private val panelRoute = NodePanelRoute()
+  private val panelRoute   = NodePanelRoute()
 
   private val httpService = ErgoHttpService(apiRoutes, swaggerRoute, panelRoute)
 
@@ -154,8 +188,12 @@ class ErgoApp(args: Args) extends ScorexLogging {
     Some(ShutdownNetwork)
   )
 
-  coordinatedShutdown.addTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "stop-upnpGateway") { () =>
-    Future(upnpGateway.foreach(_.deletePort(scorexSettings.network.bindAddress.getPort))).map(_ => Done)
+  coordinatedShutdown.addTask(
+    CoordinatedShutdown.PhaseBeforeServiceUnbind,
+    "stop-upnpGateway"
+  ) { () =>
+    Future(upnpGateway.foreach(_.deletePort(scorexSettings.network.bindAddress.getPort)))
+      .map(_ => Done)
   }
 
   if (!ergoSettings.nodeSettings.stateType.requireProofs) {
@@ -167,12 +205,13 @@ class ErgoApp(args: Args) extends ScorexLogging {
     */
   private def overrideLogLevel() {
     val loggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    val root = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
+    val root          = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
 
     root.setLevel(Level.toLevel(ergoSettings.scorexSettings.logging.level))
   }
 
-  private def swaggerConfig: String = Source.fromResource("api/openapi.yaml").getLines.mkString("\n")
+  private def swaggerConfig: String =
+    Source.fromResource("api/openapi.yaml").getLines.mkString("\n")
 
   private def run(): Future[ServerBinding] = {
     require(scorexSettings.network.agentName.length <= ErgoApp.ApplicationNameLimit)
@@ -183,36 +222,41 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
     if (ergoSettings.chainSettings.reemission.checkReemissionRules) {
       log.info("Checking re-emission rules enabled")
-      log.info(s"EIP27 activation height: " + ergoSettings.chainSettings.reemission.activationHeight)
+      log.info(
+        s"EIP27 activation height: " + ergoSettings.chainSettings.reemission.activationHeight
+      )
     }
 
     val bindAddress = scorexSettings.restApi.bindAddress
 
-    Http().newServerAt(bindAddress.getAddress.getHostAddress, bindAddress.getPort).bindFlow(httpService.compositeRoute)
+    Http()
+      .newServerAt(bindAddress.getAddress.getHostAddress, bindAddress.getPort)
+      .bindFlow(httpService.compositeRoute)
   }
 }
 
 object ErgoApp extends ScorexLogging {
   val ApplicationNameLimit: Int = 50
+
   val argParser = new scopt.OptionParser[Args]("ergo") {
-      opt[String]("config")
-        .abbr("c")
-        .action((x, c) => c.copy(userConfigPathOpt = Some(x)))
-        .text("location of ergo node configuration")
-        .optional()
-      opt[Unit]("devnet")
-        .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.DevNet)))
-        .text("set network to devnet")
-        .optional()
-      opt[Unit]("testnet")
-        .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.TestNet)))
-        .text("set network to testnet")
-        .optional()
-      opt[Unit]("mainnet")
-        .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.MainNet)))
-        .text("set network to mainnet")
-        .optional()
-      help("help").text("prints this usage text")
+    opt[String]("config")
+      .abbr("c")
+      .action((x, c) => c.copy(userConfigPathOpt = Some(x)))
+      .text("location of ergo node configuration")
+      .optional()
+    opt[Unit]("devnet")
+      .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.DevNet)))
+      .text("set network to devnet")
+      .optional()
+    opt[Unit]("testnet")
+      .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.TestNet)))
+      .text("set network to testnet")
+      .optional()
+    opt[Unit]("mainnet")
+      .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.MainNet)))
+      .text("set network to mainnet")
+      .optional()
+    help("help").text("prints this usage text")
   }
 
   /** Internal failure causing shutdown */
@@ -228,8 +272,9 @@ object ErgoApp extends ScorexLogging {
   def forceStopApplication(code: Int = 1): Nothing = sys.exit(code)
 
   /** The only proper way of application shutdown after actor system initialization */
-  def shutdownSystem(reason: CoordinatedShutdown.Reason = InternalShutdown)
-                    (implicit system: ActorSystem): Future[Done] =
+  def shutdownSystem(
+    reason: CoordinatedShutdown.Reason = InternalShutdown
+  )(implicit system: ActorSystem): Future[Done] =
     CoordinatedShutdown(system).run(reason)
 
   def main(args: Array[String]): Unit = {

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -127,13 +127,17 @@ class ErgoApp(args: Args) extends ScorexLogging {
         ModifiersSpec.messageCode           -> ergoNodeViewSynchronizerRef,
         ErgoSyncInfoMessageSpec.messageCode -> ergoNodeViewSynchronizerRef
       )
+      // Launching PeerSynchronizer actor which is then registering itself at network controller
       if (ergoSettings.scorexSettings.network.peerDiscovery) {
-        // Launching PeerSynchronizer actor which is then registering itself at network controller
-        map += PeersSpec.messageCode -> PeerSynchronizerRef(
+        val psr = PeerSynchronizerRef(
           "PeerSynchronizer",
           networkControllerRef,
           peerManagerRef,
           scorexSettings.network
+        )
+        map ++= Map(
+          PeersSpec.messageCode    -> psr,
+          GetPeersSpec.messageCode -> psr
         )
       }
       map

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -17,7 +17,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder._
 import scorex.core.consensus.{Equal, Fork, Nonsense, Older, Unknown, Younger}
 import scorex.core.network.ModifiersStatus.Requested
 import scorex.core.{ModifierTypeId, NodeViewModifier, idsToString}
-import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
+import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, SendToNetwork}
 import org.ergoplatform.network.ErgoNodeViewSynchronizer.ReceivableMessages._
 import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
@@ -202,10 +202,6 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     viewHolderRef ! GetNodeViewChanges(history = true, state = false, vault = false, mempool = true)
 
     val toDownloadCheckInterval = networkSettings.syncInterval
-
-    // register as a handler for synchronization-specific types of messages
-    val messageSpecs: Seq[MessageSpec[_]] = Seq(InvSpec, RequestModifierSpec, ModifiersSpec, syncInfoSpec)
-    networkControllerRef ! RegisterMessageSpecs(messageSpecs, self)
 
     // register as a listener for peers got connected (handshaked) or disconnected
     context.system.eventStream.subscribe(self, classOf[HandshakedPeer])

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1153,15 +1153,14 @@ object ErgoNodeViewSynchronizer {
     Props(new ErgoNodeViewSynchronizer(networkControllerRef, viewHolderRef, syncInfoSpec, settings,
       timeProvider, syncTracker, deliveryTracker))
 
-  def apply(networkControllerRef: ActorRef,
-            viewHolderRef: ActorRef,
+  def make(viewHolderRef: ActorRef,
             syncInfoSpec: ErgoSyncInfoMessageSpec.type,
             settings: ErgoSettings,
             timeProvider: NetworkTimeProvider,
             syncTracker: ErgoSyncTracker,
             deliveryTracker: DeliveryTracker)
-           (implicit context: ActorRefFactory, ex: ExecutionContext): ActorRef =
-    context.actorOf(props(networkControllerRef, viewHolderRef, syncInfoSpec, settings, timeProvider, syncTracker, deliveryTracker))
+           (implicit context: ActorRefFactory, ex: ExecutionContext): ActorRef => ActorRef =
+    networkControllerRef => context.actorOf(props(networkControllerRef, viewHolderRef, syncInfoSpec, settings, timeProvider, syncTracker, deliveryTracker))
 
   /**
     * Container for aggregated costs of accepted, declined or invalidated transactions. Can be used to track global

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -4,7 +4,7 @@ import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorSystem, DeathPactException, OneForOneStrategy, Props}
 import akka.pattern.ask
 import akka.util.Timeout
-import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, RegisterMessageSpecs, SendToNetwork}
+import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, SendToNetwork}
 import scorex.core.network.message.{GetPeersSpec, Message, MessageSpec, PeersSpec}
 import scorex.core.network.peer.{PeerInfo, PenaltyType}
 import scorex.core.network.peer.PeerManager.ReceivableMessages.{AddPeerIfEmpty, SeenPeers}
@@ -49,8 +49,6 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 
   override def preStart: Unit = {
     super.preStart()
-
-    networkControllerRef ! RegisterMessageSpecs(Seq(GetPeersSpec, peersSpec), self)
 
     val msg = Message[Unit](GetPeersSpec, Right(Unit), None)
     val stn = SendToNetwork(msg, SendToRandom)


### PR DESCRIPTION
Currently message processing has a lot of flexibility we do not actually need for Ergo protocol client. Eliminate RegisterMessageSpecs and hard-code handlers in messageHandlers.