### PR TITLE
Fix chained unconfirmed inputs query failure in getUnconfirmedInputByBoxId  Description: Fixes #2230

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
@@ -330,8 +330,9 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
                 .flatMap(_.transaction.inputs.filter(_.boxId.sameElements(boxId)))
                 .headOption
                 .flatMap { input =>
-                  state.boxById(input.boxId).map { box =>
+                  state.withMempool(pool).boxById(input.boxId).map { box =>
                     val baseInput = Json.obj(
+
                       "boxId"         -> input.boxId.asJson,
                       "spendingProof" -> input.spendingProof.asJson
                     )

--- a/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteReproSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteReproSpec.scala
@@ -1,0 +1,80 @@
+package org.ergoplatform.http.routes
+
+import akka.actor.{Actor, Props}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.Json
+import org.ergoplatform.ErgoBox.TokenId
+import org.ergoplatform.http.api.{ApiCodecs, TransactionsApiRoute}
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
+import org.ergoplatform.nodeView.ErgoReadersHolder.{GetDataFromHistory, GetReaders, Readers}
+import org.ergoplatform.settings.RESTApiSettings
+import org.ergoplatform.utils.Stubs
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.util.encode.Base16
+import org.ergoplatform.settings.Constants.TrueTree
+import sigma.Extensions.ArrayOps
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+
+class TransactionApiRouteReproSpec extends AnyFlatSpec
+  with Matchers
+  with ScalatestRouteTest
+  with Stubs
+  with ApiCodecs
+  with FailFastCirceSupport {
+
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+  import org.ergoplatform.utils.ErgoCoreTestConstants._
+
+  val prefix = "/transactions"
+
+  val restApiSettings = RESTApiSettings(new InetSocketAddress("localhost", 8080), None, None, 10.seconds, None)
+  
+  val inputBox: ErgoBox = utxoState.takeBoxes(1).head
+  val input = Input(inputBox.id, emptyProverResult)
+  
+  val emptyTokens = Array[(TokenId, Long)]()
+
+  // Output C
+  val outputC: ErgoBoxCandidate =
+     new ErgoBoxCandidate(inputBox.value, TrueTree, creationHeight = 0, emptyTokens.toColl, Map.empty)
+     
+  // Tx1: Input A -> Output C
+  val tx1: ErgoTransaction = ErgoTransaction(IndexedSeq(input), IndexedSeq(), IndexedSeq(outputC))
+
+  // Tx2: Input C -> Output E
+  val inputC = Input(tx1.outputs.head.id, emptyProverResult)
+  val outputE: ErgoBoxCandidate = 
+      new ErgoBoxCandidate(inputBox.value, TrueTree, creationHeight = 0, emptyTokens.toColl, Map.empty)
+  val tx2: ErgoTransaction = ErgoTransaction(IndexedSeq(inputC), IndexedSeq(), IndexedSeq(outputE))
+
+  // Route setup with both transactions in mempool
+  val chainedRoute: Route = {
+    // constructing memory pool with both transactions
+    val mp2 = memPool.put(UnconfirmedTransaction(tx1, None)).put(UnconfirmedTransaction(tx2, None))
+    
+    class UtxoReadersStub2 extends Actor {
+      def receive: PartialFunction[Any, Unit] = {
+        case GetReaders => sender() ! Readers(history, utxoState, mp2, wallet)
+        case GetDataFromHistory(f) => sender() ! f(history)
+      }
+    }
+    val readers2 = system.actorOf(Props(new UtxoReadersStub2))
+    TransactionsApiRoute(readers2, nodeViewRef, settings).route
+  }
+
+  it should "return unconfirmed input by boxId for chained transaction (repro)" in {
+    val searchedBoxId = tx1.outputs.head.id
+    val searchedBoxEncoded = Base16.encode(searchedBoxId)
+    
+    Get(prefix + s"/unconfirmed/inputs/byBoxId/$searchedBoxEncoded") ~> chainedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("boxId").as[String] shouldEqual Right(searchedBoxEncoded)
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -4,7 +4,8 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.SortingOption
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.utils.ErgoCorePropertyTest
 
-import java.net.{InetSocketAddress, URL}
+import java.net.InetSocketAddress
+
 import scala.concurrent.duration._
 
 class ErgoSettingsSpecification extends ErgoCorePropertyTest {
@@ -65,7 +66,8 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
       apiKeyHash = None,
       corsAllowedOrigin = Some("*"),
       timeout = 5.seconds,
-      publicUrl = Some(new URL("https://example.com:80"))
+      publicUrl = Some(new java.net.URI("https://example.com:80").toURL)
+
     )
   }
 
@@ -164,7 +166,8 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
         "http://0.0.0.0",
         "http://example.com/foo/bar",
         "http://example.com?foo=bar"
-      ).map(new URL(_))
+      ).map(new java.net.URI(_).toURL)
+
 
     invalidUrls.forall(ErgoSettingsReader.invalidRestApiUrl) shouldBe true
 
@@ -174,7 +177,8 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
         "http://example.com:80",
         "http://82.90.21.31",
         "http://82.90.21.31:80"
-      ).map(new URL(_))
+      ).map(new java.net.URI(_).toURL)
+
 
     validUrls.forall(url => !ErgoSettingsReader.invalidRestApiUrl(url)) shouldBe true
   }


### PR DESCRIPTION
Fixes #2230

## Description
This PR fixes an issue where inputs of chained unconfirmed transactions were not retrievable via the `/transactions/unconfirmed/inputs/byBoxId` endpoint. Previously, the endpoint only queried the UTXO state (confirmed boxes), causing lookups to fail for boxes that were created by other unconfirmed transactions in the mempool.

## Changes
- **[TransactionsApiRoute.scala](cci:7://file:///Users/adityagupta/Developer/ergo/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala:0:0-0:0)**: Updated `getUnconfirmedInputByBoxId` to use `state.withMempool(pool).boxById(...)`. This ensures that if a box is not found in the confirmed UTXO set, the system looks for it in the mempool.
- **[TransactionApiRouteReproSpec.scala](cci:7://file:///Users/adityagupta/Developer/ergo/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteReproSpec.scala:0:0-0:0)**: Added a new regression test case that:
    1. Creates two transactions, `Tx1` and `Tx2`, where `Tx2` spends an output of `Tx1`.
    2. Places both in the mempool.
    3. Verifies that the input of `Tx2` (which is `Tx1`'s unconfirmed output) can be retrieved via the API.
- **[ErgoSettingsSpecification.scala](cci:7://file:///Users/adityagupta/Developer/ergo/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala:0:0-0:0)**: Fixed `java.net.URL` constructor deprecation errors that were causing build failures during testing (replaced with `URI.create(...).toURL()`).

## Verification
- Run the new reproduction test:
  ```bash
  sbt "testOnly org.ergoplatform.http.routes.TransactionApiRouteReproSpec"