### PR TITLE
add ErgoException with code/cause and migrate throw sites

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/BlockSection.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/BlockSection.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.modifiers
 
 import io.circe.Encoder
+import org.ergoplatform.ErgoException
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions}
@@ -23,7 +24,7 @@ object BlockSection {
     case bt: BlockTransactions => BlockTransactions.jsonEncoder(bt)
     case adp: ADProofs => ADProofs.jsonEncoder(adp)
     case ext: Extension => Extension.jsonEncoder(ext)
-    case other => throw new Exception(s"Unknown block section type: $other")
+    case other => throw new ErgoException(ErgoException.UnknownTypeError, s"Unknown block section type: $other")
   }
 
   /** Immutable empty array can be shared to avoid allocations. */

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/ErgoFullBlock.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/ErgoFullBlock.scala
@@ -4,6 +4,7 @@ import cats.syntax.either._
 import sigmastate.utils.Helpers._
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor, Json}
+import org.ergoplatform.ErgoException
 import org.ergoplatform.http.api.ApiCodecs
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
@@ -41,7 +42,7 @@ case class ErgoFullBlock(header: Header,
   override lazy val size: Int = header.size + blockTransactions.size + adProofs.map(_.size).getOrElse(0)
 
   override def serializer: ErgoSerializer[ErgoFullBlock] =
-    throw new Error("Serialization for ErgoFullBlock is not (and will be not) implemented")
+    throw new ErgoException(ErgoException.UnknownTypeError, "Serialization for ErgoFullBlock is not (and will be not) implemented")
 
   def height: Int = header.height
 

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/HistoryModifierSerializer.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/HistoryModifierSerializer.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.modifiers.history
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSerializer}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
@@ -23,7 +24,7 @@ object HistoryModifierSerializer extends ErgoSerializer[BlockSection] {
         w.put(Extension.modifierTypeId)
         ExtensionSerializer.serialize(m, w)
       case m =>
-        throw new Error(s"Serialization for unknown modifier: $m")
+        throw new ErgoException(ErgoException.UnknownTypeError, s"Serialization for unknown modifier: $m")
     }
   }
 
@@ -38,7 +39,7 @@ object HistoryModifierSerializer extends ErgoSerializer[BlockSection] {
       case Extension.`modifierTypeId` =>
         ExtensionSerializer.parse(r)
       case m =>
-        throw new Error(s"Deserialization for unknown type byte: $m")
+        throw new ErgoException(ErgoException.UnknownTypeError, s"Deserialization for unknown type byte: $m")
     }
   }
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/ModifiersSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/ModifiersSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.network.message
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.modifiers.{ErgoNodeViewModifier, NetworkObjectTypeId}
 import org.ergoplatform.network.message.MessageConstants.MessageCode
 import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
@@ -57,7 +58,7 @@ object ModifiersSpec extends MessageSpecV1[ModifiersData] with ScorexLogging {
       val objBytesCnt = r.getUInt().toIntExact
       val newMsgSize = msgSize + ErgoNodeViewModifier.ModifierIdSize + objBytesCnt
       if (newMsgSize > maxMsgSizeWithReserve) { // buffer for safety
-        throw new Exception("Too big message with modifiers, size: " + maxMsgSizeWithReserve)
+        throw new ErgoException(ErgoException.NetworkError, "Too big message with modifiers, size: " + maxMsgSizeWithReserve)
       }
       val obj = r.getBytes(objBytesCnt)
       resMap += (id -> obj)

--- a/ergo-core/src/main/scala/org/ergoplatform/nodeView/history/ErgoSyncInfo.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/nodeView/history/ErgoSyncInfo.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.history
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.consensus.SyncInfo
 import org.ergoplatform.modifiers.ErgoNodeViewModifier
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
@@ -96,7 +97,7 @@ object ErgoSyncInfoSerializer extends ErgoSerializer[ErgoSyncInfo] with ScorexLo
         }
         ErgoSyncInfoV2(headers)
       } else {
-        throw new Exception(s"Wrong SyncInfo version: $r")
+        throw new ErgoException(ErgoException.NetworkError, s"Wrong SyncInfo version: $r")
       }
     } else { // parse v1 sync message
       require(length <= ErgoSyncInfo.MaxBlockIds + 1, "Too many block ids in sync info")

--- a/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.state
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.core.BytesSerializable
 import org.ergoplatform.modifiers.ErgoFullBlock
@@ -162,7 +163,7 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
 
       if ((height >= finishingHeight && height < finishingHeight + votingEpochLength && !votingSettings.softForkApproved(votesCollected)) ||
         (height >= finishingHeight && height < afterActivationHeight && votingSettings.softForkApproved(votesCollected))) {
-        throw new Exception(s"Voting for fork is prohibited at height $height")
+        throw new ErgoException(ErgoException.ValidationError, s"Voting for fork is prohibited at height $height")
       }
     }
   }

