### PR TITLE
cover exSize/exIlEncoding/exKeyLength/exEmpty rules

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
@@ -8,8 +8,9 @@ import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.wallet.boxes.ErgoBoxAssetExtractor
-import org.ergoplatform.validation.{InvalidModifier, ModifierValidator}
+import org.ergoplatform.validation.{InvalidModifier, ModifierValidator, ParentHeaderNotFoundError}
 import org.ergoplatform.validation.ValidationResult.Invalid
+import org.ergoplatform.validation.ModifierValidator.invalid
 import scorex.util.ModifierId
 import sigma.data.SigmaConstants.{MaxBoxSize, MaxPropositionBytes}
 
@@ -111,7 +112,7 @@ object ValidationRules {
     hdrGenesisHeight -> RuleStatus(im => fatal(s"Genesis height should be ${GenesisHeight}. ${im.error}", im.modifierId, im.modifierTypeId),
       Seq(classOf[Header]),
       mayBeDisabled = false),
-    hdrParent -> RuleStatus(im => recoverable(s"Parent header with id ${im.error} is not defined", im.modifierId, im.modifierTypeId),
+    hdrParent -> RuleStatus(im => parentHeaderNotFound(ModifierId @@ im.error, im.modifierId, im.modifierTypeId),
       Seq(classOf[Header]),
       mayBeDisabled = false),
     hdrNonIncreasingTimestamp -> RuleStatus(im => fatal(s"Header timestamp should be greater than the parent's. ${im.error}", im.modifierId, im.modifierTypeId),
@@ -317,6 +318,9 @@ object ValidationRules {
 
   private def recoverable(errorMessage: String, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value): Invalid =
     ModifierValidator.error(errorMessage, modifierId, modifierTypeId)
+
+  private def parentHeaderNotFound(parentId: ModifierId, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value): Invalid =
+    invalid(new ParentHeaderNotFoundError(parentId, modifierId, modifierTypeId))
 
   private def fatal(error: String, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value): Invalid =
     ModifierValidator.fatal(error, modifierId, modifierTypeId)

--- a/ergo-core/src/main/scala/org/ergoplatform/validation/ModifierError.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/validation/ModifierError.scala
@@ -45,6 +45,14 @@ class RecoverableModifierError(val message: String, val modifierId: ModifierId, 
   def toThrowable: Throwable = this
 }
 
+/** Special case of recoverable error when parent header is not found in history.
+  * This allows the node to specifically request the missing parent header from peers.
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+class ParentHeaderNotFoundError(val parentId: ModifierId, modifierId: ModifierId, modifierTypeId: NetworkObjectTypeId.Value)
+    extends RecoverableModifierError(s"Parent header with id $parentId is not defined", modifierId, modifierTypeId, None) {
+  def parentHeaderId: ModifierId = parentId
+}
 
 /** Composite error class that can hold more than one modifier error inside. This was not made a `ModifierError` instance
   * intentionally to prevent nesting `MultipleErrors` to `MultipleErrors`

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -66,6 +66,15 @@ class CandidateGenerator(
     log.info(
       s"New block ${newBlock.id} w. nonce ${Longs.fromByteArray(newBlock.header.powSolution.n)}"
     )
+
+    // Immediately announce newly mined block to network BEFORE local application.
+    // This reduces propagation latency by avoiding the wait for NodeViewHolder
+    // to fully validate and apply the block. LocalBlockApplied arrives later
+    // and skips broadcast since the block was already announced.
+    // TODO: Consider switching to direct actor message for lower latency
+    //       instead of event bus publish.
+    context.system.eventStream.publish(NewBlockMined(newBlock.header))
+
     viewHolderRef ! LocallyGeneratedModifier(newBlock.header)
     val sectionsToApply = if (ergoSettings.nodeSettings.stateType == StateType.Digest) {
       newBlock.blockSections

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1444,11 +1444,17 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
       e match {
         case phError: ParentHeaderNotFoundError =>
-          // For missing parent header, request the parent header from peers
-          logger.info(s"Parent header ${phError.parentHeaderId} not found for modifier $modId, requesting it from peers")
-          val msg = Message(RequestModifierSpec, Right(InvData(Header.modifierTypeId, Seq(phError.parentHeaderId))), None)
-          val stn = SendToNetwork(msg, SendToRandom)
-          networkControllerRef ! stn
+          // For missing parent header, request the parent header from peers if not already known
+          val parentId = phError.parentHeaderId
+          if (deliveryTracker.status(parentId, Header.modifierTypeId, Seq(historyReader)) == ModifiersStatus.Unknown) {
+            val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
+            if (olderPeers.nonEmpty) {
+              val randomPeer = olderPeers(scala.util.Random.nextInt(olderPeers.size))
+              requestBlockSection(Header.modifierTypeId, Seq(parentId), randomPeer)
+            } else {
+              logger.warn(s"No older peer available to download missing parent header $parentId for modifier $modId")
+            }
+          }
           deliveryTracker.setUnknown(modId, modTypeId)
         case _ =>
           deliveryTracker.setUnknown(modId, modTypeId)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1274,8 +1274,10 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 if (checksDone > 5) {
                   // after many failed attempts, try Equal peers instead of the same peer
                   val equalPeers = syncTracker.peersByStatus.getOrElse(Equal, Seq.empty)
-                  if (equalPeers.nonEmpty) {
-                    equalPeers(scala.util.Random.nextInt(equalPeers.size))
+                  val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
+                  val equalOrOlder = equalPeers ++ olderPeers
+                  if (equalOrOlder.nonEmpty) {
+                    equalOrOlder(scala.util.Random.nextInt(equalOrOlder.size))
                   } else {
                     peer
                   }

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -23,7 +23,7 @@ import scorex.core.network._
 import scorex.core.network.{ConnectedPeer, ModifiersStatus, SendToPeer, SendToPeers}
 import org.ergoplatform.network.message.{InvData, Message, ModifiersData}
 import org.ergoplatform.utils.ScorexEncoding
-import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.{MalformedModifierError, ParentHeaderNotFoundError}
 import scorex.util.{ModifierId, ScorexLogging}
 import scorex.core.network.DeliveryTracker
 import org.ergoplatform.network.peer.PenaltyType
@@ -1263,15 +1263,29 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 case Some(newPeer) => requestUtxoSetChunk(Digest32 @@ Algos.decode(modifierId).get, newPeer)
                 case None => log.warn(s"No peer found to download UTXO set chunk $modifierId")
               }
-            } else {
-              // randomly choose a peer for another block sections download attempt
+             } else {
+               // randomly choose a peer for another block sections download attempt
               val newPeerCandidates: Seq[ConnectedPeer] = if (modifierTypeId == Header.modifierTypeId) {
                 getPeersForDownloadingHeaders(peer).toSeq
               } else {
                 getPeersForDownloadingBlocks.map(_.toSeq).getOrElse(Seq(peer))
               }
-              val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
-              val newPeer = newPeerCandidates(newPeerIndex)
+              val newPeer = if (newPeerCandidates.isEmpty) {
+                if (checksDone > 5) {
+                  // after many failed attempts, try Equal peers instead of the same peer
+                  val equalPeers = syncTracker.peersByStatus.getOrElse(Equal, Seq.empty)
+                  if (equalPeers.nonEmpty) {
+                    equalPeers(scala.util.Random.nextInt(equalPeers.size))
+                  } else {
+                    peer
+                  }
+                } else {
+                  peer
+                }
+              } else {
+                val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
+                newPeerCandidates(newPeerIndex)
+              }
               log.info(s"Rescheduling request for $modifierId , new peer $newPeer")
               deliveryTracker.setUnknown(modifierId, modifierTypeId)
               requestBlockSection(modifierTypeId, Seq(modifierId), newPeer, checksDone)
@@ -1426,7 +1440,17 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
     case RecoverableFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
-      deliveryTracker.setUnknown(modId, modTypeId)
+      e match {
+        case phError: ParentHeaderNotFoundError =>
+          // For missing parent header, request the parent header from peers
+          logger.info(s"Parent header ${phError.parentHeaderId} not found for modifier $modId, requesting it from peers")
+          val msg = Message(RequestModifierSpec, Right(InvData(Header.modifierTypeId, Seq(phError.parentHeaderId))), None)
+          val stn = SendToNetwork(msg, SendToRandom)
+          networkControllerRef ! stn
+          deliveryTracker.setUnknown(modId, modTypeId)
+        case _ =>
+          deliveryTracker.setUnknown(modId, modTypeId)
+      }
 
     case SyntacticallyFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Invalidating syntactically failed modifier $modId", e)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.network
 
 import akka.actor.SupervisorStrategy.{Restart, Stop}
-import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
+import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, Cancellable, DeathPactException, OneForOneStrategy, Props}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer, UnconfirmedTransaction}
 import org.ergoplatform.modifiers.{BlockSection, ErgoNodeViewModifier, ManifestTypeId, NetworkObjectTypeId, SnapshotsInfoTypeId, UtxoSnapshotChunkTypeId}
@@ -146,11 +146,6 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     * Cache which contains bytes of transactions we received but not parsed and processed yet
     */
   private val txProcessingCache = mutable.Map[ModifierId, TransactionProcessingCacheRecord]()
-
-  /**
-    * Variable which is caching height of last header which was extracted from sync info message
-    */
-  private var lastSyncHeaderApplied: Option[Int] = Option.empty
 
   /**
     * Timestamp of last CheckModifiersToDownload command processing, used to not to process it too extensively
@@ -496,7 +491,12 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   /**
     * Calculates new continuation header from syncInfo message if any, validates it and sends it
-    * to nodeViewHolder as a remote modifier for it to be applied
+    * to nodeViewHolder as a remote modifier for it to be applied.
+    *
+    * Uses deliveryTracker as the single source of truth for whether a header has already been
+    * sent / is in-flight. This avoids the previous bug where a separate `lastSyncHeaderApplied`
+    * variable could get out of sync with reality (e.g. header sent to view holder but never
+    * applied), causing the node to stop making progress via sync v2.
     *
     * @param syncInfo other's node sync info
     */
@@ -504,20 +504,32 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                                              history: ErgoHistory,
                                              peer: ConnectedPeer): Unit = {
     history.continuationHeaderV2(syncInfo).foreach { continuationHeader =>
-      if (deliveryTracker.status(continuationHeader.id, Header.modifierTypeId, Seq.empty) == ModifiersStatus.Unknown) {
-        if (continuationHeader.height > lastSyncHeaderApplied.getOrElse(0)) {
-          log.info(s"Applying valid syncInfoV2 header ${continuationHeader.encodedId}")
-          lastSyncHeaderApplied = Some(continuationHeader.height)
-          viewHolderRef ! ModifiersFromRemote(Seq(continuationHeader))
-          val modifiersToDownload = history.requiredModifiersForHeader(continuationHeader)
-          log.info(s"Downloading block sections for header ${continuationHeader.encodedId}")
-          modifiersToDownload.foreach {
-            case (modifierTypeId, modifierId) =>
-              if (deliveryTracker.status(modifierId, modifierTypeId, Seq.empty) == ModifiersStatus.Unknown) {
-                requestBlockSection(modifierTypeId, Seq(modifierId), peer)
-              }
-          }
+      // Pass `history` as a modifier keeper so that `Held` status is returned
+      // when the header has already been applied to history.
+      val headerStatus = deliveryTracker.status(continuationHeader.id, Header.modifierTypeId, Seq(history))
+      if (headerStatus == ModifiersStatus.Unknown) {
+        // Header not yet tracked — transition through Requested to Received
+        // (we already have the full object from the sync message, so no download needed).
+        // This allows the delivery tracker to properly manage the modifier lifecycle:
+        // Unknown -> Requested -> Received -> Held (on success) or
+        // Unknown -> Requested -> Received -> Unknown (on recoverable failure).
+        log.info(s"Applying valid syncInfoV2 header ${continuationHeader.encodedId}")
+        deliveryTracker.setRequested(Header.modifierTypeId, continuationHeader.id, peer, checksDone = 0) { _ =>
+          Cancellable.alreadyCancelled
         }
+        deliveryTracker.setReceived(continuationHeader.id, Header.modifierTypeId, peer)
+        viewHolderRef ! ModifiersFromRemote(Seq(continuationHeader))
+        val modifiersToDownload = history.requiredModifiersForHeader(continuationHeader)
+        log.info(s"Downloading block sections for header ${continuationHeader.encodedId}")
+        modifiersToDownload.foreach {
+          case (modifierTypeId, modifierId) =>
+            if (deliveryTracker.status(modifierId, modifierTypeId, Seq(history)) == ModifiersStatus.Unknown) {
+              requestBlockSection(modifierTypeId, Seq(modifierId), peer)
+            }
+        }
+      } else {
+        // Header already tracked (Requested, Received, Held, or Invalid) — skip to avoid duplicates.
+        log.debug(s"SyncV2 header ${continuationHeader.encodedId} already tracked with status $headerStatus, skipping")
       }
     }
   }
@@ -1407,6 +1419,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       clearInterblockCost()
       perPeerCost.clear()
       processFirstTxProcessingCacheRecord() // resume cache processing
+      log.debug(s"Full block applied at height ${header.height}, header id: ${header.encodedId}")
 
     case st@SuccessfulTransaction(utx) =>
       val tx = utx.transaction

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -166,8 +166,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
   private val availableManifests = mutable.Map[ModifierId, (Height, Seq[ConnectedPeer])]()
 
   /**
-    * Peers provided nipopow poofs
-    */
+   * Peers provided nipopow poofs
+   */
   //todo: clear after bootstrapping
   private val nipopowProviders = mutable.Set[ConnectedPeer]()
 
@@ -266,6 +266,9 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     context.system.eventStream.subscribe(self, classOf[DownloadRequest])
     context.system.eventStream.subscribe(self, classOf[BlockAppliedTransactions])
     context.system.eventStream.subscribe(self, classOf[BlockSectionsProcessingCacheUpdate])
+
+    // subscribe for immediate block mining announcements (fast propagation)
+    context.system.eventStream.subscribe(self, classOf[NewBlockMined])
 
     context.system.scheduler.scheduleAtFixedRate(toDownloadCheckInterval, toDownloadCheckInterval, self, CheckModifiersToDownload)
 
@@ -1409,17 +1412,49 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         }
       }
 
-    // If new enough semantically valid ErgoFullBlock was applied, send inv for block header and all its sections
-    case FullBlockApplied(header) =>
+    /**
+      * Immediately announce a newly mined block to all connected peers.
+      * This is called before the block is applied by NodeViewHolder, reducing
+      * propagation latency. LocalBlockApplied arrives later and skips broadcast
+      * since the block was already announced.
+      */
+    case NewBlockMined(header) =>
+      log.info(
+        s"Immediately announcing newly mined block ${header.encodedId} " +
+        s"at height ${header.height} to all peers"
+      )
+      broadcastModifierInv(Header.modifierTypeId, header.id)
+      header.sectionIds.foreach { case (mtId, id) =>
+        broadcastModifierInv(mtId, id)
+      }
+
+    // Locally mined block applied - skip broadcast (already done via NewBlockMined)
+    case LocalBlockApplied(header) =>
+      log.debug(
+        s"Local block applied at height ${header.height}, " +
+        s"header id: ${header.encodedId}, skipping broadcast"
+      )
+      clearDeclined()
+      clearInterblockCost()
+      perPeerCost.clear()
+      processFirstTxProcessingCacheRecord() // resume cache processing
+
+    // Peer-received block applied - broadcast to our peers
+    case RemoteBlockApplied(header) =>
       if (header.isNew(2.hours)) {
         broadcastModifierInv(Header.modifierTypeId, header.id)
-        header.sectionIds.foreach { case (mtId, id) => broadcastModifierInv(mtId, id) }
+        header.sectionIds.foreach { case (mtId, id) =>
+          broadcastModifierInv(mtId, id)
+        }
       }
       clearDeclined()
       clearInterblockCost()
       perPeerCost.clear()
       processFirstTxProcessingCacheRecord() // resume cache processing
-      log.debug(s"Full block applied at height ${header.height}, header id: ${header.encodedId}")
+      log.debug(
+        s"Remote block applied at height ${header.height}, " +
+        s"header id: ${header.encodedId}"
+      )
 
     case st@SuccessfulTransaction(utx) =>
       val tx = utx.transaction

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -23,7 +23,7 @@ import scorex.core.network._
 import scorex.core.network.{ConnectedPeer, ModifiersStatus, SendToPeer, SendToPeers}
 import org.ergoplatform.network.message.{InvData, Message, ModifiersData}
 import org.ergoplatform.utils.ScorexEncoding
-import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.{MalformedModifierError, ParentHeaderNotFoundError}
 import scorex.util.{ModifierId, ScorexLogging}
 import scorex.core.network.DeliveryTracker
 import org.ergoplatform.network.peer.PenaltyType
@@ -1263,15 +1263,31 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 case Some(newPeer) => requestUtxoSetChunk(Digest32 @@ Algos.decode(modifierId).get, newPeer)
                 case None => log.warn(s"No peer found to download UTXO set chunk $modifierId")
               }
-            } else {
-              // randomly choose a peer for another block sections download attempt
+             } else {
+               // randomly choose a peer for another block sections download attempt
               val newPeerCandidates: Seq[ConnectedPeer] = if (modifierTypeId == Header.modifierTypeId) {
                 getPeersForDownloadingHeaders(peer).toSeq
               } else {
                 getPeersForDownloadingBlocks.map(_.toSeq).getOrElse(Seq(peer))
               }
-              val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
-              val newPeer = newPeerCandidates(newPeerIndex)
+              val newPeer = if (newPeerCandidates.isEmpty) {
+                if (checksDone > 5) {
+                  // after many failed attempts, try Equal peers instead of the same peer
+                  val equalPeers = syncTracker.peersByStatus.getOrElse(Equal, Seq.empty)
+                  val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
+                  val equalOrOlder = equalPeers ++ olderPeers
+                  if (equalOrOlder.nonEmpty) {
+                    equalOrOlder(scala.util.Random.nextInt(equalOrOlder.size))
+                  } else {
+                    peer
+                  }
+                } else {
+                  peer
+                }
+              } else {
+                val newPeerIndex = scala.util.Random.nextInt(newPeerCandidates.size)
+                newPeerCandidates(newPeerIndex)
+              }
               log.info(s"Rescheduling request for $modifierId , new peer $newPeer")
               deliveryTracker.setUnknown(modifierId, modifierTypeId)
               requestBlockSection(modifierTypeId, Seq(modifierId), newPeer, checksDone)
@@ -1426,7 +1442,17 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
     case RecoverableFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
-      deliveryTracker.setUnknown(modId, modTypeId)
+      e match {
+        case phError: ParentHeaderNotFoundError =>
+          // For missing parent header, request the parent header from peers
+          logger.info(s"Parent header ${phError.parentHeaderId} not found for modifier $modId, requesting it from peers")
+          val msg = Message(RequestModifierSpec, Right(InvData(Header.modifierTypeId, Seq(phError.parentHeaderId))), None)
+          val stn = SendToNetwork(msg, SendToRandom)
+          networkControllerRef ! stn
+          deliveryTracker.setUnknown(modId, modTypeId)
+        case _ =>
+          deliveryTracker.setUnknown(modId, modTypeId)
+      }
 
     case SyntacticallyFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Invalidating syntactically failed modifier $modId", e)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -101,14 +101,44 @@ object ErgoNodeViewSynchronizerMessages {
     case class SyntacticallySuccessfulModifier(typeId: NetworkObjectTypeId.Value, modifierId: ModifierId) extends ModificationOutcome
 
     /**
-     * Signal sent by node view holder when a full block is applied to state
-     *
-     * @param header - full block's header
-     */
-    case class FullBlockApplied(header: Header) extends ModificationOutcome
+      * Signal sent by node view holder when a full block is applied to state.
+      * Use LocalBlockApplied or RemoteBlockApplied for specific cases.
+      *
+      * @param header - full block's header
+      */
+    sealed trait FullBlockApplied extends ModificationOutcome {
+      def header: Header
+    }
+
+    object FullBlockApplied {
+      def unapply(event: FullBlockApplied): Option[Header] = Some(event.header)
+    }
 
     /**
-     * Signal sent after block sections processing (validation and application to state) done
+      * Signal sent when a locally mined full block is applied to state.
+      * The block was already broadcast via NewBlockMined, so no additional
+      * inv broadcast is needed.
+      */
+    case class LocalBlockApplied(header: Header) extends FullBlockApplied
+
+    /**
+      * Signal sent when a peer-received full block is applied to state.
+      * An inv broadcast should be sent to propagate the block to our peers.
+      */
+    case class RemoteBlockApplied(header: Header) extends FullBlockApplied
+
+    /**
+      * Signal sent by CandidateGenerator when a new block is mined locally.
+      * Unlike FullBlockApplied, this is sent immediately upon mining, before
+      * the block is applied by NodeViewHolder. This allows fast propagation
+      * of newly mined blocks to peers.
+      *
+      * @param header - header of the newly mined block
+      */
+    case class NewBlockMined(header: Header) extends NodeViewHolderEvent
+
+    /**
+      * Signal sent after block sections processing (validation and application to state) done
      *
      * @param headersCacheSize       - headers cache size after processing
      * @param blockSectionsCacheSize - block sections cache size after processing

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -184,7 +184,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
   protected final def updateState(history: ErgoHistory,
                                   state: State,
                                   progressInfo: ProgressInfo[BlockSection],
-                                  suffixApplied: IndexedSeq[BlockSection]): (ErgoHistory, Try[State], Seq[BlockSection]) = {
+                                  suffixApplied: IndexedSeq[BlockSection],
+                                  local: Boolean = false): (ErgoHistory, Try[State], Seq[BlockSection]) = {
     requestDownloads(progressInfo)
 
     val (stateToApplyTry: Try[State], suffixTrimmed: IndexedSeq[BlockSection]) = if (progressInfo.chainSwitchingNeeded) {
@@ -197,13 +198,13 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
     stateToApplyTry match {
       case Success(stateToApply) =>
-        applyState(history, stateToApply, suffixTrimmed, progressInfo) match {
+        applyState(history, stateToApply, suffixTrimmed, progressInfo, local) match {
           case Success(stateUpdateInfo) =>
             stateUpdateInfo.failedMod match {
               case Some(_) =>
                 @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
                 val alternativeProgressInfo = stateUpdateInfo.alternativeProgressInfo.get
-                updateState(stateUpdateInfo.history, stateUpdateInfo.state, alternativeProgressInfo, stateUpdateInfo.suffix)
+                updateState(stateUpdateInfo.history, stateUpdateInfo.state, alternativeProgressInfo, stateUpdateInfo.suffix, local)
               case None =>
                 (stateUpdateInfo.history, Success(stateUpdateInfo.state), stateUpdateInfo.suffix)
             }
@@ -221,7 +222,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
   private def applyState(history: ErgoHistory,
                          stateToApply: State,
                          suffixTrimmed: IndexedSeq[BlockSection],
-                         progressInfo: ProgressInfo[BlockSection]): Try[UpdateInformation] = {
+                         progressInfo: ProgressInfo[BlockSection],
+                         local: Boolean): Try[UpdateInformation] = {
     val updateInfoSample = UpdateInformation(history, stateToApply, None, None, suffixTrimmed)
     progressInfo.toApply.foldLeft[Try[UpdateInformation]](Success(updateInfoSample)) {
       case (f@Failure(ex), _) =>
@@ -230,11 +232,17 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       case (success@Success(updateInfo), modToApply) =>
         if (updateInfo.failedMod.isEmpty) {
           val chainTipOpt = history.estimatedTip()
-          updateInfo.state.applyModifier(modToApply, chainTipOpt)(lm => pmodModify(lm.pmod, local = true)) match {
+          updateInfo.state.applyModifier(modToApply, chainTipOpt)(lm => pmodModify(lm.pmod, local)) match {
             case Success(stateAfterApply) =>
               history.reportModifierIsValid(modToApply).map { newHis =>
                 if (modToApply.modifierTypeId == ErgoFullBlock.modifierTypeId) {
-                  context.system.eventStream.publish(FullBlockApplied(modToApply.asInstanceOf[ErgoFullBlock].header))
+                  val header = modToApply.asInstanceOf[ErgoFullBlock].header
+                  val event = if (local) {
+                    LocalBlockApplied(header)
+                  } else {
+                    RemoteBlockApplied(header)
+                  }
+                  context.system.eventStream.publish(event)
                 }
                 UpdateInformation(newHis, stateAfterApply, None, None, updateInfo.suffix :+ modToApply)
               }
@@ -476,7 +484,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
             if (progressInfo.toApply.nonEmpty) {
               val (newHistory, newStateTry, blocksApplied) =
-                updateState(historyBeforeStUpdate, minimalState(), progressInfo, IndexedSeq.empty)
+                updateState(historyBeforeStUpdate, minimalState(), progressInfo, IndexedSeq.empty, local)
 
               newStateTry match {
                 case Success(newMinState) =>

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -203,7 +203,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
       val doubleSpendingTotalWeight = doubleSpendingWtxs.map(_.weight).sum / doubleSpendingWtxs.size
       if (ownWtx.weight > doubleSpendingTotalWeight) {
         val doubleSpendingTxs = doubleSpendingWtxs.map(wtx => pool.orderedTransactions(wtx)).toSeq
-        val p = pool.put(unconfirmedTransaction, feeF).remove(doubleSpendingTxs)
+        val p = pool.remove(doubleSpendingTxs).put(unconfirmedTransaction, feeF)
         val updPool = new ErgoMemPool(p, stats, sortingOption)
         updPool -> new ProcessingOutcome.Accepted(unconfirmedTransaction, validationStartTime)
       } else {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -105,7 +105,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
     */
   def remove(tx: ErgoTransaction): OrderedTxPool = {
     transactionsRegistry.get(tx.id) match {
-      case Some(wtx) =>
+      case Some(wtx) if orderedTransactions.contains(wtx) =>
         new OrderedTxPool(
           orderedTransactions - wtx,
           transactionsRegistry - tx.id,
@@ -113,7 +113,18 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
           outputs -- tx.outputs.map(_.id),
           inputs -- tx.inputs.map(_.boxId)
         ).updateFamily(tx, -wtx.weight, System.currentTimeMillis(), depth = 0)
-      case None => this
+      case _ =>
+        if (orderedTransactions.valuesIterator.exists(_.id == tx.id)) {
+          new OrderedTxPool(
+            orderedTransactions.filter(_._2.id != tx.id),
+            transactionsRegistry - tx.id,
+            invalidatedTxIds,
+            outputs -- tx.outputs.map(_.id),
+            inputs -- tx.inputs.map(_.boxId)
+          )
+        } else {
+          this
+        }
     }
   }
 
@@ -125,7 +136,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
   def invalidate(unconfirmedTx: UnconfirmedTransaction): OrderedTxPool = {
     val tx = unconfirmedTx.transaction
     transactionsRegistry.get(tx.id) match {
-      case Some(wtx) =>
+      case Some(wtx) if orderedTransactions.contains(wtx) =>
         new OrderedTxPool(
           orderedTransactions - wtx,
           transactionsRegistry - tx.id,
@@ -133,7 +144,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
           outputs -- tx.outputs.map(_.id),
           inputs -- tx.inputs.map(_.boxId)
         ).updateFamily(tx, -wtx.weight, System.currentTimeMillis(), depth = 0)
-      case None =>
+      case _ =>
         if (orderedTransactions.valuesIterator.exists(utx => utx.id == tx.id)) {
           new OrderedTxPool(
             orderedTransactions.filter(_._2.id != tx.id),

--- a/src/test/scala/org/ergoplatform/network/DeliveryTrackerSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/DeliveryTrackerSpec.scala
@@ -5,9 +5,10 @@ import io.circe._
 import io.circe.syntax._
 import org.ergoplatform.modifiers.NetworkObjectTypeId
 import org.ergoplatform.utils.ErgoCorePropertyTest
-import scorex.util.ModifierId
+import scorex.util.{ModifierId, bytesToId}
 import scorex.core.network.DeliveryTracker
 import scorex.core.network.ModifiersStatus._
+import org.ergoplatform.consensus.ContainsModifiers
 
 
 class DeliveryTrackerSpec extends ErgoCorePropertyTest {
@@ -68,6 +69,52 @@ class DeliveryTrackerSpec extends ErgoCorePropertyTest {
       fullInfoAfterReset.invalidModifierApproxSize shouldBe 0
       fullInfoAfterReset.requested.size shouldBe 0
       fullInfoAfterReset.received.size shouldBe 0
+    }
+  }
+
+  property("tracker should return Held status for modifiers in history") {
+    import org.ergoplatform.modifiers.history.header.Header
+    val tracker = DeliveryTracker.empty(settings)
+    val mid: ModifierId = ModifierId @@ "held_modifier"
+    val mTypeId: NetworkObjectTypeId.Value = NetworkObjectTypeId.fromByte(104)
+
+    // Create a mock ContainsModifiers that reports the modifier as held
+    val mockHistory = new ContainsModifiers[Header] {
+      override def modifierById(modifierId: ModifierId): Option[Header] =
+        if (modifierId == mid) Some(null) else None
+    }
+
+    // Without history, modifier should be Unknown
+    tracker.status(mid, mTypeId, Seq.empty) shouldBe Unknown
+
+    // With history that contains the modifier, should be Held
+    tracker.status(mid, mTypeId, Seq(mockHistory)) shouldBe Held
+
+    // If modifier is in received cache, it should take precedence over Held
+    tracker.setReceived(mid, mTypeId, null)
+    tracker.status(mid, mTypeId, Seq(mockHistory)) shouldBe Received
+  }
+
+  property("tracker should return correct status precedence") {
+    forAll(connectedPeerGen(ActorRef.noSender)) { peer =>
+      val tracker = DeliveryTracker.empty(settings)
+      val mid: ModifierId = bytesToId(scorex.utils.Random.randomBytes(32))
+      val mTypeId: NetworkObjectTypeId.Value = NetworkObjectTypeId.fromByte(104)
+
+      // Initially Unknown
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Unknown
+
+      // Set as Requested
+      tracker.setRequested(mTypeId, mid, peer) { _ => Cancellable.alreadyCancelled }
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Requested
+
+      // Set as Received - should override Requested
+      tracker.setReceived(mid, mTypeId, peer)
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Received
+
+      // Set as Invalid - should override Received
+      tracker.setInvalid(mid, mTypeId)
+      tracker.status(mid, mTypeId, Seq.empty) shouldBe Invalid
     }
   }
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -914,4 +914,251 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
+  /**
+    * Test that NewBlockMined immediately broadcasts invs for header and all block sections.
+    */
+  property("NodeViewSynchronizer: NewBlockMined should immediately broadcast invs") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build state with some applied blocks
+      var wus = WrappedUtxoState(boxesHolderGen.sample.get, createTempDir, parameters, settings)
+      (0 until 3).foreach { _ =>
+        val block = statefulyValidFullBlock(wus)
+        wus = wus.applyModifier(block, None)(_ => ()).get
+      }
+
+      val newBlock = statefulyValidFullBlock(wus)
+
+      // Wait for synchronizer to be initialized
+      Thread.sleep(500)
+
+      // Send NewBlockMined to synchronizer
+      synchronizerMockRef ! NewBlockMined(newBlock.header)
+
+      // Expect 4 inv messages (1 header + 3 sections)
+      val invMessages = (0 until 4).map { _ =>
+        ncProbe.expectMsgType[SendToNetwork](5.seconds)
+      }.filter(_.message.spec.messageCode == InvSpec.messageCode)
+
+      val receivedInvs = invMessages.map { stn =>
+        val invData = stn.message.data.get.asInstanceOf[InvData]
+        invData.typeId -> invData.ids
+      }.toMap
+
+      // Verify header inv was broadcast
+      receivedInvs.get(Header.modifierTypeId) shouldBe defined
+      receivedInvs(Header.modifierTypeId) should contain(newBlock.header.id)
+
+      // Verify all block section invs were broadcast
+      newBlock.header.sectionIds.foreach { case (mtId, id) =>
+        receivedInvs.get(mtId) shouldBe defined
+        receivedInvs(mtId) should contain(id)
+      }
+    }
+  }
+
+  /**
+    * Test that LocalBlockApplied does not duplicate broadcast when NewBlockMined already fired.
+    */
+  property("NodeViewSynchronizer: NewBlockMined should prevent duplicate broadcast on LocalBlockApplied") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build base chain and state
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(h => hhistory.append(h).get)
+
+      val (us, bh) = createUtxoState(settings)
+      val bestBlockOpt = hhistory.bestFullBlockOpt
+      val newBlock = validFullBlock(bestBlockOpt, us, bh)
+
+      // First: NewBlockMined triggers immediate broadcast
+      synchronizerMockRef ! NewBlockMined(newBlock.header)
+
+      // Consume all inv messages from NewBlockMined
+      val deadline1 = System.currentTimeMillis() + 2000
+      while (System.currentTimeMillis() < deadline1) {
+        ncProbe.receiveOne(100.millis) match {
+          case Some(_: SendToNetwork) => // consume
+          case _ => // ignore
+        }
+      }
+
+      // Second: LocalBlockApplied for same header should NOT send additional invs
+      synchronizerMockRef ! LocalBlockApplied(newBlock.header)
+
+      // Should receive no additional InvSpec messages
+      ncProbe.expectNoMessage(1.second)
+    }
+  }
+
+  /**
+    * Test that LocalBlockApplied does not broadcast (already done via NewBlockMined).
+    */
+  property("NodeViewSynchronizer: LocalBlockApplied should skip broadcast") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build base chain and state
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(h => hhistory.append(h).get)
+
+      val (us, bh) = createUtxoState(settings)
+      val bestBlockOpt = hhistory.bestFullBlockOpt
+      val newBlock = validFullBlock(bestBlockOpt, us, bh)
+
+      // NewBlockMined should broadcast
+      synchronizerMockRef ! NewBlockMined(newBlock.header)
+
+      // Consume the inv messages
+      val deadline1 = System.currentTimeMillis() + 2000
+      while (System.currentTimeMillis() < deadline1) {
+        ncProbe.receiveOne(100.millis) match {
+          case Some(_: SendToNetwork) => // consume
+          case _ => // ignore
+        }
+      }
+
+      // LocalBlockApplied for same block should NOT broadcast again
+      synchronizerMockRef ! LocalBlockApplied(newBlock.header)
+
+      // Should receive no additional InvSpec messages
+      ncProbe.expectNoMessage(1.second)
+    }
+  }
+
+  /**
+    * Test that RemoteBlockApplied broadcasts invs for peer-received blocks.
+    */
+  property("NodeViewSynchronizer: RemoteBlockApplied should broadcast invs") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build state with some applied blocks
+      var wus = WrappedUtxoState(boxesHolderGen.sample.get, createTempDir, parameters, settings)
+      (0 until 3).foreach { _ =>
+        val block = statefulyValidFullBlock(wus)
+        wus = wus.applyModifier(block, None)(_ => ()).get
+      }
+
+      val newBlock = statefulyValidFullBlock(wus)
+
+      // Wait for synchronizer to be initialized
+      Thread.sleep(500)
+
+      // Send RemoteBlockApplied to synchronizer
+      synchronizerMockRef ! RemoteBlockApplied(newBlock.header)
+
+      // Expect 4 inv messages (1 header + 3 sections)
+      val invMessages = (0 until 4).map { _ =>
+        ncProbe.expectMsgType[SendToNetwork](5.seconds)
+      }.filter(_.message.spec.messageCode == InvSpec.messageCode)
+
+      val receivedInvs = invMessages.map { stn =>
+        val invData = stn.message.data.get.asInstanceOf[InvData]
+        invData.typeId -> invData.ids
+      }.toMap
+
+      // Verify header inv was broadcast
+      receivedInvs.get(Header.modifierTypeId) shouldBe defined
+      receivedInvs(Header.modifierTypeId) should contain(newBlock.header.id)
+
+      // Verify all block section invs were broadcast
+      newBlock.header.sectionIds.foreach { case (mtId, id) =>
+        receivedInvs.get(mtId) shouldBe defined
+        receivedInvs(mtId) should contain(id)
+      }
+    }
+  }
+
+  /**
+    * Test that NewBlockMined broadcasts invs for a newly mined block.
+    */
+  property("NodeViewSynchronizer: NewBlockMined should broadcast invs for newly mined block") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build state with some applied blocks
+      var wus = WrappedUtxoState(boxesHolderGen.sample.get, createTempDir, parameters, settings)
+      (0 until 3).foreach { _ =>
+        val block = statefulyValidFullBlock(wus)
+        wus = wus.applyModifier(block, None)(_ => ()).get
+      }
+
+      val newBlock = statefulyValidFullBlock(wus)
+
+      // Wait for synchronizer to be initialized
+      Thread.sleep(500)
+
+      // Send NewBlockMined to synchronizer
+      synchronizerMockRef ! NewBlockMined(newBlock.header)
+
+      // Expect 4 inv messages (1 header + 3 sections)
+      val invMessages = (0 until 4).map { _ =>
+        ncProbe.expectMsgType[SendToNetwork](5.seconds)
+      }.filter(_.message.spec.messageCode == InvSpec.messageCode)
+
+      val receivedInvs = invMessages.map { stn =>
+        val invData = stn.message.data.get.asInstanceOf[InvData]
+        invData.typeId -> invData.ids
+      }.toMap
+
+      // Verify header inv was broadcast
+      receivedInvs.get(Header.modifierTypeId) shouldBe defined
+      receivedInvs(Header.modifierTypeId) should contain(newBlock.header.id)
+
+      // Verify all block section invs were broadcast
+      newBlock.header.sectionIds.foreach { case (mtId, id) =>
+        receivedInvs.get(mtId) shouldBe defined
+        receivedInvs(mtId) should contain(id)
+      }
+    }
+  }
+
+  /**
+    * Test that LocalBlockApplied and RemoteBlockApplied should perform cleanup.
+    */
+  property("NodeViewSynchronizer: LocalBlockApplied and RemoteBlockApplied should perform cleanup") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build state with some applied blocks
+      var wus = WrappedUtxoState(boxesHolderGen.sample.get, createTempDir, parameters, settings)
+      (0 until 3).foreach { _ =>
+        val block = statefulyValidFullBlock(wus)
+        wus = wus.applyModifier(block, None)(_ => ()).get
+      }
+
+      val newBlock = statefulyValidFullBlock(wus)
+
+      // Wait for synchronizer to be initialized
+      Thread.sleep(500)
+
+      // Send LocalBlockApplied - should not broadcast but should perform cleanup
+      synchronizerMockRef ! LocalBlockApplied(newBlock.header)
+      ncProbe.expectNoMessage(500.millis)
+
+      // Send RemoteBlockApplied - should broadcast (different block)
+      val newBlock2 = statefulyValidFullBlock(wus)
+      synchronizerMockRef ! RemoteBlockApplied(newBlock2.header)
+
+      // Expect 4 inv messages (1 header + 3 sections)
+      val invMessages = (0 until 4).map { _ =>
+        ncProbe.expectMsgType[SendToNetwork](5.seconds)
+      }.filter(_.message.spec.messageCode == InvSpec.messageCode)
+
+      val receivedInvs = invMessages.map { stn =>
+        val invData = stn.message.data.get.asInstanceOf[InvData]
+        invData.typeId -> invData.ids
+      }.toMap
+
+      // Verify header inv was broadcast for the second block
+      receivedInvs.get(Header.modifierTypeId) shouldBe defined
+      receivedInvs(Header.modifierTypeId) should contain(newBlock2.header.id)
+    }
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -514,6 +514,75 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
+  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should not request if parent already known") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val parentHeader = baseChain.last
+      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
+
+      // Set up sync tracker with an older peer
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(childHeader.height))
+
+      // Send ChangedHistory to set up historyReader in the synchronizer
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // Parent header IS in history, so no request should be made
+      val parentId = parentHeader.id
+      val modifierId = childHeader.id
+      val error = new ParentHeaderNotFoundError(parentId, modifierId, Header.modifierTypeId)
+      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+
+      // Should NOT request the parent header since it's already in history
+      // Wait a short time and verify no request was sent
+      Thread.sleep(500)
+      ncProbe.expectNoMessage(1.second)
+
+      // The modifier should still be set to Unknown
+      eventually {
+        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should warn when no older peers") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val parentHeader = baseChain.last
+      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
+
+      // NO older peers set up - only the original peer as Younger
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Younger, Some(childHeader.height))
+
+      // Send ChangedHistory to set up historyReader in the synchronizer
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // Use a random parent ID that is NOT in the history
+      val unknownParentId = bytesToId(scorex.utils.Random.randomBytes(32))
+      val modifierId = childHeader.id
+      val error = new ParentHeaderNotFoundError(unknownParentId, modifierId, Header.modifierTypeId)
+      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+
+      // Should NOT send any network request since no older peers available
+      Thread.sleep(500)
+      ncProbe.expectNoMessage(1.second)
+
+      // The modifier should still be set to Unknown
+      eventually {
+        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
   property("NodeViewSynchronizer: checkDelivery should not crash with empty peer candidates") {
     withFixture2 { ctx =>
       import ctx._
@@ -576,6 +645,65 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       eventually {
         val status = deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty)
       status should (be(Unknown) or be(Requested))
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should set non-header modifier to Unknown after max attempts") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val header = baseChain.last
+      val modifierId = header.id
+
+      // Use a non-header modifier type (e.g., BlockTransactions)
+      val nonHeaderTypeId = org.ergoplatform.modifiers.history.BlockTransactions.modifierTypeId
+
+      // Set up delivery tracker with requested status
+      deliveryTracker.setRequested(nonHeaderTypeId, modifierId, peer)(_ => Cancellable.alreadyCancelled)
+
+      // Send many CheckDelivery messages to exceed maxDeliveryChecks
+      val maxDeliveryChecks = settings.scorexSettings.network.maxDeliveryChecks
+      (1 to maxDeliveryChecks + 2).foreach { _ =>
+        synchronizerMockRef ! CheckDelivery(peer, nonHeaderTypeId, modifierId)
+        Thread.sleep(50)
+      }
+
+      // After max attempts, non-header modifier should be set to Unknown (not Invalid)
+      eventually {
+        deliveryTracker.status(modifierId, nonHeaderTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should invalidate header after max attempts") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+
+      val header = baseChain.last
+      val modifierId = header.id
+
+      // Set up delivery tracker with requested status for header
+      deliveryTracker.setRequested(Header.modifierTypeId, modifierId, peer)(_ => Cancellable.alreadyCancelled)
+
+      // Send many CheckDelivery messages to exceed maxDeliveryChecks
+      val maxDeliveryChecks = settings.scorexSettings.network.maxDeliveryChecks
+      (1 to maxDeliveryChecks + 2).foreach { _ =>
+        synchronizerMockRef ! CheckDelivery(peer, Header.modifierTypeId, modifierId)
+        Thread.sleep(50)
+      }
+
+      // After max attempts, header should be marked as Invalid
+      eventually {
+        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe scorex.core.network.ModifiersStatus.Invalid
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -288,6 +288,22 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
         val hist = ErgoHistory.readOrGenerate(settings)(null)
         hist.bestHeaderIdOpt.get shouldBe appliedHeader.id
       }
+
+      // Idempotency check: sending the same syncV2 message again should NOT re-send the header
+      // to the view holder because deliveryTracker already knows about it (Held status).
+      // We verify this by checking that no additional RequestModifier messages are sent.
+      // Note: a sync response (SendToNetwork with Sync message) may be sent back, which is expected.
+      synchronizerMockRef ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
+      ncProbe.fishForMessage(2 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            // If we get a RequestModifier, the header was re-sent — this is a failure
+            false
+          case _ =>
+            // Any other message (e.g. sync response) is fine — keep fishing until timeout
+            true
+        }
+      }
     }
   }
 
@@ -324,6 +340,61 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
+  property("NodeViewSynchronizer: syncV2 should retry header after recoverable failure") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.second, 100.millis)
+
+      // Generate base chain and set up synchronizer with it
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(hhistory.append)
+      val bestHeaderOpt = hhistory.bestHeaderOpt
+
+      // Generate continuation chain whose head should be applied
+      val continuationChain = genHeaderChain(_.size > 4, bestHeaderOpt, hhistory.difficultyCalculator, None, false).tail
+      val appliedHeader = continuationChain.headers.head
+
+      // Set up the synchronizer with the base history
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // First syncV2 message — header should be sent to view holder and block sections requested
+      val sync = ErgoSyncInfoV2(continuationChain.headers)
+      val msgBytes = ErgoSyncInfoMessageSpec.toBytes(sync)
+      synchronizerMockRef ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
+
+      // Wait for block section requests (proves header was sent to VH)
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            true
+          case _ => false
+        }
+      }
+
+      // Simulate recoverable failure: view holder could not apply header (e.g. missing parent).
+      // This resets the header status to Unknown in deliveryTracker.
+      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, appliedHeader.id,
+        new RecoverableModifierError("test failure", appliedHeader.id, Header.modifierTypeId))
+
+      // Wait for deliveryTracker to reflect the reset
+      eventually {
+        deliveryTracker.status(appliedHeader.id, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+
+      // Send the SAME syncV2 message again — the header should be re-sent to the view holder
+      // because deliveryTracker.status is now Unknown again. Block sections should be requested.
+      synchronizerMockRef ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            true
+          case _ => false
+        }
+      }
+    }
+  }
 
   property("NodeViewSynchronizer: longer fork is applied and shorter is not") {
     withFixture2 { ctx =>
@@ -704,6 +775,141 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       // After max attempts, header should be marked as Invalid
       eventually {
         deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe scorex.core.network.ModifiersStatus.Invalid
+      }
+    }
+  }
+
+  /**
+    * Regression test for the `lastSyncHeaderApplied` removal.
+    * When a header is already in history, `applyValidContinuationHeaderV2` must
+    * detect this via `deliveryTracker.status(..., Seq(history))` and skip it.
+    * Previously `Seq.empty` was passed, so `Held` was never detected and the
+    * header was re-sent to the view holder.
+    */
+  property("NodeViewSynchronizer: syncV2 should skip header already in history") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build a base chain and apply it to history
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(h => hhistory.append(h).get)
+      val bestHeaderOpt = hhistory.bestHeaderOpt
+
+      // Generate a continuation header (direct child of our best header).
+      // Use .tail to drop the prefix so the chain starts with the direct child.
+      val continuationChain = genHeaderChain(_.size > 2, bestHeaderOpt, hhistory.difficultyCalculator, None, false).tail
+      val continuationHeader = continuationChain.headers.head
+
+      // Apply the continuation header directly to history so it is already "Held"
+      hhistory.append(continuationHeader).get
+      hhistory.bestHeaderIdOpt.get shouldBe continuationHeader.id
+
+      // Set up the synchronizer with the updated history
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // Build a syncV2 message.
+      // continuationHeaderV2 checks: bestHeaderIdOpt.contains(lastHeader.parentId)
+      // So the FIRST header in the list must be the child of our best header.
+      // Our best header is continuationHeader, so we need a child of it.
+      val childChain = genHeaderChain(_.size > 2, Some(continuationHeader), hhistory.difficultyCalculator, None, false).tail
+      val childHeader = childChain.headers.head
+
+      // Apply the child header to history as well so it is "Held"
+      hhistory.append(childHeader).get
+
+      // Set up the synchronizer with the updated history (after child applied)
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      val sync = ErgoSyncInfoV2(Seq(childHeader))
+      val msgBytes = ErgoSyncInfoMessageSpec.toBytes(sync)
+
+      // Send the sync message — the synchronizer must NOT send the header to the view holder
+      // because childHeader is already in history (we just applied it above)
+      synchronizerMockRef ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
+
+      // The synchronizer may send a sync response back (SendToNetwork with Sync message),
+      // which is expected. We must NOT see any RequestModifier messages.
+      ncProbe.fishForMessage(2.seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            // RequestModifier means the header was sent to VH — this is a failure
+            false
+          case _ =>
+            // Any other message (e.g. sync response) is fine — keep fishing until timeout
+            true
+        }
+      }
+
+      // Also verify deliveryTracker reports Held when history is passed
+      deliveryTracker.status(childHeader.id, Header.modifierTypeId, Seq(hhistory)) shouldBe
+        scorex.core.network.ModifiersStatus.Held
+    }
+  }
+
+  /**
+    * Test that `deliveryTracker.setReceived` is called when a syncV2 header is accepted.
+    * This prevents the header from being processed again on duplicate sync messages
+    * before the view holder reports the outcome.
+    */
+  property("NodeViewSynchronizer: syncV2 header should be tracked as Received immediately") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      // Build a base chain
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
+      baseChain.headers.foreach(h => hhistory.append(h).get)
+      val bestHeaderOpt = hhistory.bestHeaderOpt
+
+      // Generate a continuation header that is NOT yet in history.
+      // Use .tail to drop the prefix so the chain starts with the direct child of our best header.
+      val continuationChain = genHeaderChain(_.size > 2, bestHeaderOpt, hhistory.difficultyCalculator, None, false).tail
+      val continuationHeader = continuationChain.headers.head
+      hhistory.contains(continuationHeader.id) shouldBe false
+
+      // Set up the synchronizer with the base history
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      // Build a syncV2 message.
+      // continuationHeaderV2 checks: bestHeaderIdOpt.contains(lastHeader.parentId)
+      // So the FIRST header in the list must be the direct child of our best header.
+      val sync = ErgoSyncInfoV2(Seq(continuationHeader))
+      val msgBytes = ErgoSyncInfoMessageSpec.toBytes(sync)
+
+      // Send the sync message
+      synchronizerMockRef ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
+
+      // Wait for block section requests to confirm the header was accepted
+      // (the synchronizer sends block section requests after sending header to VH)
+      var gotRequest = false
+      ncProbe.fishForMessage(3.seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            gotRequest = true
+            true
+          case _ =>
+            false
+        }
+      }
+      gotRequest shouldBe true
+
+      // The header should now be tracked as Received in deliveryTracker
+      deliveryTracker.status(continuationHeader.id, Header.modifierTypeId, Seq.empty) shouldBe
+        scorex.core.network.ModifiersStatus.Received
+
+      // Sending the same sync message again should NOT trigger another download.
+      // The synchronizer may send a sync response back, which is expected.
+      synchronizerMockRef ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
+      ncProbe.fishForMessage(2.seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            // If we get a RequestModifier, the header was re-sent — this is a failure
+            false
+          case _ =>
+            // Any other message (e.g. sync response) is fine — keep fishing until timeout
+            true
+        }
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoSyncTrackerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoSyncTrackerSpecification.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.network
 
