### PR TITLE
Invalidate hot-fix

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -137,8 +137,13 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     pool.get(unconfirmedTransactionId) match {
       case Some(utx) => invalidate(utx)
       case None =>
-        log.warn(s"Can't invalidate transaction $unconfirmedTransactionId as it is not in the pool")
-        this
+        log.warn(s"pool.get failed for $unconfirmedTransactionId")
+        pool.orderedTransactions.valuesIterator.find(_.id == unconfirmedTransactionId) match {
+          case Some(utx) => invalidate(utx)
+          case None =>
+            log.warn(s"Can't invalidate transaction $unconfirmedTransactionId as it is not in the pool")
+            this
+        }
     }
   }
 


### PR DESCRIPTION
In this PR, if unconfirmed transaction to be invalidated could not be found via `(pool: OrderedTxPool).get`, additional check is done to find it via `(pool: OrderedTxPool).get`, and dump warning into the log about `pool` inconsistency (to check and fix it inconsistency exists) 