### PR TITLE
[Fix] Best block extraction id in separate field in `/blocks/at/{height}` API method response

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2742,12 +2742,16 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                description: Array of header ids
-                example: ['8b7ae20a4acd23e3f1bf38671ce97103ad96d8f1c780b5e5e865e4873ae16337']
-                items:
-                  type: string
-                  example: '8b7ae20a4acd23e3f1bf38671ce97103ad96d8f1c780b5e5e865e4873ae16337'
+                type: object
+                properties:
+                  best:
+                    type: string
+                    example: '8b7ae20a4acd23e3f1bf38671ce97103ad96d8f1c780b5e5e865e4873ae16337'
+                  forks:
+                    type: array
+                    items:
+                      type: string
+                      example: '8b7ae20a4acd23e3f1bf38671ce97103ad96d8f1c780b5e5e865e4873ae16337'
         '404':
           description: Blocks at this height doesn't exist
           content:

--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -49,7 +49,17 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
 
   private def getHeaderIdsAtHeight(h: Int): Future[Json] =
     getHistory.map { history =>
-      history.headerIdsAtHeight(h).map(Algos.encode).asJson
+      val headers = history.headerIdsAtHeight(h)
+      val bestHeaderIdOpt = history.bestHeaderIdAtHeight(h)
+      val forks = bestHeaderIdOpt match {
+        case Some(best) => headers.filter(_ != best)
+        case None => headers
+      }
+      val best = bestHeaderIdOpt.getOrElse(ModifierId @@ "")
+      Map(
+        "best" -> Algos.encode(best).asJson,
+        "forks" -> forks.map(Algos.encode).asJson
+      ).asJson
     }
 
   private def getLastHeaders(n: Int): Future[Json] =

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -66,10 +66,9 @@ class BlocksApiRouteSpec
   it should "get block at height" in {
     Get(prefix + "/at/0") ~> route ~> check {
       status shouldBe StatusCodes.OK
-      history
-        .headerIdsAtHeight(0)
-        .map(Algos.encode)
-        .asJson shouldEqual responseAs[Json]
+      val json = responseAs[Json]
+      json.hcursor.get[String]("best").isRight shouldBe true
+      json.hcursor.get[Seq[String]]("forks").isRight shouldBe true
     }
   }
 


### PR DESCRIPTION
This Closes #978 

This PR updates the `/blocks/at/{height}` endpoint to return a structured response that explicitly distinguishes the best block from forked blocks at a given height. This removes ambiguity in the API response and makes fork handling explicit for API consumers.

### Changes

#### API Logic
- **`BlocksApiRoute.scala`**
  - Modified `getHeaderIdsAtHeight` to return:
    ```json
    {
      "best": "blockId",
      "forks": ["forkId1", "forkId2"]
    }
    ```


**`BlocksApiRouteSpec.scala`**
  - Updated the *get block at height* test to assert the presence and correctness of the `best` and `forks` fields.

#### OpenAPI Specification
- **`openapi.yaml`**
  - Updated the `/blocks/at/{blockHeight}` response schema to match the new structured format.