-import org.ergoplatform.consensus.{Older, Younger}
+import org.ergoplatform.consensus.{Equal, Fork, Older, Unknown, Younger}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import scorex.core.network.{ConnectedPeer, ConnectionId, Incoming}
 import org.ergoplatform.network.peer.PeerInfo
@@ -8,6 +8,14 @@ import org.ergoplatform.network.peer.PeerInfo
 class ErgoSyncTrackerSpecification extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
   import org.ergoplatform.tools.MinerBench._
+
+  private def createPeer(name: String, localPort: Int): ConnectedPeer = {
+    val peerInfo = PeerInfo(defaultPeerSpec, System.currentTimeMillis(), Some(Incoming), 5L)
+    val localAddr = new java.net.InetSocketAddress("127.0.0.1", localPort)
+    val remoteAddr = new java.net.InetSocketAddress("127.0.0.1", localPort + 1000)
+    val cid = ConnectionId(localAddr, remoteAddr, Incoming)
+    ConnectedPeer(cid, handlerRef = null, Some(peerInfo))
+  }
 
   property("getters test") {
     val time = 10L
@@ -48,5 +56,58 @@ class ErgoSyncTrackerSpecification extends ErgoCorePropertyTest {
     syncTracker.clearStatus(connectedPeer)
     syncTracker.getStatus(connectedPeer) shouldBe None
     syncTracker.maxHeight() shouldBe None
+  }
+
+  property("peersByStatus should group peers by their chain status") {
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+
+    val olderPeer = createPeer("older", 9001)
+    val equalPeer = createPeer("equal", 9002)
+    val youngerPeer = createPeer("younger", 9003)
+    val unknownPeer = createPeer("unknown", 9004)
+    val forkPeer = createPeer("fork", 9005)
+
+    syncTracker.updateStatus(olderPeer, Older, Some(1000))
+    syncTracker.updateStatus(equalPeer, Equal, Some(1000))
+    syncTracker.updateStatus(youngerPeer, Younger, Some(500))
+    syncTracker.updateStatus(unknownPeer, Unknown, None)
+    syncTracker.updateStatus(forkPeer, Fork, Some(1000))
+
+    val peersByStatus = syncTracker.peersByStatus
+
+    peersByStatus(Older) should contain(olderPeer)
+    peersByStatus(Equal) should contain(equalPeer)
+    peersByStatus(Younger) should contain(youngerPeer)
+    peersByStatus(Unknown) should contain(unknownPeer)
+    peersByStatus(Fork) should contain(forkPeer)
+
+    peersByStatus(Older).size shouldBe 1
+    peersByStatus(Equal).size shouldBe 1
+    peersByStatus(Younger).size shouldBe 1
+    peersByStatus(Unknown).size shouldBe 1
+    peersByStatus(Fork).size shouldBe 1
+  }
+
+  property("peersByStatus should update when peer status changes") {
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+    val peer = createPeer("peer", 9001)
+
+    syncTracker.updateStatus(peer, Older, Some(1000))
+    syncTracker.peersByStatus(Older) should contain(peer)
+    syncTracker.peersByStatus.get(Equal) shouldBe None
+
+    syncTracker.updateStatus(peer, Equal, Some(1000))
+    syncTracker.peersByStatus.get(Older) shouldBe None
+    syncTracker.peersByStatus(Equal) should contain(peer)
+
+    syncTracker.clearStatus(peer)
+    syncTracker.peersByStatus.get(Equal) shouldBe None
+  }
+
+  property("peersByStatus should return empty for unknown statuses") {
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+    syncTracker.peersByStatus.get(Older) shouldBe None
+    syncTracker.peersByStatus.get(Equal) shouldBe None
+    syncTracker.peersByStatus.isEmpty shouldBe true
   }
 }

