### PR TITLE
i1881 use 400 for non-existing endpoints and 404 for non-existing resources

### DIFF
--- a/src/main/scala/scorex/core/api/http/ApiRejectionHandler.scala
+++ b/src/main/scala/scorex/core/api/http/ApiRejectionHandler.scala
@@ -31,6 +31,6 @@ object ApiRejectionHandler {
     }
     .handle { case ValidationRejection(msg, _) => ApiError.BadRequest(msg) }
     .handle { case x => ApiError.InternalError(s"Unhandled rejection: $x") }
-    .handleNotFound { ApiError.NotExists("The requested resource could not be found.") }
+    .handleNotFound { ApiError.BadRequest("The requested resource/endpoint could not be found.") }
     .result()
 }


### PR DESCRIPTION
Closes https://github.com/ergoplatform/ergo/issues/1881

Now requests to non-existing endpoint like `/blablabla` result in `400` 
Resource seeking requests like `/transactions/unconfirmed/byTransactionId/{txId}` result in `404` 

This way it is possible to differentiate between a node not having certain endpoint or not having certain resource.