### PR TITLE
Fix #1631: Handle rollback with keepVersions=0 during node restart

### DIFF
--- a/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
+++ b/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
@@ -401,6 +401,10 @@ class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
         } else {
           require(lastVersion.get.sameElements(versionID))
         }
+      } else if (keepVersions == 0 && lastVersion.exists(_.sameElements(versionID))) {
+        // When keepVersions=0, we don't maintain version history, but the version 
+        // is still tracked in lastVersion. Rollback to current version is a no-op.
+        // This handles the case when the node restarts during active sync with keepVersions=0.
       } else {
         throw new NoSuchElementException("versionID not found, can not rollback")
       }


### PR DESCRIPTION
Problem:
When a node is restarted during active sync (where keepVersions is temporarily set to 0), the state restoration fails with a NoSuchElementException in the rollbackTo() method. This occurs because:
1. During active sync, keepVersions is set to 0 to avoid maintaining undo history for blocks far behind the chain tip
2. The current state version is still tracked in lastVersionID and persisted in the database via last_version_key
3. On node restart, PersistentBatchAVLProver.create() attempts to restore the state by calling storage.rollback(version)
4. The rollbackTo() method fails because the version exists in lastVersionID but not in the versions array (since no undo data was maintained with keepVersions=0)

Solution:
Modified LDBVersionedStore.rollbackTo() to handle the special case where keepVersions=0 and we're attempting to rollback to the current version. In this scenario, the rollback is treated as a no-op since:

- We're already at the requested version (lastVersion matches)
- There's no undo history to apply (by design when keepVersions=0)
- The database state is already correct for that version