### PR TITLE
Implement different languages  in website

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/mnemonic/WordList.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/mnemonic/WordList.scala
@@ -28,5 +28,13 @@ object WordList {
     Try(loadFile()).map(r => try r.getLines().toList finally r.close())
 
   private def resourceLoader(fileName: String): () => BufferedSource =
-    () => Source.fromInputStream(getClass.getResourceAsStream(s"/wordlist/$fileName"))(Codec.UTF8)
+    () => {
+      val path = s"/wordlist/$fileName"
+      val stream =
+        Option(getClass.getResourceAsStream(path))
+          .orElse(Option(Thread.currentThread().getContextClassLoader.getResourceAsStream(path)))
+          .orElse(Option(ClassLoader.getSystemResourceAsStream(path)))
+          .getOrElse(throw new IllegalArgumentException(s"Wordlist resource not found: $path"))
+      Source.fromInputStream(stream)(Codec.UTF8)
+    }
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/mnemonic/WordListSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/mnemonic/WordListSpec.scala
@@ -1,0 +1,36 @@
+package org.ergoplatform.wallet.mnemonic
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class WordListSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "WordList and Mnemonic"
+
+  it should "load all available wordlists and have 2048 words each" in {
+    WordList.AvailableLanguages.foreach { lang =>
+      val wl = WordList.load(lang).get
+      wl.words.length shouldBe 2048
+      wl.words.forall(_.nonEmpty) shouldBe true
+    }
+  }
+
+  it should "use ideographic space for Japanese and space for others" in {
+    val ja = WordList.load("japanese").get
+    ja.delimiter shouldBe "\u3000"
+
+    WordList.AvailableLanguages.filterNot(_ == "japanese").foreach { lang =>
+      val wl = WordList.load(lang).get
+      wl.delimiter shouldBe " "
+    }
+  }
+
+  it should "generate mnemonic for each language with fixed entropy" in {
+    val entropy = Array.fill[Byte](20)(1) // 160 bits entropy
+    WordList.AvailableLanguages.foreach { lang =>
+      val m = new Mnemonic(lang, 160)
+      val phrase = m.toMnemonic(entropy).get
+      phrase.getData().nonEmpty shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
### Hackathon
This contribution is submitted as part of the **Unstoppable Hackathon**.

---

### Summary
This PR fixes issues where non-English mnemonic wordlists were not loading reliably at runtime due to classpath and resource resolution limitations. It also adds comprehensive unit tests to ensure all supported languages load correctly and that language-specific behavior (such as Japanese delimiters) is preserved.

---

### Problem
The `WordList` implementation relied solely on `getClass.getResourceAsStream` for loading wordlist resources.  
This approach can fail in certain environments (e.g., fat JARs, different classloaders, test runners), leading to missing mnemonic wordlists for languages such as Japanese, Chinese, and Korean.

---

### Solution
- Hardened resource loading in `WordList.resourceLoader` by:
  - Attempting `getClass.getResourceAsStream`
  - Falling back to the thread context classloader
  - Falling back to the system classloader
  - Throwing a clear `IllegalArgumentException` if the resource is not found
- Added comprehensive unit tests in `WordListSpec` to:
  - Verify all supported languages load exactly 2048 words
  - Confirm Japanese mnemonics use the ideographic space (`\u3000`) delimiter
  - Ensure mnemonic generation works for a fixed entropy across all languages

---

### Files Changed
- **`ergo-wallet/src/main/scala/org/ergoplatform/wallet/mnemonic/WordList.scala`**
  - Added robust multi-classloader fallback for loading `/wordlist/*.txt`
  - Improved error reporting when resources are missing
- **`ergo-wallet/src/test/scala/org/ergoplatform/wallet/mnemonic/WordListSpec.scala`**
  - Added tests for wordlist loading, delimiter correctness, and mnemonic generation

---

### Verification
- Ran wallet tests:
  ```bash
  sbt "project ergo-wallet" test
