### PR TITLE
reject ADProof with trailing bytes

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/ADProofs.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/ADProofs.scala
@@ -57,7 +57,18 @@ case class ADProofs(headerId: ModifierId,
       verifier.digest match {
         case Some(digest) =>
           if (java.util.Arrays.equals(digest, expectedHash)) {
-            Success(oldValues)
+            // Reject proofs with bytes past the last direction bit consumed by the
+            // verifier — without this, a malicious miner can append garbage to a
+            // canonical proof and have the block accepted by digest-mode peers while
+            // utxo-mode peers (which regenerate the proof) reject it.
+            val consumedBits = ADProofs.directionsIndexField.getInt(verifier)
+            val consumedBytes = (consumedBits + 7) / 8
+            if (consumedBytes == proofBytes.length) {
+              Success(oldValues)
+            } else {
+              val msg = s"ADProof has ${proofBytes.length - consumedBytes} trailing byte(s)"
+              Failure(new IllegalArgumentException(msg))
+            }
           } else {
             val msg = s"Unexpected result digest: ${Algos.encode(digest)} != ${Algos.encode(expectedHash)}"
             Failure(new IllegalArgumentException(msg))
@@ -74,6 +85,16 @@ object ADProofs extends ApiCodecs {
   val modifierTypeId: NetworkObjectTypeId.Value = ProofsTypeId.value
 
   val KL = 32
+
+  // scrypto's BatchAVLVerifier tracks the number of direction bits consumed
+  // from the proof bytes in a `private var directionsIndex: Int`. We need it
+  // in `verify` to detect trailing bytes. Until scrypto exposes a public accessor,
+  // reach it via reflection. Cached as a static field so the JVM only does the lookup once.
+  private[history] val directionsIndexField: java.lang.reflect.Field = {
+    val f = classOf[BatchAVLVerifier[_, _]].getDeclaredField("directionsIndex")
+    f.setAccessible(true)
+    f
+  }
 
   def proofDigest(proofBytes: SerializedAdProof): Digest32 = Algos.hash(proofBytes)
 

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/AdProofSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/AdProofSpec.scala
@@ -89,8 +89,9 @@ class AdProofSpec extends ErgoCorePropertyTest {
     proof.verify(StateChanges(IndexedSeq.empty, operationsInDifferentOrder, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure
   }
 
-  //todo: what to do with that?
-  ignore("verify should be failed if there are more proof bytes that needed") {
+  // Proofs with trailing bytes are rejected so that digest-mode peers can't be split off from utxo-mode peers by a
+  // miner that appends garbage and updates header.ADProofsRoot accordingly.
+  property("verify should be failed if there are more proof bytes that needed") {
     val (operations, prevDigest, newDigest, pf) = createEnv()
     val proof = ADProofs(emptyModifierId, SerializedAdProof @@ (pf :+ 't'.toByte))
     proof.verify(StateChanges(IndexedSeq.empty, operations, IndexedSeq.empty), prevDigest, newDigest) shouldBe 'failure

--- a/src/test/scala/org/ergoplatform/nodeView/state/DigestStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/DigestStateSpecification.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.modifiers.history.ADProofs
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.utils.{ErgoCorePropertyTest, RandomWrapper}
 import org.ergoplatform.core._
-import scorex.crypto.authds.ADDigest
+import scorex.crypto.authds.{ADDigest, SerializedAdProof}
 import sigma.interpreter.ProverResult
 
 class DigestStateSpecification extends ErgoCorePropertyTest {
@@ -134,6 +134,26 @@ class DigestStateSpecification extends ErgoCorePropertyTest {
 
       val txs3 = IndexedSeq(txWithDataInputs, headTx, nextTx)
       ds.validateTransactions(txs3, digest2, proof2, emptyStateContext) shouldBe 'failure
+    }
+  }
+
+  // Without the trailing-bytes check in ADProofs.verify a miner can append garbage to a proof and
+  // set header.ADProofsRoot to its hash, splitting digest peers off the utxo peers' chain.
+  property("validateTransactions() - proof with trailing bytes is rejected") {
+    forAll(boxesHolderGen) { bh =>
+      val us = createUtxoState(bh, parameters)
+      val ds = createDigestState(us.version, us.rootDigest)
+      val block = validFullBlock(parentOpt = None, us, bh)
+
+      val origProofs = block.adProofs.get
+      val txs = block.blockTransactions.txs
+      val expectedHash = block.header.stateRoot
+
+      ds.validateTransactions(txs, expectedHash, origProofs, emptyStateContext) shouldBe 'success
+
+      val tamperedBytes = SerializedAdProof @@ (origProofs.proofBytes :+ 't'.toByte)
+      val tamperedProof = ADProofs(origProofs.headerId, tamperedBytes)
+      ds.validateTransactions(txs, expectedHash, tamperedProof, emptyStateContext) shouldBe 'failure
     }
   }
 


### PR DESCRIPTION
Closes #499.

`ADProofs.verify` accepted proofs with extra trailing bytes — scrypto's `BatchAVLVerifier` reads only what it needs and silently ignores the rest. A miner could append garbage, set `header.ADProofsRoot = hash(paddedProof)`, and have the block accepted by digest peers but rejected by utxo peers (which regenerate the canonical proof) — a consensus fork.

Fix: after `verify` succeeds, read the verifier's `directionsIndex` (private in scrypto, reached via reflection until scrypto exposes an accessor) and reject any proof longer than `ceil(directionsIndex / 8)`.

Follow-up (separate PR): add `def bytesConsumed: Int` upstream in scrypto and drop the reflection.
