### PR TITLE
Fix for API dying eventually with extraIndexer turned on

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -617,14 +617,14 @@ indexer-dispatcher {
   # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
   # What kind of ExecutionService to use
-  executor = "fork-join-executor"
-  # Configuration for the fork join pool
-  fork-join-executor {
-    # Min number of threads to cap factor-based parallelism number to
-    parallelism-min = 1
-    # Parallelism (threads) ... ceil(available processors * factor)
-    parallelism-factor = 1.0
-    # Max number of threads to cap factor-based parallelism number to
-    parallelism-max = 4
+  executor = "thread-pool-executor"
+  # Configuration for the thread pool
+  thread-pool-executor {
+    # minimum number of threads to cap factor-based core number to
+    core-pool-size-min = 1
+    # No of core threads ... ceil(available processors * factor)
+    core-pool-size-factor = 1.0
+    # maximum number of threads to cap factor-based number to
+    core-pool-size-max = 3
   }
 }


### PR DESCRIPTION
In this PR, thread-pool executor chosen for extra indexer, as sharing fork-join executor's pool is leading in some situations to API having no threads to operate it seems 

close #2154 