### PR TITLE
Fix for duplicate addresses on derivation after wallet restoration 

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -317,7 +317,7 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
             // remove old wallet state, see https://github.com/ergoplatform/ergo/issues/1313
             recreateRegistry(state, settings).flatMap { stateV1 =>
               recreateStorage(stateV1, settings).map { stateV2 =>
-                mnemonic -> stateV2.copy(secretStorageOpt = Some(newSecretStorage))
+                mnemonic -> stateV2.copy(secretStorageOpt = Some(newSecretStorage), walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings))
               }
             }
           }
@@ -332,20 +332,21 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
                     mnemonic: SecretString,
                     mnemonicPassOpt: Option[SecretString],
                     walletPass: SecretString,
-                    usePre1627KeyDerivation: Boolean): Try[ErgoWalletState] =
-    if (settings.nodeSettings.isFullBlocksPruned)
+                    usePre1627KeyDerivation: Boolean): Try[ErgoWalletState] = {
+    if (settings.nodeSettings.isFullBlocksPruned) {
       Failure(new IllegalArgumentException("Unable to restore wallet when pruning is enabled"))
-    else
+    } else {
       Try(JsonSecretStorage.restore(mnemonic, mnemonicPassOpt, walletPass, settings.walletSettings.secretStorage, usePre1627KeyDerivation))
         .flatMap { secretStorage =>
           // remove old wallet state, see https://github.com/ergoplatform/ergo/issues/1313
           recreateRegistry(state, settings).flatMap { stateV1 =>
             recreateStorage(stateV1, settings).map { stateV2 =>
-              stateV2.copy(secretStorageOpt = Some(secretStorage))
+              stateV2.copy(secretStorageOpt = Some(secretStorage), walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings))
             }
           }
         }
-
+    }
+  }
 
   override def unlockWallet(state: ErgoWalletState,
                    walletPass: SecretString,

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -20,6 +20,7 @@ import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
 import org.ergoplatform.wallet.boxes.{ErgoBoxSerializer, ReplaceCompactCollectBoxSelector, TrackedBox}
 import org.ergoplatform.wallet.crypto.ErgoSignature
+import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterAll
@@ -347,4 +348,89 @@ class ErgoWalletServiceSpec
       }
     }
   }
+
+  property("key derivation after init wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wpass = SecretString.create("y")
+        val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
+        val walletState = ErgoWalletState(
+          new WalletStorage(store, settings),
+          secretStorageOpt = Option.empty,
+          new WalletRegistry(versionedStore)(settings.walletSettings),
+          OffChainRegistry.empty,
+          outputsFilter = Option.empty,
+          WalletVars(Some(prover), Seq.empty, None),
+          stateReaderOpt = Option.empty,
+          mempoolReaderOpt = None,
+          utxoStateReaderOpt = Option.empty,
+          parameters,
+          maxInputsToUse = 1000,
+          rescanInProgress = false
+        )
+        val s = settings.copy(nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1))
+        val walletService = new ErgoWalletServiceImpl(s)
+        val ws = walletService.initWallet(
+          walletState,
+          s,
+          walletPass = wpass,
+          None
+        ).get._2
+
+        ws.secretStorageOpt.get.unlock(wpass)
+        ws.walletVars.trackedPubKeys.size shouldBe 1
+        val uws = ws
+
+        val uws2 = walletService.deriveNextKey(uws, usePreEip3Derivation = true).get._2
+        uws2.walletVars.trackedPubKeys.size shouldBe 2
+
+        val uws3 = walletService.deriveNextKey(uws2, usePreEip3Derivation = false).get._2
+        uws3.walletVars.trackedPubKeys.size shouldBe 3
+      }
+    }
+  }
+
+  property("key derivation after restoring wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wpass = SecretString.create("y")
+        val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
+        val walletState = ErgoWalletState(
+          new WalletStorage(store, settings),
+          secretStorageOpt = Option.empty,
+          new WalletRegistry(versionedStore)(settings.walletSettings),
+          OffChainRegistry.empty,
+          outputsFilter = Option.empty,
+          WalletVars(Some(prover), Seq.empty, None),
+          stateReaderOpt = Option.empty,
+          mempoolReaderOpt = None,
+          utxoStateReaderOpt = Option.empty,
+          parameters,
+          maxInputsToUse = 1000,
+          rescanInProgress = false
+        )
+        val s = settings.copy(nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1))
+        val walletService = new ErgoWalletServiceImpl(s)
+        val ws = walletService.restoreWallet(
+          walletState,
+          s,
+          mnemonic = SecretString.create("x"),
+          mnemonicPassOpt = None,
+          walletPass = wpass,
+          usePre1627KeyDerivation = false
+        ).get
+
+        ws.secretStorageOpt.get.unlock(wpass)
+        ws.walletVars.trackedPubKeys.size shouldBe 1
+        val uws = ws
+
+        val uws2 = walletService.deriveNextKey(uws, false).get._2
+        uws2.walletVars.trackedPubKeys.size shouldBe 2
+
+        val uws3 = walletService.deriveNextKey(uws2, false).get._2
+        uws3.walletVars.trackedPubKeys.size shouldBe 3
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
close #2223 

In this PR, a bug with wallet cache inconsistency after init/restore , resulting in the same address being shown in the panel UI after first derivation, got fixed