### PR TITLE
Cross-compile ergo-wallet to Scala 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.10, 2.11.12]
+        scala: [2.13.8, 2.12.10, 2.11.12]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ logLevel := Level.Debug
 // this values should be in sync with ergo-wallet/build.sbt
 val scala211 = "2.11.12"
 val scala212 = "2.12.10"
+val scala213 = "2.13.8"
 
 lazy val commonSettings = Seq(
   organization := "org.ergoplatform",
@@ -264,7 +265,7 @@ lazy val avldb_benchmarks = (project in file("avldb/benchmarks"))
 lazy val ergoWallet = (project in file("ergo-wallet"))
   .disablePlugins(ScapegoatSbtPlugin) // not compatible with crossScalaVersions
   .settings(
-    crossScalaVersions := Seq(scalaVersion.value, scala211),
+    crossScalaVersions := Seq(scala213, scalaVersion.value, scala211),
     commonSettings,
     name := "ergo-wallet",
     libraryDependencies ++= Seq(

--- a/ergo-wallet/build.sbt
+++ b/ergo-wallet/build.sbt
@@ -1,12 +1,13 @@
 // this values should be in sync with root (i.e. ../build.sbt)
 val scala211 = "2.11.12"
 val scala212 = "2.12.10"
+val scala213 = "2.13.8"
 
 val circeVersion = "0.13.0"
 val circeVersion211 = "0.10.0"
 
 libraryDependencies ++= Seq(
-  "org.scodec" %% "scodec-bits" % "1.1.6",
+  "org.scodec" %% "scodec-bits" % "1.1.34",
 
   "io.circe" %% "circe-core" % (if (scalaVersion.value == scala211) circeVersion211 else circeVersion),
   "io.circe" %% "circe-generic" % (if (scalaVersion.value == scala211) circeVersion211 else circeVersion),

--- a/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
+++ b/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
@@ -2,7 +2,7 @@ package org.ergoplatform.wallet.interface4j.crypto;
 
 import org.ergoplatform.ErgoLikeTransaction;
 import org.ergoplatform.UnsignedErgoLikeTransaction;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import sigmastate.basics.DLogProtocol;
 import java.util.Map;
 
@@ -27,7 +27,7 @@ public class ErgoUnsafeProver {
      */
     public ErgoLikeTransaction prove(UnsignedErgoLikeTransaction unsignedTx, Map<String, DLogProtocol.DLogProverInput> sks) {
         // JavaConversions used to support Scala 2.11
-        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, JavaConversions.mapAsScalaMap(sks));
+        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, JavaConverters.mapAsScalaMap(sks));
     }
 
 }

--- a/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
+++ b/ergo-wallet/src/main/java/org/ergoplatform/wallet/interface4j/crypto/ErgoUnsafeProver.java
@@ -26,8 +26,10 @@ public class ErgoUnsafeProver {
      * @return signed transaction
      */
     public ErgoLikeTransaction prove(UnsignedErgoLikeTransaction unsignedTx, Map<String, DLogProtocol.DLogProverInput> sks) {
-        // JavaConversions used to support Scala 2.11
-        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(unsignedTx, JavaConverters.mapAsScalaMap(sks));
+        // This method of JavaConverters is supported across Scala 2.11-2.13
+        return org.ergoplatform.wallet.interpreter.ErgoUnsafeProver.prove(
+                unsignedTx,
+                JavaConverters.mapAsScalaMapConverter(sks).asScala());
     }
 
 }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -104,7 +104,7 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
         assetsMet
       )) {
         formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets).mapRight { changeBoxes =>
-          selectionResultWithEip27Output(res, changeBoxes)
+          selectionResultWithEip27Output(res.toSeq, changeBoxes)
         }
       } else {
         Left(NotEnoughTokensError(

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ErgoBoxAssetExtractor.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ErgoBoxAssetExtractor.scala
@@ -3,6 +3,8 @@ package org.ergoplatform.wallet.boxes
 import org.ergoplatform.ErgoBoxCandidate
 import sigmastate.eval.Extensions._
 import java7.compat.Math
+
+import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable
 import scala.util.Try
 
@@ -29,7 +31,7 @@ object ErgoBoxAssetExtractor {
         )
         box.additionalTokens.foreach {
           case (assetId, amount) =>
-            val aiWrapped = mutable.WrappedArray.make(assetId)
+            val aiWrapped = ArraySeq.unsafeWrapArray(assetId)
             val total     = map.getOrElse(aiWrapped, 0L)
             map.put(aiWrapped, Math.addExact(total, amount))
         }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/mnemonic/Mnemonic.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/mnemonic/Mnemonic.scala
@@ -66,8 +66,8 @@ object Mnemonic {
     * Converts mnemonic phrase to seed it was derived from.
     */
   def toSeed(mnemonic: SecretString, passOpt: Option[SecretString] = None): Array[Byte] = {
-    val normalizedMnemonic = normalize(mnemonic.getData(), NFKD).toCharArray
-    val normalizedPass = normalize(("mnemonic".toCharArray ++ passOpt.fold("".toCharArray())(_.getData())), NFKD)
+    val normalizedMnemonic = normalize(ArrayCharSequence(mnemonic.getData()), NFKD).toCharArray
+    val normalizedPass = normalize(ArrayCharSequence("mnemonic".toCharArray ++ passOpt.fold("".toCharArray())(_.getData())), NFKD)
 
     passOpt.fold(())(_.erase())
     

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -234,7 +234,7 @@ object TransactionBuilder {
 
     // add burnTokens to target assets so that they are excluded from the change outputs
     // thus total outputs assets will be reduced which is interpreted as _token burning_
-    val tokensOutWithBurned = AssetUtils.mergeAssets(tokensOutNoMinted, burnTokens)
+    val tokensOutWithBurned = AssetUtils.mergeAssets(tokensOutNoMinted.toMap, burnTokens)
 
     val selection = boxSelector.select(inputs.toIterator, outputTotal, tokensOutWithBurned) match {
       case Left(err) => throw new IllegalArgumentException(

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/mnemonic/MnemonicSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/mnemonic/MnemonicSpec.scala
@@ -404,7 +404,7 @@ class MnemonicSpec
     val strength = Mnemonic.AllowedStrengths.zip(Mnemonic.MnemonicSentenceSizes).find(_._2 == sentenceSize).map(_._1).get
     val mnemonic = new Mnemonic(langId, strength)
     Base16.encode(Mnemonic.toSeed(SecretString.create(sentence), Some(SecretString.create(pass)))) shouldEqual seed
-    normalize(mnemonic.toMnemonic(Base16.decode(entropy).get).get.getData(), NFKD) shouldEqual normalize(sentence, NFKD)
+    normalize(ArrayCharSequence(mnemonic.toMnemonic(Base16.decode(entropy).get).get.getData()), NFKD) shouldEqual normalize(sentence, NFKD)
   }
 
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/utils/Generators.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/utils/Generators.scala
@@ -15,7 +15,6 @@ import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.{SByte, SType}
 import org.ergoplatform.wallet.Constants.{ScanId, PaymentsScanId}
 import scorex.util._
-import scala.collection.IndexedSeq
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.ErgoBoxCandidate
 import org.ergoplatform.ErgoScriptPredef


### PR DESCRIPTION
This PR adds support of Scala 2.13 to ergo-wallet (necessary for Appkit to also support 2.13)