### PR TITLE
Fix for "bounds must be positive" and faster missing parent header download

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
@@ -8,8 +8,9 @@ import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.wallet.boxes.ErgoBoxAssetExtractor
-import org.ergoplatform.validation.{InvalidModifier, ModifierValidator}
+import org.ergoplatform.validation.{InvalidModifier, ModifierValidator, ParentHeaderNotFoundError}
 import org.ergoplatform.validation.ValidationResult.Invalid
+import org.ergoplatform.validation.ModifierValidator.invalid
 import scorex.util.ModifierId
 import sigma.data.SigmaConstants.{MaxBoxSize, MaxPropositionBytes}
 
@@ -111,7 +112,7 @@ object ValidationRules {
     hdrGenesisHeight -> RuleStatus(im => fatal(s"Genesis height should be ${GenesisHeight}. ${im.error}", im.modifierId, im.modifierTypeId),
       Seq(classOf[Header]),
       mayBeDisabled = false),
-    hdrParent -> RuleStatus(im => recoverable(s"Parent header with id ${im.error} is not defined", im.modifierId, im.modifierTypeId),
+    hdrParent -> RuleStatus(im => parentHeaderNotFound(ModifierId @@ im.error, im.modifierId, im.modifierTypeId),
       Seq(classOf[Header]),
       mayBeDisabled = false),
     hdrNonIncreasingTimestamp -> RuleStatus(im => fatal(s"Header timestamp should be greater than the parent's. ${im.error}", im.modifierId, im.modifierTypeId),
@@ -317,6 +318,9 @@ object ValidationRules {
 
   private def recoverable(errorMessage: String, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value): Invalid =
     ModifierValidator.error(errorMessage, modifierId, modifierTypeId)
+
+  private def parentHeaderNotFound(parentId: ModifierId, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value): Invalid =
+    invalid(new ParentHeaderNotFoundError(parentId, modifierId, modifierTypeId))
 
   private def fatal(error: String, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value): Invalid =
     ModifierValidator.fatal(error, modifierId, modifierTypeId)

--- a/ergo-core/src/main/scala/org/ergoplatform/validation/ModifierError.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/validation/ModifierError.scala
@@ -45,6 +45,14 @@ class RecoverableModifierError(val message: String, val modifierId: ModifierId, 
   def toThrowable: Throwable = this
 }
 
+/** Special case of recoverable error when parent header is not found in history.
+  * This allows the node to specifically request the missing parent header from peers.
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+class ParentHeaderNotFoundError(val parentId: ModifierId, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value)
+    extends RecoverableModifierError(s"Parent header with id $parentId is not defined", modifierId, modifierTypeId, None) {
+  def parentHeaderId: ModifierId = parentId
+}
 
 /** Composite error class that can hold more than one modifier error inside. This was not made a `ModifierError` instance
   * intentionally to prevent nesting `MultipleErrors` to `MultipleErrors`

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1444,11 +1444,17 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
       e match {
         case phError: ParentHeaderNotFoundError =>
-          // For missing parent header, request the parent header from peers
-          logger.info(s"Parent header ${phError.parentHeaderId} not found for modifier $modId, requesting it from peers")
-          val msg = Message(RequestModifierSpec, Right(InvData(Header.modifierTypeId, Seq(phError.parentHeaderId))), None)
-          val stn = SendToNetwork(msg, SendToRandom)
-          networkControllerRef ! stn
+          // For missing parent header, request the parent header from peers if not already known
+          val parentId = phError.parentHeaderId
+          if (deliveryTracker.status(parentId, Header.modifierTypeId, Seq(historyReader)) == ModifiersStatus.Unknown) {
+            val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
+            if (olderPeers.nonEmpty) {
+              val randomPeer = olderPeers(scala.util.Random.nextInt(olderPeers.size))
+              requestBlockSection(Header.modifierTypeId, Seq(parentId), randomPeer)
+            } else {
+              logger.warn(s"No older peer available to download missing parent header $parentId for modifier $modId")
+            }
+          }
           deliveryTracker.setUnknown(modId, modTypeId)
         case _ =>
           deliveryTracker.setUnknown(modId, modTypeId)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1274,8 +1274,10 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 if (checksDone > 5) {
                   // after many failed attempts, try Equal peers instead of the same peer
                   val equalPeers = syncTracker.peersByStatus.getOrElse(Equal, Seq.empty)
-                  if (equalPeers.nonEmpty) {
-                    equalPeers(scala.util.Random.nextInt(equalPeers.size))
+                  val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
+                  val equalOrOlder = equalPeers ++ olderPeers
+                  if (equalOrOlder.nonEmpty) {
+                    equalOrOlder(scala.util.Random.nextInt(equalOrOlder.size))
                   } else {
                     peer
                   }

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -23,7 +23,7 @@ import scorex.core.network._
 import scorex.core.network.{ConnectedPeer, ModifiersStatus, SendToPeer, SendToPeers}
 import org.ergoplatform.network.message.{InvData, Message, ModifiersData}
 import org.ergoplatform.utils.ScorexEncoding
-import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.{MalformedModifierError, ParentHeaderNotFoundError}
 import scorex.util.{ModifierId, ScorexLogging}
 import scorex.core.network.DeliveryTracker
 import org.ergoplatform.network.peer.PenaltyType
@@ -1263,15 +1263,29 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 case Some(newPeer) => requestUtxoSetChunk(Digest32 @@ Algos.decode(modifierId).get, newPeer)
                 case None => log.warn(s"No peer found to download UTXO set chunk $modifierId")
               }
-            } else {
-              // randomly choose a peer for another block sections download attempt
+             } else {
+               // randomly choose a peer for another block sections download attempt
               val newPeerCandidates: Seq[ConnectedPeer] = if (modifierTypeId == Header.modifierTypeId) {
                 getPeersForDownloadingHeaders(peer).toSeq
               } else {
                 getPeersForDownloadingBlocks.map(_.toSeq).getOrElse(Seq(peer))
               }
-              val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
-              val newPeer = newPeerCandidates(newPeerIndex)
+              val newPeer = if (newPeerCandidates.isEmpty) {
+                if (checksDone > 5) {
+                  // after many failed attempts, try Equal peers instead of the same peer
+                  val equalPeers = syncTracker.peersByStatus.getOrElse(Equal, Seq.empty)
+                  if (equalPeers.nonEmpty) {
+                    equalPeers(scala.util.Random.nextInt(equalPeers.size))
+                  } else {
+                    peer
+                  }
+                } else {
+                  peer
+                }
+              } else {
+                val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
+                newPeerCandidates(newPeerIndex)
+              }
               log.info(s"Rescheduling request for $modifierId , new peer $newPeer")
               deliveryTracker.setUnknown(modifierId, modifierTypeId)
               requestBlockSection(modifierTypeId, Seq(modifierId), newPeer, checksDone)
@@ -1426,7 +1440,17 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
     case RecoverableFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
-      deliveryTracker.setUnknown(modId, modTypeId)
+      e match {
+        case phError: ParentHeaderNotFoundError =>
+          // For missing parent header, request the parent header from peers
+          logger.info(s"Parent header ${phError.parentHeaderId} not found for modifier $modId, requesting it from peers")
+          val msg = Message(RequestModifierSpec, Right(InvData(Header.modifierTypeId, Seq(phError.parentHeaderId))), None)
+          val stn = SendToNetwork(msg, SendToRandom)
+          networkControllerRef ! stn
+          deliveryTracker.setUnknown(modId, modTypeId)
+        case _ =>
+          deliveryTracker.setUnknown(modId, modTypeId)
+      }
 
     case SyntacticallyFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Invalidating syntactically failed modifier $modId", e)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -23,7 +23,7 @@ import scorex.core.network._
 import scorex.core.network.{ConnectedPeer, ModifiersStatus, SendToPeer, SendToPeers}
 import org.ergoplatform.network.message.{InvData, Message, ModifiersData}
 import org.ergoplatform.utils.ScorexEncoding
-import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.{MalformedModifierError, ParentHeaderNotFoundError}
 import scorex.util.{ModifierId, ScorexLogging}
 import scorex.core.network.DeliveryTracker
 import org.ergoplatform.network.peer.PenaltyType
@@ -1263,15 +1263,31 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 case Some(newPeer) => requestUtxoSetChunk(Digest32 @@ Algos.decode(modifierId).get, newPeer)
                 case None => log.warn(s"No peer found to download UTXO set chunk $modifierId")
               }
-            } else {
-              // randomly choose a peer for another block sections download attempt
+             } else {
+               // randomly choose a peer for another block sections download attempt
               val newPeerCandidates: Seq[ConnectedPeer] = if (modifierTypeId == Header.modifierTypeId) {
                 getPeersForDownloadingHeaders(peer).toSeq
               } else {
                 getPeersForDownloadingBlocks.map(_.toSeq).getOrElse(Seq(peer))
               }
-              val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
-              val newPeer = newPeerCandidates(newPeerIndex)
+              val newPeer = if (newPeerCandidates.isEmpty) {
+                if (checksDone > 5) {
+                  // after many failed attempts, try Equal peers instead of the same peer
+                  val equalPeers = syncTracker.peersByStatus.getOrElse(Equal, Seq.empty)
+                  val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
+                  val equalOrOlder = equalPeers ++ olderPeers
+                  if (equalOrOlder.nonEmpty) {
+                    equalOrOlder(scala.util.Random.nextInt(equalOrOlder.size))
+                  } else {
+                    peer
+                  }
+                } else {
+                  peer
+                }
+              } else {
+                val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
+                newPeerCandidates(newPeerIndex)
+              }
               log.info(s"Rescheduling request for $modifierId , new peer $newPeer")
               deliveryTracker.setUnknown(modifierId, modifierTypeId)
               requestBlockSection(modifierTypeId, Seq(modifierId), newPeer, checksDone)
@@ -1426,7 +1442,17 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
     case RecoverableFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
-      deliveryTracker.setUnknown(modId, modTypeId)
+      e match {
+        case phError: ParentHeaderNotFoundError =>
+          // For missing parent header, request the parent header from peers
+          logger.info(s"Parent header ${phError.parentHeaderId} not found for modifier $modId, requesting it from peers")
+          val msg = Message(RequestModifierSpec, Right(InvData(Header.modifierTypeId, Seq(phError.parentHeaderId))), None)
+          val stn = SendToNetwork(msg, SendToRandom)
+          networkControllerRef ! stn
+          deliveryTracker.setUnknown(modId, modTypeId)
+        case _ =>
+          deliveryTracker.setUnknown(modId, modTypeId)
+      }
 
     case SyntacticallyFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Invalidating syntactically failed modifier $modId", e)

--- a/src/test/scala/org/ergoplatform/network/DeliveryTrackerSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/DeliveryTrackerSpec.scala
@@ -5,9 +5,10 @@ import io.circe._
 import io.circe.syntax._
 import org.ergoplatform.modifiers.NetworkObjectTypeId
 import org.ergoplatform.utils.ErgoCorePropertyTest
-import scorex.util.ModifierId
+import scorex.util.{ModifierId, bytesToId}
 import scorex.core.network.DeliveryTracker
 import scorex.core.network.ModifiersStatus._
+import org.ergoplatform.consensus.ContainsModifiers
 
 
 class DeliveryTrackerSpec extends ErgoCorePropertyTest {
@@ -68,6 +69,52 @@ class DeliveryTrackerSpec extends ErgoCorePropertyTest {
       fullInfoAfterReset.invalidModifierApproxSize shouldBe 0
       fullInfoAfterReset.requested.size shouldBe 0
       fullInfoAfterReset.received.size shouldBe 0
+    }
+  }
+
+  property("tracker should return Held status for modifiers in history") {
+    import org.ergoplatform.modifiers.history.header.Header
+    val tracker = DeliveryTracker.empty(settings)
+    val mid: ModifierId = ModifierId @@ "held_modifier"
+    val mTypeId: NetworkObjectTypeId.Value = NetworkObjectTypeId.fromByte(104)
+
+    // Create a mock ContainsModifiers that reports the modifier as held
+    val mockHistory = new ContainsModifiers[Header] {
+      override def modifierById(modifierId: ModifierId): Option[Header] =
+        if (modifierId == mid) Some(null) else None
+    }
+
+    // Without history, modifier should be Unknown
+    tracker.status(mid, mTypeId, Seq.empty) shouldBe Unknown
+
+    // With history that contains the modifier, should be Held
+    tracker.status(mid, mTypeId, Seq(mockHistory)) shouldBe Held
+
+    // If modifier is in received cache, it should take precedence over Held
+    tracker.setReceived(mid, mTypeId, null)
+    tracker.status(mid, mTypeId, Seq(mockHistory)) shouldBe Received
+  }
+
+  property("tracker should return correct status precedence") {
+    forAll(connectedPeerGen(ActorRef.noSender)) { peer =>
+      val tracker = DeliveryTracker.empty(settings)
+      val mid: ModifierId = bytesToId(scorex.utils.Random.randomBytes(32))
+      val mTypeId: NetworkObjectTypeId.Value = NetworkObjectTypeId.fromByte(104)
+
+      // Initially Unknown
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Unknown
+
+      // Set as Requested
+      tracker.setRequested(mTypeId, mid, peer) { _ => Cancellable.alreadyCancelled }
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Requested
+
+      // Set as Received - should override Requested
+      tracker.setReceived(mid, mTypeId, peer)
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Received
+
+      // Set as Invalid - should override Received
+      tracker.setInvalid(mid, mTypeId)
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Invalid
     }
   }
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -514,6 +514,75 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
+  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should not request if parent already known") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val parentHeader = baseChain.last
+      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
+
+      // Set up sync tracker with an older peer
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(childHeader.height))
+
+      // Send ChangedHistory to set up historyReader in the synchronizer
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // Parent header IS in history, so no request should be made
+      val parentId = parentHeader.id
+      val modifierId = childHeader.id
+      val error = new ParentHeaderNotFoundError(parentId, modifierId, Header.modifierTypeId)
+      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+
+      // Should NOT request the parent header since it's already in history
+      // Wait a short time and verify no request was sent
+      Thread.sleep(500)
+      ncProbe.expectNoMessage(1.second)
+
+      // The modifier should still be set to Unknown
+      eventually {
+        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should warn when no older peers") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val parentHeader = baseChain.last
+      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
+
+      // NO older peers set up - only the original peer as Younger
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Younger, Some(childHeader.height))
+
+      // Send ChangedHistory to set up historyReader in the synchronizer
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // Use a random parent ID that is NOT in the history
+      val unknownParentId = bytesToId(scorex.utils.Random.randomBytes(32))
+      val modifierId = childHeader.id
+      val error = new ParentHeaderNotFoundError(unknownParentId, modifierId, Header.modifierTypeId)
+      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+
+      // Should NOT send any network request since no older peers available
+      Thread.sleep(500)
+      ncProbe.expectNoMessage(1.second)
+
+      // The modifier should still be set to Unknown
+      eventually {
+        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
   property("NodeViewSynchronizer: checkDelivery should not crash with empty peer candidates") {
     withFixture2 { ctx =>
       import ctx._
@@ -576,6 +645,65 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       eventually {
         val status = deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty)
       status should (be(Unknown) or be(Requested))
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should set non-header modifier to Unknown after max attempts") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val header = baseChain.last
+      val modifierId = header.id
+
+      // Use a non-header modifier type (e.g., BlockTransactions)
+      val nonHeaderTypeId = org.ergoplatform.modifiers.history.BlockTransactions.modifierTypeId
+
+      // Set up delivery tracker with requested status
+      deliveryTracker.setRequested(nonHeaderTypeId, modifierId, peer)(_ => Cancellable.alreadyCancelled)
+
+      // Send many CheckDelivery messages to exceed maxDeliveryChecks
+      val maxDeliveryChecks = settings.scorexSettings.network.maxDeliveryChecks
+      (1 to maxDeliveryChecks + 2).foreach { _ =>
+        synchronizerMockRef ! CheckDelivery(peer, nonHeaderTypeId, modifierId)
+        Thread.sleep(50)
+      }
+
+      // After max attempts, non-header modifier should be set to Unknown (not Invalid)
+      eventually {
+        deliveryTracker.status(modifierId, nonHeaderTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should invalidate header after max attempts") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val header = baseChain.last
+      val modifierId = header.id
+
+      // Set up delivery tracker with requested status for header
+      deliveryTracker.setRequested(Header.modifierTypeId, modifierId, peer)(_ => Cancellable.alreadyCancelled)
+
+      // Send many CheckDelivery messages to exceed maxDeliveryChecks
+      val maxDeliveryChecks = settings.scorexSettings.network.maxDeliveryChecks
+      (1 to maxDeliveryChecks + 2).foreach { _ =>
+        synchronizerMockRef ! CheckDelivery(peer, Header.modifierTypeId, modifierId)
+        Thread.sleep(50)
+      }
+
+      // After max attempts, header should be marked as Invalid
+      eventually {
+        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe scorex.core.network.ModifiersStatus.Invalid
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoSyncTrackerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoSyncTrackerSpecification.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.network
 
-import org.ergoplatform.consensus.{Older, Younger}
+import org.ergoplatform.consensus.{Equal, Fork, Older, Unknown, Younger}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import scorex.core.network.{ConnectedPeer, ConnectionId, Incoming}
 import org.ergoplatform.network.peer.PeerInfo
@@ -8,6 +8,14 @@ import org.ergoplatform.network.peer.PeerInfo
 class ErgoSyncTrackerSpecification extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
   import org.ergoplatform.tools.MinerBench._
+
+  private def createPeer(name: String, localPort: Int): ConnectedPeer = {
+    val peerInfo = PeerInfo(defaultPeerSpec, System.currentTimeMillis(), Some(Incoming), 5L)
+    val localAddr = new java.net.InetSocketAddress("127.0.0.1", localPort)
+    val remoteAddr = new java.net.InetSocketAddress("127.0.0.1", localPort + 1000)
+    val cid = ConnectionId(localAddr, remoteAddr, Incoming)
+    ConnectedPeer(cid, handlerRef = null, Some(peerInfo))
+  }
 
   property("getters test") {
     val time = 10L
@@ -48,5 +56,58 @@ class ErgoSyncTrackerSpecification extends ErgoCorePropertyTest {
     syncTracker.clearStatus(connectedPeer)
     syncTracker.getStatus(connectedPeer) shouldBe None
     syncTracker.maxHeight() shouldBe None
+  }
+
+  property("peersByStatus should group peers by their chain status") {
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+
+    val olderPeer = createPeer("older", 9001)
+    val equalPeer = createPeer("equal", 9002)
+    val youngerPeer = createPeer("younger", 9003)
+    val unknownPeer = createPeer("unknown", 9004)
+    val forkPeer = createPeer("fork", 9005)
+
+    syncTracker.updateStatus(olderPeer, Older, Some(1000))
+    syncTracker.updateStatus(equalPeer, Equal, Some(1000))
+    syncTracker.updateStatus(youngerPeer, Younger, Some(500))
+    syncTracker.updateStatus(unknownPeer, Unknown, None)
+    syncTracker.updateStatus(forkPeer, Fork, Some(1000))
+
+    val peersByStatus = syncTracker.peersByStatus
+
+    peersByStatus(Older) should contain(olderPeer)
+    peersByStatus(Equal) should contain(equalPeer)
+    peersByStatus(Younger) should contain(youngerPeer)
+    peersByStatus(Unknown) should contain(unknownPeer)
+    peersByStatus(Fork) should contain(forkPeer)
+
+    peersByStatus(Older).size shouldBe 1
+    peersByStatus(Equal).size shouldBe 1
+    peersByStatus(Younger).size shouldBe 1
+    peersByStatus(Unknown).size shouldBe 1
+    peersByStatus(Fork).size shouldBe 1
+  }
+
+  property("peersByStatus should update when peer status changes") {
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+    val peer = createPeer("peer", 9001)
+
+    syncTracker.updateStatus(peer, Older, Some(1000))
+    syncTracker.peersByStatus(Older) should contain(peer)
+    syncTracker.peersByStatus.get(Equal) shouldBe None
+
+    syncTracker.updateStatus(peer, Equal, Some(1000))
+    syncTracker.peersByStatus.get(Older) shouldBe None
+    syncTracker.peersByStatus(Equal) should contain(peer)
+
+    syncTracker.clearStatus(peer)
+    syncTracker.peersByStatus.get(Equal) shouldBe None
+  }
+
+  property("peersByStatus should return empty for unknown statuses") {
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+    syncTracker.peersByStatus.get(Older) shouldBe None
+    syncTracker.peersByStatus.get(Equal) shouldBe None
+    syncTracker.peersByStatus.isEmpty shouldBe true
   }
 }


### PR DESCRIPTION
### Summary
This PR fixes the "bounds must be positive" validation error and improves node synchronization robustness when parent headers are missing.

### Changes
- **Validation**: Fix bounds validation and introduce `ParentHeaderNotFoundError` for better error handling
- **Sync logic**: Automatically request missing parent headers from older peers when `ParentHeaderNotFoundError` is encountered
- **Peer selection**: Add fallback to Equal/Older peers after repeated failed download attempts (>5 retries)
- **Tests**: Add comprehensive tests for header recovery, peer fallback logic
