### PR TITLE
prevent bestFullBlock/bestHeader divergence on sibling forks

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -82,7 +82,10 @@ trait FullBlockProcessor extends HeadersProcessor {
 
   private def processBetterChain: BlockProcessing = {
     case ToProcess(fullBlock, newModRow, Some(newBestBlockHeader), _)
-      if bestFullBlockOpt.nonEmpty && isBetterChain(newBestBlockHeader.id) && isLinkable(fullBlock.header) =>
+      if bestFullBlockOpt.nonEmpty &&
+        isBetterChain(newBestBlockHeader.id) &&
+        isInBestChain(newBestBlockHeader.id) &&
+        isLinkable(fullBlock.header) =>
 
       val prevBest = bestFullBlockOpt.get
 

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -63,6 +63,31 @@ class VerifyADHistorySpecification extends ErgoCorePropertyTest with NoShrink {
   }
 
 
+  property("bestFullBlock must stay on the best-header chain when a sibling full block arrives") {
+    var (history, _) = genHistory()
+
+    val commonChain = genChain(2, history)
+    history = applyChain(history, commonChain)
+    val ancestor = commonChain.last
+    history.bestFullBlockOpt.get.header shouldBe ancestor.header
+    history.bestHeaderOpt.get shouldBe ancestor.header
+
+    val a3 = genChain(1, ancestor).tail.head
+    Thread.sleep(2)
+    val b3 = genChain(1, ancestor).tail.head
+    b3.header.id should not be a3.header.id
+
+    history = applyHeaderChain(history, HeaderChain(Seq(a3.header)))
+    history.bestHeaderOpt.get shouldBe a3.header
+    history.bestFullBlockOpt.get.header shouldBe ancestor.header
+
+    history = applyBlock(history, b3)
+
+    history.bestHeaderOpt.get shouldBe a3.header
+    history.bestFullBlockOpt.get.header shouldBe ancestor.header
+    history.isInBestChain(history.bestFullBlockOpt.get.header) shouldBe true
+  }
+
   property("ErgoModifiersCache.findCandidateKey() should find headers in case of forks") {
     val modifiersCache = new ErgoModifiersCache(Int.MaxValue)
 


### PR DESCRIPTION
Fixes #525. `processBetterChain` promoted any full block whose score beat the current `bestFullBlock`, even when its header wasn't on the best-header chain — leaving `bestFullBlock` and `bestHeader` on different forks at the same height.

Adds an `isInBestChain` precondition. Off-chain full blocks fall through to `nonBestBlock` (stored, not promoted) and get picked up if the header chain later switches to their fork. Synced and reorg paths unaffected.

## Follow-ups

- `commonBlock` reader (#328 option 1) — prior attempt in #330.
- Linearize header chain by full-block work (#331 / #328 option 2) — prior attempt in #333.
- Port `BestChainInconsistencySpec` from `origin/i525` as an `it:test`.