### PR TITLE
add JMH benchmark for Throwable construction cost

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -263,6 +263,15 @@ lazy val ergoCore = (project in file("ergo-core"))
     Test / parallelExecution := false,
   )
 
+lazy val ergoCore_benchmarks = (project in file("ergo-core/benchmarks"))
+  .settings(
+    commonSettings,
+    name := "ergo-core-benchmarks",
+    publishArtifact := false
+  )
+  .dependsOn(ergoCore)
+  .enablePlugins(JmhPlugin)
+
 lazy val ergoWallet = (project in file("ergo-wallet"))
   .disablePlugins(ScapegoatSbtPlugin) // not compatible with crossScalaVersions
   .settings(

--- a/ergo-core/benchmarks/src/main/scala/org/ergoplatform/benchmarks/ThrowableBench.scala
+++ b/ergo-core/benchmarks/src/main/scala/org/ergoplatform/benchmarks/ThrowableBench.scala
@@ -1,0 +1,55 @@
+package org.ergoplatform.benchmarks
+
+import java.util.concurrent.TimeUnit
+
+import org.ergoplatform.modifiers.HeaderTypeId
+import org.ergoplatform.modifiers.NetworkObjectTypeId
+import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.RecoverableModifierError
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import scorex.util.ModifierId
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class ThrowableBench {
+
+  private val msg: String = "validation failure"
+  private val mid: ModifierId =
+    ModifierId @@ "0000000000000000000000000000000000000000000000000000000000000000"
+  private val tid: NetworkObjectTypeId.Value = HeaderTypeId.value
+
+  private val preallocatedRecoverable: RecoverableModifierError =
+    new RecoverableModifierError(msg, mid, tid, None)
+
+  @Benchmark
+  def throwMalformed(bh: Blackhole): Unit = {
+    try {
+      throw new MalformedModifierError(msg, mid, tid, None)
+    } catch {
+      case t: Throwable => bh.consume(t)
+    }
+  }
+
+  @Benchmark
+  def throwRecoverable(bh: Blackhole): Unit = {
+    try {
+      throw new RecoverableModifierError(msg, mid, tid, None)
+    } catch {
+      case t: Throwable => bh.consume(t)
+    }
+  }
+
+  @Benchmark
+  def throwSingleton(bh: Blackhole): Unit = {
+    try {
+      throw preallocatedRecoverable
+    } catch {
+      case t: Throwable => bh.consume(t)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a JMH benchmark (`ergo-core/benchmarks/`) measuring the per-throw cost of `MalformedModifierError` (plain `Exception`), `RecoverableModifierError` (`NoStackTrace`), and a preallocated singleton.

Numbers on JDK 11:

ThrowableBench.throwMalformed    522.136 ns/op
ThrowableBench.throwRecoverable    6.894 ns/op
ThrowableBench.throwSingleton      1.422 ns/op



`NoStackTrace` is ~76× faster, a singleton ~367×. Confirms the existing `NoStackTrace` on `RecoverableModifierError` (the only hot-path validation throw) captures the available win; other throw sites fire on abnormal input where the stack trace is the primary debug signal — so no production code changes ship with this PR. Closes the long-standing question raised in #746.

Run with: `sbt "ergoCore_benchmarks/Jmh/run -i 5 -wi 3 -f1 -t1 .*ThrowableBench.*"`