### PR TITLE
Versioned block transaction serializer since 6.0, not 5.0

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
@@ -185,7 +185,7 @@ object BlockTransactionsSerializer extends ErgoSerializer[BlockTransactions] {
       lazy val version = Header.scriptAndTreeFromBlockVersions(blockVersion)
 
       (1 to txCount).map { _ =>
-        if (blockVersion >= VersionContext.V6SoftForkVersion) {
+        if (blockVersion >= Header.Interpreter60Version) {
           if (headerId == "3f5a4acbdfd76a97f2fdf387559c2a67b4ea5f9e9bcf66ef079cde766c6e9398") {
             // todo: public testnet bug with v7 tree included in v4 block, remove after testnet relaunch
             VersionContext.withVersions(1, 1) {


### PR DESCRIPTION
Seems there is 5.0 block in the testnet which has tree version > activated script version (probably transaction was written there before such rule got into 5.0 mainnet version). So to handle it correctly, versioned block transaction serializer is done since 6.0, not 5.0, in this PR. 