### PR TITLE
coordinated shutdown on critical actor failure

### DIFF
--- a/src/main/scala/org/ergoplatform/CriticalActorsWatcher.scala
+++ b/src/main/scala/org/ergoplatform/CriticalActorsWatcher.scala
@@ -1,0 +1,44 @@
+package org.ergoplatform
+
+import akka.actor.{Actor, ActorRef, Props, Terminated}
+import scorex.util.ScorexLogging
+
+/**
+  * Watches a set of critical actors. If any of them terminates, triggers a
+  * coordinated shutdown of the whole node so storage and network are closed cleanly
+  * rather than leaving the node running in a broken state.
+  *
+  * Additional actors can be added at runtime via [[CriticalActorsWatcher.Watch]],
+  * which is useful for refs that are only available after another actor has been
+  * constructed (e.g. ErgoNodeViewSynchronizer, which is created lazily inside
+  * NetworkController's message handler closure).
+  */
+class CriticalActorsWatcher(initial: Seq[ActorRef]) extends Actor with ScorexLogging {
+
+  override def preStart(): Unit = {
+    initial.foreach(context.watch)
+    log.info(
+      s"CriticalActorsWatcher watching ${initial.size} actors: " +
+        initial.map(_.path.name).mkString(", ")
+    )
+  }
+
+  override def receive: Receive = {
+    case CriticalActorsWatcher.Watch(ref) =>
+      context.watch(ref)
+      log.info(s"CriticalActorsWatcher now also watching ${ref.path.name}")
+
+    case Terminated(ref) =>
+      log.error(s"Critical actor terminated: ${ref.path} - initiating coordinated shutdown")
+      ErgoApp.shutdownSystem()(context.system)
+  }
+}
+
+object CriticalActorsWatcher {
+
+  /** Add another actor to the watched set. */
+  final case class Watch(ref: ActorRef)
+
+  def props(initial: Seq[ActorRef]): Props =
+    Props(new CriticalActorsWatcher(initial))
+}

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -119,11 +119,17 @@ class ErgoApp(args: Args) extends ScorexLogging {
     deliveryTracker
   )
 