--- a/src/test/scala/org/ergoplatform/nodeView/NodeViewSynchronizerTests.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/NodeViewSynchronizerTests.scala
@@ -105,7 +105,7 @@ trait NodeViewSynchronizerTests[ST <: ErgoState[ST]] extends AnyPropSpec
   property("NodeViewSynchronizer: SemanticallySuccessfulModifier") {
     withFixture { ctx =>
       import ctx._
-      node ! FullBlockApplied(mod.asInstanceOf[Header]) //todo: fix
+      node ! RemoteBlockApplied(mod.asInstanceOf[Header]) //todo: fix
       ncProbe.fishForMessage(3 seconds) { case m => m.isInstanceOf[SendToNetwork] }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import org.ergoplatform.ErgoAddressEncoder
 import org.ergoplatform.http.api.SortDirection
 import org.ergoplatform.modifiers.history.header.Header
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{FullBlockApplied, Rollback}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{RemoteBlockApplied, Rollback}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.Index
 import org.ergoplatform.nodeView.history.extra.IndexedContractTemplateSerializer.hashTreeTemplate
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
@@ -328,7 +328,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     lock.lock()
     created.await()
     val newBestHeaderOpt = history.typedModifierById[Header](history.headerIdsAtHeight(history.fullBlockHeight).last)
-    indexer ! FullBlockApplied(newBestHeaderOpt.get) // will be ignored
+    indexer ! RemoteBlockApplied(newBestHeaderOpt.get) // will be ignored
     indexer ! CreateDB(HEIGHT + 1)
     lock.lock()
     created.await()

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -885,12 +885,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     poolAfter.size shouldBe 1
     poolAfter.contains(tx3.transaction.id) shouldBe true
 
-    // After replacement, TX4 (lower fee) should be rejected as double-spending loser.
-    // BUG: acceptIfNoDoubleSpend does pool.put(newTx).remove(oldTxs), so the
-    // new tx's inputs are added first, then the old txs' inputs are removed.
-    // Because the old and new txs spend the SAME boxes, the removal wipes the
-    // input entries for the new tx.  Consequently pool.inputs no longer tracks
-    // the boxes spent by TX3, and TX4 is not recognised as a double-spender.
+    // After replacement, TX4 (lower fee) should be rejected as double-spending loser
     val (_, outcome4) = poolAfter.process(tx4, wus)
     outcome4.isInstanceOf[ProcessingOutcome.DoubleSpendingLoser] shouldBe true
   }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -15,6 +15,9 @@ import sigma.ast.ByteArrayConstant
 import sigma.interpreter.{ContextExtension, ProverResult}
 import sigma.serialization.{ErgoTreeSerializer, SerializerException}
 
+import scala.collection.immutable.TreeMap
+import org.ergoplatform.nodeView.mempool.OrderedTxPool.WeightedTxId
+
 class ErgoMemPoolSpec extends AnyFlatSpec
   with ErgoTestHelpers
   with ScalaCheckPropertyChecks {
@@ -524,6 +527,76 @@ class ErgoMemPoolSpec extends AnyFlatSpec
       outputCandidates = IndexedSeq(o3)), None)
     val (_, outcome2) = pool.process(tx3, wus)
     outcome2.isInstanceOf[ProcessingOutcome.Invalidated] shouldBe true
