### PR TITLE
i1885 another bunch of optimizations

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
@@ -48,9 +48,7 @@ trait BoxSelector extends ScorexLogging {
     */
   def reemissionAmount[T <: ErgoBoxAssets](boxes: Seq[T]): Long = {
     reemissionDataOpt.map { reemissionData =>
-      boxes
-        .flatMap(_.tokens.get(reemissionData.reemissionTokenId))
-        .sum
+      boxes.foldLeft(0L) { case (sum, b) => sum + b.tokens.getOrElse(reemissionData.reemissionTokenId, 0L) }
     }.getOrElse(0L)
   }
 

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -136,7 +136,7 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
                       targetBoxAssets: TokensMap,
                       reemissionAmt: Long): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
     AssetUtils.subtractAssetsMut(foundBoxAssets, targetBoxAssets)
-    val changeBoxesAssets: Seq[mutable.Map[ModifierId, Long]] = foundBoxAssets.grouped(MaxAssetsPerBox).toSeq
+    val changeBoxesAssets: Seq[mutable.Map[ModifierId, Long]] = foundBoxAssets.grouped(MaxAssetsPerBox).toIndexedSeq
     val changeBalance = foundBalance - targetBalance
     //at least a minimum amount of ERG should be assigned per a created box
     if (changeBoxesAssets.size * MinBoxValue > changeBalance) {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -256,7 +256,7 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
     val inputBoxes = selectionResult.boxes.toIndexedSeq
     new UnsignedErgoTransaction(
-      inputBoxes.map(_.box.id).map(id => new UnsignedInput(id)),
+      inputBoxes.map(tx => new UnsignedInput(tx.box.id)),
       dataInputs,
       (payTo ++ changeBoxCandidates).toIndexedSeq
     )


### PR DESCRIPTION
More optimizations after profiling https://github.com/ergoplatform/ergo/issues/1885

- more efficient `sum` of box values
- using mutability in intensive loops
- calling `keySet` only once instead of `x` times
- avoiding LinkedList when `size` is called
- avoiding multiple `.map` -> `.map` ops

I speeded up a bit more