+  private val criticalActorsWatcherRef: ActorRef = actorSystem.actorOf(
+    CriticalActorsWatcher.props(Seq(nodeViewHolderRef, readersHolderRef, peerManagerRef)),
+    "criticalActorsWatcher"
+  )
+
   private val messageHandlers: ActorRef => Map[MessageCode, ActorRef] =
     networkControllerRef => {
       val ergoNodeViewSynchronizerRef = ergoNodeViewSynchronizerRefPartial(
         networkControllerRef
       )
+      criticalActorsWatcherRef ! CriticalActorsWatcher.Watch(ergoNodeViewSynchronizerRef)
       var map: Map[MessageCode, ActorRef] = Map(
         InvSpec.messageCode                 -> ergoNodeViewSynchronizerRef,
         RequestModifierSpec.messageCode     -> ergoNodeViewSynchronizerRef,
@@ -164,6 +170,8 @@ class ErgoApp(args: Args) extends ScorexLogging {
       scorexContext,
       messageHandlers
     )
+
+  criticalActorsWatcherRef ! CriticalActorsWatcher.Watch(networkControllerRef)
 
   private val statsCollectorRef: ActorRef = ErgoStatsCollectorRef(
     readersHolderRef,

--- a/src/test/scala/org/ergoplatform/CriticalActorsWatcherSpec.scala
+++ b/src/test/scala/org/ergoplatform/CriticalActorsWatcherSpec.scala
@@ -1,0 +1,94 @@
+package org.ergoplatform
+
+import akka.Done
+import akka.actor.{ActorSystem, CoordinatedShutdown, PoisonPill}
+import akka.testkit.{TestKit, TestProbe}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
+
+class CriticalActorsWatcherSpec
+  extends TestKit(ActorSystem("CriticalActorsWatcherSpec"))
+  with AnyFlatSpecLike
+  with Matchers {
+
+  /** Register a CoordinatedShutdown task that completes the returned promise when shutdown starts.
+    * Test config disables `terminate-actor-system`, so the system stays alive across runs. */
+  private def shutdownProbe(sys: ActorSystem, taskName: String): Promise[Done] = {
+    val p = Promise[Done]()
+    CoordinatedShutdown(sys).addTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, taskName) { () =>
+      p.trySuccess(Done)
+      Future.successful(Done)
+    }
+    p
+  }
+
+  "CriticalActorsWatcher" should "trigger coordinated shutdown when a watched actor terminates" in {
+    val sys = ActorSystem("watcher-trigger-on-death")
+    try {
+      val probeA = TestProbe()(sys)
+      val probeB = TestProbe()(sys)
+      val probeC = TestProbe()(sys)
+
+      val shutdownStarted = shutdownProbe(sys, "test-shutdown-probe")
+
+      sys.actorOf(
+        CriticalActorsWatcher.props(Seq(probeA.ref, probeB.ref, probeC.ref)),
+        "watcher"
+      )
+
+      probeB.ref ! PoisonPill
+
+      Await.result(shutdownStarted.future, 5.seconds) shouldBe Done
+    } finally {
+      Await.ready(sys.terminate(), 5.seconds)
+    }
+  }
+
+  it should "trigger shutdown for an actor added via the Watch message" in {
+    val sys = ActorSystem("watcher-trigger-on-dynamic-watch")
+    try {
+      val initial = TestProbe()(sys)
+      val added   = TestProbe()(sys)
+
+      val shutdownStarted = shutdownProbe(sys, "test-shutdown-probe-dynamic")
+
+      val watcher = sys.actorOf(
+        CriticalActorsWatcher.props(Seq(initial.ref)),
+        "watcher"
+      )
+
+      watcher ! CriticalActorsWatcher.Watch(added.ref)
+      // Give the watcher a moment to process the Watch before we kill `added`.
+      added.ref ! PoisonPill
+
+      Await.result(shutdownStarted.future, 5.seconds) shouldBe Done
+    } finally {
+      Await.ready(sys.terminate(), 5.seconds)
+    }
+  }
+
+  it should "not trigger shutdown while all watched actors are alive" in {
+    val sys = ActorSystem("watcher-no-shutdown-when-alive")
+    try {
+      val probeA = TestProbe()(sys)
+      val probeB = TestProbe()(sys)
+
+      val shutdownStarted = shutdownProbe(sys, "test-shutdown-probe-quiet")
+
+      sys.actorOf(
+        CriticalActorsWatcher.props(Seq(probeA.ref, probeB.ref)),
+        "watcher"
+      )
+
+      // Wait briefly and ensure the shutdown promise has not been completed.
+      intercept[java.util.concurrent.TimeoutException] {
+        Await.result(shutdownStarted.future, 1.second)
+      }
+    } finally {
+      Await.ready(sys.terminate(), 5.seconds)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New `CriticalActorsWatcher` actor: watches the five top-level actors whose loss makes the node unsafe to keep running (`NodeViewHolder`, `ReadersHolder`, `PeerManager`, `NetworkController`, `NodeViewSynchronizer`) and triggers `CoordinatedShutdown` on any `Terminated`.
- `ErgoApp` spawns the watcher right after the core actors are created. The synchronizer ref is added dynamically via a `Watch` message from inside the `messageHandlers` closure, since it's only materialized when `NetworkController`
  constructs.
- Reuses existing `ErgoApp.shutdownSystem` / `CoordinatedShutdown` plumbing — no new shutdown machinery. Existing `postStop` hooks (e.g. `ErgoNodeViewHolder` closing history/state storage) run during `actor-system-terminate`.
- Mempool auditor, miner, indexer, stats collector and peer synchronizer are intentionally **not** watched — their failure is a degradation, not a fatal fault.

Closes #688 