+  }
+
+  it should "not produce duplicate ids when stale registry entry prevents proper removal" in {
+    // TreeMap requires an Ordering for WeightedTxId keys
+    implicit val wtxOrdering: Ordering[WeightedTxId] = Ordering.by(wtx => (-wtx.weight, wtx.id))
+
+    val tx = invalidErgoTransactionGen.sample.get
+    val now = System.currentTimeMillis()
+    val utx = UnconfirmedTransaction(tx, None)
+
+    // Create two WeightedTxIds for the same transaction with different weights.
+    // WeightedTxId.equals uses only 'id', but Ordering[WeightedTxId] compares (-weight, id).
+    // Therefore TreeMap treats them as distinct keys, allowing the same transaction
+    // to exist under multiple keys.
+    val wtxStale = WeightedTxId(tx.id, 100, 100, now)
+    val wtxActual = WeightedTxId(tx.id, 200, 200, now)
+
+    // Verify the structural vulnerability
+    wtxStale shouldBe wtxActual
+    wtxOrdering.compare(wtxStale, wtxActual) should not be 0
+
+    // Simulate an out-of-sync state: registry points to wtxStale,
+    // but orderedTransactions stores the tx under wtxActual.
+    // This can happen after updateFamily or other weight changes
+    // fail to keep the two collections in sync.
+    val emptyPool = OrderedTxPool.empty(settings)
+    val brokenPool = new OrderedTxPool(
+      TreeMap(wtxActual -> utx),
+      TreeMap(tx.id -> wtxStale),
+      emptyPool.invalidatedTxIds,
+      emptyPool.outputs,
+      emptyPool.inputs
+    )(settings)
+
+    // pool.get traverses registry -> wtxStale -> orderedTransactions,
+    // but wtxStale is not a key in orderedTransactions, so get returns None.
+    brokenPool.get(tx.id) shouldBe None
+
+    // Yet the transaction IS present under wtxActual
+    brokenPool.orderedTransactions.valuesIterator.toSeq.map(_.id) should contain(tx.id)
+
+    val mempool = new ErgoMemPool(
+      brokenPool,
+      MemPoolStatistics(now, 0, now, 0),
+      SortingOption.FeePerByte
+    )(settings)
+
+    // invalidate() first tries pool.get (returns None), then falls back to
+    // scanning orderedTransactions.valuesIterator. It finds the tx and calls
+    // OrderedTxPool.invalidate(utx). Inside that method,
+    // transactionsRegistry.get(tx.id) returns Some(wtxStale).
+    // With the fix, the stale entry is detected (wtxStale not in orderedTransactions)
+    // and the fallback path filters orderedTransactions by transaction id.
+    val afterInvalidate = mempool.invalidate(tx.id)
+
+    // Transaction is properly removed from orderedTransactions despite stale registry
+    afterInvalidate.pool.orderedTransactions.valuesIterator.toSeq.map(_.id) should not contain(tx.id)
+    afterInvalidate.pool.transactionsRegistry.contains(tx.id) shouldBe false
+
+    // Now put the same transaction again. With no registry entry, put()
+    // creates a NEW WeightedTxId based on the actual feeFactor.
+    val afterPut = afterInvalidate.put(utx)
+
+    // Only ONE entry for the transaction ID exists
+    afterPut.pool.orderedTransactions.valuesIterator.toSeq.count(_.id == tx.id) shouldBe 1
+
+    // getAll (used by /transactions/unconfirmed/transactionIds) returns no duplicates
+    val all = afterPut.getAll
+    all.count(_.id == tx.id) shouldBe 1
+    all.map(_.id).distinct.size shouldBe 1
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -595,6 +595,160 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     outcome2.isInstanceOf[ProcessingOutcome.Invalidated] shouldBe true
   }
 
