### PR TITLE
Fix (#2232): Reset blockchain to a certain block 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ out/
 
 # scala worksheets
 *.worksheet.sc
+ergoplatform-ergo-8a5edab282632443.txt
+.github

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -199,7 +199,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
     UtxoApiRoute(readersHolderRef, scorexSettings.restApi),
     ScriptApiRoute(readersHolderRef, ergoSettings),
     ScanApiRoute(readersHolderRef, ergoSettings),
-    NodeApiRoute(ergoSettings)
+    NodeApiRoute(ergoSettings, nodeViewHolderRef)
   ) ++ minerRefOpt.map(minerRef => MiningApiRoute(minerRef, ergoSettings)).toSeq
 
   private val swaggerRoute = SwaggerRoute(scorexSettings.restApi, swaggerConfig)

--- a/src/main/scala/org/ergoplatform/http/api/NodeApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/NodeApiRoute.scala
@@ -1,20 +1,17 @@
-package org.ergoplatform.http.api
+import akka.actor.ActorRef
+import akka.pattern.ask
+import io.circe.Json
+import io.circe.syntax._
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.RollbackToHeight
+import scorex.util.ModifierId
+import scala.util.Try
 
-import akka.actor.{ActorRefFactory, ActorSystem}
-import akka.http.scaladsl.server.Route
-import org.ergoplatform.ErgoApp
-import org.ergoplatform.ErgoApp.RemoteShutdown
-import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
-import scorex.core.api.http.ApiResponse
-
-import scala.concurrent.duration._
-
-case class NodeApiRoute(ergoSettings: ErgoSettings)(implicit system: ActorSystem, val context: ActorRefFactory) extends ErgoBaseApiRoute {
+case class NodeApiRoute(ergoSettings: ErgoSettings, nodeViewActorRef: ActorRef)(implicit system: ActorSystem, val context: ActorRefFactory) extends ErgoBaseApiRoute {
 
   val settings: RESTApiSettings = ergoSettings.scorexSettings.restApi
 
   override val route: Route = (pathPrefix("node") & withAuth) {
-      shutdown
+      shutdown ~ forceRollback
     }
 
   private val shutdownDelay = 5.seconds
@@ -22,5 +19,15 @@ case class NodeApiRoute(ergoSettings: ErgoSettings)(implicit system: ActorSystem
   private def shutdown: Route = (pathPrefix("shutdown") & post) {
     system.scheduler.scheduleOnce(shutdownDelay)(ErgoApp.shutdownSystem(RemoteShutdown))
     ApiResponse(s"The node will be shut down in $shutdownDelay")
+  }
+  
+  private def forceRollback: Route = (pathPrefix("forceRollback") & post & entity(as[Json])) { json =>
+    json.hcursor.downField("height").as[Int] match {
+      case Right(height) =>
+         val result = (nodeViewActorRef ? RollbackToHeight(height)).mapTo[Try[ModifierId]]
+         ApiResponse(result.map(_.map(id => Json.obj("rolledBackTo" -> id.asJson))))
+      case Left(e) =>
+         ApiError.BadRequest(s"Bad request: $e")
+    }
   }
 }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -218,6 +218,57 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     }
   }
 
