### PR TITLE
feat(#1722) : add initial wallet height setting to avoid rescanning from genesis

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -382,8 +382,16 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
 
     deleteRecursive(registryFolder)
 
-    WalletRegistry.apply(settings).map { reg =>
-      state.copy(registry = reg)
+    WalletRegistry.apply(settings).flatMap { reg =>
+      // Set the wallet height to current blockchain height to avoid rescanning from genesis
+      val currentHeight = state.fullHeight
+      if (currentHeight > 0) {
+        log.info(s"Setting wallet initial height to current blockchain height: $currentHeight")
+        reg.setInitialHeight(currentHeight).map(_ => state.copy(registry = reg))
+      } else {
+        // If blockchain height is 0 (no blocks yet), keep default height 0
+        Success(state.copy(registry = reg))
+      }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -426,6 +426,18 @@ class WalletRegistry(private val store: LDBVersionedStore)(ws: WalletSettings) e
   }
 
   /**
+    * Set the initial wallet height without any balance changes.
+    * This is used when initializing or restoring a wallet to avoid rescanning from genesis.
+    *
+    * @param height - the height to set
+    */
+  def setInitialHeight(height: Int): Try[Unit] = {
+    val digest = WalletDigest(height, 0, Seq.empty)
+    val bag = putDigest(KeyValuePairsBag.empty, digest)
+    bag.transact(store, scorex.utils.Random.randomBytes(32))
+  }
+
+  /**
     * Remove association between an application and a box.
     * Please note that in case of rollback association remains removed!
     *


### PR DESCRIPTION
Problem:
Currently, when a wallet is initialized (/wallet/init) or restored (/wallet/restore), the node wallet re-scans the blockchain from height 0 (genesis). This is unnecessary and inefficient, especially for nodes with long blockchain histories.

Root Cause:
The initWallet and restoreWallet methods call recreateRegistry() which deletes and recreates the wallet registry database. The new registry starts at height 0 (EmptyHistoryHeight). When new blocks arrive after wallet initialization, the wallet attempts to scan from height 1 onwards, effectively rescanning the entire blockchain.

Solution:
Set the wallet registry height to the current blockchain height immediately after recreating the registry during wallet initialization/restoration. This ensures the wallet only scans new blocks going forward, not historical blocks.

Changes
:
- [WalletRegistry.scala]: Added setInitialHeight(height: Int) method to set the wallet height without balance changes
- [ErgoWalletService.scala]: Modified recreateRegistry() to call setInitialHeight() with the current blockchain height (state.fullHeight)

Behavior
:
- Before: Wallet initialized at height 0, rescans all blocks from genesis
- After: Wallet initialized at current blockchain height, only scans new blocks

This is the correct behavior because:

- A newly initialized wallet has no prior transaction history to discover
- A restored wallet should use the /wallet/rescan endpoint if historical transactions need to be recovered
- Users can explicitly call /wallet/rescan with fromHeight: 0 if they want to scan from genesis