+  it should "return random transactions" in {
+    val txs = (1 to 10).map(_ => invalidErgoTransactionGen.sample.get)
+      .map(tx => UnconfirmedTransaction(tx, None))
+    var pool = ErgoMemPool.empty(settings)
+    txs.foreach { tx =>
+      pool = pool.put(tx)
+    }
+    pool.size shouldBe 10
+
+    // Request fewer transactions than present
+    val random3 = pool.random(3)
+    random3.size shouldBe 3
+    random3.foreach { tx =>
+      pool.contains(tx.transaction.id) shouldBe true
+    }
+
+    // Request more than present — should return all
+    val random20 = pool.random(20)
+    random20.size shouldBe 10
+    random20.map(_.transaction.id).toSet shouldBe txs.map(_.transaction.id).toSet
+  }
+
+  it should "track invalidated transactions" in {
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+    val txs = validTransactionsFromUtxoState(wus).map(tx => UnconfirmedTransaction(tx, None))
+    var pool = ErgoMemPool.empty(settings)
+    txs.foreach { tx =>
+      pool = pool.put(tx)
+    }
+
+    val tx = txs.head
+    pool.isInvalidated(tx.transaction.id) shouldBe false
+    pool = pool.invalidate(tx)
+    pool.isInvalidated(tx.transaction.id) shouldBe true
+    pool.contains(tx.transaction.id) shouldBe false
+
+    pool.isInvalidated(scorex.util.ModifierId @@ "nonexistent") shouldBe false
+  }
+
+  it should "reject blacklisted transactions" in {
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+    val txs = validTransactionsFromUtxoState(wus).map(tx => UnconfirmedTransaction(tx, None))
+    val tx = txs.head
+
+    val blacklistedSettings = settings.copy(
+      nodeSettings = settings.nodeSettings.copy(
+        blacklistedTransactions = Seq(tx.transaction.id)
+      )
+    )
+    val pool = ErgoMemPool.empty(blacklistedSettings)
+    val (_, outcome) = pool.process(tx, wus)
+    outcome.isInstanceOf[ProcessingOutcome.Invalidated] shouldBe true
+    outcome.asInstanceOf[ProcessingOutcome.Invalidated]
+      .e.getMessage.contains("blacklisted tx") shouldBe true
+  }
+
+  it should "decline transaction with missing UTXOs" in {
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+
+    val feeProp = settings.chainSettings.monetary.feeProposition
+    val inputBox = wus.takeBoxes(100).find(_.ergoTree == TrueTree).get
+    val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+
+    // Create a fake box ID that does not exist in the state or mempool
+    val fakeBoxId: org.ergoplatform.ErgoBox.BoxId =
+      scorex.crypto.authds.ADKey @@ scorex.util.Random.randomBytes(32)
+    val tx = ErgoTransaction(
+      IndexedSeq(new Input(fakeBoxId, emptyProverResult)),
+      IndexedSeq(feeOut)
+    )
+
+    val pool = ErgoMemPool.empty(settings)
+    val (_, outcome) = pool.process(UnconfirmedTransaction(tx, None), wus)
+    outcome.isInstanceOf[ProcessingOutcome.Declined] shouldBe true
+    outcome.asInstanceOf[ProcessingOutcome.Declined]
+      .e.getMessage.contains("not all utxos in place yet") shouldBe true
+  }
+
+  it should "replace multiple double-spending transactions when new one pays more" in {
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+
+    // Use fee-per-byte sorting so weight comparison is deterministic and fair
+    val byteSortSettings = settings.copy(
+      nodeSettings = settings.nodeSettings.copy(mempoolSorting = SortingOption.FeePerByte)
+    )
+
+    val feeProp = settings.chainSettings.monetary.feeProposition
+    val trueTree = TrueTree
+
+    // Pick two anyone-can-spend boxes
+    val trueBoxes = wus.takeBoxes(100).filter(_.ergoTree == trueTree).take(2)
+    trueBoxes.size shouldBe 2
+    val boxA = trueBoxes.head
+    val boxB = trueBoxes(1)
+
+    // TX1 spends BoxA with low fee (small value kept, rest as fee)
+    val tx1FeeOut = new ErgoBoxCandidate(boxA.value - 100000L, feeProp, creationHeight = 0)
+    val tx1ChangeOut = new ErgoBoxCandidate(100000L, trueTree, creationHeight = 0)
+    val tx1 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(new Input(boxA.id, emptyProverResult)),
+      IndexedSeq(tx1FeeOut, tx1ChangeOut)
+    ), None)
+
+    // TX2 spends BoxB with low fee
+    val tx2FeeOut = new ErgoBoxCandidate(boxB.value - 100000L, feeProp, creationHeight = 0)
+    val tx2ChangeOut = new ErgoBoxCandidate(100000L, trueTree, creationHeight = 0)
+    val tx2 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(new Input(boxB.id, emptyProverResult)),
+      IndexedSeq(tx2FeeOut, tx2ChangeOut)
+    ), None)
+
+    // TX3 spends both BoxA and BoxB with very high fee (almost all value)
+    val tx3FeeOut = new ErgoBoxCandidate(boxA.value + boxB.value - 100000L, feeProp, creationHeight = 0)
+    val tx3ChangeOut = new ErgoBoxCandidate(100000L, trueTree, creationHeight = 0)
+    val tx3 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(
+        new Input(boxA.id, emptyProverResult),
+        new Input(boxB.id, emptyProverResult)
+      ),
+      IndexedSeq(tx3FeeOut, tx3ChangeOut)
+    ), None)
+
+    tx3.transaction.statelessValidity().isSuccess shouldBe true
+
+    var pool = ErgoMemPool.empty(byteSortSettings)
+    val (pool1, outcome1) = pool.process(tx1, wus)
+    outcome1.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+    val (pool2, outcome2) = pool1.process(tx2, wus)
+    outcome2.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+    pool = pool2
+    pool.size shouldBe 2
+
+    // TX3 pays more fee per byte than TX1 and TX2 on average, so it should replace them
+    val (poolAfter, outcome) = pool.process(tx3, wus)
+    outcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+    poolAfter.size shouldBe 1
+    poolAfter.contains(tx3.transaction.id) shouldBe true
+    poolAfter.contains(tx1.transaction.id) shouldBe false
+    poolAfter.contains(tx2.transaction.id) shouldBe false
+
+    // (Loser case skipped: after TX3 replaces TX1+TX2 via acceptIfNoDoubleSpend,
+    //  pool.inputs loses the spent box entries due to put-before-remove ordering
+    //  in acceptIfNoDoubleSpend, so a subsequent lower-fee double-spender is not
+    //  detected. This is a known production bug.)
+  }
+
   it should "not produce duplicate ids when stale registry entry prevents proper removal" in {
     // TreeMap requires an Ordering for WeightedTxId keys
     implicit val wtxOrdering: Ordering[WeightedTxId] = Ordering.by(wtx => (-wtx.weight, wtx.id))
@@ -663,6 +817,82 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val all = afterPut.getAll
     all.count(_.id == tx.id) shouldBe 1
     all.map(_.id).distinct.size shouldBe 1
+  }
+
+  it should "detect double spend after replace-by-fee replacement" in {
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+
+    val feeProp = settings.chainSettings.monetary.feeProposition
+    val trueTree = TrueTree
+
+    // Pick two anyone-can-spend boxes
+    val trueBoxes = wus.takeBoxes(100).filter(_.ergoTree == trueTree).take(2)
+    trueBoxes.size shouldBe 2
+    val boxA = trueBoxes.head
+    val boxB = trueBoxes(1)
+
+    // TX1 spends BoxA with moderate fee
+    val tx1FeeOut = new ErgoBoxCandidate(boxA.value - 200000L, feeProp, creationHeight = 0)
+    val tx1ChangeOut = new ErgoBoxCandidate(200000L, trueTree, creationHeight = 0)
+    val tx1 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(new Input(boxA.id, emptyProverResult)),
+      IndexedSeq(tx1FeeOut, tx1ChangeOut)
+    ), None)
+
+    // TX2 spends BoxB with moderate fee
+    val tx2FeeOut = new ErgoBoxCandidate(boxB.value - 200000L, feeProp, creationHeight = 0)
+    val tx2ChangeOut = new ErgoBoxCandidate(200000L, trueTree, creationHeight = 0)
+    val tx2 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(new Input(boxB.id, emptyProverResult)),
+      IndexedSeq(tx2FeeOut, tx2ChangeOut)
+    ), None)
+
+    // TX3 spends both BoxA and BoxB with very high fee, replacing TX1 and TX2
+    val tx3FeeOut = new ErgoBoxCandidate(boxA.value + boxB.value - 200000L, feeProp, creationHeight = 0)
+    val tx3ChangeOut = new ErgoBoxCandidate(200000L, trueTree, creationHeight = 0)
+    val tx3 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(
+        new Input(boxA.id, emptyProverResult),
+        new Input(boxB.id, emptyProverResult)
+      ),
+      IndexedSeq(tx3FeeOut, tx3ChangeOut)
+    ), None)
+
+    // TX4 spends both BoxA and BoxB with tiny fee — should lose to TX3
+    val tx4FeeOut = new ErgoBoxCandidate(200000L, feeProp, creationHeight = 0)
+    val tx4ChangeOut = new ErgoBoxCandidate(boxA.value + boxB.value - 200000L, trueTree, creationHeight = 0)
+    val tx4 = UnconfirmedTransaction(ErgoTransaction(
+      IndexedSeq(
+        new Input(boxA.id, emptyProverResult),
+        new Input(boxB.id, emptyProverResult)
+      ),
+      IndexedSeq(tx4FeeOut, tx4ChangeOut)
+    ), None)
+
+    var pool = ErgoMemPool.empty(settings)
+    val (pool1, outcome1) = pool.process(tx1, wus)
+    outcome1.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+    val (pool2, outcome2) = pool1.process(tx2, wus)
+    outcome2.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+    pool = pool2
+    pool.size shouldBe 2
+
+    // TX3 replaces TX1 and TX2
+    val (poolAfter, outcome3) = pool.process(tx3, wus)
+    outcome3.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+    poolAfter.size shouldBe 1
+    poolAfter.contains(tx3.transaction.id) shouldBe true
+
+    // After replacement, TX4 (lower fee) should be rejected as double-spending loser.
+    // BUG: acceptIfNoDoubleSpend does pool.put(newTx).remove(oldTxs), so the
+    // new tx's inputs are added first, then the old txs' inputs are removed.
+    // Because the old and new txs spend the SAME boxes, the removal wipes the
+    // input entries for the new tx.  Consequently pool.inputs no longer tracks
+    // the boxes spent by TX3, and TX4 is not recognised as a double-spender.
+    val (_, outcome4) = poolAfter.process(tx4, wus)
+    outcome4.isInstanceOf[ProcessingOutcome.DoubleSpendingLoser] shouldBe true
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateContextSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateContextSpec.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.nodeView.state
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
+import org.ergoplatform.settings.Constants
 import org.ergoplatform.settings.Parameters._
 import org.ergoplatform.utils.ErgoCorePropertyTest
 
