### PR TITLE
Network specific launch parameters

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/settings/LaunchParameters.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/LaunchParameters.scala
@@ -1,8 +1,2 @@
 package org.ergoplatform.settings
 
-/**
-  * Parameters corresponding to initial moment of time in the mainnet and the testnet
-  */
-object LaunchParameters extends Parameters(height = 0,
-  parametersTable = Parameters.DefaultParameters,
-  proposedUpdate = ErgoValidationSettingsUpdate.empty)

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/MainnetLaunchParameters.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/MainnetLaunchParameters.scala
@@ -1,0 +1,15 @@
+package org.ergoplatform.settings
+
+import org.ergoplatform.modifiers.history.header.Header
+
+/**
+  * Parameters corresponding to initial moment of time in the mainnet and the testnet
+  */
+object MainnetLaunchParameters extends Parameters(height = 0,
+  parametersTable = Parameters.DefaultParameters,
+  proposedUpdate = ErgoValidationSettingsUpdate.empty)
+
+
+object DevnetLaunchParameters extends Parameters(height = 0,
+  parametersTable = Parameters.DefaultParameters.updated(Parameters.BlockVersion, Header.Interpreter50Version),
+  proposedUpdate = ErgoValidationSettingsUpdate.empty)

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Parameters.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Parameters.scala
@@ -130,12 +130,10 @@ class Parameters(val height: Height,
       activatedUpdate = proposedUpdate
     }
 
-    // Forced version update to version 2 at height provided in settings
-    if (height == votingSettings.version2ActivationHeight) {
-      // Forced update should happen, but some soft-fork update happened before.
-      // Node should fail at this point, as the situation is unclear
-      require(table(BlockVersion) == 1, "Protocol version is not 1 on the hard-fork")
-      table = table.updated(BlockVersion, table(BlockVersion) + 1)
+    // Forced version update to version 2 at height provided in settings.
+    // Needed as it was non-voted hard-fork in the mainnet.
+    if (height == votingSettings.version2ActivationHeight && table(BlockVersion) == 1) {
+      table = table.updated(BlockVersion, 2)
     }
     (table, activatedUpdate)
   }

--- a/ergo-core/src/test/scala/org/ergoplatform/utils/ErgoCoreTestConstants.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/utils/ErgoCoreTestConstants.scala
@@ -41,7 +41,7 @@ object ErgoCoreTestConstants extends ScorexLogging {
   implicit val validationSettingsNoIl: ErgoValidationSettings = validationSettings
     .updated(ErgoValidationSettingsUpdate(Seq(exIlUnableToValidate, exIlEncoding, exIlStructure, exEmpty), Seq()))
 
-  val parameters: Parameters = LaunchParameters
+  val parameters: Parameters = MainnetLaunchParameters
   val nipopowAlgos = new NipopowAlgos(chainSettings)
 
   val emission: EmissionRules = chainSettings.emissionRules

--- a/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
+++ b/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
@@ -12,7 +12,7 @@ import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.state.{ErgoStateReader, StateType}
-import org.ergoplatform.settings.{Algos, ErgoSettings, LaunchParameters, Parameters}
+import org.ergoplatform.settings.{Algos, ErgoSettings, Parameters}
 import scorex.core.network.ConnectedPeer
 import scorex.core.network.NetworkController.ReceivableMessages.{GetConnectedPeers, GetPeersStatus}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
@@ -63,7 +63,7 @@ class ErgoStatsCollector(readersHolder: ActorRef,
     launchTime = System.currentTimeMillis(),
     lastIncomingMessageTime = System.currentTimeMillis(),
     None,
-    LaunchParameters,
+    settings.launchParameters,
     eip27Supported = true,
     settings.scorexSettings.restApi.publicUrl,
     settings.nodeSettings.extraIndex)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -13,7 +13,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.wallet.ErgoWallet
 import org.ergoplatform.wallet.utils.FileUtils
-import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, LaunchParameters, NetworkType, ScorexSettings}
+import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, NetworkType, ScorexSettings}
 import org.ergoplatform.core._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.{BlockAppliedTransactions, CurrentView, DownloadRequest}
@@ -414,8 +414,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
     val history = ErgoHistory.readOrGenerate(settings)
 
-    val wallet = ErgoWallet.readOrGenerate(
-      history.getReader, settings, LaunchParameters)
+    val wallet = ErgoWallet.readOrGenerate(history.getReader, settings, settings.launchParameters)
 
     val memPool = ErgoMemPool.empty(settings)
 

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
@@ -12,7 +12,7 @@ import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.modifiers.state.StateChanges
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.settings.ValidationRules._
-import org.ergoplatform.settings.{ChainSettings, Constants, ErgoSettings, LaunchParameters, NodeConfigurationSettings}
+import org.ergoplatform.settings.{ChainSettings, Constants, ErgoSettings, NodeConfigurationSettings}
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.validation.ValidationResult.Valid
 import org.ergoplatform.validation.{ModifierValidator, ValidationResult}
