### PR TITLE
Filter bogus addresses from Peers gossip with misbehavior penalty

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -146,7 +146,8 @@ class ErgoApp(args: Args) extends ScorexLogging {
           "PeerSynchronizer",
           networkControllerRef,
           peerManagerRef,
-          scorexSettings.network
+          scorexSettings.network,
+          ergoSettings.networkType
         )
         map ++= Map(
           PeersSpec.messageCode    -> psr,

--- a/src/main/scala/org/ergoplatform/network/peer/PeerAddressFilter.scala
+++ b/src/main/scala/org/ergoplatform/network/peer/PeerAddressFilter.scala
@@ -1,0 +1,97 @@
+package org.ergoplatform.network.peer
+
+import java.net.{Inet4Address, Inet6Address, InetAddress, InetSocketAddress}
+
+import org.ergoplatform.settings.NetworkType
+
+/**
+  * Classifies peer addresses as "bogus" — unroutable or otherwise illegitimate
+  * for a public Ergo peer to advertise via the `Peers` gossip message.
+  *
+  * Network-conditional: a private RFC 1918 address (e.g. 192.168.0.1) is bogus
+  * on mainnet (no legitimate mainnet peer is reachable there) but may be valid
+  * on a testnet running inside a developer's LAN.
+  */
+object PeerAddressFilter {
+
+  /**
+    * @return true if `addr` is bogus on the given `networkType`. Bogus entries
+    *         should be dropped from incoming `Peers` gossip; gossiping bogus
+    *         addresses earns a penalty (the gossiper is buggy or malicious).
+    */
+  def isBogus(addr: InetSocketAddress, networkType: NetworkType): Boolean = {
+    Option(addr.getAddress).exists { ip =>
+      isAlwaysBogus(ip) || (networkType.isMainNet && isMainnetOnlyBogus(ip))
+    }
+  }
+
+  /**
+    * Never a legitimate Ergo peer regardless of network. Note: IPv4-mapped IPv6
+    * addresses (::ffff:0:0/96) are auto-normalized by `InetAddress.getByAddress`
+    * to `Inet4Address`, so they fall through to the IPv4 path below — no
+    * separate v4-mapped check is needed.
+    */
+  private def isAlwaysBogus(ip: InetAddress): Boolean = {
+    ip.isLoopbackAddress ||      // 127.0.0.0/8, ::1
+    ip.isLinkLocalAddress ||     // 169.254.0.0/16, fe80::/10
+    ip.isMulticastAddress ||     // 224.0.0.0/4, ff00::/8
+    ip.isAnyLocalAddress ||      // 0.0.0.0, ::
+    isV4BroadcastOrReserved(ip)  // 240.0.0.0/4 (incl. 255.255.255.255), 198.18/15
+  }
+
+  /**
+    * Bogus on mainnet, legitimate on testnet running inside a private network.
+    * RFC 1918 / CGN / IPv6 ULA / documentation ranges.
+    */
+  private def isMainnetOnlyBogus(ip: InetAddress): Boolean = {
+    ip.isSiteLocalAddress ||  // 10/8, 172.16/12, 192.168/16 (RFC 1918)
+    isCgn(ip) ||              // 100.64.0.0/10 (RFC 6598)
+    isUniqueLocal(ip) ||      // fc00::/7 (RFC 4193)
+    isDocumentation(ip)       // 192.0.2/24, 198.51.100/24, 203.0.113/24, 2001:db8::/32
+  }
+
+  // 240.0.0.0/4 reserved (RFC 1112, includes 255.255.255.255 broadcast)
+  // 198.18.0.0/15 benchmark (RFC 2544)
+  private def isV4BroadcastOrReserved(ip: InetAddress): Boolean = ip match {
+    case v4: Inet4Address =>
+      val bytes = v4.getAddress
+      val b0 = bytes(0) & 0xff
+      val b1 = bytes(1) & 0xff
+      (b0 & 0xf0) == 0xf0 ||                     // 240/4
+        (b0 == 198 && (b1 == 18 || b1 == 19))    // 198.18/15
+    case _ => false
+  }
+
+  // 100.64.0.0/10 — Carrier-Grade NAT (RFC 6598)
+  private def isCgn(ip: InetAddress): Boolean = ip match {
+    case v4: Inet4Address =>
+      val bytes = v4.getAddress
+      (bytes(0) & 0xff) == 100 && ((bytes(1) & 0xff) & 0xc0) == 0x40
+    case _ => false
+  }
+
+  // fc00::/7 — IPv6 Unique Local Addresses (RFC 4193)
+  private def isUniqueLocal(ip: InetAddress): Boolean = ip match {
+    case v6: Inet6Address =>
+      (v6.getAddress()(0) & 0xfe) == 0xfc
+    case _ => false
+  }
+
+  // 192.0.2/24, 198.51.100/24, 203.0.113/24 (RFC 5737)
+  // 2001:db8::/32 (RFC 3849)
+  private def isDocumentation(ip: InetAddress): Boolean = ip match {
+    case v4: Inet4Address =>
+      val bytes = v4.getAddress
+      val b0 = bytes(0) & 0xff
+      val b1 = bytes(1) & 0xff
+      val b2 = bytes(2) & 0xff
+      (b0 == 192 && b1 == 0 && b2 == 2) ||
+        (b0 == 198 && b1 == 51 && b2 == 100) ||
+        (b0 == 203 && b1 == 0 && b2 == 113)
+    case v6: Inet6Address =>
+      val bytes = v6.getAddress
+      (bytes(0) & 0xff) == 0x20 && (bytes(1) & 0xff) == 0x01 &&
+        (bytes(2) & 0xff) == 0x0d && (bytes(3) & 0xff) == 0xb8
+    case _ => false
+  }
+}

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -7,9 +7,9 @@ import akka.util.Timeout
 import org.ergoplatform.network.PeerSpec
 import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, SendToNetwork}
 import org.ergoplatform.network.message.{GetPeersSpec, Message, MessageSpec, PeersSpec}
