### PR TITLE
Fix for EIP-27 output having creationHeight=0

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
@@ -77,7 +77,14 @@ object BoxSelector {
     */
   val ScanDepthFactor = 300
 
-  class BoxSelectionResult[T <: ErgoBoxAssets](val boxes: Seq[T],
+  /**
+    * Containter for box selector output
+    *
+    * @param inputBoxes - transaction inputs chosen by a selector
+    * @param changeBoxes - change outputs
+    * @param payToReemissionBox - pay-to-reemission output mde according to EIP-27, if needed
+    */
+  class BoxSelectionResult[T <: ErgoBoxAssets](val inputBoxes: Seq[T],
                                                val changeBoxes: Seq[ErgoBoxAssets],
                                                val payToReemissionBox: Option[ErgoBoxAssets])
 

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.wallet.boxes
 
-import org.ergoplatform.ErgoBoxAssets
+import org.ergoplatform.{ErgoBoxAssets, ErgoBoxAssetsHolder}
 import org.ergoplatform.SigmaConstants.MaxBoxSize
 import org.ergoplatform.wallet.TokensMap
 import org.ergoplatform.wallet.boxes.BoxSelector.{BoxSelectionError, BoxSelectionResult}
@@ -52,6 +52,17 @@ trait BoxSelector extends ScorexLogging {
     }.getOrElse(0L)
   }
 
+  def selectionResultWithEip27Output[T <: ErgoBoxAssets](inputBoxes: Seq[T],
+                                                         changeBoxes: Seq[ErgoBoxAssets]): BoxSelectionResult[T] = {
+    val reemissionAmt = reemissionAmount(inputBoxes)
+    val payToReemissionBox = if(reemissionAmt > 0) {
+      Some(ErgoBoxAssetsHolder(reemissionAmt))
+    } else {
+      None
+    }
+    new BoxSelectionResult(inputBoxes, changeBoxes, payToReemissionBox)
+  }
+
 }
 
 object BoxSelector {
@@ -66,7 +77,9 @@ object BoxSelector {
     */
   val ScanDepthFactor = 300
 
-  final case class BoxSelectionResult[T <: ErgoBoxAssets](boxes: Seq[T], changeBoxes: Seq[ErgoBoxAssets])
+  class BoxSelectionResult[T <: ErgoBoxAssets](val boxes: Seq[T],
+                                               val changeBoxes: Seq[ErgoBoxAssets],
+                                               val payToReemissionBox: Option[ErgoBoxAssets])
 
   /**
     * Returns how much ERG can be taken from a box when it is spent.

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -88,8 +88,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
     val compactedBalance = boxes.foldLeft(0L) { case (sum, b) => sum + BoxSelector.valueOf(b, reemissionDataOpt) }
     val compactedAssets = mutable.Map[ModifierId, Long]()
     AssetUtils.mergeAssetsMut(compactedAssets, boxes.map(_.tokens): _*)
-    val ra = reemissionAmount(boxes)
-    super.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets, ra)
+    super.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets)
   }
 
   protected[boxes] def collectDust[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
@@ -102,7 +101,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
     val dust = tail.sortBy(_.value).take(diff).filter(b => !bsr.boxes.contains(b))
 
     val boxes = bsr.boxes ++ dust
-    calcChange(boxes, targetBalance, targetAssets).mapRight(changeBoxes => BoxSelectionResult(boxes, changeBoxes))
+    calcChange(boxes, targetBalance, targetAssets).mapRight(changeBoxes => selectionResultWithEip27Output(boxes, changeBoxes))
   }
 
   protected[boxes] def compress[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
@@ -124,7 +123,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
       }
       val compactedBoxes = boxes.filter(b => !thrownBoxes.contains(b))
       calcChange(compactedBoxes, targetBalance, targetAssets)
-        .mapRight(changeBoxes => BoxSelectionResult(compactedBoxes, changeBoxes))
+        .mapRight(changeBoxes => selectionResultWithEip27Output(compactedBoxes, changeBoxes))
     } else {
       Right(bsr)
     }
@@ -166,7 +165,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
     if (boxesToAdd.nonEmpty) {
       val compactedBoxes = bsr.boxes.filter(b => !boxesToDrop.contains(b)) ++ boxesToAdd
       calcChange(compactedBoxes, targetBalance, targetAssets)
-        .mapRight(changeBoxes => BoxSelectionResult(compactedBoxes, changeBoxes))
+        .mapRight(changeBoxes => selectionResultWithEip27Output(compactedBoxes, changeBoxes))
     } else {
       Right(bsr)
     }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -242,7 +242,7 @@ object TransactionBuilder {
       case Right(v) => v
     }
     // although we're only interested in change boxes, make sure selection contains exact inputs
-    assert(selection.boxes == inputs, s"unexpected selected boxes, expected: $inputs, got ${selection.boxes}")
+    assert(selection.inputBoxes == inputs, s"unexpected selected boxes, expected: $inputs, got ${selection.inputBoxes}")
     val changeBoxes = selection.changeBoxes
     val changeBoxesHaveTokens = changeBoxes.exists(_.tokens.nonEmpty)
 

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -65,31 +65,31 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val s1 = selector.select(uBoxes.toIterator, noFilter, 1, Map())
     s1 shouldBe 'right
     s1.right.get.changeBoxes.isEmpty shouldBe true
-    s1.right.get.boxes.head shouldBe uBox1
+    s1.right.get.inputBoxes.head shouldBe uBox1
 
     val s2 = selector.select(uBoxes.toIterator, noFilter, 10, Map())
     s2 shouldBe 'right
     s2.right.get.changeBoxes.size == 1
     s2.right.get.changeBoxes.head.value shouldBe 1
-    s2.right.get.boxes shouldBe Seq(uBox1, uBox2)
+    s2.right.get.inputBoxes shouldBe Seq(uBox1, uBox2)
 
     val s3 = selector.select(uBoxes.toIterator, noFilter, 11, Map())
     s3 shouldBe 'right
     s3.right.get.changeBoxes.isEmpty shouldBe true
-    s3.right.get.boxes shouldBe Seq(uBox1, uBox2)
+    s3.right.get.inputBoxes shouldBe Seq(uBox1, uBox2)
 
     //box2 should be filtered out
     val s4 = selector.select(uBoxes.toIterator, onChainFilter, 11, Map())
     s4 shouldBe 'right
     s4.right.get.changeBoxes.size == 1
     s4.right.get.changeBoxes.head.value shouldBe 90
-    s4.right.get.boxes shouldBe Seq(uBox1, uBox3)
+    s4.right.get.inputBoxes shouldBe Seq(uBox1, uBox3)
 
     val s5 = selector.select(uBoxes.toIterator, noFilter, 61, Map())
     s5 shouldBe 'right
     s5.right.get.changeBoxes.size == 1
     s5.right.get.changeBoxes.head.value shouldBe 50
-    s5.right.get.boxes shouldBe Seq(uBox1, uBox2, uBox3)
+    s5.right.get.inputBoxes shouldBe Seq(uBox1, uBox2, uBox3)
   }
 
   property("properly selects coins - assets w. 1 change box") {
@@ -111,14 +111,14 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val s1 = selector.select(uBoxes.toIterator, noFilter, 1 * MinBoxValue, Map(assetId1 -> 1))
     s1 shouldBe 'right
     s1.right.get.changeBoxes.isEmpty shouldBe true
-    s1.right.get.boxes.head shouldBe uBox1
+    s1.right.get.inputBoxes.head shouldBe uBox1
 
     val s2 = selector.select(uBoxes.toIterator, noFilter, 1 * MinBoxValue, Map(assetId1 -> 11))
     s2 shouldBe 'right
     s2.right.get.changeBoxes.size == 1
     s2.right.get.changeBoxes.head.value shouldBe 100 * MinBoxValue
     s2.right.get.changeBoxes.head.tokens(assetId1) shouldBe 90
-    s2.right.get.boxes shouldBe Seq(uBox1, uBox3)
+    s2.right.get.inputBoxes shouldBe Seq(uBox1, uBox3)
 
     selector.select(uBoxes.toIterator, onChainFilter, 1, Map(assetId2 -> 1)).left.value shouldBe a [NotEnoughTokensError]
     selector.select(uBoxes.toIterator, noFilter, 1, Map(assetId2 -> 11)).left.value shouldBe a [NotEnoughTokensError]
@@ -130,7 +130,7 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     s3.right.get.changeBoxes.head.value shouldBe 110 * MinBoxValue
     s3.right.get.changeBoxes.head.tokens(assetId1) shouldBe 90
     s3.right.get.changeBoxes.head.tokens(assetId2) shouldBe 9
-    s3.right.get.boxes shouldBe Seq(uBox1, uBox2, uBox3)
+    s3.right.get.inputBoxes shouldBe Seq(uBox1, uBox2, uBox3)
 
     selector.select(uBoxes.toIterator, onChainFilter, 1 * MinBoxValue, Map(assetId1 -> 11, assetId2 -> 1)).left.value shouldBe
       a [NotEnoughTokensError]
@@ -167,8 +167,8 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
     val s1 = selector.select(uBoxes.toIterator, noFilter, 1 * MinBoxValue, Map(assetId3 -> 11))
     s1 shouldBe 'right
 
-    s1.right.get.boxes.size shouldBe 3
-    s1.right.get.boxes should contain theSameElementsAs(Seq(uBox1, uBox2, uBox3))
+    s1.right.get.inputBoxes.size shouldBe 3
+    s1.right.get.inputBoxes should contain theSameElementsAs(Seq(uBox1, uBox2, uBox3))
 
     s1.right.get.changeBoxes.size shouldBe 1
     s1.right.get.changeBoxes(0).value shouldBe 110 * MinBoxValue

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -268,9 +268,8 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
 
     val s2 = selector.select(Iterator(uBox), noFilter, (fullValue - reemissionAmt) / 4, Map.empty)
 
-    val cb2 = s2.right.get.changeBoxes
+    val cb2 = s2.right.get.payToReemissionBox
 
-    cb2.length shouldBe 2
-    cb2.head.value shouldBe reemissionAmt
+    cb2.get.value shouldBe reemissionAmt
   }
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
@@ -35,7 +35,9 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
 
     //now we test that compress works under select
     val sr = selector.select(inputValues.map(trackedBox).toIterator, noFilter, targetBalance, Map()).right.value
-    sr shouldBe res
+    sr.boxes shouldBe res.boxes
+    sr.changeBoxes shouldBe res.changeBoxes
+    sr.payToReemissionBox shouldBe res.payToReemissionBox
   }
 
   property("replace() - no candidates") {

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
@@ -30,12 +30,12 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
       inputValues.map(trackedBox), Seq(), None
     )
     val res = selector.compress(boxSelectionResult, targetBalance, Map()).right.value
-    res.boxes.length shouldBe 3
-    res.boxes.map(_.value) shouldBe Seq(100L, 200L, 1000L)
+    res.inputBoxes.length shouldBe 3
+    res.inputBoxes.map(_.value) shouldBe Seq(100L, 200L, 1000L)
 
     //now we test that compress works under select
     val sr = selector.select(inputValues.map(trackedBox).toIterator, noFilter, targetBalance, Map()).right.value
-    sr.boxes shouldBe res.boxes
+    sr.inputBoxes shouldBe res.inputBoxes
     sr.changeBoxes shouldBe res.changeBoxes
     sr.payToReemissionBox shouldBe res.payToReemissionBox
   }
@@ -46,7 +46,7 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val targetBalance = 1303
     val boxSelectionResult = new BoxSelectionResult(inputValues.map(trackedBox), Seq(), None)
     val res = selector.replace(boxSelectionResult, Seq(), targetBalance, Map()).right.value
-    res.boxes.map(_.value) shouldBe inputValues
+    res.inputBoxes.map(_.value) shouldBe inputValues
   }
 
   property("replace() done - partial replacement") {
@@ -55,8 +55,8 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val targetBalance = 1303
     val boxSelectionResult = new BoxSelectionResult(inputValues.map(trackedBox), Seq(), None)
     val res = selector.replace(boxSelectionResult, Seq(trackedBox(300), trackedBox(200)), targetBalance, Map()).right.value
-    res.boxes.length shouldBe 3
-    res.boxes.map(_.value) shouldBe Seq(200L, 1000L, 300L)
+    res.inputBoxes.length shouldBe 3
+    res.inputBoxes.map(_.value) shouldBe Seq(200L, 1000L, 300L)
   }
 
   property("replace() done - full replacement") {
@@ -65,8 +65,8 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val targetBalance = 1303
     val boxSelectionResult = new BoxSelectionResult(inputValues.map(trackedBox), Seq(), None)
     val res = selector.replace(boxSelectionResult, Seq(trackedBox(2000)), targetBalance, Map()).right.value
-    res.boxes.length shouldBe 1
-    res.boxes.map(_.value) shouldBe Seq(2000L)
+    res.inputBoxes.length shouldBe 1
+    res.inputBoxes.map(_.value) shouldBe Seq(2000L)
   }
 
   property("compact() and replace() under select()"){
@@ -76,25 +76,25 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     {
       val targetBalance = 6
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
-      res.boxes.map(_.value) shouldBe Seq(1, 2, 3)
+      res.inputBoxes.map(_.value) shouldBe Seq(1, 2, 3)
     }
 
     {
       val targetBalance = 17
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
-      res.boxes.map(_.value) shouldBe Seq(10, 9, 8)
+      res.inputBoxes.map(_.value) shouldBe Seq(10, 9, 8)
     }
 
     {
       val targetBalance = 25
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
-      res.boxes.map(_.value) shouldBe Seq(10, 9, 8)
+      res.inputBoxes.map(_.value) shouldBe Seq(10, 9, 8)
     }
 
     {
       val targetBalance = 27
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
-      res.boxes.map(_.value) shouldBe Seq(10, 9, 8)
+      res.inputBoxes.map(_.value) shouldBe Seq(10, 9, 8)
     }
   }
 
@@ -106,14 +106,14 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     {
       val targetBalance = 6
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
-      res.boxes.length shouldBe optimalInputs
+      res.inputBoxes.length shouldBe optimalInputs
     }
 
     {
       val targetBalance = 1
       val res = selector.select(inputValues.toIterator, noFilter, targetBalance, Map()).right.value
-      res.boxes.length shouldBe res.boxes.distinct.length
-      res.boxes.length shouldBe optimalInputs
+      res.inputBoxes.length shouldBe res.inputBoxes.distinct.length
+      res.inputBoxes.length shouldBe optimalInputs
     }
   }
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
@@ -26,8 +26,8 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val inputValues = Seq(100L, 1L, 2L, 200L, 1000L)
     val targetBalance = 1300
 
-    val boxSelectionResult = BoxSelectionResult(
-      inputValues.map(trackedBox), Seq()
+    val boxSelectionResult = new BoxSelectionResult(
+      inputValues.map(trackedBox), Seq(), None
     )
     val res = selector.compress(boxSelectionResult, targetBalance, Map()).right.value
     res.boxes.length shouldBe 3
@@ -42,7 +42,7 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)
     val inputValues = Seq(100L, 1L, 2L, 200L, 1000L)
     val targetBalance = 1303
-    val boxSelectionResult = BoxSelectionResult(inputValues.map(trackedBox), Seq())
+    val boxSelectionResult = new BoxSelectionResult(inputValues.map(trackedBox), Seq(), None)
     val res = selector.replace(boxSelectionResult, Seq(), targetBalance, Map()).right.value
     res.boxes.map(_.value) shouldBe inputValues
   }
@@ -51,7 +51,7 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)
     val inputValues = Seq(100L, 1L, 2L, 200L, 1000L)
     val targetBalance = 1303
-    val boxSelectionResult = BoxSelectionResult(inputValues.map(trackedBox), Seq())
+    val boxSelectionResult = new BoxSelectionResult(inputValues.map(trackedBox), Seq(), None)
     val res = selector.replace(boxSelectionResult, Seq(trackedBox(300), trackedBox(200)), targetBalance, Map()).right.value
     res.boxes.length shouldBe 3
     res.boxes.map(_.value) shouldBe Seq(200L, 1000L, 300L)
@@ -61,7 +61,7 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
     val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)
     val inputValues = Seq(100L, 1L, 2L, 200L, 1000L)
     val targetBalance = 1303
-    val boxSelectionResult = BoxSelectionResult(inputValues.map(trackedBox), Seq())
+    val boxSelectionResult = new BoxSelectionResult(inputValues.map(trackedBox), Seq(), None)
     val res = selector.replace(boxSelectionResult, Seq(trackedBox(2000)), targetBalance, Map()).right.value
     res.boxes.length shouldBe 1
     res.boxes.map(_.value) shouldBe Seq(2000L)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -443,7 +443,7 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       .select(inputBoxes.iterator, state.walletFilter, targetBalance, assetsMap)
       .leftMap(m => new Exception(m.message))
       .map { res =>
-        val ergoBoxes = res.boxes.map(_.box)
+        val ergoBoxes = res.inputBoxes.map(_.box)
         val changeBoxes = res.changeBoxes.map(b => ChangeBox(b.value, b.tokens))
         CollectedBoxes(ergoBoxes, changeBoxes)
       }.toTry

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -260,7 +260,7 @@ trait ErgoWalletSupport extends ScorexLogging {
           new ErgoBoxCandidate(changeBox.value, changeAddressOpt.get, walletHeight, assets.toColl)
       }
     }
-    val inputBoxes = selectionResult.boxes.toIndexedSeq
+    val inputBoxes = selectionResult.inputBoxes.toIndexedSeq
     new UnsignedErgoTransaction(
       inputBoxes.map(tx => new UnsignedInput(tx.box.id)),
       dataInputs,
@@ -342,7 +342,7 @@ trait ErgoWalletSupport extends ScorexLogging {
         val dataInputs = ErgoWalletService.stringsToBoxes(dataInputsRaw).toIndexedSeq
         selectionOpt.map { selectionResult =>
           val changeAddressOpt: Option[ProveDlog] = state.getChangeAddress(addressEncoder).map(_.pubkey)
-          prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.boxes
+          prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.inputBoxes
         } match {
           case Right((txTry, inputs)) => txTry.map(tx => (tx, inputs.map(_.box).toIndexedSeq, dataInputs))
           case Left(e) => Failure(

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -242,7 +242,13 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
 
     val dataInputs = dataInputBoxes.map(dataInputBox => DataInput(dataInputBox.id))
-    val changeBoxCandidates = selectionResult.changeBoxes.map { changeBoxAssets =>
+    val changeBoxCandidates = {
+      // EIP-27 output
+      selectionResult.payToReemissionBox.toSeq.map {eip27OutputAssets =>
+        val p2r = ergoSettings.chainSettings.reemission.reemissionRules.payToReemission
+        new ErgoBoxCandidate(eip27OutputAssets.value, p2r, walletHeight)
+      }
+    } ++ selectionResult.changeBoxes.map { changeBoxAssets =>
       changeBoxAssets match {
         case candidate: ErgoBoxCandidate =>
           candidate

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -98,7 +98,7 @@ class ErgoWalletServiceSpec
 
     forAll(ergoBoxCandidateGen, ergoBoxCandidateGen, validErgoTransactionGen, proveDlogGen) {
       case (outputCandidate, outputChangeCandidate, (ergoBoxes, _), proveDlog) =>
-        val selectionResult = BoxSelectionResult(inputBoxes, Seq(outputChangeCandidate))
+        val selectionResult = new BoxSelectionResult(inputBoxes, Seq(outputChangeCandidate), None)
         val tx = prepareUnsignedTransaction(Seq(outputCandidate), startHeight, selectionResult, ergoBoxes, Option(proveDlog)).get
         tx.inputs shouldBe inputBoxes.map(_.box.id).map(id => new UnsignedInput(id))
         tx.dataInputs shouldBe ergoBoxes.map(dataInputBox => DataInput(dataInputBox.id))


### PR DESCRIPTION
In this PR, issue #1920 , when pay-to-reemission output has creationHeight=0, is fixed