### PR TITLE
#2051 Add limit and offset parameter to /wallet/boxes/unspent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     types:
       - opened
       - synchronize
+      
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
-      
+      - synchronize    
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -4479,6 +4479,24 @@ paths:
           type: integer
           format: int32
           default: -1
+      - in: query
+        name: limit
+        required: false
+        description: amount of elements to retrieve
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 50
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
     get:
       security:
         - ApiKeyAuth: [api_key]
@@ -4570,6 +4588,24 @@ paths:
           type: integer
           format: int32
           default: -1
+      - in: query
+        name: limit
+        required: false
+        description: amount of elements to retrieve
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 50
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
     get:
       security:
         - ApiKeyAuth: [api_key]

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -4487,7 +4487,8 @@ paths:
           type: integer
           format: int32
           minimum: 1
-          default: 50
+          default: 500
+          maximum: 2500
       - in: query
         name: offset
         required: false
@@ -4596,7 +4597,8 @@ paths:
           type: integer
           format: int32
           minimum: 1
-          default: 50
+          default: 500
+          maximum: 2500
       - in: query
         name: offset
         required: false

--- a/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
@@ -66,19 +66,21 @@ case class ScanApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
   }
 
   def unspentR: Route = (path("unspentBoxes" / IntNumber) & get & boxParams) {
-    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val scanId = ScanId @@ scanIdInt.toShort
       val considerUnconfirmed = minConfNum == -1
       withWallet(_.scanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight).map {
         _.filter(boxConfirmationFilter(_, minConfNum, maxConfNum))
+        .slice(offset, offset + limit)
       })
   }
 
   def spentR: Route = (path("spentBoxes" / IntNumber) & get & boxParams) {
-    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val scanId = ScanId @@ scanIdInt.toShort
       withWallet(_.scanSpentBoxes(scanId).map {
         _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+        .slice(offset, offset + limit)
       })
   }
 

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 trait WalletApiOperations extends ErgoBaseApiRoute {
 
   val readersHolder: ActorRef
-  val MaxLimit = 500
+  val MaxLimit = 2500
 
   private def isLegalOffset(offset: Int): Boolean = offset >= 0
 
@@ -33,7 +33,7 @@ trait WalletApiOperations extends ErgoBaseApiRoute {
       "maxConfirmations".as[Int] ? -1, 
       "minInclusionHeight".as[Int] ? 0, 
       "maxInclusionHeight".as[Int] ? -1,
-      "limit".as[Int] ? 50,
+      "limit".as[Int] ? 500,
       "offset".as[Int] ? 0  
     ).tfilter(
       isLegalBoxParamCombination,

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -306,23 +306,26 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def unspentBoxesR: Route = (path("boxes" / "unspent") & get & boxParams) {
-    (minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val considerUnconfirmed = minConfNum == -1
-      withWallet {
-        _.walletBoxes(unspentOnly = true, considerUnconfirmed)
-          .map {
-            _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+      withWallet { wallet =>
+        wallet.walletBoxes(unspentOnly = true, considerUnconfirmed)
+          .map { boxes =>
+            boxes
+              .filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+              .slice(offset, offset + limit)
           }
       }
   }
 
   def boxesR: Route = (path("boxes") & get & boxParams) {
-    (minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (minConfNum, maxConfNum, minHeight, maxHeight, limit, offset)  =>
       val considerUnconfirmed = minConfNum == -1
       withWallet {
         _.walletBoxes(unspentOnly = false, considerUnconfirmed = considerUnconfirmed)
           .map {
             _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+            .slice(offset, offset + limit)
           }
       }
   }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -264,6 +264,19 @@ class WalletApiRouteSpec extends AnyFlatSpec
     }
   }
 
+  it should "return unspent wallet boxes with specified limit and offset" in {
+    val limit = 1
+    val offset = 0
+
+    val postfixWithLimitOffset = s"/boxes/unspent?limit=$limit&offset=$offset"
+
+    Get(prefix + postfixWithLimitOffset) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val response = responseAs[List[Json]]
+      response.size shouldBe limit 
+    }
+  }
+
   it should "return wallet transactions" in {
     Get(prefix + "/transactions") ~> route ~> check {
       status shouldBe StatusCodes.OK


### PR DESCRIPTION
This PR addresses:
https://github.com/ergoplatform/ergo/issues/2051

and adds limit and offset to wallet/boxes/unspent, using default value of 50 for limit and max value of 500 for limit. Includes basic parameter checks and uses slice to apply offset and limit