### PR TITLE
Rework segment retrieval, added ordering test

### DIFF
--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/SegmentSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/SegmentSpec.scala
@@ -11,81 +11,65 @@ import org.ergoplatform.modifiers.{BlockSection, NonHeaderBlockSection}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.settings.ErgoSettings
+import scorex.util
 
 import scala.util.Try
 
 class SegmentSpec extends ErgoCorePropertyTest {
 
-  property("correct slicing in getFromSegments") {
-    implicit val segmentTreshold: Int = 512
+  implicit val segmentTreshold: Int = 512
 
-    val hash = ModifierId @@ Base16.encode(Array.fill(32)(0.toByte))
-    val boxes = new ArrayBuffer[Long]()
-    (1 to 1706).foreach{i =>
-      boxes.append(i)
-    }
+  val hash: util.ModifierId.Type = ModifierId @@ Base16.encode(Array.fill(32)(0.toByte))
+  val boxes = new ArrayBuffer[Long]()
+  (1 to 1706).foreach{i =>
+    boxes.append(i)
+  }
 
-    val segment0 = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.take(segmentTreshold))
-    val segment1 = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.slice(segmentTreshold, segmentTreshold * 2))
-    val segment2 = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.slice(segmentTreshold * 2, segmentTreshold * 3))
-    val ia = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.slice(segmentTreshold * 3, boxes.size).reverse)
+  val segment0: IndexedErgoAddress = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.take(segmentTreshold))
+  val segment1: IndexedErgoAddress = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.slice(segmentTreshold, segmentTreshold * 2))
+  val segment2: IndexedErgoAddress = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.slice(segmentTreshold * 2, segmentTreshold * 3))
+  val ia: IndexedErgoAddress = IndexedErgoAddress(hash, new ArrayBuffer[Long](), boxes.slice(segmentTreshold * 3, boxes.size))
 
-    val hr = new ErgoHistoryReader {
-      override protected[history] val historyStorage: HistoryStorage = new HistoryStorage(null, null, null ,null) {
-        override def getExtraIndex(id: ModifierId): Option[ExtraIndex] = {
-          val b = Base16.decode(id).get.head
-          if(b == 0) {
-            Some(segment0)
-          } else if(b == 1) {
-            Some(segment1)
-          } else if(b == 2) {
-            Some(segment2)
-          } else {
-            None
-          }
+  val hr: ErgoHistoryReader = new ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = new HistoryStorage(null, null, null ,null) {
+      override def getExtraIndex(id: ModifierId): Option[ExtraIndex] = {
+        val b = Base16.decode(id).get.head
+        if(b == 0) {
+          Some(segment0)
+        } else if(b == 1) {
+          Some(segment1)
+        } else if(b == 2) {
+          Some(segment2)
+        } else {
+          None
         }
       }
-
-      override protected val settings: ErgoSettings = null
-
-      /**
-        * Whether state requires to download adProofs before full block application
-        */
-      override protected def requireProofs: Boolean = ???
-
-      /**
-        * @param m - modifier to process
-        * @return ProgressInfo - info required for State to be consistent with History
-        */
-      override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] = ???
-
-      /**
-        * @param m - modifier to validate
-        * @return Success() if modifier is valid from History point of view, Failure(error) otherwise
-        */
-      override protected def validate(m: NonHeaderBlockSection): Try[Unit] = ???
-
-      override val powScheme: AutolykosPowScheme = null
     }
+    override protected val settings: ErgoSettings = null
+    override protected def requireProofs: Boolean = ???
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] = ???
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] = ???
+    override val powScheme: AutolykosPowScheme = null
+  }
 
-    def getFromSegments(offset: Int, limit: Int) = {
-      ia.getFromSegments(
-        history = hr,
-        offset,
-        limit,
-        segmentCount = 3,
-        ia.boxes,
-        idOf = {
-          case (_, i) => ModifierId @@ Base16.encode(Array.fill(32)(i.toByte))
-        },
-        arraySelector = { ai => ai.boxes },
-        retrieve = {
-          case (arr, _) => arr.toArray
-        },
-        txsFlag = false
-      )
-    }
+  def getFromSegments(offset: Int, limit: Int): Array[Long] = {
+    ia.getFromSegments(
+      history = hr,
+      offset,
+      limit,
+      segmentCount = 3,
+      ia.boxes,
+      idOf = {
+        case (_, i) => ModifierId @@ Base16.encode(Array.fill(32)(i.toByte))
+      },
+      arraySelector = { ai => ai.boxes },
+      retrieve = {
+        case (arr, _) => arr.toArray
+      }
+    )
+  }
 
+  property("correct slicing in getFromSegments") {
    val lim = 200
 
     val a1 = getFromSegments(0, lim)
@@ -182,6 +166,49 @@ class SegmentSpec extends ErgoCorePropertyTest {
     c3.distinct.length shouldBe 342
     c4.distinct.length shouldBe 0
     (c1 ++ c2 ++ c3).distinct.length shouldBe 1706
+  }
+
+  property("correct ordering in getFromSegments") {
+    val lim = 200
+
+    val a1 = getFromSegments(0, lim)
+    val a2 = getFromSegments(lim, lim)
+    val a3 = getFromSegments(2 * lim, lim)
+    val a4 = getFromSegments(3 * lim, lim)
+    val a5 = getFromSegments(4 * lim, lim)
+    val a6 = getFromSegments(5 * lim, lim)
+    val a7 = getFromSegments(6 * lim, lim)
+    val a8 = getFromSegments(7 * lim, lim)
+    val a9 = getFromSegments(8 * lim, lim)
+    val a10 = getFromSegments(9 * lim, lim)
+
+    val full = a1 ++ a2 ++ a3 ++ a4 ++ a5 ++ a6 ++ a7 ++ a8 ++ a9 ++ a10
+    full.reverse.sameElements(full.sorted) shouldBe true
+
+    val lim2 = 100
+
+    val b1 = getFromSegments(0, lim2)
+    val b2 = getFromSegments(lim2, lim2)
+    val b3 = getFromSegments(2 * lim2, lim2)
+    val b4 = getFromSegments(3 * lim2, lim2)
+    val b5 = getFromSegments(4 * lim2, lim2)
+    val b6 = getFromSegments(5 * lim2, lim2)
+    val b7 = getFromSegments(6 * lim2, lim2)
+    val b8 = getFromSegments(7 * lim2, lim2)
+    val b9 = getFromSegments(8 * lim2, lim2)
+    val b10 = getFromSegments(9 * lim2, lim2)
+    val b11 = getFromSegments(10 * lim2, lim2)
+    val b12 = getFromSegments(11 * lim2, lim2)
+    val b13 = getFromSegments(12 * lim2, lim2)
+    val b14 = getFromSegments(13 * lim2, lim2)
+    val b15 = getFromSegments(14 * lim2, lim2)
+    val b16 = getFromSegments(15 * lim2, lim2)
+    val b17 = getFromSegments(16 * lim2, lim2)
+    val b18 = getFromSegments(17 * lim2, lim2)
+    val b19 = getFromSegments(18 * lim2, lim2)
+
+    val full2 = b1 ++ b2 ++ b3 ++ b4 ++ b5 ++ b6 ++ b7 ++ b8 ++ b9 ++ b10 ++ b11 ++ b12 ++ b13 ++ b14 ++ b15 ++ b16 ++ b17 ++ b18 ++ b19
+    full2.reverse.sameElements(full2.sorted) shouldBe true
   }
 
 }


### PR DESCRIPTION
The transaction and box by address or token indexer APIs returned records out of order.