### PR TITLE
Upgrade sigma to v5.0.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ val circeVersion = "0.13.0"
 val akkaVersion = "2.6.10"
 val akkaHttpVersion = "10.2.4"
 
-val sigmaStateVersion = "5.0.8"
+val sigmaStateVersion = "5.0.10"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)
 val effectiveSigmaStateVersion = Option(System.getenv().get("SIGMASTATE_VERSION")).getOrElse(sigmaStateVersion)

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoInterpreter.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoInterpreter.scala
@@ -4,11 +4,11 @@ import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.sdk.wallet.protocol.context.ErgoLikeParameters
 import org.ergoplatform.wallet.protocol.Constants
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoLikeContext, ErgoLikeInterpreter}
-import scorex.crypto.authds.ADDigest
 import scorex.util.ScorexLogging
 import sigmastate.Values.ErgoTree
 import sigmastate.interpreter.Interpreter.{ScriptEnv, VerificationResult}
 import sigmastate.{AvlTreeData, AvlTreeFlags}
+import special.collection.Coll
 
 import scala.util.Try
 
@@ -100,7 +100,7 @@ object ErgoInterpreter {
     new ErgoInterpreter(params)
 
   /** Create [[AvlTreeData]] with the given digest and all operations enabled. */
-  def avlTreeFromDigest(digest: ADDigest): AvlTreeData = {
+  def avlTreeFromDigest(digest: Coll[Byte]): AvlTreeData = {
     val flags = AvlTreeFlags(insertAllowed = true, updateAllowed = true, removeAllowed = true)
     AvlTreeData(digest, flags, Constants.HashLength)
   }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/serialization/JsonCodecsWrapper.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/serialization/JsonCodecsWrapper.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.wallet.serialization
 
-import org.ergoplatform.JsonCodecs
+import org.ergoplatform.sdk.JsonCodecs
 
 /**
   * JSON Codecs provided as singleton package, not trait.

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/interpreter/InterpreterSpecCommon.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/interpreter/InterpreterSpecCommon.scala
@@ -1,9 +1,9 @@
 package org.ergoplatform.wallet.interpreter
 
 import org.ergoplatform.sdk.wallet.protocol.context.{ErgoLikeParameters, ErgoLikeStateContext}
-import scorex.crypto.authds.ADDigest
 import scorex.util.encode.Base16
 import sigmastate.basics.CryptoConstants
+import sigmastate.eval.Extensions.ArrayOps
 import sigmastate.eval.{CGroupElement, CPreHeader, Colls}
 import special.collection.Coll
 import special.sigma.{Header, PreHeader}
@@ -39,9 +39,10 @@ trait InterpreterSpecCommon {
 
     override def sigmaLastHeaders: Coll[Header] = Colls.emptyColl
 
-    override def previousStateDigest: ADDigest =
-      ADDigest @@ Base16.decode("a5df145d41ab15a01e0cd3ffbab046f0d029e5412293072ad0f5827428589b9302")
+    override def previousStateDigest: Coll[Byte] =
+      Base16.decode("a5df145d41ab15a01e0cd3ffbab046f0d029e5412293072ad0f5827428589b9302")
         .getOrElse(throw new Error(s"Failed to parse genesisStateDigest"))
+        .toColl
 
     override def sigmaPreHeader: PreHeader = CPreHeader(
       version = 0,

--- a/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
@@ -36,6 +36,8 @@ import sigmastate.serialization.OpCodes
 import special.sigma.AnyValue
 import org.ergoplatform.nodeView.state.SnapshotsInfo
 import org.ergoplatform.nodeView.state.UtxoState.ManifestId
+import org.ergoplatform.sdk.JsonCodecs
+
 import java.math.BigInteger
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/org/ergoplatform/http/api/ScanEntities.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScanEntities.scala
@@ -2,7 +2,8 @@ package org.ergoplatform.http.api
 
 import io.circe.{Decoder, HCursor}
 import org.ergoplatform.ErgoBox.BoxId
-import org.ergoplatform.{ErgoBox, JsonCodecs}
+import org.ergoplatform.ErgoBox
+import org.ergoplatform.sdk.JsonCodecs
 import org.ergoplatform.wallet.Constants.ScanId
 
 /**

--- a/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/header/Header.scala
@@ -142,7 +142,7 @@ object Header extends ApiCodecs {
       version = header.version,
       parentId = header.parentId.toBytes.toColl,
       ADProofsRoot = header.ADProofsRoot.asInstanceOf[Array[Byte]].toColl,
-      stateRoot = CAvlTree(ErgoInterpreter.avlTreeFromDigest(header.stateRoot)),
+      stateRoot = CAvlTree(ErgoInterpreter.avlTreeFromDigest(header.stateRoot.toColl)),
       transactionsRoot = header.transactionsRoot.asInstanceOf[Array[Byte]].toColl,
       timestamp = header.timestamp,
       nBits = header.nBits,

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/TransactionMembershipProof.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/TransactionMembershipProof.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.mempool
 
 import io.circe.{Encoder, Json}
-import org.ergoplatform.JsonCodecs
+import org.ergoplatform.sdk.JsonCodecs
 import org.ergoplatform.settings.Algos
 import scorex.crypto.authds.merkle.MerkleProof
 import scorex.crypto.hash.Digest32

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
@@ -18,6 +18,7 @@ import scorex.crypto.authds.ADDigest
 import scorex.util.ScorexLogging
 import scorex.util.serialization.{Reader, Writer}
 import sigmastate.basics.CryptoConstants.EcPointType
+import sigmastate.eval.Extensions.ArrayOps
 import sigmastate.eval.SigmaDsl
 import special.collection.Coll
 
@@ -83,10 +84,10 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
 
   // todo remove from ErgoLikeContext and from ErgoStateContext
   // State root hash before the last block
-  override def previousStateDigest: ADDigest = if (sigmaLastHeaders.toArray.nonEmpty) {
-    ADDigest @@ sigmaLastHeaders.toArray.head.stateRoot.digest.toArray
+  override def previousStateDigest: Coll[Byte] = if (sigmaLastHeaders.toArray.nonEmpty) {
+    sigmaLastHeaders.toArray.head.stateRoot.digest
   } else {
-    genesisStateDigest
+    genesisStateDigest.toColl
   }
 
   /* NOHF PROOF:
@@ -274,7 +275,7 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
   }.flatten
 
   override def toString: String =
-    s"ErgoStateContext($currentHeight, ${encoder.encode(previousStateDigest)}, $lastHeaders, $currentParameters)"
+    s"ErgoStateContext($currentHeight, ${encoder.encode(previousStateDigest.toArray)}, $lastHeaders, $currentParameters)"
 
 
   /**

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/models/CollectedBoxes.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/models/CollectedBoxes.scala
@@ -3,7 +3,8 @@ package org.ergoplatform.nodeView.wallet.models
 import io.circe.generic.encoding.DerivedObjectEncoder.deriveEncoder
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
-import org.ergoplatform.{ErgoBox, JsonCodecs}
+import org.ergoplatform.ErgoBox
+import org.ergoplatform.sdk.JsonCodecs
 
 /**
   * Response for requested boxes that contains ErgoBoxes and ChangeBoxes


### PR DESCRIPTION
In this PR:

- Sigma updated to v5.0.10
- some fields changed from ADDigest to Coll[Byte] (i.e. from Array[Byte] to Coll[Byte]). This fixes equality of case classes as Sigma uses content based equality.
- necessary refactoring (due to the above changes) is done