### PR TITLE
More mempool fixes

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -91,9 +91,9 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
           val maxTxCost = ergoSettings.nodeSettings.maxTransactionCost
           utxo.withMempool(mp)
             .validateWithCost(tx, maxTxCost)
-            .map(cost => UnconfirmedTransaction(tx, Some(cost), now, now, bytes, source = None))
+            .map(cost => new UnconfirmedTransaction(tx, Some(cost), now, now, bytes, source = None))
         case _ =>
-          tx.statelessValidity().map(_ => UnconfirmedTransaction(tx, None, now, now, bytes, source = None))
+          tx.statelessValidity().map(_ => new UnconfirmedTransaction(tx, None, now, now, bytes, source = None))
       }
   }
 

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/UnconfirmedTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/UnconfirmedTransaction.scala
@@ -13,12 +13,12 @@ import scorex.util.{ModifierId, ScorexLogging}
   * @param transactionBytes - transaction bytes, to avoid serializations when we send it over the wire
   * @param source - peer which delivered the transaction (None if transaction submitted via API)
   */
-case class UnconfirmedTransaction(transaction: ErgoTransaction,
-                                  lastCost: Option[Int],
-                                  createdTime: Long,
-                                  lastCheckedTime: Long,
-                                  transactionBytes: Option[Array[Byte]],
-                                  source: Option[ConnectedPeer])
+class UnconfirmedTransaction(val transaction: ErgoTransaction,
+                             val lastCost: Option[Int],
+                             val createdTime: Long,
+                             val lastCheckedTime: Long,
+                             val transactionBytes: Option[Array[Byte]],
+                             val source: Option[ConnectedPeer])
   extends ScorexLogging {
 
   def id: ModifierId = transaction.id
@@ -27,7 +27,13 @@ case class UnconfirmedTransaction(transaction: ErgoTransaction,
     * Updates cost and last checked time of unconfirmed transaction
     */
   def withCost(cost: Int): UnconfirmedTransaction = {
-    copy(lastCost = Some(cost), lastCheckedTime = System.currentTimeMillis())
+    new UnconfirmedTransaction(
+      transaction,
+      lastCost = Some(cost),
+      createdTime,
+      lastCheckedTime = System.currentTimeMillis(),
+      transactionBytes,
+      source)
   }
 
   override def equals(obj: Any): Boolean = obj match {
@@ -42,12 +48,12 @@ object UnconfirmedTransaction {
 
   def apply(tx: ErgoTransaction, source: Option[ConnectedPeer]): UnconfirmedTransaction = {
     val now = System.currentTimeMillis()
-    UnconfirmedTransaction(tx, None, now, now, Some(tx.bytes), source)
+    new UnconfirmedTransaction(tx, None, now, now, Some(tx.bytes), source)
   }
 
   def apply(tx: ErgoTransaction, txBytes: Array[Byte], source: Option[ConnectedPeer]): UnconfirmedTransaction = {
     val now = System.currentTimeMillis()
-    UnconfirmedTransaction(tx, None, now, now, Some(txBytes), source)
+    new UnconfirmedTransaction(tx, None, now, now, Some(txBytes), source)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoSyncTracker.scala
@@ -189,8 +189,9 @@ final case class ErgoSyncTracker(networkSettings: NetworkSettings) extends Score
           unknowns
         }
         val nonOutdated = eldersAndUnknown ++ forks
+        val now = currentTime()
         nonOutdated.filter { case (_, status) =>
-          (currentTime() - status.lastSyncSentTime.getOrElse(0L)).millis >= MinSyncInterval
+          (now - status.lastSyncSentTime.getOrElse(0L)).millis >= MinSyncInterval
         }.map(_._1)
       }
 

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -88,17 +88,13 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
 
   /**
     * Method to put a transaction into the memory pool. Validation of the transactions against
-    * the state is done in NodeVieHolder. This put() method can check whether a transaction is valid
+    * the state is done in NodeViewHolder. This put() method can check whether a transaction is valid
     * @param unconfirmedTx
     * @return Success(updatedPool), if transaction successfully added to the pool, Failure(_) otherwise
     */
   def put(unconfirmedTx: UnconfirmedTransaction): ErgoMemPool = {
-    if (!pool.contains(unconfirmedTx.id)) {
-      val updatedPool = pool.put(unconfirmedTx, feeFactor(unconfirmedTx))
-      new ErgoMemPool(updatedPool, stats, sortingOption)
-    } else {
-      this
-    }
+    val updatedPool = pool.put(unconfirmedTx, feeFactor(unconfirmedTx))
+    new ErgoMemPool(updatedPool, stats, sortingOption)
   }
 
   def put(txs: TraversableOnce[UnconfirmedTransaction]): ErgoMemPool = {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -135,7 +135,8 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
       case None =>
         log.warn(s"pool.get failed for $unconfirmedTransactionId")
         pool.orderedTransactions.valuesIterator.find(_.id == unconfirmedTransactionId) match {
-          case Some(utx) => invalidate(utx)
+          case Some(utx) =>
+            invalidate(utx)
           case None =>
             log.warn(s"Can't invalidate transaction $unconfirmedTransactionId as it is not in the pool")
             this

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -131,7 +131,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
           inputs -- tx.inputs.map(_.boxId)
         ).updateFamily(tx, -wtx.weight, System.currentTimeMillis(), depth = 0)
       case None =>
-        if (transactionsRegistry.contains(tx.id)) {
+        if (orderedTransactions.valuesIterator.exists(utx => utx.id == tx.id)) {
           new OrderedTxPool(
             orderedTransactions,
             transactionsRegistry - tx.id,

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -119,6 +119,9 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
 
   def remove(utx: UnconfirmedTransaction): OrderedTxPool = remove(utx.transaction)
 
+  /**
+    * Remove transaction from the pool and add it to invalidated transaction ids cache
+    */
   def invalidate(unconfirmedTx: UnconfirmedTransaction): OrderedTxPool = {
     val tx = unconfirmedTx.transaction
     transactionsRegistry.get(tx.id) match {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -133,7 +133,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
       case None =>
         if (orderedTransactions.valuesIterator.exists(utx => utx.id == tx.id)) {
           new OrderedTxPool(
-            orderedTransactions,
+            orderedTransactions.filter(_._2.id != tx.id),
             transactionsRegistry - tx.id,
             invalidatedTxIds.put(tx.id),
             outputs -- tx.outputs.map(_.id),

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -378,6 +378,20 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     pool.size shouldBe 0
     pool.stats.takenTxns shouldBe (family_depth + 1) * txs.size
   }
+
+  it should "put not adding transaction twice" in {
+    val pool = ErgoMemPool.empty(settings).pool
+    val tx = invalidErgoTransactionGen.sample.get
+    val now = System.currentTimeMillis()
+
+    val utx1 = UnconfirmedTransaction(tx, None, now, now, None, None)
+    val utx2 = UnconfirmedTransaction(tx, None, now, now, None, None)
+    val utx3 = UnconfirmedTransaction(tx, None, now + 1, now + 1, None, None)
+    val updPool = pool.put(utx1, 100).remove(utx1).put(utx2, 500).put(utx3, 5000)
+    updPool.size shouldBe 1
+    updPool.get(utx3.id).get.lastCheckedTime shouldBe (now + 1)
+  }
+
 }
 
 

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -384,9 +384,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val tx = invalidErgoTransactionGen.sample.get
     val now = System.currentTimeMillis()
 
-    val utx1 = UnconfirmedTransaction(tx, None, now, now, None, None)
-    val utx2 = UnconfirmedTransaction(tx, None, now, now, None, None)
-    val utx3 = UnconfirmedTransaction(tx, None, now + 1, now + 1, None, None)
+    val utx1 = new UnconfirmedTransaction(tx, None, now, now, None, None)
+    val utx2 = new UnconfirmedTransaction(tx, None, now, now, None, None)
+    val utx3 = new UnconfirmedTransaction(tx, None, now + 1, now + 1, None, None)
     val updPool = pool.put(utx1, 100).remove(utx1).put(utx2, 500).put(utx3, 5000)
     updPool.size shouldBe 1
     updPool.get(utx3.id).get.lastCheckedTime shouldBe (now + 1)


### PR DESCRIPTION
In this PR, there are two fixes for mempool operations:
* put() now replacing unconfirmed transaction if transaction it is wrapping is already in the pool
* invalidate() now checking mempool (OrderedTxPool) inconsistency , to have consistent pool after invalidation before https://github.com/ergoplatform/ergo/issues/1952 is done 