### PR TITLE
 Fix #1633: Allow controlling stdout log level via configuration file

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Settings.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Settings.scala
@@ -10,7 +10,7 @@ import java.io.File
 import java.net.{InetSocketAddress, URL}
 import scala.concurrent.duration._
 
-case class LoggingSettings(level: String)
+case class LoggingSettings(level: String, stdoutLevel: Option[String] = None)
 
 case class RESTApiSettings(
   bindAddress: InetSocketAddress,

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettingsReader.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettingsReader.scala
@@ -3,6 +3,9 @@ package org.ergoplatform.settings
 import java.io.{File, FileOutputStream}
 import java.nio.channels.Channels
 import ch.qos.logback.classic.{Level, LoggerContext}
+import ch.qos.logback.classic.filter.ThresholdFilter
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
 import org.slf4j.{Logger, LoggerFactory}
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import net.ceedubs.ficus.Ficus._
@@ -39,7 +42,7 @@ object ErgoSettingsReader extends ScorexLogging
     val scorexSettings = config.as[ScorexSettings](scorexConfigPath)
     val votingTargets = VotingTargets.fromConfig(config)
 
-    overrideLogLevel(scorexSettings.logging.level)
+    overrideLogLevel(scorexSettings.logging.level, scorexSettings.logging.stdoutLevel)
 
     if (nodeSettings.stateType == Digest && nodeSettings.mining) {
       log.error("Malformed configuration file was provided! Mining is not possible with digest state. Aborting!")
@@ -207,13 +210,29 @@ object ErgoSettingsReader extends ScorexLogging
   /**
    * Override the log level at runtime with values provided in config/user provided config.
    */
-  private def overrideLogLevel(level: String): Unit = level match {
-    case "TRACE" | "ERROR" | "INFO" | "WARN" | "DEBUG" =>
-      log.info(s"Log level set to $level")
-      val loggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-      val root          = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
-      root.setLevel(Level.toLevel(level))
-    case _ => log.warn("No log level configuration provided")
+  private def overrideLogLevel(level: String, stdoutLevelOpt: Option[String]): Unit = {
+    val loggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+    val root          = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
+
+    level match {
+      case "TRACE" | "ERROR" | "INFO" | "WARN" | "DEBUG" =>
+        log.info(s"Log level set to $level")
+        root.setLevel(Level.toLevel(level))
+      case _ => log.warn("No log level configuration provided")
+    }
+
+    stdoutLevelOpt.foreach { stdoutLevel =>
+      val appender = root.getAppender("STDOUT").asInstanceOf[Appender[ILoggingEvent]]
+      if (appender != null) {
+        appender.clearAllFilters()
+        val filter = new ThresholdFilter()
+        filter.setLevel(stdoutLevel)
+        filter.setContext(loggerContext)
+        filter.start()
+        appender.addFilter(filter)
+        log.info(s"Stdout log level set to $stdoutLevel")
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR addresses issue #1633 by adding the ability to control the log level, specifically the stdout log level, via the daemon configuration file (ergo.conf or [application.conf].

Changes:
- Modified LoggingSettings in [ergo-core to include an optional stdoutLevel field.
- Updated ErgoSettingsReader to read scorex.logging.stdoutLevel from the configuration.
- Implemented logic in overrideLogLevel to dynamically update the STDOUT appender's filter based on the configured stdoutLevel.

Usage:
Users can now add the following to their configuration file to control the log level:
```
scorex {
  logging {
    level = "DEBUG"        # Sets the root log level (affects both file and stdout)
    stdoutLevel = "INFO"   # Sets the stdout log level specifically (filters stdout)
  }
}
```

This allows users to have detailed logs in the file (e.g., DEBUG) while keeping the stdout output clean (e.g., INFO or WARN), which is particularly useful when running in Docker.