### PR TITLE
Indexer performance upgrade and bugfixes

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -5942,7 +5942,7 @@ paths:
                     type: array
                     description: Array of boxes
                     items:
-                      $ref: '#/components/schemas/IndexedErgoTransaction'
+                      $ref: '#/components/schemas/IndexedErgoBox'
                   total:
                     type: integer
                     description: Total number of retreived boxes
@@ -5998,7 +5998,7 @@ paths:
                 type: array
                 description: Array of boxes
                 items:
-                  $ref: '#/components/schemas/IndexedErgoTransaction'
+                  $ref: '#/components/schemas/IndexedErgoBox'
         '404':
           description: No unspent boxes found for wanted address
           content:

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -5989,6 +5989,13 @@ paths:
             type: integer
             format: int32
             default: 5
+        - in: query
+          name: sortDirection
+          required: false
+          description: desc = new boxes first ; asc = old boxes first
+          schema:
+            type: string
+            default: desc
       responses:
         '200':
           description: unspent boxes associated with wanted address
@@ -6137,6 +6144,13 @@ paths:
             type: integer
             format: int32
             default: 5
+        - in: query
+          name: sortDirection
+          required: false
+          description: desc = new boxes first ; asc = old boxes first
+          schema:
+            type: string
+            default: desc
       responses:
         '200':
           description: unspent boxes with wanted ergotree

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -115,7 +115,7 @@ ergo {
       blockSectionsCacheSize = 12
 
       # Number of recently used extra indexes that will be kept in memory (has no effect if extraIndex is disabled)
-      extraCacheSize = 500
+      extraCacheSize = 1000
 
       # Number of recently used headers that will be kept in memory
       headersCacheSize = 1000

--- a/src/main/scala/org/ergoplatform/http/api/BlockchainApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlockchainApiRoute.scala
@@ -101,7 +101,7 @@ case class BlockchainApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSetting
   private def getIndexedHeightF: Future[Json] =
     getHistory.map { history =>
       Json.obj(
-        "indexedHeight" -> ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey)(history).getInt().asJson,
+        "indexedHeight" -> ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, history).getInt().asJson,
         "fullHeight" -> history.fullBlockHeight.asJson
       )
     }

--- a/src/main/scala/org/ergoplatform/http/api/BlockchainApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlockchainApiRoute.scala
@@ -9,6 +9,7 @@ import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetDataFromHistory, GetReaders, Readers}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{GlobalBoxIndexKey, GlobalTxIndexKey}
+import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
 import org.ergoplatform.nodeView.history.extra._
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.settings.ErgoSettings
@@ -70,7 +71,7 @@ case class BlockchainApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSetting
     (readersHolder ? GetReaders).mapTo[Readers].map(r => (r.h, r.m))
 
   private def getAddress(tree: ErgoTree)(history: ErgoHistoryReader): Option[IndexedErgoAddress] = {
-    history.typedExtraIndexById[IndexedErgoAddress](bytesToId(IndexedErgoAddressSerializer.hashErgoTree(tree)))
+    history.typedExtraIndexById[IndexedErgoAddress](hashErgoTree(tree))
   }
 
   private def getAddress(addr: ErgoAddress)(history: ErgoHistoryReader): Option[IndexedErgoAddress] = getAddress(addr.script)(history)

--- a/src/main/scala/org/ergoplatform/http/api/BlockchainApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlockchainApiRoute.scala
@@ -287,7 +287,7 @@ case class BlockchainApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSetting
   }
 
   private def getUnconfirmedForAddress(address: ErgoAddress)(mempool: ErgoMemPoolReader): BalanceInfo = {
-    val bal: BalanceInfo = new BalanceInfo
+    val bal: BalanceInfo = BalanceInfo()
     mempool.getAll.map(_.transaction).foreach(tx => {
       tx.outputs.foreach(box => {
         if(address.equals(ExtraIndexer.getAddress(box.ergoTree))) bal.add(box)
@@ -302,7 +302,7 @@ case class BlockchainApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSetting
         case Some(addr) =>
           (addr.balanceInfo.get.retreiveAdditionalTokenInfo(history), getUnconfirmedForAddress(address)(mempool).retreiveAdditionalTokenInfo(history))
         case None =>
-          (new BalanceInfo, getUnconfirmedForAddress(address)(mempool).retreiveAdditionalTokenInfo(history))
+          (BalanceInfo(), getUnconfirmedForAddress(address)(mempool).retreiveAdditionalTokenInfo(history))
       }
     }
   }

--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -98,17 +98,3 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   }
 
 }
