### PR TITLE
Polishing bootstrapping with UTXO set snapshot code towards release

### DIFF
--- a/avldb/src/main/scala/scorex/core/serialization/ManifestSerializer.scala
+++ b/avldb/src/main/scala/scorex/core/serialization/ManifestSerializer.scala
@@ -11,6 +11,9 @@ import scorex.util.serialization.{Reader, Writer}
 class ManifestSerializer(manifestDepth: Byte) extends ErgoSerializer[BatchAVLProverManifest[DigestType]] {
   private val nodeSerializer = VersionedLDBAVLStorage.noStoreSerializer
 
+  /**
+    * Serialize manifest provided as top subtree and height separately. Used in tests.
+    */
   def serialize(rootNode: ProverNodes[DigestType], rootNodeHeight: Byte, w: Writer): Unit = {
     w.put(rootNodeHeight)
     w.put(manifestDepth)
@@ -29,6 +32,7 @@ class ManifestSerializer(manifestDepth: Byte) extends ErgoSerializer[BatchAVLPro
 
     loop(rootNode, level = 1)
   }
+
   override def serialize(manifest: BatchAVLProverManifest[DigestType], w: Writer): Unit = {
     serialize(manifest.root, manifest.rootHeight.toByte, w)
   }

--- a/avldb/src/main/scala/scorex/core/serialization/ManifestSerializer.scala
+++ b/avldb/src/main/scala/scorex/core/serialization/ManifestSerializer.scala
@@ -11,8 +11,7 @@ import scorex.util.serialization.{Reader, Writer}
 class ManifestSerializer(manifestDepth: Byte) extends ErgoSerializer[BatchAVLProverManifest[DigestType]] {
   private val nodeSerializer = VersionedLDBAVLStorage.noStoreSerializer
 
-  override def serialize(manifest: BatchAVLProverManifest[DigestType], w: Writer): Unit = {
-    val rootNodeHeight = manifest.rootHeight.toByte
+  def serialize(rootNode: ProverNodes[DigestType], rootNodeHeight: Byte, w: Writer): Unit = {
     w.put(rootNodeHeight)
     w.put(manifestDepth)
 
@@ -24,10 +23,14 @@ class ManifestSerializer(manifestDepth: Byte) extends ErgoSerializer[BatchAVLPro
         case i: InternalProverNode[DigestType] if level < manifestDepth =>
           loop(i.left, level + 1)
           loop(i.right, level + 1)
+        case _: InternalProverNode[DigestType] =>
       }
     }
 
-    loop(manifest.root, level = 1)
+    loop(rootNode, level = 1)
+  }
+  override def serialize(manifest: BatchAVLProverManifest[DigestType], w: Writer): Unit = {
+    serialize(manifest.root, manifest.rootHeight.toByte, w)
   }
 
   override def parse(r: Reader): BatchAVLProverManifest[DigestType] = {

--- a/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
+++ b/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
@@ -423,7 +423,10 @@ class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
   def processSnapshot[T](logic: SnapshotReadInterface => T): Try[T] = {
     val ro = new ReadOptions()
     try {
+      lock.writeLock().lock()
       ro.snapshot(db.getSnapshot)
+      lock.writeLock().unlock()
+
       object readInterface extends SnapshotReadInterface {
         def get(key: Array[Byte]): Array[Byte] = db.get(key, ro)
       }

--- a/papers/utxo.md
+++ b/papers/utxo.md
@@ -23,9 +23,9 @@ UTXO set is authenticated via AVL+ tree. Design principles for tree construction
 [https://eprint.iacr.org/2016/994.pdf](https://eprint.iacr.org/2016/994.pdf), the implementation of the 
 tree is available in [the Scrypto framework](https://github.com/input-output-hk/scrypto).
 
-Time is broken into epochs, 1 epoch = 51,200 blocks (~72 days).
+Time is broken into epochs, 1 epoch = 52,224 blocks (~72.5 days).
 Snapshot is taken after last block of an epoch, namely, after processing a block with 
-height *h % 51200 == 51199*.
+height *h % 51200 == 52,224*.
 
 Chunk format
 ------------

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -23,6 +23,7 @@ ergo {
 
     utxo {
         # Download and apply UTXO set snapshot and full-blocks after that
+        # Done in 5.0.12, but better to bootstrap since version 5.0.13
         utxoBootstrap = false
 
         # how many utxo set snapshots to store, 0 means that they are not stored at all

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -47,18 +47,6 @@ ergo {
 
       injectionBoxBytesEncoded = "80a8d6b9071003040005808098f4e9b5ca6a0402d1ed91c1b2a4730000730193c5a7c5b2a47302008f9e2d0220fa2bf23962cdf51b07722d6237c0c7b8a44f78856c0f7ec308dc1ef1a92a5101d9a2cc8a09abfaed87afacfbb7daee79a6b26f10c6613fc13d3f3953e5521d1a808088fccdbcc32300fca71b8b95f6ad14ce600a126c8842334d40d35f8754176c4cda2c95219f19f700"
     }
-
-    utxo {
-       # Download and apply UTXO set snapshot and full-blocks after that
-       utxoBootstrap = false
-
-       # how many utxo set snapshots to store, 0 means that they are not stored at all
-       storingUtxoSnapshots = 2
-
-       # how many utxo set snapshots for a height with same id we need to find in p2p network
-       # in order to start downloading it
-       p2pUtxoSnapshots = 2
-    }
   }
 
   node {
@@ -84,6 +72,18 @@ ergo {
 
     # maximum cost of transaction for it to be propagated
     maxTransactionCost = 4900000
+
+    utxo {
+        # Download and apply UTXO set snapshot and full-blocks after that
+        utxoBootstrap = false
+
+        # how many utxo set snapshots to store, 0 means that they are not stored at all
+        storingUtxoSnapshots = 2
+
+        # how many utxo set snapshots for a height with same id we need to find in p2p network
+        # in order to start downloading it
+        p2pUtxoSnapshots = 2
+    }
   }
 
 }

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -47,6 +47,18 @@ ergo {
 
       injectionBoxBytesEncoded = "80a8d6b9071003040005808098f4e9b5ca6a0402d1ed91c1b2a4730000730193c5a7c5b2a47302008f9e2d0220fa2bf23962cdf51b07722d6237c0c7b8a44f78856c0f7ec308dc1ef1a92a5101d9a2cc8a09abfaed87afacfbb7daee79a6b26f10c6613fc13d3f3953e5521d1a808088fccdbcc32300fca71b8b95f6ad14ce600a126c8842334d40d35f8754176c4cda2c95219f19f700"
     }
+
+    utxo {
+       # Download and apply UTXO set snapshot and full-blocks after that
+       utxoBootstrap = false
+
+       # how many utxo set snapshots to store, 0 means that they are not stored at all
+       storingUtxoSnapshots = 2
+
+       # how many utxo set snapshots for a height with same id we need to find in p2p network
+       # in order to start downloading it
+       p2pUtxoSnapshots = 2
+    }
   }
 
   node {

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -974,6 +974,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
             hr.utxoSetSnapshotDownloadPlan() match {
               case Some(downloadPlan) =>
                 if (downloadPlan.fullyDownloaded) {
+                  log.info("All the UTXO set snapshot chunks downloaded")
                   // if all the chunks of snapshot are downloaded, initialize UTXO set state with it
                   if (!hr.isUtxoSnapshotApplied) {
                     val h = downloadPlan.snapshotHeight

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -575,7 +575,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     if (peersCount >= MinSnapshots) {
       networkControllerRef ! SendToNetwork(msg, SendToPeers(peers))
     } else {
-      log.info(s"Less UTXO-snapshot supporting peers found than required mininum ($peersCount < $MinSnapshots)")
+      log.warn(s"Less UTXO-snapshot supporting peers found than required mininum ($peersCount < $MinSnapshots)")
     }
   }
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1408,8 +1408,12 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       logger.debug("Chain is good")
 
     case ChainIsStuck(error) =>
-      log.warn(s"Chain is stuck! $error\nDelivery tracker State:\n$deliveryTracker\nSync tracker state:\n$syncTracker")
-      deliveryTracker.reset()
+      if (historyReader.fullBlockHeight > 0) {
+        log.warn(s"Chain is stuck! $error\nDelivery tracker State:\n$deliveryTracker\nSync tracker state:\n$syncTracker")
+        deliveryTracker.reset()
+      } else {
+        log.debug("Got ChainIsStuck signal when no full-blocks applied yet")
+      }
   }
 
   /** handlers of messages coming from peers */

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -610,7 +610,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
           maxModifiers = deliveryTracker.modifiersToDownload,
           minModifiersPerBucket,
           maxModifiersPerBucket
-        )(getPeersForDownloadingBlocks) { howManyPerType =>
+        )(getPeersForDownloadingBlocks) { _ =>
           // leave block section ids only not touched before
           modifiersToFetch.flatMap { case (tid, mids) =>
             val updMids = mids.filter { mid =>

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -905,14 +905,14 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       val encodedManifestId = ModifierId @@ Algos.encode(manifestId)
       val ownId = hr.bestHeaderAtHeight(height).map(_.stateRoot).map(stateDigest => splitDigest(stateDigest)._1)
       if (ownId.getOrElse(Array.emptyByteArray).sameElements(manifestId)) {
-        log.debug(s"Got manifest $encodedManifestId for height $height from $remote")
+        log.debug(s"Discovered manifest $encodedManifestId for height $height from $remote")
         // add manifest to available manifests dictionary if it is not written there yet
         val existingOffers = availableManifests.getOrElse(encodedManifestId, (height -> Seq.empty))
         if (!existingOffers._2.contains(remote)) {
           log.info(s"Found new manifest ${Algos.encode(manifestId)} for height $height at $remote")
           availableManifests.put(encodedManifestId, height -> (existingOffers._2 :+ remote))
         } else {
-          log.warn(s"Got manifest $manifestId twice from $remote")
+          log.warn(s"Double manifest declaration for $manifestId from $remote")
         }
       } else {
         log.error(s"Got wrong manifest id $encodedManifestId from $remote")

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -971,7 +971,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       case Success(subtree) =>
         val chunkId = ModifierId @@ Algos.encode(subtree.id)
         deliveryTracker.getRequestedInfo(UtxoSnapshotChunkTypeId.value, chunkId) match {
-          case Some(ri) if ri.peer == remote =>
+          case Some(_) =>
             log.debug(s"Got utxo snapshot chunk, id: $chunkId, size: ${serializedChunk.length}")
             deliveryTracker.setUnknown(chunkId, UtxoSnapshotChunkTypeId.value)
             hr.registerDownloadedChunk(subtree.id, serializedChunk)
@@ -1000,8 +1000,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 log.warn(s"No download plan found when processing UTXO set snapshot chunk $chunkId")
             }
 
-          case _ =>
-            log.info(s"Penalizing spamming peer $remote sent non-asked UTXO set snapshot $chunkId")
+          case None =>
+            log.info(s"Penalizing spamming peer $remote sent non-asked UTXO set snapshot chunk $chunkId")
             penalizeSpammingPeer(remote)
         }
 

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -284,13 +284,11 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     case InitStateFromSnapshot(height, blockId) =>
       if (!history().isUtxoSnapshotApplied) {
         val store = minimalState().store
-        history().createPersistentProver(store, blockId) match {
-          //todo: pass metadata?
+        history().createPersistentProver(store, history(), height, blockId) match {
           case Success(pp) =>
             log.info(s"Restoring state from prover with digest ${pp.digest} reconstructed for height $height")
             history().utxoSnapshotApplied(height)
             val newState = new UtxoState(pp, version = VersionTag @@@ blockId, store, settings)
-            // todo: apply 10 headers before utxo set snapshot?
             updateNodeView(updatedState = Some(newState.asInstanceOf[State]))
           case Failure(t) =>
             log.error("UTXO set snapshot application failed: ", t)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -295,6 +295,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           case Failure(t) =>
             log.error("UTXO set snapshot application failed: ", t)
         }
+      } else {
+        log.warn("InitStateFromSnapshot arrived when state already initialized")
       }
 
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -618,7 +618,7 @@ trait ErgoHistoryReader
     */
   def estimatedTip(): Option[Height] = {
     Try { //error may happen if history not initialized
-      if(isHeadersChainSynced) {
+      if (isHeadersChainSynced) {
         Some(headersHeight)
       } else {
         None

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.settings.ErgoSettings
   * A class that keeps and calculates minimal height for full blocks starting from which we need to download these full
   * blocks from the network and keep them in our history.
   */
-trait FullBlockPruningProcessor {
+trait FullBlockPruningProcessor extends MinimalFullBlockHeightFunctions {
 
   protected def settings: ErgoSettings
 
@@ -18,7 +18,6 @@ trait FullBlockPruningProcessor {
   private def VotingEpochLength = chainSettings.voting.votingLength
 
   @volatile private[history] var isHeadersChainSyncedVar: Boolean = false
-  @volatile private[history] var minimalFullBlockHeightVar: Int = ErgoHistory.GenesisHeight
 
   private def extensionWithParametersHeight(height: Int): Int = {
     require(height >= VotingEpochLength)
@@ -33,7 +32,7 @@ trait FullBlockPruningProcessor {
 
   /** Start height to download full blocks from
     */
-  def minimalFullBlockHeight: Int = minimalFullBlockHeightVar
+  def minimalFullBlockHeight: Int = readMinimalFullBlockHeight()
 
   /** Check if headers chain is synchronized with the network and modifier is not too old
     */
@@ -47,15 +46,16 @@ trait FullBlockPruningProcessor {
     * @return minimal height to process best full block
     */
   def updateBestFullBlock(header: Header): Int = {
-    minimalFullBlockHeightVar = if (!nodeConfig.isFullBlocksPruned) {
-      ErgoHistory.GenesisHeight // keep all blocks in history
-    } else if (!isHeadersChainSynced && !nodeConfig.stateType.requireProofs) {
-      // just synced with the headers chain - determine first full block to apply
-      //TODO start with the height of UTXO snapshot applied. For now we start from genesis until this is implemented
-      ErgoHistory.GenesisHeight
+    val minimalFullBlockHeight = if (nodeConfig.blocksToKeep < 0) {
+      if (nodeConfig.utxoSettings.utxoBootstrap) {
+        // we have constant min full block height corresponding to first block after utxo set snapshot
+        readMinimalFullBlockHeight()
+      } else {
+        ErgoHistory.GenesisHeight // keep all blocks in history as no pruning set
+      }
     } else {
       // Start from config.blocksToKeep blocks back
-      val h = Math.max(minimalFullBlockHeight, header.height - nodeConfig.blocksToKeep + 1)
+      val h = Math.max(readMinimalFullBlockHeight(), header.height - nodeConfig.blocksToKeep + 1)
       // ... but not later than the beginning of a voting epoch
       if (h > VotingEpochLength) {
         Math.min(h, extensionWithParametersHeight(h))
@@ -64,7 +64,8 @@ trait FullBlockPruningProcessor {
       }
     }
     if (!isHeadersChainSynced) isHeadersChainSyncedVar = true
-    minimalFullBlockHeightVar
+    writeMinimalFullBlockHeight(minimalFullBlockHeight)
+    minimalFullBlockHeight
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -10,7 +10,7 @@ import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.nodeView.history.ErgoHistory
-import org.ergoplatform.nodeView.history.ErgoHistory.{Difficulty, GenesisHeight}
+import org.ergoplatform.nodeView.history.ErgoHistory.{Difficulty, GenesisHeight, Height}
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.settings.Constants.HashLength
 import org.ergoplatform.settings.ValidationRules._
@@ -21,6 +21,7 @@ import scorex.core.utils.ScorexEncoding
 import scorex.core.validation.{InvalidModifier, ModifierValidator, ValidationResult, ValidationState}
 import scorex.db.ByteArrayWrapper
 import scorex.util._
+import scorex.util.encode.Base16
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
@@ -30,6 +31,22 @@ import scala.util.{Failure, Success, Try}
   * Contains all functions required by History to process Headers.
   */
 trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with ScorexEncoding {
+
+  /**
+    * Key for database record storing ID of best block header
+    */
+  protected val BestHeaderKey: ByteArrayWrapper = ByteArrayWrapper(Array.fill(HashLength)(Header.modifierTypeId))
+
+  /**
+    * Key for database record storing ID of best full block
+    */
+  protected val BestFullBlockKey: ByteArrayWrapper = ByteArrayWrapper(Array.fill(HashLength)(-1))
+
+  protected val MinFullBlockHeightKey = {
+    // hash of "minfullheight" UTF-8 string
+    ByteArrayWrapper(Base16.decode("4987eb6a8fecbed88a6f733f456cdf4e334b944f4436be4cab50cacb442e15e6").get)
+  }
+
 
   protected val historyStorage: HistoryStorage
 
@@ -55,6 +72,14 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
 
   protected[history] def validityKey(id: ModifierId): ByteArrayWrapper =
     ByteArrayWrapper(Algos.hash("validity".getBytes(ErgoHistory.CharsetName) ++ idToBytes(id)))
+
+  override def writeMinimalFullBlockHeight(height: Height): Unit = {
+    historyStorage.insert(Array(MinFullBlockHeightKey -> Ints.toByteArray(height)), Array.empty[BlockSection])
+  }
+
+  override def readMinimalFullBlockHeight(): Height = {
+    historyStorage.getIndex(MinFullBlockHeightKey).map(Ints.fromByteArray).getOrElse(ErgoHistory.GenesisHeight)
+  }
 
   def bestHeaderIdOpt: Option[ModifierId] = historyStorage.getIndex(BestHeaderKey).map(bytesToId)
 
@@ -157,10 +182,6 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     * @return Success() if header is valid, Failure(error) otherwise
     */
   protected def validate(header: Header): Try[Unit] = HeaderValidator.validate(header).toTry
-
-  protected val BestHeaderKey: ByteArrayWrapper = ByteArrayWrapper(Array.fill(HashLength)(Header.modifierTypeId))
-
-  protected val BestFullBlockKey: ByteArrayWrapper = ByteArrayWrapper(Array.fill(HashLength)(-1))
 
   /**
     * @param id - header id

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -42,6 +42,9 @@ trait HeadersProcessor extends ToDownloadProcessor with ScorexLogging with Score
     */
   protected val BestFullBlockKey: ByteArrayWrapper = ByteArrayWrapper(Array.fill(HashLength)(-1))
 
+  /**
+    * Key for database record storing height of first full block stored
+    */
   protected val MinFullBlockHeightKey = {
     // hash of "minfullheight" UTF-8 string
     ByteArrayWrapper(Base16.decode("4987eb6a8fecbed88a6f733f456cdf4e334b944f4436be4cab50cacb442e15e6").get)

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/MinimalFullBlockHeightFunctions.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/MinimalFullBlockHeightFunctions.scala
@@ -1,0 +1,15 @@
+package org.ergoplatform.nodeView.history.storage.modifierprocessors
+
+import org.ergoplatform.nodeView.history.ErgoHistory.Height
+
+trait MinimalFullBlockHeightFunctions {
+  // minimal height to applu full blocks from
+  // its value depends on node settings,
+  // if download with UTXO set snapshot is used, the value is being set to a first block after the snapshot,
+  // if blockToKeep > 0, the value is being set to a first block of blockchain suffix after headers downloaded
+
+  def writeMinimalFullBlockHeight(height: Height): Unit
+
+  def readMinimalFullBlockHeight(): Height
+
+}

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/MinimalFullBlockHeightFunctions.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/MinimalFullBlockHeightFunctions.scala
@@ -2,14 +2,23 @@ package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
 import org.ergoplatform.nodeView.history.ErgoHistory.Height
 
+/**
+  * Interface to methods providing updating and reading height of first full block stored in local database
+  */
 trait MinimalFullBlockHeightFunctions {
-  // minimal height to applu full blocks from
-  // its value depends on node settings,
-  // if download with UTXO set snapshot is used, the value is being set to a first block after the snapshot,
-  // if blockToKeep > 0, the value is being set to a first block of blockchain suffix after headers downloaded
 
-  def writeMinimalFullBlockHeight(height: Height): Unit
-
+  /**
+    * @return minimal height to applu full blocks from. Its value depends on node settings,
+    * if bootstrapping with UTXO set snapshot is used, the value is being set to a first block after the snapshot,
+    * for other modes, if blockToKeep > 0, the value is being set to a first block of blockchain suffix
+    * after headers downloaded, and the value is updated when new blocks added to the chain. If blockToKeep == 0,
+    * min full block height is set to genesis block height (1).
+    */
   def readMinimalFullBlockHeight(): Height
+
+  /**
+    * Update min full block height, see `readMinimalFullBlockHeight` scaladoc on how it should be done
+    */
+  def writeMinimalFullBlockHeight(height: Height): Unit
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotDownloadPlan.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotDownloadPlan.scala
@@ -60,8 +60,15 @@ object UtxoSetSnapshotDownloadPlan {
     val now = System.currentTimeMillis()
 
     // it is safe to call .toByte below, as the whole tree has height <= 127, and manifest even less
-    UtxoSetSnapshotDownloadPlan(now, blockHeight, manifest.id, manifest.rootHeight.toByte, subtrees.toIndexedSeq,
-      IndexedSeq.empty, 0, peersToDownload)
+    UtxoSetSnapshotDownloadPlan(
+      latestUpdateTime = now,
+      snapshotHeight = blockHeight,
+      utxoSetRootHash = manifest.id,
+      utxoSetTreeHeight = manifest.rootHeight.toByte,
+      expectedChunkIds = subtrees.toIndexedSeq,
+      downloadedChunkIds = IndexedSeq.empty,
+      downloadingChunks = 0,
+      peersToDownload = peersToDownload)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotDownloadPlan.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotDownloadPlan.scala
@@ -10,6 +10,7 @@ import scorex.crypto.hash.Digest32
 /**
   * Entity which stores information about state of UTXO set snapshots downloading
   *
+  * @param createdTime - time when snapshot was created
   * @param latestUpdateTime - latest time when anything was updated for the state of UTXO set snapshot
   * @param snapshotHeight - height of a block UTXO set snapshot is corresponding to (UTXO set if after the block applied)
   * @param utxoSetRootHash - root hash of AVL+ tree which is authenticating UTXO set snasphot
@@ -20,7 +21,8 @@ import scorex.crypto.hash.Digest32
   * @param downloadingChunks - number of UTXO set shapshot chunks the node is currently downloading
   * @param peersToDownload - peers UTXO set snapshot chunks can be downloaded from
   */
-case class UtxoSetSnapshotDownloadPlan(latestUpdateTime: Long,
+case class UtxoSetSnapshotDownloadPlan(createdTime: Long,
+                                       latestUpdateTime: Long,
                                        snapshotHeight: Height,
                                        utxoSetRootHash: Digest32,
                                        utxoSetTreeHeight: Byte,
@@ -61,6 +63,7 @@ object UtxoSetSnapshotDownloadPlan {
 
     // it is safe to call .toByte below, as the whole tree has height <= 127, and manifest even less
     UtxoSetSnapshotDownloadPlan(
+      createdTime = now,
       latestUpdateTime = now,
       snapshotHeight = blockHeight,
       utxoSetRootHash = manifest.id,

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
@@ -191,7 +191,7 @@ trait UtxoSetSnapshotProcessor extends ScorexLogging {
     _manifest match {
       case Some(manifest) =>
         log.info("Starting UTXO set snapshot transfer into state database")
-        ErgoStateReader.reconstructStateContextBeforeEpoch(stateStore, historyReader, height, settings) match {
+        ErgoStateReader.reconstructStateContextBeforeEpoch(historyReader, height, settings) match {
           case Success(esc) =>
             val metadata = UtxoState.metadata(VersionTag @@@ blockId, VersionedLDBAVLStorage.digest(manifest.id, manifest.rootHeight), None, esc)
             VersionedLDBAVLStorage.recreate(manifest, downloadedChunksIterator(), additionalData = metadata.toIterator, stateStore).flatMap {

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
@@ -60,6 +60,10 @@ trait UtxoSetSnapshotProcessor extends ScorexLogging {
     * after.
     */
   def utxoSnapshotApplied(height: Height): Unit = {
+    val utxoPhaseTime = {
+      _cachedDownloadPlan.map(_.latestUpdateTime).getOrElse(0L) - _cachedDownloadPlan.map(_.createdTime).getOrElse(0L)
+    }
+    log.info(s"UTXO set downloading and application time: $utxoPhaseTime")
     // remove downloaded utxo set snapshots chunks
     val ts0 = System.currentTimeMillis()
     _cachedDownloadPlan.foreach { plan =>

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
@@ -63,7 +63,7 @@ trait UtxoSetSnapshotProcessor extends ScorexLogging {
     val utxoPhaseTime = {
       _cachedDownloadPlan.map(_.latestUpdateTime).getOrElse(0L) - _cachedDownloadPlan.map(_.createdTime).getOrElse(0L)
     }
-    log.info(s"UTXO set downloading and application time: $utxoPhaseTime")
+    log.info(s"UTXO set downloading and application time: ${utxoPhaseTime / 1000.0} s.")
     // remove downloaded utxo set snapshots chunks
     val ts0 = System.currentTimeMillis()
     _cachedDownloadPlan.foreach { plan =>

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
@@ -157,8 +157,7 @@ trait UtxoSetSnapshotProcessor extends ScorexLogging {
       case Some(plan) =>
         cfor(0)(_ < plan.downloadedChunkIds.size, _ + 1) { idx =>
           if (!plan.downloadedChunkIds(idx) && plan.expectedChunkIds(idx).sameElements(chunkId)) {
-            val idxBytes = Ints.toByteArray(idx)
-            historyStorage.insert(downloadedChunksPrefix ++ idxBytes, chunkSerialized)
+            historyStorage.insert(chunkIdFromIndex(idx), chunkSerialized)
             val updDownloaded = plan.downloadedChunkIds.updated(idx, true)
             val updDownloading = plan.downloadingChunks - 1
             val updPlan = plan.copy(latestUpdateTime = System.currentTimeMillis(), downloadedChunkIds = updDownloaded, downloadingChunks = updDownloading)
@@ -171,11 +170,13 @@ trait UtxoSetSnapshotProcessor extends ScorexLogging {
     }
   }
 
+  private def chunkIdFromIndex(index: Int): Array[Byte] = {
+    val idxBytes = Ints.toByteArray(index)
+    downloadedChunksPrefix ++ idxBytes
+  }
+
   private def downloadedChunkIdsIterator(totalChunks: Int): Iterator[Array[Byte]] = {
-    Iterator.range(0, totalChunks).map { idx =>
-      val idxBytes = Ints.toByteArray(idx)
-      downloadedChunksPrefix ++ idxBytes
-    }
+    Iterator.range(0, totalChunks).map(chunkIdFromIndex)
   }
 
   /**
@@ -235,4 +236,5 @@ trait UtxoSetSnapshotProcessor extends ScorexLogging {
         Failure(new Exception(msg))
     }
   }
+
 }

--- a/src/main/scala/org/ergoplatform/nodeView/state/SnapshotsDb.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/SnapshotsDb.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.nodeView.state
 
 import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.nodeView.state.UtxoState.{ManifestId, SubtreeId}
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{Algos, ErgoSettings}
 import scorex.core.serialization.ManifestSerializer
 import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage
 import scorex.crypto.hash.Digest32
@@ -10,6 +10,8 @@ import scorex.db.{LDBFactory, LDBKVStore}
 import scorex.util.ScorexLogging
 import scorex.util.encode.Base16
 
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -39,48 +41,69 @@ class SnapshotsDb(store: LDBKVStore) extends ScorexLogging {
 
     // sort manifests by height to prune oldest ones after
     val manifests = readSnapshotsInfo.availableManifests.toSeq.sortBy(_._1)
+    val manifestSerializer = ManifestSerializer.defaultSerializer
 
-    val (toPrune, toLeave) = if (manifests.size > toStore) {
-      val tp = manifests.dropRight(toStore)
-      val tl = manifests.takeRight(toStore)
-      tp -> tl
-    } else {
-      log.info("No snapshots to prune")
-      return
-    }
+    if (manifests.size > toStore) {
 
-    toPrune.foreach { case (h, manifestId) =>
-      log.info(s"Pruning snapshot at height $h")
-      val keysToRemove: Array[Array[Byte]] = store.get(manifestId) match {
-        case Some(manifestBytes) =>
-          ManifestSerializer.defaultSerializer.parseBytesTry(manifestBytes) match {
-            case Success(m) =>
-              (m.subtreesIds += manifestId).toArray // todo: more efficient construction
-            case Failure(e) =>
-              log.error(s"Can't parse manifest ${Base16.encode(manifestId)} :", e)
-              Array.empty
-          }
-        case None =>
-          log.error(s"Manifest ${Base16.encode(manifestId)} not found:")
-          Array.empty
+      val lastManifestBytes = manifests.last._2
+      val lastManifestSubtrees =
+        manifestSerializer
+          .parseBytesTry(lastManifestBytes)
+          .map(_.subtreesIds)
+          .getOrElse(ArrayBuffer.empty)
+          .map(Algos.encode)
+          .toSet
+
+      val toPrune = manifests.dropRight(toStore)
+      val toLeave = manifests.takeRight(toStore)
+
+      toPrune.foreach { case (h, manifestId) =>
+        val pt0 = System.currentTimeMillis()
+        val keysToRemove: Array[Array[Byte]] = store.get(manifestId) match {
+          case Some(manifestBytes) =>
+            manifestSerializer.parseBytesTry(manifestBytes) match {
+              case Success(m) =>
+                val keys = mutable.ArrayBuilder.make[Array[Byte]]()
+                val subtrees = m.subtreesIds
+                keys.sizeHint(subtrees.size + 1)
+                keys += manifestId
+                // filter out subtrees which are the same in the latest version of tree snapshot
+                subtrees.foreach { subtreeId =>
+                  if (!lastManifestSubtrees.contains(Algos.encode(subtreeId))) {
+                    keys += subtreeId
+                  }
+                }
+                keys.result()
+              case Failure(e) =>
+                log.error(s"Can't parse manifest ${Base16.encode(manifestId)} :", e)
+                Array.empty
+            }
+          case None =>
+            log.error(s"Manifest ${Base16.encode(manifestId)} not found when should be pruned")
+            Array.empty
+        }
+        store.remove(keysToRemove)
+        val pt = System.currentTimeMillis()
+        log.info(s"Pruning snapshot at height $h done in ${pt - pt0} ms.")
       }
-      store.remove(keysToRemove)
+
+      val updInfo = new SnapshotsInfo(toLeave.toMap)
+      writeSnapshotsInfo(updInfo)
+
+      log.info("Snapshots pruning finished")
+    } else {
+      log.debug("No snapshots to prune")
     }
-
-    val updInfo = new SnapshotsInfo(toLeave.toMap)
-    writeSnapshotsInfo(updInfo)
-
-    log.info("Snapshots pruning finished")
   }
 
   /**
     * Lazily read current UTXO set snapshot from versioned AVL+ tree database and store it in this snapshots database
     *
-    * @param pullFrom - versioned AVL+ tree database to pull snapshot from
-    * @param height - height of a block snapshot is corresponding to
+    * @param pullFrom         - versioned AVL+ tree database to pull snapshot from
+    * @param height           - height of a block snapshot is corresponding to
     * @param expectedRootHash - expected tree root hash in `pullFrom` database
     * @return - id of the snapshot (root hash of its authenticating AVL+ tree),
-    *           or error happened during read-write process
+    *         or error happened during read-write process
     */
   def writeSnapshot(pullFrom: VersionedLDBAVLStorage,
                     height: Height,
@@ -95,6 +118,7 @@ class SnapshotsDb(store: LDBKVStore) extends ScorexLogging {
 
   /**
     * Read manifest bytes without deserializing it. Useful when manifest is to be sent over the wir
+    *
     * @param id - manifest id
     */
   def readManifestBytes(id: ManifestId): Option[Array[Byte]] = {
@@ -103,6 +127,7 @@ class SnapshotsDb(store: LDBKVStore) extends ScorexLogging {
 
   /**
     * Read subtree bytes without deserializing it. Useful when subtree is to be sent over the wir
+    *
     * @param id - subtree id
     */
   def readSubtreeBytes(id: SubtreeId): Option[Array[Byte]] = {

--- a/src/main/scala/org/ergoplatform/nodeView/state/SnapshotsDb.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/SnapshotsDb.scala
@@ -45,10 +45,10 @@ class SnapshotsDb(store: LDBKVStore) extends ScorexLogging {
 
     if (manifests.size > toStore) {
 
-      val lastManifestBytes = manifests.last._2
+      val lastManifestBytesOpt = store.get(manifests.last._2)
       val lastManifestSubtrees =
-        manifestSerializer
-          .parseBytesTry(lastManifestBytes)
+        lastManifestBytesOpt
+          .flatMap(bs => manifestSerializer.parseBytesTry(bs).toOption)
           .map(_.subtreesIds)
           .getOrElse(ArrayBuffer.empty)
           .map(Algos.encode)

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoSetSnapshotPersistence.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoSetSnapshotPersistence.scala
@@ -51,9 +51,8 @@ trait UtxoSetSnapshotPersistence extends ScorexLogging {
     if (ergoSettings.nodeSettings.areSnapshotsStored &&
         timeToTakeSnapshot(height) &&
         estimatedTip.nonEmpty &&
-        estimatedTip.get - height <= MakeSnapshotEvery) {
+        estimatedTip.get - height <= MakeSnapshotEvery * ergoSettings.nodeSettings.utxoSettings.storingUtxoSnapshots) {
 
-      import scala.concurrent.ExecutionContext.Implicits.global
       val ms0 = System.currentTimeMillis()
 
       // drop tree height byte from digest to get current root hash of AVL+ tree
@@ -67,7 +66,7 @@ trait UtxoSetSnapshotPersistence extends ScorexLogging {
         snapshotsDb.pruneSnapshots(ergoSettings.nodeSettings.utxoSettings.storingUtxoSnapshots)
         val ft = System.currentTimeMillis()
         log.info("Work within future finished in: " + (ft - ft0) + " ms.")
-      }
+      }(scala.concurrent.ExecutionContext.Implicits.global)
       val ms = System.currentTimeMillis()
       log.info("Main thread time to dump utxo set snapshot: " + (ms - ms0))
     }

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoSetSnapshotPersistence.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoSetSnapshotPersistence.scala
@@ -47,11 +47,11 @@ trait UtxoSetSnapshotPersistence extends ScorexLogging {
     def timeToTakeSnapshot(height: Int): Boolean = {
       height % MakeSnapshotEvery == MakeSnapshotEvery - 1
     }
-
+    log.info(s"checking snapshot for $height, simple check: " + timeToTakeSnapshot(height))
     if (ergoSettings.nodeSettings.areSnapshotsStored &&
         timeToTakeSnapshot(height) &&
         estimatedTip.nonEmpty &&
-        estimatedTip.get - height <= MakeSnapshotEvery * ergoSettings.nodeSettings.utxoSettings.storingUtxoSnapshots) {
+        estimatedTip.get - height <= MakeSnapshotEvery) {
 
       val ms0 = System.currentTimeMillis()
 

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoSetSnapshotPersistence.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoSetSnapshotPersistence.scala
@@ -68,7 +68,7 @@ trait UtxoSetSnapshotPersistence extends ScorexLogging {
         log.info("Work within future finished in: " + (ft - ft0) + " ms.")
       }(scala.concurrent.ExecutionContext.Implicits.global)
       val ms = System.currentTimeMillis()
-      log.info("Main thread time to dump utxo set snapshot: " + (ms - ms0))
+      log.info("Main thread time to dump utxo set snapshot: " + (ms - ms0) + " ms.")
     }
   }
 

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 53
+  val MakeSnapshotEvery = 37
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 43
+  val MakeSnapshotEvery = 100
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 60
+  val MakeSnapshotEvery = 79
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -73,8 +73,11 @@ object Constants {
   // Maximum extension size during bytes parsing
   val MaxExtensionSizeMax: Int = 1024 * 1024
 
-  // UTXO set snapshot to be taken every this number of blocks
-  val MakeSnapshotEvery = 51200
+  // todo: change before deployment
+  /**
+    * UTXO set snapshot to be taken every this number of blocks
+    */
+  val MakeSnapshotEvery = 53
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 37
+  val MakeSnapshotEvery = 60
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -83,7 +83,7 @@ object Constants {
     * 1024 is divisible by 128 also.
     */
   // todo: change before deployment to 51200
-  val MakeSnapshotEvery = 30
+  val MakeSnapshotEvery = 500
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -83,7 +83,7 @@ object Constants {
     * 1024 is divisible by 128 also.
     */
   // todo: change before deployment to 51200
-  val MakeSnapshotEvery = 500
+  val MakeSnapshotEvery = 1024
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 42
+  val MakeSnapshotEvery = 43
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -82,7 +82,7 @@ object Constants {
     * So for the Ergo mainnet the value should be divisible by 1024 (for testnet, 128, any number divisible by
     * 1024 is divisible by 128 also.
     */
-  // todo: change before deployment to 51200
+  // todo: change before deployment to 52224
   val MakeSnapshotEvery = 1024
 
   /**

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 79
+  val MakeSnapshotEvery = 42
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -77,7 +77,7 @@ object Constants {
   /**
     * UTXO set snapshot to be taken every this number of blocks
     */
-  val MakeSnapshotEvery = 100
+  val MakeSnapshotEvery = 30
 
   /**
     * AVL+ tree node parameters. The tree is used to authenticate UTXO set.

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -78,8 +78,11 @@ object Constants {
     * The value MUST be divisible by voting epoch length (chainSettings.voting.votingLength),
     * so after snapshot the state is corresponding to a moment before applying first block of a voting epoch,
     * and then the first block sets current validation parameters.
+    *
+    * So for the Ergo mainnet the value should be divisible by 1024 (for testnet, 128, any number divisible by
+    * 1024 is divisible by 128 also.
     */
-  // todo: change before deployment
+  // todo: change before deployment to 51200
   val MakeSnapshotEvery = 30
 
   /**

--- a/src/main/scala/org/ergoplatform/settings/Constants.scala
+++ b/src/main/scala/org/ergoplatform/settings/Constants.scala
@@ -73,10 +73,13 @@ object Constants {
   // Maximum extension size during bytes parsing
   val MaxExtensionSizeMax: Int = 1024 * 1024
 
-  // todo: change before deployment
   /**
-    * UTXO set snapshot to be taken every this number of blocks
+    * UTXO set snapshot to be taken every this number of blocks.
+    * The value MUST be divisible by voting epoch length (chainSettings.voting.votingLength),
+    * so after snapshot the state is corresponding to a moment before applying first block of a voting epoch,
+    * and then the first block sets current validation parameters.
     */
+  // todo: change before deployment
   val MakeSnapshotEvery = 30
 
   /**

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
@@ -213,6 +213,8 @@ object ErgoSettings extends ScorexLogging
         s"be local or loopback address : ${settings.scorexSettings.restApi.publicUrl.get}")
     } else if (settings.nodeSettings.utxoSettings.p2pUtxoSnapshots <= 0) {
       failWithError(s"p2pUtxoSnapshots <= 0, must be 1 at least")
+    } else if (settings.nodeSettings.extraIndex && settings.nodeSettings.isFullBlocksPruned) {
+      failWithError(s"Extra indexes could be enabled only if there is no blockchain pruning")
     } else {
       settings
     }

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
@@ -211,6 +211,8 @@ object ErgoSettings extends ScorexLogging
     } else if (settings.scorexSettings.restApi.publicUrl.exists(invalidRestApiUrl)) {
       failWithError(s"scorex.restApi.publicUrl should not contain query, path or fragment and should not " +
         s"be local or loopback address : ${settings.scorexSettings.restApi.publicUrl.get}")
+    } else if (settings.nodeSettings.utxoSettings.p2pUtxoSnapshots <= 0) {
+      failWithError(s"p2pUtxoSnapshots <= 0, must be 1 at least")
     } else {
       settings
     }

--- a/src/main/scala/org/ergoplatform/settings/NodeConfigurationSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/NodeConfigurationSettings.scala
@@ -73,7 +73,7 @@ case class NodeConfigurationSettings(stateType: StateType,
     * Whether the node keeping all the full blocks of the blockchain or not.
     * @return true if the blockchain is pruned, false if not
     */
-  val isFullBlocksPruned: Boolean = blocksToKeep >= 0
+  val isFullBlocksPruned: Boolean = blocksToKeep >= 0 || utxoSettings.utxoBootstrap
 
   val areSnapshotsStored = utxoSettings.storingUtxoSnapshots > 0
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
@@ -72,10 +72,10 @@ class BlockSectionValidationSpecification extends HistoryTestHelpers {
 
     // should not be able to apply when blocks at this height are already pruned
     history.applicableTry(section) shouldBe 'success
-    history.minimalFullBlockHeightVar = history.bestHeaderOpt.get.height + 1
+    history.writeMinimalFullBlockHeight(history.bestHeaderOpt.get.height + 1)
     history.isHeadersChainSyncedVar = true
     history.applicableTry(section) shouldBe 'failure
-    history.minimalFullBlockHeightVar = ErgoHistory.GenesisHeight
+    history.writeMinimalFullBlockHeight(ErgoHistory.GenesisHeight)
 
     // should not be able to apply if corresponding header is marked as invalid
     history.applicableTry(section) shouldBe 'success

--- a/src/test/scala/org/ergoplatform/nodeView/history/UtxoSetSnapshotProcessorSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/UtxoSetSnapshotProcessorSpecification.scala
@@ -19,10 +19,14 @@ class UtxoSetSnapshotProcessorSpecification extends HistoryTestHelpers {
   val epochLength = 20
 
   val utxoSetSnapshotProcessor = new UtxoSetSnapshotProcessor {
+    var minimalFullBlockHeightVar = ErgoHistory.GenesisHeight
     override protected val settings: ErgoSettings = s.copy(chainSettings =
       s.chainSettings.copy(voting = s.chainSettings.voting.copy(votingLength = epochLength)))
     override protected val historyStorage: HistoryStorage = HistoryStorage(settings)
-    override private[history] var minimalFullBlockHeightVar = ErgoHistory.GenesisHeight
+    override def readMinimalFullBlockHeight() = minimalFullBlockHeightVar
+    override def writeMinimalFullBlockHeight(height: Int): Unit = {
+      minimalFullBlockHeightVar = height
+    }
   }
 
   var history = generateHistory(

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -22,7 +22,7 @@ class VerifyADHistorySpecification extends HistoryTestHelpers with NoShrink {
                          minFullHeight: Option[Int] = Some(ErgoHistory.GenesisHeight)): (ErgoHistory, Seq[ErgoFullBlock]) = {
     val inHistory = generateHistory(verifyTransactions = true, StateType.Digest, PoPoWBootstrap = false, BlocksToKeep)
     minFullHeight.foreach { h =>
-      inHistory.minimalFullBlockHeightVar = h
+      inHistory.writeMinimalFullBlockHeight(h)
       inHistory.isHeadersChainSyncedVar = true
     }
 


### PR DESCRIPTION
This PR contains different fixes and improvements for bootstrapping with UTXO set snapshot, biggest are:

* reconstructing state context for validating blocks after UTXO set snapshot correctly
* removing downloaded UTXO set snapshot chunks
* min stored full block height persistence