--- a/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/StateType.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/StateType.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.state
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.nodeView.state.StateType.StateTypeCode
 
 
@@ -39,7 +40,7 @@ object StateType {
   } else if (code == Digest.stateTypeCode) {
     Digest
   } else {
-    throw new Exception(s"Unkown state type code $code")
+    throw new ErgoException(ErgoException.UnknownTypeError, s"Unkown state type code $code")
   }
 
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/ChainSettings.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/ChainSettings.scala
@@ -7,6 +7,7 @@ import org.ergoplatform.mining.AutolykosPowScheme
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.mining.emission.EmissionRules
 import scorex.crypto.authds.ADDigest
+import org.ergoplatform.ErgoException
 import scorex.util.ModifierId
 import scorex.util.encode.Base16
 
@@ -37,14 +38,18 @@ case class ChainSettings(protocolVersion: Byte,
   val isMainnet: Boolean = addressPrefix == ErgoAddressEncoder.MainnetNetworkPrefix
 
   val genesisStateDigest: ADDigest = Base16.decode(genesisStateDigestHex)
-    .fold(_ => throw new Error(s"Failed to parse genesisStateDigestHex = $genesisStateDigestHex"), ADDigest @@ _)
+    .fold(
+      e => throw new ErgoException(ErgoException.ConfigError, s"Failed to parse genesisStateDigestHex = $genesisStateDigestHex", Some(e)),
+      ADDigest @@ _)
 
   val emissionRules: EmissionRules = new EmissionRules(monetary)
 
   val addressEncoder = new ErgoAddressEncoder(addressPrefix)
 
   val initialDifficulty: BigInt = Base16.decode(initialDifficultyHex)
-    .fold(_ => throw new Error(s"Failed to parse initialDifficultyHex = $initialDifficultyHex"), BigInt(_))
+    .fold(
+      e => throw new ErgoException(ErgoException.ConfigError, s"Failed to parse initialDifficultyHex = $initialDifficultyHex", Some(e)),
+      BigInt(_))
 
   /**
     * Initial (genesis block) difficulty encoded as nbits
@@ -52,6 +57,8 @@ case class ChainSettings(protocolVersion: Byte,
   val initialNBits: Long = DifficultySerializer.encodeCompactBits(initialDifficulty)
 
   val initialDifficultyVersion2: BigInt = Base16.decode(voting.version2ActivationDifficultyHex)
-    .fold(_ => throw new Error(s"Failed to parse initialDifficultyVersion2 = $initialDifficultyHex"), BigInt(_))
+    .fold(
+      e => throw new ErgoException(ErgoException.ConfigError, s"Failed to parse initialDifficultyVersion2 = $initialDifficultyHex", Some(e)),
+      BigInt(_))
 
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Parameters.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Parameters.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.settings
 import com.google.common.primitives.Ints
 import io.circe.Encoder
 import io.circe.syntax._
+import org.ergoplatform.ErgoException
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.serialization.ErgoSerializer
 import scorex.util.serialization.{Reader, Writer}
@@ -398,17 +399,17 @@ object Parameters {
     */
   def matchParameters(p1: Parameters, p2: Parameters): Try[Unit] = Try {
     if (p1.height != p2.height) {
-      throw new Exception(s"Different height in parameters, p1 = $p1, p2 = $p2")
+      throw new ErgoException(ErgoException.ValidationError, s"Different height in parameters, p1 = $p1, p2 = $p2")
     }
     if (p1.parametersTable.size != p2.parametersTable.size) {
-      throw new Exception(s"Parameters differ in size, p1 = $p1, p2 = $p2")
+      throw new ErgoException(ErgoException.ValidationError, s"Parameters differ in size, p1 = $p1, p2 = $p2")
     }
     if (p1.proposedUpdate != p2.proposedUpdate) {
-      throw new Exception(s"Parameters proposedUpdate differs, p1 = ${p1.proposedUpdate}, p2 = ${p2.proposedUpdate}")
+      throw new ErgoException(ErgoException.ValidationError, s"Parameters proposedUpdate differs, p1 = ${p1.proposedUpdate}, p2 = ${p2.proposedUpdate}")
     }
     p1.parametersTable.foreach { case (k, v) =>
       val v2 = p2.parametersTable(k)
-      if (v2 != v) throw new Exception(s"Calculated and received parameters differ in parameter $k ($v != $v2)")
+      if (v2 != v) throw new ErgoException(ErgoException.ValidationError, s"Calculated and received parameters differ in parameter $k ($v != $v2)")
     }
   }
 
@@ -423,17 +424,17 @@ object Parameters {
     } else {
       Try {
         if (p1.height != p2.height) {
-          throw new Exception(s"Different height in parameters, p1 = $p1, p2 = $p2")
+          throw new ErgoException(ErgoException.ValidationError, s"Different height in parameters, p1 = $p1, p2 = $p2")
         }
         if (!(p1.parametersTable.size <= p2.parametersTable.size)) { // the only difference from matchParameters
-          throw new Exception(s"Parameters differ in size, p1 = $p1, p2 = $p2")
+          throw new ErgoException(ErgoException.ValidationError, s"Parameters differ in size, p1 = $p1, p2 = $p2")
         }
         if (p1.proposedUpdate != p2.proposedUpdate) {
-          throw new Exception(s"Parameters proposedUpdate differs, p1 = ${p1.proposedUpdate}, p2 = ${p2.proposedUpdate}")
+          throw new ErgoException(ErgoException.ValidationError, s"Parameters proposedUpdate differs, p1 = ${p1.proposedUpdate}, p2 = ${p2.proposedUpdate}")
         }
         p1.parametersTable.foreach { case (k, v) =>
           val v2 = p2.parametersTable(k)
-          if (v2 != v) throw new Exception(s"Calculated and received parameters differ in parameter $k ($v != $v2)")
+          if (v2 != v) throw new ErgoException(ErgoException.ValidationError, s"Calculated and received parameters differ in parameter $k ($v != $v2)")
         }
       }
     }

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Settings.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Settings.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.settings
 import com.typesafe.config.{Config, ConfigFactory}
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import org.ergoplatform.ErgoException
 import org.ergoplatform.network.message.MessageConstants._
 import scorex.util.ScorexLogging
 
@@ -92,7 +93,7 @@ object ScorexSettings extends ScorexLogging with SettingsReaders {
       case Some(file) =>
         val cfg = ConfigFactory.parseFile(file)
         if (!cfg.hasPath(configPath)) {
-          throw new Error("Malformed configuration file was provided! Aborting!")
+          throw new ErgoException(ErgoException.ConfigError, "Malformed configuration file was provided! Aborting!")
         }
         ConfigFactory
           .defaultOverrides()

--- a/ergo-wallet/src/main/scala/org/ergoplatform/ErgoException.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/ErgoException.scala
@@ -1,0 +1,21 @@
+package org.ergoplatform
+
+/**
+  * Base exception for Ergo-specific errors.
+  *
+  * @param code    numeric error code identifying the error category
+  * @param message human-readable description
+  * @param cause   optional underlying throwable
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
+class ErgoException(val code: Int, message: String, cause: Option[Throwable] = None)
+  extends Exception(message, cause.orNull)
+
+object ErgoException {
+  val ConfigError      = 1001
+  val StateError       = 1002
+  val NetworkError     = 1003
+  val ValidationError  = 1004
+  val WalletError      = 1005
+  val UnknownTypeError = 1006
+}

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -230,7 +230,8 @@ object TransactionBuilder {
     val tokensOutWithBurned = AssetUtils.mergeAssets(tokensOutNoMinted.toMap, burnTokens)
 
     val selection = boxSelector.select(inputs.toIterator, outputTotal, tokensOutWithBurned) match {
-      case Left(err) => throw new IllegalArgumentException(
+      case Left(err) => throw new ErgoException(
+        ErgoException.ValidationError,
         s"failed to calculate change for outputTotal: $outputTotal, \ntokens: $tokensOut, \nburnTokens: $burnTokens, \ninputs: $inputs, \nreason: $err")
       case Right(v) => v
     }

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.mining
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Props}
 import akka.pattern.StatusReply
 import com.google.common.primitives.Longs
+import org.ergoplatform.ErgoException
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform.mining.AutolykosPowScheme.derivedHeaderFields
 import org.ergoplatform.mining.difficulty.DifficultySerializer
@@ -601,7 +602,8 @@ object CandidateGenerator extends ScorexLogging {
       val eliminateTransactions = EliminateTransactions(toEliminate)
 
       if (txs.isEmpty) {
-        throw new IllegalArgumentException(
+        throw new ErgoException(
+          ErgoException.ValidationError,
           s"Proofs for 0 txs cannot be generated : emissionTxs: ${emissionTxs.size}, priorityTxs: ${prioritizedTransactions.size}, poolTxs: ${poolTxs.size}"
         )
       }

--- a/src/main/scala/org/ergoplatform/network/message/MessageSerializer.scala
+++ b/src/main/scala/org/ergoplatform/network/message/MessageSerializer.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.network.message
 
 import java.nio.ByteOrder
 import akka.util.ByteString
+import org.ergoplatform.ErgoException
 import scorex.core.network.{ConnectedPeer, MaliciousBehaviorException}
 import scorex.crypto.hash.Blake2b256
 import scala.util.Try
@@ -59,7 +60,7 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
           )
         }
         val spec = specsMap
-          .getOrElse(msgCode, throw new Error(s"No message handler found for $msgCode"))
+          .getOrElse(msgCode, throw new ErgoException(ErgoException.NetworkError, s"No message handler found for $msgCode"))
         val msgData = if (length > 0) {
           val checksum = it.getBytes(ChecksumLength)
           val data     = it.getBytes(length)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.nodeView
 
 import akka.actor.SupervisorStrategy.Escalate
 import akka.actor.{Actor, ActorRef, ActorSystem, OneForOneStrategy, Props}
-import org.ergoplatform.{CriticalSystemException, ErgoApp}
+import org.ergoplatform.{CriticalSystemException, ErgoApp, ErgoException}
 import org.ergoplatform.consensus.ProgressInfo
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
@@ -590,7 +590,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           .getOrElse(recreatedState())
         val toApply = newChain.headers.map { h =>
           history.getFullBlock(h)
-            .fold(throw new Error(s"Failed to get full block for header $h"))(fb => fb)
+            .fold(
+              e => throw new ErgoException(ErgoException.StateError, s"Failed to get full block for header $h", Some(e)),
+              identity)
         }
         toApply.foldLeft[Try[State]](Success(initState)) { case (acc, m) =>
           log.info(s"Applying block ${m.height} during node start-up to restore consistent state: ${m.id}")

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexSerializer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexSerializer.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.history.extra
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.serialization.ErgoSerializer
 import scorex.util.serialization.{Reader, Writer}
 
@@ -29,7 +30,7 @@ object ExtraIndexSerializer  extends ErgoSerializer[ExtraIndex]{
           w.put(IndexedToken.extraIndexTypeId)
           IndexedTokenSerializer.serialize(m, w)
         case m =>
-          throw new Error(s"Serialization for unknown index: $m")
+          throw new ErgoException(ErgoException.UnknownTypeError, s"Serialization for unknown index: $m")
       }
     }
 
@@ -50,7 +51,7 @@ object ExtraIndexSerializer  extends ErgoSerializer[ExtraIndex]{
         case IndexedToken.`extraIndexTypeId` =>
           IndexedTokenSerializer.parse(r)
         case m =>
-          throw new Error(s"Deserialization for unknown type byte: $m")
+          throw new ErgoException(ErgoException.UnknownTypeError, s"Deserialization for unknown type byte: $m")
       }
     }
   }

--- a/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/ErgoState.scala
@@ -176,7 +176,9 @@ object ErgoState extends ScorexLogging {
         toInsert.remove(wrappedBoxId) match {
           case None =>
             if (toRemove.put(wrappedBoxId, Remove(i.boxId)).nonEmpty) {
-              throw new IllegalArgumentException(s"Tx : ${tx.id} is double-spending input id : $wrappedBoxId")
+              throw new ErgoException(
+                ErgoException.ValidationError,
+                s"Tx : ${tx.id} is double-spending input id : $wrappedBoxId")
             }
           case _ => // old value removed, do nothing
         }

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoState.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.state
 
 import java.io.File
-import org.ergoplatform.ErgoBox
+import org.ergoplatform.{ErgoBox, ErgoException}
 import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.core.VersionTag
 import org.ergoplatform.modifiers.history.header.Header
@@ -146,11 +146,11 @@ class UtxoState(override val persistentProver: PersistentBatchAVLProver[Digest32
 
             if (!store.get(org.ergoplatform.core.idToBytes(fb.id))
                   .exists(w => java.util.Arrays.equals(w, fb.header.stateRoot))) {
-              throw new Exception("Storage kept roothash is not equal to the declared one")
+              throw new ErgoException(ErgoException.StateError, "Storage kept roothash is not equal to the declared one")
             }
 
             if (!java.util.Arrays.equals(fb.header.stateRoot, persistentProver.digest)) {
-              throw new Exception("Calculated stateRoot is not equal to the declared one")
+              throw new ErgoException(ErgoException.StateError, "Calculated stateRoot is not equal to the declared one")
             }
 
             var proofHash = ADProofs.proofDigest(proofBytes)
@@ -186,10 +186,10 @@ class UtxoState(override val persistentProver: PersistentBatchAVLProver[Digest32
                   proofHash = ADProofs.proofDigest(proofBytes)
 
                   if(!java.util.Arrays.equals(fb.header.ADProofsRoot, proofHash)) {
-                    throw new Exception("Regenerated proofHash is not equal to the declared one")
+                    throw new ErgoException(ErgoException.StateError, "Regenerated proofHash is not equal to the declared one")
                   }
                 case Failure(e) =>
-                  throw new Exception("Can't generate state changes on proof regeneration ", e)
+                  throw new ErgoException(ErgoException.StateError, "Can't generate state changes on proof regeneration ", Some(e))
               }
             }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -299,7 +299,9 @@ trait ErgoWalletSupport extends ScorexLogging {
           //inputs are to be filtered by the wallet filter, which is removing boxes spent offchain
           state.getBoxesToSpend.filter(box => state.walletFilter(box))
         case None =>
-          throw new Exception(s"Cannot generateUnsignedTransaction($requests, $inputsRaw): wallet is locked")
+          throw new ErgoException(
+            ErgoException.WalletError,
+            s"Cannot generateUnsignedTransaction($requests, $inputsRaw): wallet is locked")
       }
     }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/IdUtils.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/IdUtils.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.wallet
 
+import org.ergoplatform.ErgoException
 import org.ergoplatform.ErgoBox.{BoxId, TokenId}
 import org.ergoplatform.settings.Algos
 import scorex.crypto.authds.ADKey
@@ -19,11 +20,15 @@ object IdUtils {
   def encodedBoxId(id: BoxId): EncodedBoxId = EncodedBoxId @@ Algos.encode(id)
 
   def decodedBoxId(id: EncodedBoxId): BoxId = ADKey @@ Algos.decode(id)
-    .getOrElse(throw new Error("Failed to decode box id"))
+    .fold(
+      e => throw new ErgoException(ErgoException.WalletError, "Failed to decode box id", Some(e)),
+      identity)
 
   def encodedTokenId(id: TokenId): EncodedTokenId = ModifierId @@ Algos.encode(id)
 
   def decodedTokenId(id: EncodedTokenId): TokenId =
-    Digest32Coll @@ (Algos.decode(id).getOrElse(throw new Error("Failed to decode token id"))).toColl
+    Digest32Coll @@ (Algos.decode(id).fold(
+      e => throw new ErgoException(ErgoException.WalletError, "Failed to decode token id", Some(e)),
+      identity)).toColl
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.wallet.persistence
 
-import org.ergoplatform.ErgoBox
+import org.ergoplatform.{ErgoBox, ErgoException}
 import org.ergoplatform.ErgoBox.BoxId
 import org.ergoplatform.ErgoLikeContext.Height
 import org.ergoplatform.modifiers.history.header.PreGenesisHeader
@@ -387,7 +387,7 @@ class WalletRegistry(private val store: LDBVersionedStore)(ws: WalletSettings) e
         putBox(bag0, newBox)
       case (true, true) =>
         //old and new scans are empty, can't do anything useful
-        throw new Exception("Can't remove a box which does not exist")
+        throw new ErgoException(ErgoException.WalletError, "Can't remove a box which does not exist")
     }
 
     // Flag showing that box has been added to the payments app (p2pk-wallet) or removed from it
@@ -415,7 +415,9 @@ class WalletRegistry(private val store: LDBVersionedStore)(ws: WalletSettings) e
           digest.walletBalance - box.value,
           walletAssets.toArray[(EncodedTokenId, Long)])
       } else {
-        throw new Exception(s"Wallet can't update digest for a box with old scans $oldScans, new ones $newScans")
+        throw new ErgoException(
+          ErgoException.WalletError,
+          s"Wallet can't update digest for a box with old scans $oldScans, new ones $newScans")
       }
       putDigest(bag1, updDigest)
     } else {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/TransactionGenerationRequest.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/TransactionGenerationRequest.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.wallet.requests
 
 import io.circe._
-import org.ergoplatform.ErgoAddress
+import org.ergoplatform.{ErgoAddress, ErgoException}
 import org.ergoplatform.http.api.ApiCodecs
 import org.ergoplatform.nodeView.wallet.ErgoAddressJsonEncoder
 import org.ergoplatform.settings.ErgoSettings
@@ -16,7 +16,7 @@ class TransactionRequestEncoder(ergoSettings: ErgoSettings) extends Encoder[Tran
     case pr: PaymentRequest => new PaymentRequestEncoder(ergoSettings)(pr)
     case ar: AssetIssueRequest => new AssetIssueRequestEncoder(ergoSettings)(ar)
     case br: BurnTokensRequest => new BurnTokensRequestEncoder()(br)
-    case other => throw new Exception(s"Unknown TransactionRequest type: $other")
+    case other => throw new ErgoException(ErgoException.UnknownTypeError, s"Unknown TransactionRequest type: $other")
   }
 
 }

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettings.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.settings
 
 import org.ergoplatform.mining.groupElemFromBytes
-import org.ergoplatform.{ErgoAddressEncoder, P2PKAddress}
+import org.ergoplatform.{ErgoAddressEncoder, ErgoException, P2PKAddress}
 import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 
@@ -22,8 +22,12 @@ case class ErgoSettings(directory: String,
 
   val miningPubKey: Option[ProveDlog] = nodeSettings.miningPubKeyHex
     .flatMap { str =>
-      val keyBytes = Base16.decode(str)
-        .getOrElse(throw new Error(s"Failed to parse `miningPubKeyHex = ${nodeSettings.miningPubKeyHex}`"))
+      val keyBytes = Base16.decode(str).fold(
+        e => throw new ErgoException(
+          ErgoException.ConfigError,
+          s"Failed to parse `miningPubKeyHex = ${nodeSettings.miningPubKeyHex}`",
+          Some(e)),
+        identity)
       Try(ProveDlog(groupElemFromBytes(keyBytes)))
         .orElse(addressEncoder.fromString(str).collect { case p2pk: P2PKAddress => p2pk.pubkey })
         .toOption

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettingsReader.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettingsReader.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import org.ergoplatform.nodeView.state.StateType.Digest
-import org.ergoplatform.ErgoApp
+import org.ergoplatform.{ErgoApp, ErgoException}
 import scorex.util.ScorexLogging
 import org.ergoplatform.settings.ErgoSettings.{configPath, scorexConfigPath}
 
@@ -31,7 +31,7 @@ object ErgoSettingsReader extends ScorexLogging
     val directory = config.as[String](s"$configPath.directory")
     val networkTypeName = config.as[String](s"$configPath.networkType")
     val networkType = NetworkType.fromString(networkTypeName)
-      .getOrElse(throw new Error(s"Unknown `networkType = $networkTypeName`"))
+      .getOrElse(throw new ErgoException(ErgoException.ConfigError, s"Unknown `networkType = $networkTypeName`"))
     val nodeSettings = config.as[NodeConfigurationSettings](s"$configPath.node")
     val chainSettings = config.as[ChainSettings](s"$configPath.chain")
     val walletSettings = config.as[WalletSettings](s"$configPath.wallet")


### PR DESCRIPTION
## Summary

Introduces `ErgoException(code, message, cause)` as a base class for Ergo-specific errors, placed in `ergo-wallet` so it's available across all modules.

Migrates 42 ad-hoc `throw new Exception/Error/IllegalArgumentException` sites across `ergo-core`, `ergo-wallet`, and the main node. Where the original code discarded an underlying `Throwable` (via `Try.fold(_ => …)` or `Try.getOrElse(throw …)`), it's now preserved as `cause`.

Error codes are grouped by category: `ConfigError`, `StateError`, `NetworkError`, `ValidationError`, `WalletError`, `UnknownTypeError`.

`ConfigException.BadValue` calls into the Typesafe Config API are left as-is.

Closes #912 