-
-case class SortDirection(value: Int) {
-  def apply(str: String): SortDirection = str.toLowerCase match {
-    case "asc" => new SortDirection(SortDirection.ASC)
-    case "desc" => new SortDirection(SortDirection.DESC)
-    case _ => new SortDirection(SortDirection.INVALID)
-  }
-}
-
-object SortDirection {
-  val ASC: Int = 1
-  val DESC: Int = 0
-  val INVALID: Int = -1
-}

--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -98,3 +98,17 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   }
 
 }
+
+case class SortDirection(value: Int) {
+  def apply(str: String): SortDirection = str.toLowerCase match {
+    case "asc" => new SortDirection(SortDirection.ASC)
+    case "desc" => new SortDirection(SortDirection.DESC)
+    case _ => new SortDirection(SortDirection.INVALID)
+  }
+}
+
+object SortDirection {
+  val ASC: Int = 1
+  val DESC: Int = 0
+  val INVALID: Int = -1
+}

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -284,7 +284,8 @@ object ErgoHistory extends ScorexLogging {
   def readOrGenerate(ergoSettings: ErgoSettings)(implicit context: ActorContext): ErgoHistory = {
     var db = HistoryStorage(ergoSettings)
 
-    if(ergoSettings.nodeSettings.extraIndex) { // check extra indexer db schema
+    // ExtraIndexer db check
+    if(ergoSettings.nodeSettings.extraIndex) { // check db schema
       val schemaVersion: Int = getIndex(SchemaVersionKey, db).getInt
       if (schemaVersion != NewestVersion) {
         if(getIndex(IndexedHeightKey, db).getInt > 0)

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -9,7 +9,7 @@ import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.{Header, PreGenesisHeader}
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NonHeaderBlockSection}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.StartExtraIndexer
-import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{NewestVersion, NewestVersionBytes, SchemaVersionKey, getIndex}
+import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{IndexedHeightKey, NewestVersion, NewestVersionBytes, SchemaVersionKey, getIndex}
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.history.storage.modifierprocessors._
 import org.ergoplatform.settings._
@@ -286,8 +286,9 @@ object ErgoHistory extends ScorexLogging {
 
     if(ergoSettings.nodeSettings.extraIndex) { // check extra indexer db schema
       val schemaVersion: Int = getIndex(SchemaVersionKey, db).getInt
-      if (schemaVersion != NewestVersion) { // older schema -> delete and reopen db
-        db = db.deleteExtraDB(ergoSettings)
+      if (schemaVersion != NewestVersion) {
+        if(getIndex(IndexedHeightKey, db).getInt > 0)
+          db = db.deleteExtraDB(ergoSettings) // older schema -> delete and reopen db
         db.insertExtra(Array((SchemaVersionKey, NewestVersionBytes)), Array.empty) // update version key
       }
     }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/BalanceInfo.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/BalanceInfo.scala
@@ -12,11 +12,21 @@ import spire.implicits.cfor
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-class BalanceInfo(var nanoErgs: Long = 0L,
-                  val tokens: ArrayBuffer[(ModifierId,Long)] = ArrayBuffer.empty[(ModifierId,Long)]) extends ScorexLogging {
+/**
+  * Class that tracks the ERG and token balances in [[IndexedErgoAddress]]
+  */
+case class BalanceInfo() extends ScorexLogging {
+
+  var nanoErgs: Long = 0L
+  val tokens: ArrayBuffer[(ModifierId,Long)] = ArrayBuffer.empty[(ModifierId,Long)]
 
   val additionalTokenInfo: mutable.HashMap[ModifierId,(String,Int)] = mutable.HashMap.empty[ModifierId,(String,Int)]
 
+  /**
+    * Get full token information from database.
+    * @param history - database handle
+    * @return this object
+    */
   def retreiveAdditionalTokenInfo(history: ErgoHistoryReader): BalanceInfo = {
     additionalTokenInfo ++= tokens.map(token => {
       val iT: IndexedToken = history.typedExtraIndexById[IndexedToken](uniqueId(token._1)).get
@@ -25,6 +35,11 @@ class BalanceInfo(var nanoErgs: Long = 0L,
     this
   }
 
+  /**
+    * Find index of token with given id in tokens
+    * @param id - id to look for
+    * @return index of id, if any
+    */
   private def index(id: ModifierId): Option[Int] = {
     cfor(0)(_ < tokens.length, _ + 1) { i =>
       if(tokens(i)._1 == id) return Some(i)
@@ -32,6 +47,10 @@ class BalanceInfo(var nanoErgs: Long = 0L,
     None
   }
 
+  /**
+    * Record an address receiving a box.
+    * @param box - box received
+    */
   def add(box: ErgoBox): Unit = {
     nanoErgs += box.value
     cfor(0)(_ < box.additionalTokens.length, _ + 1) { i =>
@@ -43,6 +62,11 @@ class BalanceInfo(var nanoErgs: Long = 0L,
     }
   }
 
+  /**
+    * Record an address spending a box.
+    * @param box - box spent
+    * @param ae - address encoder to use in case of an error message
+    */
   def subtract(box: ErgoBox)(implicit ae: ErgoAddressEncoder): Unit = {
     nanoErgs = math.max(nanoErgs - box.value, 0)
     cfor(0)(_ < box.additionalTokens.length, _ + 1) { i =>
@@ -74,7 +98,8 @@ object BalanceInfoSerializer extends ScorexSerializer[BalanceInfo] {
   }
 
   override def parse(r: Reader): BalanceInfo = {
-    val bI: BalanceInfo = new BalanceInfo(r.getLong())
+    val bI: BalanceInfo = BalanceInfo()
+    bI.nanoErgs = r.getLong()
     val tokensLen: Int = r.getInt()
     cfor(0)(_ < tokensLen, _ + 1) { _ =>
       bI.tokens += Tuple2(bytesToId(r.getBytes(32)), r.getLong())

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -319,9 +319,7 @@ trait ExtraIndexerBase extends ScorexLogging {
         iEb.spendingHeightOpt = None
         iEb.spendingTxIdOpt = None
         val address = history.typedExtraIndexById[IndexedErgoAddress](bytesToId(hashErgoTree(iEb.box.ergoTree))).get.addBox(iEb, record = false)
-        val addr: String = ae.fromProposition(iEb.box.ergoTree).get.toString.take(5)
         address.findAndModBox(iEb.globalIndex, history)
-        System.out.println(s"$addr spent box: ${iEb.globalIndex} -> ${address.boxes.mkString("(",",",")")}")
         historyStorage.insertExtra(Array.empty, Array[ExtraIndex](iEb, address) ++ address.segments)
         address.segments.clear()
       })

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -370,7 +370,7 @@ class ExtraIndexer(cacheSettings: CacheSettings,
                    ae: ErgoAddressEncoder)
   extends Actor with ExtraIndexerBase {
 
-  override val saveLimit: Int = cacheSettings.history.extraCacheSize * 10
+  override val saveLimit: Int = cacheSettings.history.extraCacheSize * 20
 
   override implicit val addressEncoder: ErgoAddressEncoder = ae
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.network.ErgoNodeViewSynchronizer.ReceivableMessages.{FullBlockApplied, Rollback}
-import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{GlobalBoxIndexKey, GlobalTxIndexKey, IndexedHeightKey, getIndex}
+import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{GlobalBoxIndexKey, GlobalTxIndexKey, IndexedHeightKey, fastIdToBytes, getIndex}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.StartExtraIndexer
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddress.segmentTreshold
@@ -454,6 +454,6 @@ object ExtraIndexer {
   * Base trait for all additional indexes made by ExtraIndexer
   */
 trait ExtraIndex {
-  def id: ModifierId = bytesToId(serializedId)
-  def serializedId: Array[Byte]
+  lazy val id: ModifierId = bytesToId(serializedId)
+  def serializedId: Array[Byte] = fastIdToBytes(id)
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -224,7 +224,7 @@ trait ExtraIndexerBase extends ScorexLogging {
         findAndUpdateTree(hashErgoTree(box.ergoTree), Right(boxes(boxId)))
 
         // check if box is creating a new token, if yes record it
-        if (tokenRegistersSet(box))
+        if(tokenRegistersSet(box))
           cfor(0)(_ < box.additionalTokens.length, _ + 1) { j =>
             if (!tokens.exists(x => java.util.Arrays.equals(x._1, box.additionalTokens(j)._1)))
               general += IndexedToken.fromBox(box, j)
@@ -329,7 +329,8 @@ trait ExtraIndexerBase extends ScorexLogging {
       if(tokenRegistersSet(iEb.box))
         cfor(0)(_ < iEb.box.additionalTokens.length, _ + 1) { i =>
           history.typedExtraIndexById[IndexedToken](IndexedToken.fromBox(iEb.box, i).id) match {
-            case Some(token) => toRemove += token.id // token created, delete
+            case Some(token) if token.boxId == iEb.id =>
+              toRemove += token.id // token created, delete
             case None => // no token created
           }
         }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -442,7 +442,7 @@ object ExtraIndexer {
   }
 
   val NewestVersion: Int = 1
-  val NewestVersionBytes: Array[Byte] = ByteBuffer.allocate(4).putInt(NewestVersion).array()
+  val NewestVersionBytes: Array[Byte] = ByteBuffer.allocate(4).putInt(NewestVersion).array
 
   val IndexedHeightKey: Array[Byte] = Algos.hash("indexed height")
   val GlobalTxIndexKey: Array[Byte] = Algos.hash("txns height")

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -133,8 +133,6 @@ trait ExtraIndexerBase extends ScorexLogging {
     */
   private def saveProgress(writeLog: Boolean = true): Unit = {
 
-    if(modCount == 0) return
-
     val start: Long = System.currentTimeMillis
 
     // perform segmentation on big addresses and save their internal segment buffer
@@ -263,8 +261,6 @@ trait ExtraIndexerBase extends ScorexLogging {
     */
   protected def run(): Unit = {
 
-
-
     indexedHeight  = getIndex(IndexedHeightKey, history).getInt
     globalTxIndex  = getIndex(GlobalTxIndexKey, history).getLong
     globalBoxIndex = getIndex(GlobalBoxIndexKey, history).getLong
@@ -344,6 +340,7 @@ trait ExtraIndexerBase extends ScorexLogging {
     globalBoxIndex += 1
     historyStorage.removeExtra(toRemove.toArray)
     indexedHeight = height
+    caughtUp = false
 
     saveProgress(false)
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.history.extra
 
 import org.ergoplatform.ErgoAddressEncoder
-import org.ergoplatform.http.api.SortDirection.{ASC, DESC, Type}
+import org.ergoplatform.http.api.SortDirection.{ASC, DESC, Direction}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{ExtraIndexTypeId, fastIdToBytes}
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddress.{getBoxes, getFromSegments, getTxs, segmentTreshold, slice}
@@ -144,7 +144,7 @@ case class IndexedErgoAddress(treeHash: ModifierId,
     * @param sortDir - whether to start retreival from newest box ([[DESC]]) or oldest box ([[ASC]])
     * @return array of unspent boxes
     */
-  def retrieveUtxos(history: ErgoHistoryReader, offset: Int, limit: Int, sortDir: Type): Array[IndexedErgoBox] = {
+  def retrieveUtxos(history: ErgoHistoryReader, offset: Int, limit: Int, sortDir: Direction): Array[IndexedErgoBox] = {
     val data: ArrayBuffer[IndexedErgoBox] = ArrayBuffer.empty[IndexedErgoBox]
     sortDir match {
       case DESC =>

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
@@ -164,7 +164,7 @@ case class IndexedErgoAddress(treeHash: ModifierId,
     val data: ArrayBuffer[IndexedErgoBox] = ArrayBuffer.empty[IndexedErgoBox]
     data ++= boxes.filter(_ > 0).map(n => NumericBoxIndex.getBoxByNumber(history, n).get)
     var segment: Int = boxSegmentCount
-    while(data.length < limit && segment > 0) {
+    while(data.length < (limit + offset) && segment > 0) {
       segment -= 1
       history.typedExtraIndexById[IndexedErgoAddress](boxSegmentId(treeHash, segment)).get.boxes
         .filter(_ > 0).map(n => NumericBoxIndex.getBoxByNumber(history, n).get) ++=: data

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoBox.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoBox.scala
@@ -2,9 +2,7 @@ package org.ergoplatform.nodeView.history.extra
 
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{ExtraIndexTypeId, fastIdToBytes}
-import org.ergoplatform.nodeView.wallet.WalletBox
-import org.ergoplatform.wallet.Constants.ScanId
-import org.ergoplatform.wallet.boxes.{ErgoBoxSerializer, TrackedBox}
+import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
 import scorex.core.serialization.ScorexSerializer
 import scorex.util.{ModifierId, bytesToId}
 import scorex.util.serialization.{Reader, Writer}
@@ -21,15 +19,7 @@ class IndexedErgoBox(val inclusionHeight: Int,
                      var spendingTxIdOpt: Option[ModifierId],
                      var spendingHeightOpt: Option[Int],
                      val box: ErgoBox,
-                     val globalIndex: Long)
-  extends WalletBox(TrackedBox(box.transactionId,
-                               box.index,
-                               Some(inclusionHeight),
-                               spendingTxIdOpt,
-                               spendingHeightOpt,
-                               box,
-                               Set.empty[ScanId]),
-                               None) with ExtraIndex {
+                     val globalIndex: Long) extends ExtraIndex {
 
   override def serializedId: Array[Byte] = box.id
 
@@ -45,6 +35,12 @@ class IndexedErgoBox(val inclusionHeight: Int,
     spendingHeightOpt = Some(txHeight)
     this
   }
+
+  /**
+    * Whether or not the box is spent
+    * @return true if spent, false otherwise
+    */
+  def isSpent: Boolean = spendingTxIdOpt.isDefined
 }
 object IndexedErgoBoxSerializer extends ScorexSerializer[IndexedErgoBox] {
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoBox.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoBox.scala
@@ -8,7 +8,7 @@ import scorex.util.{ModifierId, bytesToId}
 import scorex.util.serialization.{Reader, Writer}
 
 /**
-  * Index of a box.
+  * Wrapper with dditional information for ErgoBox.
   * @param inclusionHeight   - height of the block in which the creating transaction was included in
   * @param spendingTxIdOpt   - optional, id of the spending transaction
   * @param spendingHeightOpt - optional, height of the block in which the spending transaction was included in

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoTransaction.scala
@@ -11,7 +11,7 @@ import scorex.util.{ModifierId, bytesToId}
 import spire.implicits.cfor
 
 /**
-  * Index of a transaction.
+  * Minimum general information for transaction. Not storing the whole transation is done to save space.
   * @param txid        - id of this transaction
   * @param height      - height of the block which includes this transaction
   * @param globalIndex - serial number of this transaction counting from block 1

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoTransaction.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoTransaction.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.DataInput
 import org.ergoplatform.modifiers.history.BlockTransactions
-import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{ExtraIndexTypeId, fastIdToBytes}
+import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ExtraIndexTypeId
 import scorex.core.serialization.ScorexSerializer
 import scorex.util.serialization.{Reader, Writer}
 import scorex.util.{ModifierId, bytesToId}
@@ -22,8 +22,7 @@ case class IndexedErgoTransaction(txid: ModifierId,
                                   globalIndex: Long,
                                   inputNums: Array[Long]) extends ExtraIndex {
 
-  override def id: ModifierId = txid
-  override def serializedId: Array[Byte] = fastIdToBytes(txid)
+  override lazy val id: ModifierId = txid
 
   private var _blockId: ModifierId = ModifierId @@ ""
   private var _inclusionHeight: Int = 0

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
@@ -27,8 +27,7 @@ case class IndexedToken(tokenId: ModifierId,
                         description: String,
                         decimals: Int) extends ExtraIndex {
 
-  override def id: ModifierId = uniqueId(tokenId)
-  override def serializedId: Array[Byte] = fastIdToBytes(uniqueId(tokenId))
+  override lazy val id: ModifierId = uniqueId(tokenId)
 
 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
@@ -14,7 +14,7 @@ import sigmastate.{SByte, SType}
 /**
   * Index of a token containing creation information.
   * @param tokenId     - id of this token
-  * @param boxId       - id of the creation box
+  * @param boxId       - id of the box that created th is token
   * @param amount      - emission amount
   * @param name        - name of this token (UTF-8)
   * @param description - description of this token (UTF-8)

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/NumericIndex.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/NumericIndex.scala
@@ -86,9 +86,13 @@ object NumericBoxIndex {
   /**
     * Get a box from database by its index number.
     * @param history - database handle
-    * @param n       - index number of a box
+    * @param n       - index number of a box, can be negative if box is spent
     * @return box with given index, if found
     */
   def getBoxByNumber(history: ErgoHistoryReader, n: Long): Option[IndexedErgoBox] =
-    history.typedExtraIndexById[IndexedErgoBox](history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(n))).get.m)
+    history.typedExtraIndexById[IndexedErgoBox](
+      history.typedExtraIndexById[NumericBoxIndex](
+        bytesToId(NumericBoxIndex.indexToBytes(math.abs(n)))
+      ).get.m
+    )
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -40,8 +40,7 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
   val HEIGHT: Int = 50
   val BRANCHPOINT: Int = HEIGHT / 2
 
-  property("extra indexer rollback") {
-
+  def createDB(): Unit = {
     val dir: File = createTempDir
     dir.mkdirs()
 
@@ -52,20 +51,26 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
 
     ChainGenerator.generate(HEIGHT, dir)(_history)
 
-    run()
+    // reset all variables
+    indexedHeight = 0
+    globalTxIndex = 0L
+    globalBoxIndex = 0L
+    lastWroteToDB = 0
+    caughtUp = false
+    rollback = false
+    general.clear()
+    boxes.clear()
+    trees.clear()
+  }
 
-    val txIndexBefore = globalTxIndex
-    val boxIndexBefore = globalBoxIndex
-
-    var txsIndexed: Int = 0
-    var boxesIndexed: Int = 0
-
-    // manually count balances
-    val addresses: mutable.HashMap[ErgoAddress,Long] = mutable.HashMap[ErgoAddress,Long]()
-    cfor(1)(_ <= BRANCHPOINT, _ + 1) { i =>
+  def getAddresses(limit: Int = BRANCHPOINT): (mutable.HashMap[ErgoAddress,Long],Int,Int) = {
+    var txsIndexed = 0
+    var boxesIndexed = 0
+    val addresses: mutable.HashMap[ErgoAddress, Long] = mutable.HashMap[ErgoAddress, Long]()
+    cfor(1)(_ <= limit, _ + 1) { i =>
       _history.getReader.bestBlockTransactionsAt(i).get.txs.foreach(tx => {
         txsIndexed += 1
-        if(i != 1) {
+        if (i != 1) {
           tx.inputs.foreach(input => {
             val iEb: IndexedErgoBox = _history.getReader.typedExtraIndexById[IndexedErgoBox](bytesToId(input.boxId)).get
             val address: ErgoAddress = ExtraIndexer.getAddress(iEb.box.ergoTree)(addressEncoder)
@@ -74,27 +79,27 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
         }
         tx.outputs.foreach(output => {
           boxesIndexed += 1
-          val address: ErgoAddress =  addressEncoder.fromProposition(output.ergoTree).get
+          val address: ErgoAddress = addressEncoder.fromProposition(output.ergoTree).get
           addresses.put(address, addresses.getOrElse[Long](address, 0) + output.value)
         })
       })
     }
+    (addresses, txsIndexed, boxesIndexed)
+  }
 
-    removeAfter(BRANCHPOINT)
-
+  def checkAddresses(addresses: mutable.HashMap[ErgoAddress,Long]): Int = {
     var mismatches: Int = 0
-
     addresses.foreach(e => {
       _history.getReader.typedExtraIndexById[IndexedErgoAddress](hashErgoTree(e._1.script)) match {
         case Some(iEa) =>
-          if(iEa.balanceInfo.get.nanoErgs != e._2) {
+          if (iEa.balanceInfo.get.nanoErgs != e._2) {
             mismatches += 1
-            System.err.println(s"Address ${e._1.toString} has ${iEa.balanceInfo.get.nanoErgs / 1000000000}ERG, ${e._2  / 1000000000}ERG expected")
+            System.err.println(s"Address ${e._1.toString} has ${iEa.balanceInfo.get.nanoErgs / 1000000000}ERG, ${e._2 / 1000000000}ERG expected")
           }
           iEa.boxes.map(boxNum =>
             NumericBoxIndex.getBoxByNumber(history, boxNum) match {
               case Some(iEb) =>
-                if(iEb.isSpent)
+                if (iEb.isSpent)
                   boxNum.toInt should be <= 0
                 else
                   boxNum.toInt should be >= 0
@@ -102,18 +107,64 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
             }
           )
         case None =>
-          if(e._2 != 0) {
+          if (e._2 != 0) {
             mismatches += 1
             System.err.println(s"Address ${e._1.toString} should exist, but was not found")
           }
       }
     })
+    mismatches
+  }
 
-    // indexnumbers
+  property("extra indexer transactions") {
+    createDB()
+    run()
+    cfor(0)(_ < globalTxIndex, _ + 1) {n =>
+      val id = history.typedExtraIndexById[NumericTxIndex](bytesToId(NumericTxIndex.indexToBytes(n)))
+      id shouldNot be(empty)
+      history.typedExtraIndexById[IndexedErgoTransaction](id.get.m) shouldNot be(empty)
+    }
+  }
+
+  property("extra indexer boxes") {
+    createDB()
+    run()
+    cfor(0)(_ < globalBoxIndex, _ + 1) { n =>
+      val id = history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(n)))
+      id shouldNot be(empty)
+      history.typedExtraIndexById[IndexedErgoBox](id.get.m) shouldNot be(empty)
+    }
+  }
+
+  property("extra indexer addresses") {
+    createDB()
+    run()
+    val (addresses, _, _) = getAddresses(HEIGHT)
+    checkAddresses(addresses) shouldBe 0
+  }
+
+  property("extra indexer rollback") {
+    createDB()
+
+    run()
+
+    val txIndexBefore = globalTxIndex
+    val boxIndexBefore = globalBoxIndex
+
+    // manually count balances
+    val (addresses, txsIndexed, boxesIndexed) = getAddresses()
+
+    // perform rollback
+    removeAfter(BRANCHPOINT)
+
+    // address balances
+    checkAddresses(addresses) shouldBe 0
+
+    // check indexnumbers
     globalTxIndex shouldBe txsIndexed
     globalBoxIndex shouldBe boxesIndexed
 
-    // txs
+    // check txs
     cfor(0)(_ < txIndexBefore, _ + 1) {txNum =>
       val txOpt = history.typedExtraIndexById[NumericTxIndex](bytesToId(NumericTxIndex.indexToBytes(txNum)))
       if(txNum < globalTxIndex)
@@ -122,7 +173,7 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
         txOpt shouldBe None
     }
 
-    // boxes
+    // check boxes
     cfor(0)(_ < boxIndexBefore, _ + 1) { boxNum =>
       val boxOpt = history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(boxNum)))
       if (boxNum < globalBoxIndex)
@@ -131,22 +182,20 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
         boxOpt shouldBe None
     }
 
-    // balances
-    mismatches shouldBe 0
-
     // -------------------------------------------------------------------
     // restart indexer to catch up
     run()
 
+    // check indexnumbers again
     globalTxIndex shouldBe txIndexBefore
     globalBoxIndex shouldBe boxIndexBefore
 
-    // txs after caught up
+    // check txs after caught up
     cfor(0)(_ < txIndexBefore, _ + 1) { txNum =>
       history.typedExtraIndexById[NumericTxIndex](bytesToId(NumericTxIndex.indexToBytes(txNum))) shouldNot be(empty)
     }
 
-    // boxes after caught up
+    // check boxes after caught up
     cfor(0)(_ < boxIndexBefore, _ + 1) { boxNum =>
       history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(boxNum))) shouldNot be(empty)
     }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -79,7 +79,7 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
       })
     }
 
-    removeAfter(BRANCHPOINT, addressEncoder)
+    removeAfter(BRANCHPOINT)
 
     var mismatches: Int = 0
 

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -10,6 +10,7 @@ import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistory
+import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
 import org.ergoplatform.nodeView.mempool.ErgoMemPool.SortingOption
 import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateConstants, StateType, UtxoState, UtxoStateReader}
 import org.ergoplatform.settings.{ErgoSettings, NetworkType, NodeConfigurationSettings}
@@ -84,7 +85,7 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
     var mismatches: Int = 0
 
     addresses.foreach(e => {
-      _history.getReader.typedExtraIndexById[IndexedErgoAddress](bytesToId(IndexedErgoAddressSerializer.hashErgoTree(e._1.script))) match {
+      _history.getReader.typedExtraIndexById[IndexedErgoAddress](hashErgoTree(e._1.script)) match {
         case Some(iEa) =>
           if(iEa.balanceInfo.get.nanoErgs != e._2) {
             mismatches += 1

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -134,6 +134,23 @@ class ExtraIndexerSpecification extends ErgoPropertyTest with ExtraIndexerBase w
     // balances
     mismatches shouldBe 0
 
+    // -------------------------------------------------------------------
+    // restart indexer to catch up
+    run()
+
+    globalTxIndex shouldBe txIndexBefore
+    globalBoxIndex shouldBe boxIndexBefore
+
+    // txs after caught up
+    cfor(0)(_ < txIndexBefore, _ + 1) { txNum =>
+      history.typedExtraIndexById[NumericTxIndex](bytesToId(NumericTxIndex.indexToBytes(txNum))) shouldNot be(empty)
+    }
+
+    // boxes after caught up
+    cfor(0)(_ < boxIndexBefore, _ + 1) { boxNum =>
+      history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(boxNum))) shouldNot be(empty)
+    }
+
   }
 
 }

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -47,7 +47,7 @@ class ErgoSettingsSpecification extends ErgoPropertyTest {
     )
     settings.cacheSettings shouldBe CacheSettings(
       HistoryCacheSettings(
-        12, 500, 100, 1000
+        12, 1000, 100, 1000
       ),
       NetworkCacheSettings(
         invalidModifiersCacheSize                 = 10000,
@@ -96,7 +96,7 @@ class ErgoSettingsSpecification extends ErgoPropertyTest {
     )
     settings.cacheSettings shouldBe CacheSettings(
       HistoryCacheSettings(
-        12, 500, 100, 1000
+        12, 1000, 100, 1000
       ),
       NetworkCacheSettings(
         invalidModifiersCacheSize                 = 10000,
@@ -138,7 +138,7 @@ class ErgoSettingsSpecification extends ErgoPropertyTest {
     )
     settings.cacheSettings shouldBe CacheSettings(
       HistoryCacheSettings(
-        12, 500, 100, 1000
+        12, 1000, 100, 1000
       ),
       NetworkCacheSettings(
         invalidModifiersCacheSize                 = 10000,


### PR DESCRIPTION
- Changed the implementation from using ArrayBuffers to HashMaps. This allows bigger buffer sizes and faster indexing, which made sync times go from ~2,5h to ~1,5h.

- Added a "sortDirection" parameter to /blockchain/box/unspent endpoints
	- Closes #1961

- Fixed a critical bug that caused blocks to be skipped after a rollback occured. Because of this the extra database was probably "corrupted" due to missing boxes and transactions.

- Fixed another critical bug in token tracking that caused overwrites in some tokens information.
	- [x] Require extra indexer resync when updating to newer version