### PR TITLE
Canidate for 5.0.16 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ val circeVersion = "0.13.0"
 val akkaVersion = "2.6.10"
 val akkaHttpVersion = "10.2.4"
 
-val sigmaStateVersion = "5.0.12"
+val sigmaStateVersion = "5.0.13"
 
 // for testing current sigmastate build (see sigmastate-ergo-it jenkins job)
 val effectiveSigmaStateVersion = Option(System.getenv().get("SIGMASTATE_VERSION")).getOrElse(sigmaStateVersion)

--- a/src/main/resources/api/openapi-ai.yaml
+++ b/src/main/resources/api/openapi-ai.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 
 info:
-  version: "5.0.15"
+  version: "5.0.16"
   title: Ergo Node API
   description: Specification of Ergo Node API for ChatGPT plugin.
     The following endpoints supported 

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 
 info:
-  version: "5.0.15"
+  version: "5.0.16"
   title: Ergo Node API
   description: API docs for Ergo Node. Models are shared between all Ergo products
   contact:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -431,7 +431,7 @@ scorex {
     nodeName = "ergo-node"
 
     # Network protocol version to be sent in handshakes
-    appVersion = 5.0.15
+    appVersion = 5.0.16
 
     # Network agent name. May contain information about client code
     # stack, starting from core code-base up to the end graphical interface.


### PR DESCRIPTION
Candidate for 5.0.16 release, contains only update of sigma-state dependency which is fixing serialization bug happened in previous version (fix: https://github.com/ScorexFoundation/sigmastate-interpreter/pull/941). 