@@ -272,7 +272,7 @@ object ErgoState extends ScorexLogging {
     val boxes = genesisBoxes(settings.chainSettings)
     val bh = BoxHolder(boxes)
 
-    UtxoState.fromBoxHolder(bh, boxes.headOption, stateDir, settings, LaunchParameters).ensuring(us => {
+    UtxoState.fromBoxHolder(bh, boxes.headOption, stateDir, settings, settings.launchParameters).ensuring(us => {
       log.info(s"Genesis UTXO state generated with hex digest ${Base16.encode(us.rootDigest)}")
       java.util.Arrays.equals(us.rootDigest, settings.chainSettings.genesisStateDigest) && us.version == genesisStateVersion
     }) -> bh

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateReader.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.state
 import org.ergoplatform.{ErgoBox, NodeViewComponent}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
-import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, LaunchParameters, Parameters}
+import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, Parameters}
 import org.ergoplatform.core.VersionTag
 import scorex.crypto.authds.ADDigest
 import scorex.crypto.hash.Digest32
@@ -69,7 +69,7 @@ object ErgoStateReader extends ScorexLogging {
       .flatMap(b => ErgoStateContextSerializer(settings.chainSettings).parseBytesTry(b).toOption)
       .getOrElse {
         log.warn("Can't read blockchain parameters from database")
-        ErgoStateContext.empty(settings.chainSettings, LaunchParameters)
+        ErgoStateContext.empty(settings.chainSettings, settings.launchParameters)
       }
   }
 
@@ -94,7 +94,7 @@ object ErgoStateReader extends ScorexLogging {
       if (lastHeaders.size != Constants.LastHeadersInContext) {
         Failure(new Exception(s"Only ${lastHeaders.size} headers found in reconstructStateContextBeforeEpoch"))
       } else {
-        val empty = ErgoStateContext.empty(settings.chainSettings, LaunchParameters)
+        val empty = ErgoStateContext.empty(settings.chainSettings, settings.launchParameters)
         val esc = new ErgoStateContext( lastHeaders,
                                         None,
                                         empty.genesisStateDigest,

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
@@ -29,6 +29,14 @@ case class ErgoSettings(directory: String,
         .toOption
     }
 
+  def launchParameters: Parameters = {
+    if (networkType == NetworkType.DevNet) {
+      DevnetLaunchParameters
+    } else {
+      MainnetLaunchParameters
+    }
+  }
+
 }
 
 object ErgoSettings {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -90,9 +90,9 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest {
   property("monotonic creation height") {
     def stateContext(height: Int, blockVersion: Byte): ErgoStateContext = {
       val header = defaultHeaderGen.sample.get.copy(version = blockVersion, height = height)
-      val params = Parameters(LaunchParameters.height,
-                              LaunchParameters.parametersTable.updated(Parameters.BlockVersion, blockVersion),
-                              LaunchParameters.proposedUpdate)
+      val params = Parameters(MainnetLaunchParameters.height,
+                              MainnetLaunchParameters.parametersTable.updated(Parameters.BlockVersion, blockVersion),
+                              MainnetLaunchParameters.proposedUpdate)
       new ErgoStateContext(Seq(header), None, genesisStateDigest, params, ErgoValidationSettings.initial,
         VotingData.empty)(settings.chainSettings)
     }
@@ -496,7 +496,7 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest {
   property("Soft-forked execution of Ergoscript containing unknown methods") {
 
     val activatedVersion = 3.toByte
-    val params = new Parameters(0, LaunchParameters.parametersTable.updated(123, activatedVersion + 1), ErgoValidationSettingsUpdate.empty)
+    val params = new Parameters(0, MainnetLaunchParameters.parametersTable.updated(123, activatedVersion + 1), ErgoValidationSettingsUpdate.empty)
 
     // for next version, rule 1011 should be replaced , otherwise transaction validation will fail
     // in this test, the rule is replaced with self, but for real activation this choice should be revised

--- a/src/test/scala/org/ergoplatform/tools/DefaultParametersPrinter.scala
+++ b/src/test/scala/org/ergoplatform/tools/DefaultParametersPrinter.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.tools
 
-import org.ergoplatform.settings.LaunchParameters.parametersTable
+import org.ergoplatform.settings.MainnetLaunchParameters.parametersTable
 import org.ergoplatform.settings.Parameters.{maxValues, minValues, parametersDescs, stepsTable}
 
 object DefaultParametersPrinter extends App {

--- a/src/test/scala/org/ergoplatform/tools/FeeSimulator.scala
+++ b/src/test/scala/org/ergoplatform/tools/FeeSimulator.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.tools
 
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.settings.Constants._
-import org.ergoplatform.settings.LaunchParameters._
+import org.ergoplatform.settings.MainnetLaunchParameters._
 import org.ergoplatform.{ErgoBoxCandidate, Input}
 import scorex.crypto.authds.ADKey
 import scorex.utils.Random


### PR DESCRIPTION
In this PR, possibility to have initial blockchain parameters, which can vary depending on network, is introduced. For devnets, parameters set up to have Autolykos 2 and Sigma 5.0 (with JIT) costing since genesis block. 