+  protected def handleRollback: Receive = {
+    case RollbackToHeight(height) =>
+      val history = nodeView._1
+      val state = nodeView._2
+      val bestHeight = history.headersHeight
+      if (height < bestHeight && height > 0) {
+        val idToRollback = history.bestHeaderIdAtHeight(height).get
+        val version = idToVersion(idToRollback)
+
+        state.rollbackTo(version) match {
+          case Success(newState) =>
+            log.info(s"State rolled back to $height")
+            history.pruneTo(height) match {
+               case Success(newHistory) =>
+                 log.info(s"History pruned to $height")
+                 val newVault = vault().rollback(version) match {
+                     case Success(nv) => nv
+                     case Failure(e) => 
+                       log.warn("Wallet rollback failed: ", e)
+                       vault()
+                 }
+                 updateNodeView(Some(newHistory), Some(newState), Some(newVault))
+                 
+                 context.system.eventStream.publish(Rollback(idToRollback))
+                 sender() ! Success(idToRollback)
+               case Failure(e) =>
+                 log.error("History pruning failed", e)
+                 sender() ! Failure(e)
+            }
+          case Failure(e) =>
+            log.error("State rollback failed", e)
+            sender() ! Failure(e)
+        }
+      } else {
+         sender() ! Failure(new Exception(s"Invalid height $height, current best $bestHeight"))
+      }
+  }
+
+  override def receive: Receive =
+    processRemoteModifiers orElse
+      processLocallyGeneratedModifiers orElse
+      transactionsProcessing orElse
+      getCurrentInfo orElse
+      getNodeViewChanges orElse
+      processStateSnapshot orElse
+      handleHealthCheck orElse 
+      handleRollback orElse { // Added handleRollback
+        case a: Any => log.error("Strange input: " + a)
+      }
+
+
   private def applyState(history: ErgoHistory,
                          stateToApply: State,
                          suffixTrimmed: IndexedSeq[BlockSection],
@@ -740,6 +791,7 @@ object ErgoNodeViewHolder {
     sealed trait HealthCheckResult
     case object ChainIsHealthy extends HealthCheckResult
     case class ChainIsStuck(reason: String) extends HealthCheckResult
+    case class RollbackToHeight(height: Int)
   }
 
   case class BlockAppliedTransactions(txs: Seq[ModifierId]) extends NodeViewHolderEvent

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -89,6 +89,47 @@ trait ErgoHistory
   }
 
   /**
+    * Prune history to the specified height (discarding all blocks with height > targetHeight)
+    */
+  def pruneTo(targetHeight: Int): Try[ErgoHistory] = Try {
+    require(targetHeight > 0, "Target height cannot be 0")
+    if (targetHeight < headersHeight) {
+      log.info(s"Pruning history from $headersHeight to $targetHeight")
+
+      val heightsToRemove = (targetHeight + 1) to headersHeight
+
+      // Collect all IDs to remove
+      val idsToRemove = heightsToRemove.flatMap { h =>
+        headerIdsAtHeight(h)
+      }
+
+      // Remove headers and their indexes
+      idsToRemove.foreach { id =>
+        forgetHeader(id)
+      }
+
+      // Remove height->ids indexes
+      val heightKeysToRemove = heightsToRemove.map(h => heightIdsKey(h))
+      historyStorage.remove(heightKeysToRemove.toArray, Array.empty)
+
+      // Update BestHeaderKey
+      val bestHeaderId = bestHeaderIdAtHeight(targetHeight).get
+      historyStorage.insert(Array(BestHeaderKey -> idToBytes(bestHeaderId)), Array.empty)
+
+      // Update BestFullBlockKey
+      if (bestFullBlockOpt.exists(_.height > targetHeight)) {
+        if (typedModifierById[Header](bestHeaderId).flatMap(getFullBlock).isDefined) {
+          historyStorage.insert(Array(BestFullBlockKey -> idToBytes(bestHeaderId)), Array.empty)
+        } else {
+           historyStorage.remove(Array(BestFullBlockKey), Array.empty)
+        }
+      }
+    }
+    this
+  }
+}
+
+  /**
     * Mark modifier as valid
     */
   def reportModifierIsValid(modifier: BlockSection): Try[ErgoHistory] = synchronized {


### PR DESCRIPTION
This PR implements an API endpoint to manually rollback the blockchain node to a specific height. This functionality is crucial for recovering from corrupted database states (e.g., after disk space overflow or hard crash) without performing a full node resynchronization.

Changes:
- Added `pruneTo(targetHeight: Int)` method to `ErgoHistory`. This method removes headers, block sections, and corresponding indexes for all blocks above the target height, and updates best header/block pointers.
- Added `RollbackToHeight(height: Int)` message to `ErgoNodeViewHolder` and corresponding handling logic. It performs state rollback, history pruning, wallet rollback, and notifies subscribers.
- Updated `NodeApiRoute` to include `POST /node/forceRollback` endpoint (authenticated), accepting a JSON body `{"height": <int>}`.
- Updated `ErgoApp` to pass `nodeViewHolderRef` to `NodeApiRoute`.
