### PR TITLE
bump scala-sbt image to 11.0.15_1.7.1_2.13.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-11.0.15_1.6.2_2.12.16 as builder
+FROM sbtscala/scala-sbt:eclipse-temurin-11.0.15_1.7.1_2.13.8 as builder
 WORKDIR /mnt
 COPY build.sbt findbugs-exclude.xml ./
 COPY project/ project/


### PR DESCRIPTION
Make docker build a bit faster by not having to get every single version.

Since https://github.com/ergoplatform/ergo/pull/1948  uses newer version, we can at least match that one to image.

This is very minor thing... but why not :)