### PR TITLE
#2051 Add limit and offset parameter to /wallet/boxes/unspent

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -5567,6 +5567,25 @@ paths:
           type: integer
           format: int32
           default: -1
+      - in: query
+        name: limit
+        required: false
+        description: amount of elements to retrieve
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 500
+          maximum: 2500
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
     get:
       security:
         - ApiKeyAuth: [api_key]
@@ -5634,6 +5653,25 @@ paths:
           type: integer
           format: int32
           default: -1
+      - in: query
+        name: limit
+        required: false
+        description: amount of elements to retrieve
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 500
+          maximum: 2500
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
     get:
       security:
         - ApiKeyAuth: [api_key]

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -4479,6 +4479,25 @@ paths:
           type: integer
           format: int32
           default: -1
+      - in: query
+        name: limit
+        required: false
+        description: amount of elements to retrieve
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 500
+          maximum: 2500
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
     get:
       security:
         - ApiKeyAuth: [api_key]
@@ -4570,6 +4589,25 @@ paths:
           type: integer
           format: int32
           default: -1
+      - in: query
+        name: limit
+        required: false
+        description: amount of elements to retrieve
+        schema:
+          type: integer
+          format: int32
+          minimum: 1
+          default: 500
+          maximum: 2500
+      - in: query
+        name: offset
+        required: false
+        description: The number of items in list to skip
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          default: 0
     get:
       security:
         - ApiKeyAuth: [api_key]

--- a/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
@@ -66,19 +66,21 @@ case class ScanApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
   }
 
   def unspentR: Route = (path("unspentBoxes" / IntNumber) & get & boxParams) {
-    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val scanId = ScanId @@ scanIdInt.toShort
       val considerUnconfirmed = minConfNum == -1
       withWallet(_.scanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight).map {
         _.filter(boxConfirmationFilter(_, minConfNum, maxConfNum))
+        .slice(offset, offset + limit)
       })
   }
 
   def spentR: Route = (path("spentBoxes" / IntNumber) & get & boxParams) {
-    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val scanId = ScanId @@ scanIdInt.toShort
       withWallet(_.scanSpentBoxes(scanId).map {
         _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+        .slice(offset, offset + limit)
       })
   }
 

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
@@ -14,18 +14,33 @@ trait WalletApiOperations extends ErgoBaseApiRoute {
 
   val readersHolder: ActorRef
 
-  private val isLegalBoxParamCombination: ((Int, Int, Int, Int)) => Boolean = {
-    case (minConfNum, _, _, maxHeight) =>
+
+  val MaxLimit = 2500
+
+  private def isLegalOffset(offset: Int): Boolean = offset >= 0
+
+  private def isLegalLimit(limit: Int): Boolean = limit >= 1 && limit <= MaxLimit
+
+  private val isLegalBoxParamCombination: ((Int, Int, Int, Int, Int, Int)) => Boolean = {
+    case (minConfNum, _, _, maxHeight, limit, offset) =>
+      isLegalOffset(offset) && 
+      isLegalLimit(limit) &&
       // maxInclusionHeight cannot be specified when we consider unconfirmed
       !(minConfNum == -1 && maxHeight != -1)
   }
 
-  val boxParams: Directive[(Int, Int, Int, Int)] =
-    parameters("minConfirmations".as[Int] ? 0, "maxConfirmations".as[Int] ? -1, "minInclusionHeight".as[Int] ? 0, "maxInclusionHeight".as[Int] ? -1)
-      .tfilter(
-        isLegalBoxParamCombination,
-        ValidationRejection("maxInclusionHeight cannot be specified when we consider unconfirmed")
-      )
+  val boxParams: Directive[(Int, Int, Int, Int, Int, Int)] =
+    parameters(
+      "minConfirmations".as[Int] ? 0, 
+      "maxConfirmations".as[Int] ? -1, 
+      "minInclusionHeight".as[Int] ? 0, 
+      "maxInclusionHeight".as[Int] ? -1,
+      "limit".as[Int] ? 500,
+      "offset".as[Int] ? 0  
+    ).tfilter(
+      isLegalBoxParamCombination,
+      ValidationRejection("maxInclusionHeight cannot be specified when we consider unconfirmed")
+    )
 
   /**
     * Filter function that filters boxes by height or number of confirmations.

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -306,23 +306,26 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def unspentBoxesR: Route = (path("boxes" / "unspent") & get & boxParams) {
-    (minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val considerUnconfirmed = minConfNum == -1
-      withWallet {
-        _.walletBoxes(unspentOnly = true, considerUnconfirmed)
-          .map {
-            _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+      withWallet { wallet =>
+        wallet.walletBoxes(unspentOnly = true, considerUnconfirmed)
+          .map { boxes =>
+            boxes
+              .filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+              .slice(offset, offset + limit)
           }
       }
   }
 
   def boxesR: Route = (path("boxes") & get & boxParams) {
-    (minConfNum, maxConfNum, minHeight, maxHeight) =>
+    (minConfNum, maxConfNum, minHeight, maxHeight, limit, offset)  =>
       val considerUnconfirmed = minConfNum == -1
       withWallet {
         _.walletBoxes(unspentOnly = false, considerUnconfirmed = considerUnconfirmed)
           .map {
             _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+            .slice(offset, offset + limit)
           }
       }
   }


### PR DESCRIPTION
This PR addresses:
https://github.com/ergoplatform/ergo/issues/2051

and adds limit and offset to wallet/boxes/unspent, using default value of 50 for limit and max value of 500 for limit. Includes basic parameter checks and uses slice to apply offset and limit