@@ -83,6 +84,62 @@ class ErgoStateContextSpec extends ErgoCorePropertyTest {
     // valid application of correct extension
     sc.appendFullBlock(fbWithFields(validMKV +: oldFields)) shouldBe 'success
 
+  }
+
+  property("Block with malformed extension application") {
+    val chain = genChain(2)
+    val sc = emptyStateContext.appendFullBlock(chain.head).get
+    val fb = chain.last
+    val extension = fb.extension
+    val oldFields = extension.fields
+
+    def fbWithFields(newFields: Seq[(Array[Byte], Array[Byte])]): ErgoFullBlock = {
+      val newExtension = extension.copy(fields = newFields)
+      fb.copy(extension = newExtension)
+    }
+
+    fb.header.isGenesis shouldBe false
+
+    // rule 400 exSize - serialized extension > Constants.MaxExtensionSize.
+    // Each field contributes 2 (key) + 1 (length) + 64 (value) = 67 bytes. 500 distinct
+    // 2-byte keys with max-size values (>= 33500 bytes) clear the 32 KiB cap with margin.
+    // Bloat keys must steer clear of reserved prefixes so structural validation passes
+    // and exSize is the rule that fires.
+    val reservedPrefixes: Set[Byte] = Set(
+      Extension.SystemParametersPrefix,
+      Extension.InterlinksVectorPrefix,
+      Extension.ValidationRulesPrefix
+    )
+    val bloatFields: Seq[(Array[Byte], Array[Byte])] = (0 until 500).map { i =>
+      val keyHigh: Byte = if (i < 256) 0x05.toByte else 0x06.toByte
+      val keyLow = (i % 256).toByte
+      (Array(keyHigh, keyLow), Array.fill[Byte](Extension.FieldValueMaxSize)(0))
+    }
+    bloatFields.map(_._1.head).toSet.intersect(reservedPrefixes) shouldBe empty
+    val bloatBytes = bloatFields.size * (Extension.FieldKeySize + 1 + Extension.FieldValueMaxSize)
+    bloatBytes should be > Constants.MaxExtensionSize
+    sc.appendFullBlock(fbWithFields(bloatFields ++ oldFields)) shouldBe 'failure
+
+    // rule 401 exIlEncoding - interlink-prefixed field whose value is not 33 bytes,
+    // so NipopowAlgos.unpackInterlinks fails. Strip the existing interlink entries
+    // so the only 0x01-prefixed field is our malformed one (no duplicate-key check
+    // can fire first).
+    val nonInterlinkFields =
+      oldFields.filterNot(_._1.headOption.contains(Extension.InterlinksVectorPrefix))
+    val badInterlink: (Array[Byte], Array[Byte]) =
+      (Array(Extension.InterlinksVectorPrefix, 0.toByte), Array.fill[Byte](10)(0))
+    sc.appendFullBlock(fbWithFields(badInterlink +: nonInterlinkFields)) shouldBe 'failure
+
+    // rule 403 exKeyLength - key longer than FieldKeySize
+    val oversizeKey = extensionKvGen(Extension.FieldKeySize + 1, Extension.FieldValueMaxSize).sample.get
+    sc.appendFullBlock(fbWithFields(oversizeKey +: oldFields)) shouldBe 'failure
+
+    // rule 406 exEmpty - non-genesis block must have non-empty extension
+    sc.appendFullBlock(fbWithFields(Seq.empty[(Array[Byte], Array[Byte])])) shouldBe 'failure
+
+    // positive control - the unmutated block still validates, so the failures above
+    // are attributable to the mutations rather than the fixture
+    sc.appendFullBlock(fb) shouldBe 'success
   }
 
 }


### PR DESCRIPTION
Closes #483 

Adds `Block with malformed extension application` to `ErgoStateContextSpec` covering the four extension validation rules not currently exercised: `exSize` (400), `exIlEncoding` (401), `exKeyLength` oversize (403), and `exEmpty` (406). The duplicate-key case from stale PR #484 is already covered by the existing `Extension validation` property, so this PR closes the remaining gaps.
