### PR TITLE
Using BlockchainContext flag

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/UtxoValidationState.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/UtxoValidationState.scala
@@ -1,0 +1,3 @@
+package org.ergoplatform.nodeView.state
+
+case class UtxoValidationState(cost: Int, isUsingBlockchainContext: Boolean)

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
@@ -255,6 +255,7 @@ object ValidationRules {
   val txNegHeight: Short = 122 // introduced in v2 blocks
   val txReemission: Short = 123 // introduced in EIP-27 (soft-fork)
   val txMonotonicHeight: Short = 124 // introduced in v3 blocks
+  val txIsUsingBlockchainContext: Short = 125 // introduced in sigma-state v5.0.14
 
   // header validation
   val hdrGenesisParent: Short = 200

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -823,8 +823,8 @@ object CandidateGenerator extends ScorexLogging {
               maxBlockCost,
               Some(verifier)
             ) match {
-              case Success(costConsumed) =>
-                val newTxs = acc :+ (tx -> costConsumed)
+              case Success(stateConsumed) =>
+                val newTxs = acc :+ (tx -> stateConsumed.cost)
                 val newBoxes = newTxs.flatMap(_._1.outputs)
 
                 collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
@@ -833,10 +833,10 @@ object CandidateGenerator extends ScorexLogging {
                       newBoxes.find(b => java.util.Arrays.equals(b.id, i.boxId))
                     )
                     feeTx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier) match {
-                      case Success(cost) =>
-                        val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
+                      case Success(state) =>
+                        val blockTxs: Seq[CostedTransaction] = (feeTx -> state.cost) +: newTxs
                         if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                          loop(mempoolTxs.tail, newTxs, Some(feeTx -> cost), invalidTxs)
+                          loop(mempoolTxs.tail, newTxs, Some(feeTx -> state.cost), invalidTxs)
                         } else {
                           log.debug(s"Finishing block assembly on limits overflow, " +
                                     s"cost is ${currentCosted.map(_._2).sum}, cost limit: $maxBlockCost")

--- a/src/main/scala/org/ergoplatform/modifiers/mempool/UnconfirmedTransaction.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/mempool/UnconfirmedTransaction.scala
@@ -18,7 +18,8 @@ class UnconfirmedTransaction(val transaction: ErgoTransaction,
                              val createdTime: Long,
                              val lastCheckedTime: Long,
                              val transactionBytes: Option[Array[Byte]],
-                             val source: Option[ConnectedPeer])
+                             val source: Option[ConnectedPeer],
+                             val isUsingBlockchainContext: Boolean)
   extends ScorexLogging {
 
   def id: ModifierId = transaction.id
@@ -33,7 +34,8 @@ class UnconfirmedTransaction(val transaction: ErgoTransaction,
       createdTime,
       lastCheckedTime = System.currentTimeMillis(),
       transactionBytes,
-      source)
+      source,
+      isUsingBlockchainContext)
   }
 
   override def equals(obj: Any): Boolean = obj match {
@@ -48,12 +50,12 @@ object UnconfirmedTransaction {
 
   def apply(tx: ErgoTransaction, source: Option[ConnectedPeer]): UnconfirmedTransaction = {
     val now = System.currentTimeMillis()
-    new UnconfirmedTransaction(tx, None, now, now, Some(tx.bytes), source)
+    new UnconfirmedTransaction(tx, None, now, now, Some(tx.bytes), source, false)
   }
 
   def apply(tx: ErgoTransaction, txBytes: Array[Byte], source: Option[ConnectedPeer]): UnconfirmedTransaction = {
     val now = System.currentTimeMillis()
-    new UnconfirmedTransaction(tx, None, now, now, Some(txBytes), source)
+    new UnconfirmedTransaction(tx, None, now, now, Some(txBytes), source, false)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -250,8 +250,8 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
               if (tx.inputIds.forall(inputBoxId => utxoWithPool.boxById(inputBoxId).isDefined)) {
                 val validationContext = utxo.stateContext.simplifiedUpcoming()
                 utxoWithPool.validateWithCost(tx, validationContext, costLimit, None) match {
-                  case Success(cost) =>
-                    acceptIfNoDoubleSpend(unconfirmedTx.withCost(cost), validationStartTime)
+                  case Success(state) =>
+                    acceptIfNoDoubleSpend(unconfirmedTx.withCost(state.cost), validationStartTime)
                   case Failure(ex) =>
                     this.invalidate(unconfirmedTx) -> new ProcessingOutcome.Invalidated(ex, validationStartTime)
                 }

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -177,7 +177,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
             tx.inputs.map(i => newBoxes.find(b => b.id sameElements i.boxId).get)
           tx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext).get
         }
-      }
+      }.map(_.cost)
 
       fromBigMempool.length should be > 2
       fromBigMempool.map(_.size).sum should be < maxSize

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -44,7 +44,7 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest {
 
   private def checkTx(from: IndexedSeq[ErgoBox], tx: ErgoTransaction): Try[Int] = {
     tx.statelessValidity().flatMap(_ => tx.statefulValidity(from, emptyDataBoxes, emptyStateContext))
-  }
+  }.map(_.cost)
 
   private def modifyValue(boxCandidate: ErgoBoxCandidate, delta: Long): ErgoBoxCandidate = {
     new ErgoBoxCandidate(
@@ -303,10 +303,10 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest {
        val outputIncTxCost0 = txMod2.statefulValidity(from.init :+ modifiedIn0, emptyDataBoxes, emptyStateContext).get
        val outputIncTxCost1 = txMod3.statefulValidity(from.init :+ modifiedIn1, emptyDataBoxes, emptyStateContext).get
 
-       (inputIncTxCost0 - initTxCost) shouldEqual Parameters.TokenAccessCostDefault * 2 // one more group + one more token in total
-       (inputIncTxCost1 - initTxCost) shouldEqual Parameters.TokenAccessCostDefault // one more token in total
-       (outputIncTxCost0 - inputIncTxCost0) shouldEqual Parameters.TokenAccessCostDefault * 2
-       (outputIncTxCost1 - inputIncTxCost1) shouldEqual Parameters.TokenAccessCostDefault
+       (inputIncTxCost0.cost - initTxCost.cost) shouldEqual Parameters.TokenAccessCostDefault * 2 // one more group + one more token in total
+       (inputIncTxCost1.cost - initTxCost.cost) shouldEqual Parameters.TokenAccessCostDefault // one more token in total
+       (outputIncTxCost0.cost - inputIncTxCost0.cost) shouldEqual Parameters.TokenAccessCostDefault * 2
+       (outputIncTxCost1.cost - inputIncTxCost1.cost) shouldEqual Parameters.TokenAccessCostDefault
      }
    }
 
@@ -416,7 +416,7 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest {
      val sc = stateContextWith(paramsWith(approxCost))
      sc.currentParameters.maxBlockCost shouldBe approxCost
      val calculatedCost = tx.statefulValidity(from, IndexedSeq(), sc)(ErgoInterpreter(sc.currentParameters)).get
-     approxCost - calculatedCost <= 1 shouldBe true
+     approxCost - calculatedCost.cost <= 1 shouldBe true
 
      // transaction exceeds computations limit
      val sc2 = stateContextWith(paramsWith(approxCost - 1))

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -76,8 +76,8 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     var poolCost = ErgoMemPool.empty(sortByCostSettings)
     poolCost = poolCost.process(UnconfirmedTransaction(tx, None), wus)._1
     val validationContext = wus.stateContext.simplifiedUpcoming()
-    val cost = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
-    poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight
+    val state = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
+    poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, state.cost).weight
   }
 
   it should "decline already contained transaction" in {
@@ -419,9 +419,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val tx = invalidErgoTransactionGen.sample.get
     val now = System.currentTimeMillis()
 
-    val utx1 = new UnconfirmedTransaction(tx, None, now, now, None, None)
-    val utx2 = new UnconfirmedTransaction(tx, None, now, now, None, None)
-    val utx3 = new UnconfirmedTransaction(tx, None, now + 1, now + 1, None, None)
+    val utx1 = new UnconfirmedTransaction(tx, None, now, now, None, None, false)
+    val utx2 = new UnconfirmedTransaction(tx, None, now, now, None, None, false)
+    val utx3 = new UnconfirmedTransaction(tx, None, now + 1, now + 1, None, None, false)
     val updPool = pool.put(utx1, 100).remove(utx1).put(utx2, 500).put(utx3, 5000)
     updPool.size shouldBe 1
     updPool.get(utx3.id).get.lastCheckedTime shouldBe (now + 1)

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -57,7 +57,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       val unsignedTx = new UnsignedErgoTransaction(inputs, IndexedSeq(), newBoxes)
       val tx: ErgoTransaction = ErgoTransaction(defaultProver.sign(unsignedTx, IndexedSeq(foundersBox), emptyDataBoxes, us.stateContext).get)
       val txCostLimit     = initSettings.nodeSettings.maxTransactionCost
-      us.validateWithCost(tx, us.stateContext.simplifiedUpcoming(), txCostLimit, None).get should be <= 100000
+      us.validateWithCost(tx, us.stateContext.simplifiedUpcoming(), txCostLimit, None).get.cost should be <= 100000
       val block1 = validFullBlock(Some(lastBlock), us, Seq(ErgoTransaction(tx)))
       us = us.applyModifier(block1, None)(_ => ()).get
       foundersBox = tx.outputs.head
@@ -103,7 +103,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       val validationContext = us.stateContext.simplifiedUpcoming()
       val validationRes1 = us.validateWithCost(tx, validationContext, 100000, None)
       validationRes1 shouldBe 'success
-      val txCost = validationRes1.get
+      val txCost = validationRes1.get.cost
 
       val validationRes2 = us.validateWithCost(tx, validationContext, txCost - 1, None)
       validationRes2 shouldBe 'failure

--- a/src/test/scala/org/ergoplatform/utils/generators/ValidBlocksGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ValidBlocksGenerators.scala
@@ -126,7 +126,7 @@ object ValidBlocksGenerators
       tx.inputs.flatMap(i => boxesToSpend.find(_.id == i.boxId)),
       tx.dataInputs.flatMap(i => dataBoxesToUse.find(_.id == i.boxId)),
       emptyStateContext,
-      -2000000)(emptyVerifier).getOrElse(0)
+      -2000000)(emptyVerifier).map(_.cost).getOrElse(0)
   }
 
   /**


### PR DESCRIPTION
Label transactions with inputs not using blockchain context, simplify their revalidation in mempool