### PR TITLE
Add test: hdrTooOld rejects headers from forks older than keepVersions

### DIFF
--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -499,4 +499,30 @@ class VerifyADHistorySpecification extends ErgoCorePropertyTest with NoShrink {
     }
   }
 
+  property("node rejects headers from a better chain with fork point older than keepVersions") {
+    // keepVersions controls rollback depth; use a small value (3) to keep the test fast.
+    // hdrTooOld fires when fullBlockHeight - parentHeight >= keepVersions.
+    val kv = 3
+    val inHistory = generateHistory(verifyTransactions = true, StateType.Digest, PoPoWBootstrap = false,
+      blocksToKeep = kv + 2, keepVersions = kv)
+    inHistory.writeMinimalFullBlockHeight(GenesisHeight)
+    inHistory.isHeadersChainSyncedVar = true
+
+    // Apply kv + 1 = 4 full blocks: fullBlockHeight = 4, keepVersions = 3.
+    val chain = genChain(kv + 1, inHistory)
+    val history = applyChain(inHistory, chain)
+
+    history.fullBlockHeight shouldBe (kv + 1)
+    chain.head.header.height shouldBe GenesisHeight
+
+    // Fork from chain.head (height 1). parentHeight = 1.
+    // fullBlockHeight - parentHeight = 4 - 1 = 3, which is NOT < keepVersions (3).
+    // => hdrTooOld validation rule fires and the header must be rejected.
+    val deepFork = genChain(kv + 3, chain.head) // chain.head is head; tail holds new fork blocks
+    val firstForkHeader = deepFork.tail.head.header
+
+    history.append(firstForkHeader).isFailure shouldBe true
+    history.bestFullBlockOpt.value shouldBe chain.last
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
+++ b/src/test/scala/org/ergoplatform/utils/HistoryTestHelpers.scala
@@ -45,14 +45,15 @@ object HistoryTestHelpers extends FileUtils {
                       epochLength: Int = 100000000,
                       useLastEpochs: Int = 10,
                       initialDiffOpt: Option[BigInt] = None,
-                      genesisIdOpt: Option[ModifierId] = None): ErgoHistory = {
+                      genesisIdOpt: Option[ModifierId] = None,
+                      keepVersions: Int = 200): ErgoHistory = {
 
     val txCostLimit     = initSettings.nodeSettings.maxTransactionCost
     val txSizeLimit     = initSettings.nodeSettings.maxTransactionSize
     val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(stateType, verifyTransactions, blocksToKeep,
       UtxoSettings(false, 0, 2), NipopowSettings(false, 1), mining = false, txCostLimit, txSizeLimit, blockCandidateGenerationInterval = 20.seconds,
       useExternalMiner = false, internalMinersCount = 1, internalMinerPollingInterval = 1.second, miningPubKeyHex = None,
-      offlineGeneration = false, 200, 5.minutes, 100000, 1.minute, mempoolSorting = SortingOption.FeePerByte,
+      offlineGeneration = false, keepVersions, 5.minutes, 100000, 1.minute, mempoolSorting = SortingOption.FeePerByte,
       rebroadcastCount = 200, 1000000, 100, adProofsSuffixLength = 112*1024, extraIndex = false
 )
     val scorexSettings: ScorexSettings = null


### PR DESCRIPTION
## Summary
- Adds a property test in `VerifyADHistorySpecification` that documents the current behavior described in #324: when a node sees a better chain whose branch point is older than `keepVersions`, the first fork header is rejected by the `hdrTooOld` validation rule (code 209) and the best full block is unchanged.
- Adds an optional `keepVersions` parameter (default `200`, matching prior hardcoded value) to `HistoryTestHelpers.generateHistory`, so the test can run with a small `keepVersions` (3) instead of needing to mine 200+ blocks.

Refs #324 