### PR TITLE
New Mining API route for custom public key

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
@@ -4,7 +4,9 @@ import akka.actor.{ActorRef, ActorRefFactory}
 import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import io.circe.syntax._
-import io.circe.{Encoder, Json}
+import io.circe.{Decoder, Encoder, Json}
+import org.bouncycastle.util.encoders.Hex
+import org.ergoplatform.http.api.requests.MiningRequest
 import org.ergoplatform.mining.CandidateGenerator.Candidate
 import org.ergoplatform.mining.{AutolykosSolution, CandidateGenerator, ErgoMiner}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
@@ -13,8 +15,10 @@ import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
 import org.ergoplatform.{ErgoAddress, ErgoTreePredef, Pay2SAddress}
 import scorex.core.api.http.ApiResponse
 import sigma.data.ProveDlog
+import sigma.serialization.GroupElementSerializer
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 case class MiningApiRoute(miner: ActorRef,
                           ergoSettings: ErgoSettings)
@@ -23,10 +27,16 @@ case class MiningApiRoute(miner: ActorRef,
   val settings: RESTApiSettings = ergoSettings.scorexSettings.restApi
 
   implicit val addressEncoder: Encoder[ErgoAddress] = ErgoAddressJsonEncoder(ergoSettings.chainSettings).encoder
-
+  implicit val miningRequestDecoder: Decoder[MiningRequest] = { cursor =>
+    for {
+      txs <- cursor.downField("txs").as[Seq[ErgoTransaction]]
+      pk <- cursor.downField("pk").as[String]
+    } yield MiningRequest(txs, pk)
+  }
   override val route: Route = pathPrefix("mining") {
     candidateR ~
       candidateWithTxsR ~
+      candidateWithTxsAndPkR ~
       solutionR ~
       rewardAddressR ~
       rewardPublicKeyR
@@ -51,6 +61,20 @@ case class MiningApiRoute(miner: ActorRef,
     val prepareCmd = CandidateGenerator.GenerateCandidate(txs, reply = true, forced = false)
     val candidateF = miner.askWithStatus(prepareCmd).mapTo[Candidate].map(_.externalVersion)
     ApiResponse(candidateF)
+  }
+
+  def candidateWithTxsAndPkR: Route = (path("candidateWithTxsAndPk")
+    & post & entity(as[MiningRequest]) & withAuth) { txsAndPk =>
+    val tryPk = Try(GroupElementSerializer.fromBytes(Hex.decode(txsAndPk.pk)))
+    val result = tryPk match {
+      case Failure(e) =>
+        Future.failed(new Exception("Could not decode hexadecimal string for given public key"))
+      case Success(pk) =>
+        val prepareCmd = CandidateGenerator.GenerateCandidate(txsAndPk.txs, reply = true,
+          forced = false, Some(ProveDlog.apply(pk)))
+        miner.askWithStatus(prepareCmd).mapTo[Candidate].map(_.externalVersion)
+    }
+    ApiResponse(result)
   }
 
   def solutionR: Route = (path("solution") & post & entity(as[AutolykosSolution])) { solution =>

--- a/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
@@ -67,7 +67,7 @@ case class MiningApiRoute(miner: ActorRef,
     & post & entity(as[MiningRequest]) & withAuth) { txsAndPk =>
     val tryPk = Try(GroupElementSerializer.fromBytes(Hex.decode(txsAndPk.pk)))
     val result = tryPk match {
-      case Failure(e) =>
+      case Failure(_) =>
         Future.failed(new Exception("Could not decode hexadecimal string for given public key"))
       case Success(pk) =>
         val prepareCmd = CandidateGenerator.GenerateCandidate(txsAndPk.txs, reply = true,

--- a/src/main/scala/org/ergoplatform/http/api/requests/MiningRequest.scala
+++ b/src/main/scala/org/ergoplatform/http/api/requests/MiningRequest.scala
@@ -1,0 +1,11 @@
+package org.ergoplatform.http.api.requests
+
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+
+/**
+  * Represents a request to generate a candidate with the given transactions and miner public key.
+  *
+  * @param txs      Transactions to include in the block candidate
+  * @param pk       String Hexadecimal representation of public key to use as minerPk
+  */
+case class MiningRequest(txs: Seq[ErgoTransaction], pk: String)

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -152,7 +152,7 @@ class CandidateGenerator(
         context.become(initialized(state))
       }
 
-    case gen @ GenerateCandidate(txsToInclude, reply, forced) =>
+    case gen @ GenerateCandidate(txsToInclude, reply, forced, optPk) =>
       val senderOpt = if (reply) Some(sender()) else None
       if (!forced && cachedFor(state.cachedCandidate, txsToInclude)) {
         senderOpt.foreach(_ ! StatusReply.success(state.cachedCandidate.get))
@@ -162,7 +162,7 @@ class CandidateGenerator(
           state.hr,
           state.sr,
           state.mpr,
-          minerPk,
+          optPk.getOrElse(minerPk),
           txsToInclude,
           ergoSettings
         ) match {
@@ -260,7 +260,8 @@ object CandidateGenerator extends ScorexLogging {
   case class GenerateCandidate(
     txsToInclude: Seq[ErgoTransaction],
     reply: Boolean,
-    forced: Boolean
+    forced: Boolean,
+    optPk: Option[ProveDlog] = None
   )
 
   /** Local state of candidate generator to avoid mutable vars */

--- a/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
+++ b/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
@@ -156,7 +156,7 @@ class ErgoMiner(
       log.info("Starting mining triggered by incoming block")
       self ! StartMining
 
-    case GenerateCandidate(_, _, _) =>
+    case GenerateCandidate(_, _, _, _) =>
       sender() ! StatusReply.error("Miner has not started yet")
   }
 
@@ -164,7 +164,7 @@ class ErgoMiner(
     * The reason is that replying is optional and it is not possible to obtain a sender reference from MiningApiRoute 'ask'.
     */
   def started(minerState: MinerState): Receive = {
-    case genCandidate @ GenerateCandidate(_, _, _) =>
+    case genCandidate @ GenerateCandidate(_, _, _, _) =>
       minerState.candidateGeneratorRef forward genCandidate
 
     case solution: AutolykosSolution =>

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -112,7 +112,7 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
 
   class MinerStub extends Actor {
     def receive: Receive = {
-      case CandidateGenerator.GenerateCandidate(_, reply, _) =>
+      case CandidateGenerator.GenerateCandidate(_, reply, _, _) =>
         if (reply) {
           val candidate = Candidate(null, externalWorkMessage, Seq.empty) // API does not use CandidateBlock
           sender() ! StatusReply.success(candidate)


### PR DESCRIPTION
This PR adds a new mining API route to create a candidate under a given miner public key. This is needed for Lithos as collateralized pools require the block reward to go to the lender's public key. These changes should also be merged into the current testnet build.