### PR TITLE
i1893 do not erase password before Unlock

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
@@ -107,7 +107,6 @@ object JsonSecretStorage {
 
     outWriter.write(jsonRaw)
     outWriter.close()
-    pass.erase()
 
     util.Arrays.fill(seed, 0: Byte)
 

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
@@ -66,7 +66,6 @@ final class JsonSecretStorage(val secretFile: File, encryptionSettings: Encrypti
           )
           .flatMap { case (cipherText, salt, iv, tag, usePre1627KeyDerivation) => {
               val res = crypto.AES.decrypt(cipherText, pass.getData(), salt, iv, tag)(encryptionSettings)
-              pass.erase()
               res
                 .map(seed => unlockedSecret = Some(ExtendedSecretKey.deriveMasterKey(seed, usePre1627KeyDerivation.getOrElse(true))))
             }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -314,15 +314,16 @@ class ErgoWalletActor(settings: ErgoSettings,
           sender() ! Failure(new Exception("Wallet not initialized"))
       }
 
-    case UnlockWallet(encPass) =>
+    case UnlockWallet(walletPass) =>
       log.info("Unlocking wallet")
-      ergoWalletService.unlockWallet(state, encPass, settings.walletSettings.usePreEip3Derivation) match {
+      ergoWalletService.unlockWallet(state, walletPass, settings.walletSettings.usePreEip3Derivation) match {
         case Success(newState) =>
           log.info("Wallet successfully unlocked")
+          walletPass.erase()
           context.become(loadedWallet(newState))
           sender() ! Success(())
         case f@Failure(t) =>
-          encPass.erase()
+          walletPass.erase()
           log.warn("Wallet unlock failed with: ", t)
           sender() ! f
       }


### PR DESCRIPTION
Closes https://github.com/ergoplatform/ergo/issues/1893

Wallet flow is as follows : 
 - wallet `Created/Restored` -> automatically `Unlocked` with password given during `Creation/Restoration`

Problem : 
 - we automatically Erase password in the `Create/Restore` method and it is already Erased for `Unlock`

Solution : 
 - avoid Erasing password during `Create/Restore` as `Unlocking` ALWAYS follows implicitly without user having to do so
 - Erase password during `Unlock` OR if `Create/Restore` fails