-import org.ergoplatform.network.peer.{PeerInfo, PenaltyType}
+import org.ergoplatform.network.peer.{PeerAddressFilter, PeerInfo, PenaltyType}
 import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.{AddPeerIfEmpty, SeenPeers}
-import org.ergoplatform.settings.NetworkSettings
+import org.ergoplatform.settings.{NetworkSettings, NetworkType}
 import scorex.util.ScorexLogging
 import shapeless.syntax.typeable._
 
@@ -21,7 +21,8 @@ import scala.concurrent.duration._
   */
 class PeerSynchronizer(val networkControllerRef: ActorRef,
                        peerManager: ActorRef,
-                       settings: NetworkSettings)
+                       settings: NetworkSettings,
+                       networkType: NetworkType)
                       (implicit ec: ExecutionContext) extends Actor with Synchronizer with ScorexLogging {
 
 
@@ -41,8 +42,8 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
   private val peersSpec = new PeersSpec(settings.maxPeerSpecObjects)
 
   private val msgHandlers: PartialFunction[(MessageSpec[_], _, ConnectedPeer), Unit] = {
-    case (_: PeersSpec, peers: Seq[PeerSpec]@unchecked, _) if peers.cast[Seq[PeerSpec]].isDefined =>
-      addNewPeers(peers)
+    case (_: PeersSpec, peers: Seq[PeerSpec]@unchecked, source) if peers.cast[Seq[PeerSpec]].isDefined =>
+      addNewPeers(peers, source)
 
     case (spec, _, remote) if spec.messageCode == GetPeersSpec.messageCode =>
       gossipPeers(remote)
@@ -70,12 +71,30 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
   }
 
   /**
-    * Handles adding new peers to the peer database if they were previously unknown
+    * Handles adding new peers to the peer database if they were previously unknown.
     *
-    * @param peers sequence of peer specs describing a remote peers details
+    * Each entry's declared address is checked against [[PeerAddressFilter]];
+    * bogus entries (link-local, multicast, loopback, RFC 1918 on mainnet, etc.)
+    * are dropped. If any entry in the body is bogus, the gossiping `source` peer
+    * is penalized — no legitimate Ergo node has any reason to advertise an
+    * unroutable address to other peers.
+    *
+    * @param peers  sequence of peer specs describing remote peers' details
+    * @param source the peer that sent us this `Peers` gossip message
     */
-  private def addNewPeers(peers: Seq[PeerSpec]): Unit = {
-    peers.foreach(peerSpec => peerManager ! AddPeerIfEmpty(peerSpec))
+  private def addNewPeers(peers: Seq[PeerSpec], source: ConnectedPeer): Unit = {
+    val (clean, bogus) = peers.partition { spec =>
+      spec.declaredAddress match {
+        case Some(addr) => !PeerAddressFilter.isBogus(addr, networkType)
+        case None       => true // no declared address to filter; let PeerManager handle
+      }
+    }
+    clean.foreach(peerSpec => peerManager ! AddPeerIfEmpty(peerSpec))
+    if (bogus.nonEmpty) {
+      val examples = bogus.flatMap(_.declaredAddress).take(3).mkString(", ")
+      log.warn(s"$source gossiped ${bogus.size} bogus peer address(es) (e.g. $examples) on ${networkType.verboseName} — penalizing")
+      networkControllerRef ! PenalizePeer(source.connectionId.remoteAddress, PenaltyType.MisbehaviorPenalty)
+    }
   }
 
   /**
@@ -104,11 +123,11 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 }
 
 object PeerSynchronizerRef {
-  def props(networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings)
+  def props(networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings, networkType: NetworkType)
            (implicit ec: ExecutionContext): Props =
-    Props(new PeerSynchronizer(networkControllerRef, peerManager, settings))
+    Props(new PeerSynchronizer(networkControllerRef, peerManager, settings, networkType))
 
-  def apply(name: String, networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings)
+  def apply(name: String, networkControllerRef: ActorRef, peerManager: ActorRef, settings: NetworkSettings, networkType: NetworkType)
            (implicit system: ActorSystem, ec: ExecutionContext): ActorRef =
-    system.actorOf(props(networkControllerRef, peerManager, settings), name)
+    system.actorOf(props(networkControllerRef, peerManager, settings, networkType), name)
 }

--- a/src/test/scala/org/ergoplatform/network/peer/PeerAddressFilterSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/peer/PeerAddressFilterSpec.scala
@@ -1,0 +1,117 @@
+package org.ergoplatform.network.peer
+
+import java.net.{InetAddress, InetSocketAddress}
+
+import org.ergoplatform.settings.NetworkType
+import org.ergoplatform.utils.ErgoCorePropertyTest
+
+class PeerAddressFilterSpec extends ErgoCorePropertyTest {
+
+  // Use getByName so the hostname is parsed without a DNS lookup (literal IPs only).
+  private def sa(host: String): InetSocketAddress =
+    new InetSocketAddress(InetAddress.getByName(host), 9030)
+
+  property("always-bogus: loopback") {
+    PeerAddressFilter.isBogus(sa("127.0.0.1"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("127.0.0.1"), NetworkType.TestNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("::1"),       NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("::1"),       NetworkType.TestNet) shouldBe true
+  }
+
+  property("always-bogus: link-local (169.254/16, fe80::/10)") {
+    PeerAddressFilter.isBogus(sa("169.254.0.2"),   NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("169.254.0.2"),   NetworkType.TestNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("fe80::1"),       NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("fe80::1"),       NetworkType.TestNet) shouldBe true
+  }
+
+  property("always-bogus: multicast (224/4, ff00::/8)") {
+    PeerAddressFilter.isBogus(sa("224.0.0.1"),  NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("239.0.0.1"),  NetworkType.TestNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("ff02::1"),    NetworkType.MainNet) shouldBe true
+  }
+
+  property("always-bogus: unspecified (0.0.0.0, ::)") {
+    PeerAddressFilter.isBogus(sa("0.0.0.0"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("0.0.0.0"), NetworkType.TestNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("::"),      NetworkType.MainNet) shouldBe true
+  }
+
+  property("always-bogus: broadcast / reserved Class E (240/4)") {
+    PeerAddressFilter.isBogus(sa("255.255.255.255"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("240.0.0.1"),       NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("254.255.255.255"), NetworkType.TestNet) shouldBe true
+  }
+
+  property("always-bogus: benchmark range (198.18/15)") {
+    PeerAddressFilter.isBogus(sa("198.18.0.1"),  NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("198.19.0.1"),  NetworkType.TestNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("198.20.0.1"),  NetworkType.MainNet) shouldBe false
+    PeerAddressFilter.isBogus(sa("198.17.0.1"),  NetworkType.MainNet) shouldBe false
+  }
+
+  property("mainnet-only-bogus: RFC 1918 private (10/8, 172.16/12, 192.168/16)") {
+    Seq("10.0.0.1", "172.16.0.1", "172.31.255.255", "192.168.1.1").foreach { ip =>
+      PeerAddressFilter.isBogus(sa(ip), NetworkType.MainNet) shouldBe true
+      PeerAddressFilter.isBogus(sa(ip), NetworkType.TestNet) shouldBe false
+    }
+    // 172.32.0.0 is NOT in RFC 1918, must NOT be bogus
+    PeerAddressFilter.isBogus(sa("172.32.0.1"), NetworkType.MainNet) shouldBe false
+  }
+
+  property("mainnet-only-bogus: CGN (100.64.0.0/10)") {
+    PeerAddressFilter.isBogus(sa("100.64.0.1"),    NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("100.127.255.1"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("100.64.0.1"),    NetworkType.TestNet) shouldBe false
+    // 100.63.x.x and 100.128.x.x are public
+    PeerAddressFilter.isBogus(sa("100.63.0.1"),  NetworkType.MainNet) shouldBe false
+    PeerAddressFilter.isBogus(sa("100.128.0.1"), NetworkType.MainNet) shouldBe false
+  }
+
+  property("mainnet-only-bogus: IPv6 ULA (fc00::/7)") {
+    PeerAddressFilter.isBogus(sa("fc00::1"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("fd00::1"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("fc00::1"), NetworkType.TestNet) shouldBe false
+  }
+
+  property("mainnet-only-bogus: documentation ranges") {
+    Seq("192.0.2.1", "198.51.100.1", "203.0.113.1").foreach { ip =>
+      PeerAddressFilter.isBogus(sa(ip), NetworkType.MainNet) shouldBe true
+      PeerAddressFilter.isBogus(sa(ip), NetworkType.TestNet) shouldBe false
+    }
+    PeerAddressFilter.isBogus(sa("2001:db8::1"), NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(sa("2001:db8::1"), NetworkType.TestNet) shouldBe false
+  }
+
+  property("public addresses are not bogus on any network") {
+    Seq(
+      "8.8.8.8",
+      "1.1.1.1",
+      "213.239.193.208",  // Kushti's seed
+      "2001:41d0:700:6662::",  // OVH IPv6
+      "2606:4700:4700::1111"   // Cloudflare DNS IPv6
+    ).foreach { ip =>
+      PeerAddressFilter.isBogus(sa(ip), NetworkType.MainNet) shouldBe false
+      PeerAddressFilter.isBogus(sa(ip), NetworkType.TestNet) shouldBe false
+    }
+  }
+
+  property("v4-mapped IPv6 byte form is auto-normalized to Inet4Address by the JVM") {
+    // ::ffff:1.2.3.4 byte form — InetAddress.getByAddress auto-normalizes this
+    // to Inet4Address(1.2.3.4). The IPv4 path then governs whether it's bogus.
+    // 1.2.3.4 is public, so this is NOT bogus on either network — i.e., the
+    // wire-form v4-mapped representation is transparent and reuses our IPv4
+    // bogus checks.
+    val v4MappedBytes = Array.fill[Byte](10)(0) ++ Array[Byte](0xff.toByte, 0xff.toByte, 1, 2, 3, 4)
+    val asV4 = new InetSocketAddress(InetAddress.getByAddress(v4MappedBytes), 9030)
+    PeerAddressFilter.isBogus(asV4, NetworkType.MainNet) shouldBe false
+    PeerAddressFilter.isBogus(asV4, NetworkType.TestNet) shouldBe false
+
+    // And the same byte form representing a private IPv4 (192.168.1.1) DOES
+    // get caught — by the mainnet-only private-network check after normalization.
+    val v4MappedPriv = Array.fill[Byte](10)(0) ++ Array[Byte](0xff.toByte, 0xff.toByte, 192.toByte, 168.toByte, 1, 1)
+    val asV4Priv = new InetSocketAddress(InetAddress.getByAddress(v4MappedPriv), 9030)
+    PeerAddressFilter.isBogus(asV4Priv, NetworkType.MainNet) shouldBe true
+    PeerAddressFilter.isBogus(asV4Priv, NetworkType.TestNet) shouldBe false
+  }
+}


### PR DESCRIPTION
PeerSynchronizer.addNewPeers forwards every gossiped PeerSpec straight into the peer DB. A JVM peer at mainnet tip gossiped 169.254.0.2:9030 (link-local) to me; it entered the DB and burned a ~40s dial-timeout every retry cycle.

Adds PeerAddressFilter, network-conditional (loopback/link-local/multicast always; RFC1918/CGN/ULA on mainnet only). Bogus entries drop silently; the gossiper earns MisbehaviorPenalty. Equivalent Rust filter shipped in ergo-node-rust v0.5.3.
