### PR TITLE
Fix #1870: Add height range filtering at database level.

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -308,7 +308,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
     (minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val considerUnconfirmed = minConfNum == -1
       withWallet { wallet =>
-        wallet.walletBoxes(unspentOnly = true, considerUnconfirmed)
+        wallet.walletBoxes(unspentOnly = true, considerUnconfirmed, minHeight, maxHeight)
           .map { boxes =>
             boxes
               .filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
@@ -321,7 +321,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
     (minConfNum, maxConfNum, minHeight, maxHeight, limit, offset)  =>
       val considerUnconfirmed = minConfNum == -1
       withWallet {
-        _.walletBoxes(unspentOnly = false, considerUnconfirmed = considerUnconfirmed)
+        _.walletBoxes(unspentOnly = false, considerUnconfirmed = considerUnconfirmed, minHeight, maxHeight)
           .map {
             _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
             .slice(offset, offset + limit)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -174,8 +174,8 @@ class ErgoWalletActor(settings: ErgoSettings,
      * Read wallet boxes, unspent only (if corresponding flag is set), or all (both spent and unspent).
      * If considerUnconfirmed flag is set, mempool contents is considered as well.
      */
-    case GetWalletBoxes(unspent, considerUnconfirmed) =>
-      val boxes = ergoWalletService.getWalletBoxes(state, unspent, considerUnconfirmed)
+    case GetWalletBoxes(unspent, considerUnconfirmed, minHeight, maxHeight) =>
+      val boxes = ergoWalletService.getWalletBoxes(state, unspent, considerUnconfirmed, minHeight, maxHeight)
       sender() ! boxes
 
     case GetScanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -172,8 +172,10 @@ object ErgoWalletActorMessages {
    * @param unspentOnly         - return only unspent boxes
    * @param considerUnconfirmed - consider mempool (filter our unspent boxes spent in the pool if unspent = true, add
    *                            boxes created in the pool for both values of unspentOnly).
+   * @param minHeight           - min inclusion height of boxes
+   * @param maxHeight           - max inclusion height of boxes
    */
-  final case class GetWalletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean)
+  final case class GetWalletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int)
 
   /**
    * Get boxes by requested params

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -79,8 +79,8 @@ trait ErgoWalletReader extends NodeViewComponent {
   def getPrivateKeyFromPath(path: DerivationPath): Future[Try[DLogProverInput]] =
     (walletActor ? GetPrivateKeyFromPath(path)).mapTo[Try[DLogProverInput]]
 
-  def walletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean): Future[Seq[WalletBox]] =
-    (walletActor ? GetWalletBoxes(unspentOnly, considerUnconfirmed)).mapTo[Seq[WalletBox]]
+  def walletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int): Future[Seq[WalletBox]] =
+    (walletActor ? GetWalletBoxes(unspentOnly, considerUnconfirmed, minHeight, maxHeight)).mapTo[Seq[WalletBox]]
 
   def scanUnspentBoxes(scanId: ScanId, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int): Future[Seq[WalletBox]] =
     (walletActor ? GetScanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight)).mapTo[Seq[WalletBox]]

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -111,7 +111,38 @@ trait ErgoWalletService {
     */
   def recreateStorage(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState]
 
-  def getWalletBoxes(state: ErgoWalletState, unspentOnly: Boolean, considerUnconfirmed: Boolean): Seq[WalletBox]
+  def getWalletBoxes(state: ErgoWalletState, unspentOnly: Boolean, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int): Seq[WalletBox] = {
+    val currentHeight = state.fullHeight
+    val boxes = if (unspentOnly) {
+      val confirmed = if (minHeight == 0 && maxHeight == Int.MaxValue) {
+        // No height filtering requested, use the existing method
+        state.registry.walletUnspentBoxes(state.maxInputsToUse * BoxSelector.ScanDepthFactor)
+      } else {
+        // Height filtering requested, use the optimized DB query
+        state.registry.walletUnspentBoxesByInclusionHeight(minHeight, maxHeight)
+      }
+      if (considerUnconfirmed) {
+        // We filter out spent boxes in the same way as wallet does when assembling a transaction
+        (confirmed ++ state.offChainRegistry.offChainBoxes).filter(state.walletFilter)
+      } else {
+        confirmed
+      }
+    } else {
+      val confirmed = if (minHeight == 0 && maxHeight == Int.MaxValue) {
+        state.registry.walletConfirmedBoxes()
+      } else {
+        // For confirmed boxes (both spent and unspent), filter by height
+        state.registry.boxesByInclusionHeight(Constants.PaymentsScanId, minHeight, maxHeight)
+      }
+      if (considerUnconfirmed) {
+        // Just adding boxes created off-chain
+        confirmed ++ state.offChainRegistry.offChainBoxes
+      } else {
+        confirmed
+      }
+    }
+    boxes.map(tb => WalletBox(tb, currentHeight)).sortBy(_.trackedBox.inclusionHeightOpt)
+  }
 
   /**
     * @param state               current wallet state
@@ -396,10 +427,16 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       state.copy(storage = WalletStorage.readOrCreate(settings))
     }
 
-  override def getWalletBoxes(state: ErgoWalletState, unspentOnly: Boolean, considerUnconfirmed: Boolean): Seq[WalletBox] = {
+  override def getWalletBoxes(state: ErgoWalletState, unspentOnly: Boolean, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int): Seq[WalletBox] = {
     val currentHeight = state.fullHeight
     val boxes = if (unspentOnly) {
-      val confirmed = state.registry.walletUnspentBoxes(state.maxInputsToUse * BoxSelector.ScanDepthFactor)
+      val confirmed = if (minHeight == 0 && maxHeight == Int.MaxValue) {
+        // No height filtering requested, use the existing method
+        state.registry.walletUnspentBoxes(state.maxInputsToUse * BoxSelector.ScanDepthFactor)
+      } else {
+        // Height filtering requested, use the optimized DB query
+        state.registry.walletUnspentBoxesByInclusionHeight(minHeight, maxHeight)
+      }
       if (considerUnconfirmed) {
         // We filter out spent boxes in the same way as wallet does when assembling a transaction
         (confirmed ++ state.offChainRegistry.offChainBoxes).filter(state.walletFilter)
@@ -407,7 +444,12 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
         confirmed
       }
     } else {
-      val confirmed = state.registry.walletConfirmedBoxes()
+      val confirmed = if (minHeight == 0 && maxHeight == Int.MaxValue) {
+        state.registry.walletConfirmedBoxes()
+      } else {
+        // For confirmed boxes (both spent and unspent), filter by height
+        state.registry.boxesByInclusionHeight(Constants.PaymentsScanId, minHeight, maxHeight)
+      }
       if (considerUnconfirmed) {
         // Just adding boxes created off-chain
         confirmed ++ state.offChainRegistry.offChainBoxes

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -160,6 +160,15 @@ class WalletRegistry(private val store: LDBVersionedStore)(ws: WalletSettings) e
   def walletUnspentBoxes(limit: Int = Int.MaxValue): Seq[TrackedBox] = unspentBoxes(Constants.PaymentsScanId, limit)
 
   /**
+  * Read unspent boxes within height range which belong to the wallet (payments scan)
+  *
+  * @param heightFrom - min inclusion height of unspent boxes
+  * @param heightTo   - max inclusion height of unspent boxes
+  * @return sequences of wallet unspent boxes found in the database
+  */
+def walletUnspentBoxesByInclusionHeight(heightFrom: Height, heightTo: Height): Seq[TrackedBox] =
+  unspentBoxesByInclusionHeight(Constants.PaymentsScanId, heightFrom, heightTo)
+  /**
     * Spent boxes belong to the wallet (payments scan)
     */
   def walletSpentBoxes(): Seq[TrackedBox] = spentBoxes(Constants.PaymentsScanId)


### PR DESCRIPTION
Problem:
The /wallet/boxes/unspent endpoint was retrieving ALL unspent boxes from the database and then filtering them in memory by height. This approach is inefficient, especially for wallets with many boxes. The /wallet/transactions endpoint already implements efficient database-level height filtering.

Solution:
This PR implements database-level height range filtering for wallet boxes, similar to how scan boxes (getScanUnspentBoxes) and transactions already work.

Changes:
1. WalletRegistry ([WalletRegistry.scala]:

- Added walletUnspentBoxesByInclusionHeight() method that leverages existing unspentBoxesByInclusionHeight() for PaymentsScanId

2. ErgoWalletService ([ErgoWalletService.scala]:
- Updated getWalletBoxes() to accept minHeight and maxHeight parameters
- Implemented conditional logic: uses optimized DB query when height filtering is requested, otherwise uses existing method for backward compatibility

3. ErgoWalletActor & ErgoWalletActorMessages ([ErgoWalletActor.scala], [ErgoWalletActorMessages.scala]:

- Updated GetWalletBoxes message to include height parameters
- Modified actor handler to pass height parameters to service

4. ErgoWalletReader ([ErgoWalletReader.scala]:
- 
Updated walletBoxes() method signature to include height parameters

5. WalletApiRoute ([WalletApiRoute.scala]:

- Modified /boxes/unspent and /boxes routes to pass height parameters directly from HTTP request to service layer
- Height parameters are now used for DB filtering before in-memory confirmation filtering