### PR TITLE
More tests for ContextExtension semantics

### DIFF
--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -573,7 +573,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
     val b = new ErgoBox(1000000000L, Constants.TrueLeaf, Colls.emptyColl,
       Map.empty, ModifierId @@ "c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742",
       0, 0)
-    val ce = ContextExtension(Map(negId -> IntConstant(0), (-negId) -> IntConstant(1)))
+    val ce = ContextExtension(Map(negId -> IntConstant(0), (-negId).toByte -> IntConstant(1)))
     val input = Input(b.id, ProverResult(Array.emptyByteArray, ce))
 
     val oc = new ErgoBoxCandidate(b.value, b.ergoTree, b.creationHeight)

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -544,9 +544,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
   }
 
   property("context extension with neg id") {
-    val negId: Byte = -1
-
-    ADKey @@ Base16.decode("c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742").get
+    val negId: Byte = -10
 
     val b = new ErgoBox(1000000000L, Constants.TrueLeaf, Colls.emptyColl,
                          Map.empty, ModifierId @@ "c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742",
@@ -561,13 +559,13 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
       .map(ErgoTransaction.apply)
 
     txTry.isSuccess shouldBe false
+
+    txTry.toEither.left.get.isInstanceOf[NegativeArraySizeException] shouldBe true
   }
 
 
   property("context extension with neg and pos ids") {
     val negId: Byte = -20
-
-    ADKey @@ Base16.decode("c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742").get
 
     val b = new ErgoBox(1000000000L, Constants.TrueLeaf, Colls.emptyColl,
       Map.empty, ModifierId @@ "c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742",
@@ -583,6 +581,8 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
       .map(ErgoTransaction.apply)
 
     txTry.isSuccess shouldBe false
+
+    txTry.toEither.left.get.isInstanceOf[ArrayIndexOutOfBoundsException] shouldBe true
   }
 
 }

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -544,7 +544,7 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
   }
 
   property("context extension with neg id") {
-    val negId: Byte = -20
+    val negId: Byte = -1
 
     ADKey @@ Base16.decode("c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742").get
 
@@ -557,11 +557,10 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
     val utx = UnsignedErgoTransaction(IndexedSeq(input), IndexedSeq(oc))
 
-    val tx = defaultProver.sign(utx, IndexedSeq(b), IndexedSeq.empty, emptyStateContext)
+    val txTry = defaultProver.sign(utx, IndexedSeq(b), IndexedSeq.empty, emptyStateContext)
       .map(ErgoTransaction.apply)
-      .get
 
-    tx.statefulValidity(IndexedSeq(b), IndexedSeq.empty, emptyStateContext) shouldBe true
+    txTry.isSuccess shouldBe false
   }
 
 
@@ -580,45 +579,10 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
 
     val utx = UnsignedErgoTransaction(IndexedSeq(input), IndexedSeq(oc))
 
-    val tx = defaultProver.sign(utx, IndexedSeq(b), IndexedSeq.empty, emptyStateContext)
+    val txTry = defaultProver.sign(utx, IndexedSeq(b), IndexedSeq.empty, emptyStateContext)
       .map(ErgoTransaction.apply)
-      .get
 
-    tx.statefulValidity(IndexedSeq(b), IndexedSeq.empty, emptyStateContext) shouldBe true
+    txTry.isSuccess shouldBe false
   }
-
-  /*
- import sigma.{AnyValue, Coll}
- import sigmastate.SType
- import sigmastate.SType.AnyOps
- import sigmastate.Values.{ByteArrayConstant, EvaluatedValue}
- import sigmastate.eval.CostingSigmaDslBuilder.Colls
- import sigmastate.eval.Evaluation.stypeToRType
- import sigmastate.eval.Extensions.toAnyValue
- import sigmastate.interpreter.ContextExtension
-
- val ce = ContextExtension(Map(-6.toByte -> ByteArrayConstant(Array(0: Byte))))
- val ce2 = ContextExtension.serializer.fromBytes(ContextExtension.serializer.toBytes(ce))
-
- def contextVars(m: Map[Byte, AnyValue]): Coll[AnyValue] = {
-   val maxKey = if (m.keys.isEmpty) 0 else m.keys.max  // TODO optimize: max takes 90% of this method
-   val res = new Array[AnyValue](maxKey + 1)
-   for ((id, v) <- m) {
-     res(id) = v
-   }
-   Colls.fromArray(res)
- }
-
- if (false) {
-   val varMap = ce2.values.map { case (k, v: EvaluatedValue[_]) =>
-     val tVal = stypeToRType[SType](v.tpe)
-     k -> toAnyValue(v.value.asWrappedType)(tVal)
-   }.toMap
-   contextVars(varMap)
- } */
-
-
-  // val arr = new Array[Int](-5)
-
 
 }

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoTransactionSpec.scala
@@ -564,6 +564,29 @@ class ErgoTransactionSpec extends ErgoPropertyTest with ErgoTestConstants {
     tx.statefulValidity(IndexedSeq(b), IndexedSeq.empty, emptyStateContext) shouldBe true
   }
 
+
+  property("context extension with neg and pos ids") {
+    val negId: Byte = -20
+
+    ADKey @@ Base16.decode("c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742").get
+
+    val b = new ErgoBox(1000000000L, Constants.TrueLeaf, Colls.emptyColl,
+      Map.empty, ModifierId @@ "c95c2ccf55e03cac6659f71ca4df832d28e2375569cec178dcb17f3e2e5f7742",
+      0, 0)
+    val ce = ContextExtension(Map(negId -> IntConstant(0), (-negId) -> IntConstant(1)))
+    val input = Input(b.id, ProverResult(Array.emptyByteArray, ce))
+
+    val oc = new ErgoBoxCandidate(b.value, b.ergoTree, b.creationHeight)
+
+    val utx = UnsignedErgoTransaction(IndexedSeq(input), IndexedSeq(oc))
+
+    val tx = defaultProver.sign(utx, IndexedSeq(b), IndexedSeq.empty, emptyStateContext)
+      .map(ErgoTransaction.apply)
+      .get
+
+    tx.statefulValidity(IndexedSeq(b), IndexedSeq.empty, emptyStateContext) shouldBe true
+  }
+
   /*
  import sigma.{AnyValue, Coll}
  import sigmastate.SType


### PR DESCRIPTION
In this PR there are a couple of tests for validation of transactions with negative-id context extension variables