### PR TITLE
fix branch-point selection when invalidating non-branch block in best fork

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -15,8 +15,10 @@ import org.ergoplatform.nodeView.history.storage.modifierprocessors._
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.utils.LoggingUtil
 import org.ergoplatform.validation.RecoverableModifierError
+import scorex.db.ByteArrayWrapper
 import scorex.util.{ModifierId, ScorexLogging, idToBytes}
 
+import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -157,26 +159,68 @@ trait ErgoHistory
                 .ensuring(_.lengthCompare(1) >= 0, "invalidatedChain should contain at least bestFullBlock")
 
               val genesisInvalidated = invalidatedChain.lengthCompare(1) == 0
-              val branchPointHeader = if (genesisInvalidated) PreGenesisHeader else invalidatedChain.head.header
+              val validAncestor: Header =
+                if (genesisInvalidated) PreGenesisHeader else invalidatedChain.head.header
 
-              val validHeadersChain =
-                continuationHeaderChains(branchPointHeader,
-                  h => getFullBlock(h).isDefined && !invalidatedIds.contains(h.id))
+              val validFilter: Header => Boolean =
+                h => getFullBlock(h).isDefined && !invalidatedIds.contains(h.id)
+
+              // Walk back through the old best chain looking for the lowest ancestor that
+              // has a valid child *not* on the old best chain — that's a real fork point
+              // with an alternative valid continuation. Same-tip walking past the deepest
+              // valid ancestor would otherwise miss this fork when the invalidated block
+              // sits deeper than the branch block of the old best chain.
+              val bestChainMarker = ByteArrayWrapper(FullBlockProcessor.BestChainMarker)
+              def onOldBestFullChain(id: ModifierId): Boolean =
+                historyStorage.getIndex(FullBlockProcessor.chainStatusKey(id))
+                  .map(ByteArrayWrapper.apply)
+                  .contains(bestChainMarker)
+
+              @tailrec
+              def findBranchPoint(current: Header): Option[Header] = {
+                val hasAlternativeForkChild = headerIdsAtHeight(current.height + 1)
+                  .flatMap(typedModifierById[Header])
+                  .exists(h => h.parentId == current.id && validFilter(h) && !onOldBestFullChain(h.id))
+                if (hasAlternativeForkChild) Some(current)
+                else typedModifierById[Header](current.parentId) match {
+                  case Some(parent) if !invalidatedIds.contains(parent.id) => findBranchPoint(parent)
+                  case _ => None
+                }
+              }
+
+              val branchPointHeader: Header =
+                if (genesisInvalidated) validAncestor
+                else findBranchPoint(validAncestor).getOrElse(validAncestor)
+
+              val validHeadersChain: Seq[Header] =
+                continuationHeaderChains(branchPointHeader, validFilter)
                   .maxBy(_.lastOption.flatMap(x => scoreOf(x.id)).getOrElse(BigInt(0)))
 
               val validChain = validHeadersChain.tail.flatMap(getFullBlock)
 
+              // Old-best-chain segment between branchPoint (exclusive) and bestFullBlock —
+              // covers invalidated headers AND valid-but-now-demoted blocks. Resolve full
+              // blocks here, before the validity row is written: once invalidity is
+              // persisted, modifierById filters those modifiers out.
+              val demotedHeaders: Seq[Header] = bestFullBlockOpt.toSeq.flatMap(f =>
+                headerChainBack(
+                  fullBlockHeight + 1,
+                  f.header,
+                  h => h.id == branchPointHeader.id)
+                .headers
+                .drop(1))
+              val demotedFullBlocks: Seq[ErgoFullBlock] = demotedHeaders.flatMap(getFullBlock)
+
               val chainStatusRow = validChain.map(b =>
                 FullBlockProcessor.chainStatusKey(b.id) -> FullBlockProcessor.BestChainMarker) ++
-                invalidatedHeaders.map(h =>
+                demotedHeaders.map(h =>
                   FullBlockProcessor.chainStatusKey(h.id) -> FullBlockProcessor.NonBestChainMarker)
 
               val changedLinks = validHeadersChain.lastOption.map(b => BestFullBlockKey -> idToBytes(b.id)) ++
                 newBestHeaderOpt.map(h => BestHeaderKey -> idToBytes(h.id)).toSeq
               val toInsert = validityRow ++ changedLinks ++ chainStatusRow
               historyStorage.insert(toInsert, BlockSection.emptyArray).map { _ =>
-                val toRemove = if (genesisInvalidated) invalidatedChain else invalidatedChain.tail
-                this -> ProgressInfo(Some(branchPointHeader.id), toRemove, validChain, Seq.empty)
+                this -> ProgressInfo(Some(branchPointHeader.id), demotedFullBlocks, validChain, Seq.empty)
               }
             }
         }

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyNonADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyNonADHistorySpecification.scala
@@ -52,41 +52,50 @@ class VerifyNonADHistorySpecification extends ErgoCorePropertyTest {
       h.asInstanceOf[FullBlockProcessor].isInBestFullChain(b.id)
     }
 
