### PR TITLE
Check for diff header to be before suffix

### DIFF
--- a/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
@@ -241,9 +241,12 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
       // put headers needed to check difficulty of new blocks after suffix into prefix
       val epochLength = chainSettings.eip37EpochLength.getOrElse(chainSettings.epochLength)
       diffAdjustment.heightsForNextRecalculation(suffixHead.height, epochLength).foreach { height =>
-        histReader.popowHeader(height).foreach { ph =>
-          prefixBuilder += ph
-          storedHeights += ph.height
+        // check that header in or after suffix is not included, otherwise, sorting by height would be broken
+        if (height < suffixHead.height) {
+          histReader.popowHeader(height).foreach { ph =>
+            prefixBuilder += ph
+            storedHeights += ph.height
+          }
         }
       }
     }


### PR DESCRIPTION
Check for diff header to be before suffix added during NiPoPoW proof generation, otherwise, sorting by height could be broken  (proof.hasValidHeights turns out to be false in this case, invalidating the proof)