-    var history = genHistory()
-    val initChain = genChain(6, history)
+    // Invalidating any block in the better fork — branch block or not — must
+    // restore the original chain and demote the entire fork from best chain.
+    // We iterate only over indices where the valid altChain prefix stays shorter
+    // than initChain (length 6, stableChain of 3 + altChain index < 6, so index < 3),
+    // keeping the new-best-chain assertion deterministic.
+    (0 until 3).foreach { invalidIdx =>
+      var history = genHistory()
+      val initChain = genChain(6, history)
 
-    val stableChain = initChain.take(3)
-    val altChain = genChain(8, stableChain.last).tail
+      val stableChain = initChain.take(3)
+      val altChain = genChain(8, stableChain.last).tail
 
-    // apply initial initChain (1 to 6)
-    history = applyChain(history, initChain)
+      // apply initial initChain (1 to 6)
+      history = applyChain(history, initChain)
 
-    history.bestFullBlockIdOpt.get shouldEqual initChain.last.id
-    initChain.forall(b => isInBestChain(b, history)) shouldBe true
+      history.bestFullBlockIdOpt.get shouldEqual initChain.last.id
+      initChain.forall(b => isInBestChain(b, history)) shouldBe true
 
-    // apply better initChain forking initial one (1 to 3 (init initChain), 3 to 11 (new initChain))
-    history = applyChain(history, altChain)
+      // apply better initChain forking initial one (1 to 3 (init initChain), 3 to 11 (new initChain))
+      history = applyChain(history, altChain)
 
-    history.bestFullBlockIdOpt.get shouldEqual altChain.last.id
-    // first blocks from init chain are still marked as best chain
-    stableChain.forall(b => isInBestChain(b, history)) shouldBe true
-    // other blocks from init chain are no more in best chain
-    initChain.drop(3).forall(b => !isInBestChain(b, history)) shouldBe true
-    // all blocks from fork are marked as best chain
-    altChain.forall(b => isInBestChain(b, history)) shouldBe true
+      history.bestFullBlockIdOpt.get shouldEqual altChain.last.id
+      // first blocks from init chain are still marked as best chain
+      stableChain.forall(b => isInBestChain(b, history)) shouldBe true
+      // other blocks from init chain are no more in best chain
+      initChain.drop(3).forall(b => !isInBestChain(b, history)) shouldBe true
+      // all blocks from fork are marked as best chain
+      altChain.forall(b => isInBestChain(b, history)) shouldBe true
 
-    val invalidChainHead = altChain.head
+      val invalidChainHead = altChain(invalidIdx)
 
-    // invalidate modifier from fork
-    history.reportModifierIsInvalid(invalidChainHead.blockTransactions,
-      ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty))
+      // invalidate modifier from fork
+      history.reportModifierIsInvalid(invalidChainHead.blockTransactions,
+        ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty))
 
-    history.bestFullBlockIdOpt.get shouldEqual initChain.last.id
+      withClue(s"invalidating altChain($invalidIdx): ") {
+        history.bestFullBlockIdOpt.get shouldEqual initChain.last.id
 
-    // all blocks from init chain are marked as best chain again
-    initChain.forall(b => isInBestChain(b, history)) shouldBe true
-    // blocks from fork no longer marked as best chain
-    altChain.forall(b => !isInBestChain(b, history)) shouldBe true
+        // all blocks from init chain are marked as best chain again
+        initChain.forall(b => isInBestChain(b, history)) shouldBe true
+        // blocks from fork no longer marked as best chain
+        altChain.forall(b => !isInBestChain(b, history)) shouldBe true
+      }
+    }
   }
 
   property("bootstrap from headers and last full blocks") {


### PR DESCRIPTION
## Summary

`reportModifierIsInvalid` mishandled invalidation when the invalidated block sat deeper in the best fork than the fork's branch block: the walk-back stopped on the still-broken fork, so `bestFullBlock` ended up on a side-fork prefix with stale `BestChainMarker`s.

## Changes

- Walk back further through the old best chain to find an ancestor with a valid child *not* on the old best chain (the real fork point); fall back to the deepest non-invalidated ancestor for single-chain invalidations.
- Widen the demoted set to the whole old-best-chain segment between the new branch point and the previous `bestFullBlock`, and resolve its full blocks before writing the validity row.
- Parametrize the `full chain status updating` property over indices `0..2` (branch, non-branch depth 1, non-branch depth 2).

Closes #649 