### PR TITLE
add WIF (Wallet Import Format) support to wallet

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
@@ -89,6 +89,18 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
   }
 
   /**
+    * Produces updated instance of ErgoProvingInterpreter with a non-HD primitive
+    * secret included. The hierarchical-deterministic pubkey cache is left untouched
+    * since imported secrets do not participate in HD derivation.
+    *
+    * @param secret - imported secret to add
+    * @return modified prover
+    */
+  def withNewImportedSecret(secret: SecretKey): ErgoProvingInterpreter = {
+    new ErgoProvingInterpreter(secretKeys :+ secret, params, cachedHdPubKeysOpt)
+  }
+
+  /**
     * Produces updated instance of ErgoProvingInterpreter with updated parameters
     * @param newParams - updated parameters
     * @return modified prover

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/EncryptedImportedKey.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/EncryptedImportedKey.scala
@@ -1,0 +1,39 @@
+package org.ergoplatform.wallet.secrets
+
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import scorex.util.encode.Base16
+
+/**
+  * One AES-GCM-encrypted 32-byte secp256k1 scalar persisted in the
+  * `imported/keys.json` file inside the wallet's secret directory.
+  */
+final case class EncryptedImportedKey(
+  cipherText: String,
+  salt: String,
+  iv: String,
+  authTag: String,
+  publicKey: String
+)
+
+object EncryptedImportedKey {
+
+  def apply(
+    cipherText: Array[Byte],
+    salt: Array[Byte],
+    iv: Array[Byte],
+    authTag: Array[Byte],
+    publicKey: Array[Byte]
+  ): EncryptedImportedKey =
+    new EncryptedImportedKey(
+      Base16.encode(cipherText),
+      Base16.encode(salt),
+      Base16.encode(iv),
+      Base16.encode(authTag),
+      Base16.encode(publicKey)
+    )
+
+  implicit val encoder: Encoder[EncryptedImportedKey] = deriveEncoder
+  implicit val decoder: Decoder[EncryptedImportedKey] = deriveDecoder
+
+}

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/ImportedSecretsStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/ImportedSecretsStorage.scala
@@ -1,0 +1,202 @@
+package org.ergoplatform.wallet.secrets
+
+import io.circe.parser._
+import io.circe.syntax._
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey, Index}
+import scorex.util.encode.Base16
+import sigma.crypto.{BigIntegers, CryptoFacade}
+import sigmastate.crypto.DLogProtocol.DLogProverInput
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
+import java.util
+import javax.crypto.spec.{GCMParameterSpec, SecretKeySpec}
+import javax.crypto.{AEADBadTagException, Cipher, Mac}
+import scala.util.{Failure, Try}
+
+/**
+  * Persistent storage for raw (non-HD) private keys imported via WIF.
+  *
+  * Each scalar is encrypted with AES-256-GCM under a key-encryption key (KEK)
+  * derived from the wallet's master seed. As a consequence imported keys are
+  * available exactly when the master is unlocked: there is no separate password
+  * prompt at import or export time.
+  *
+  * On disk: a single JSON file (`imported/keys.json` inside the wallet's secret
+  * directory) holding a JSON array of [[EncryptedImportedKey]] records. The
+  * file is rewritten atomically on each append. Absence of the file is
+  * equivalent to "no imported keys".
+  */
+final class ImportedSecretsStorage(val path: Path) {
+
+  private val GcmTagBits: Int = 128
+
+  // KEK retained while wallet is unlocked. Zeroed on lock().
+  private var unlockedKek: Option[Array[Byte]] = None
+  // Decrypted scalars in the order they appear in the file. None == locked.
+  private var unlockedSecrets: Option[Vector[Array[Byte]]] = None
+  // Cached encrypted records (so append can rewrite the file without a re-read).
+  private var encryptedRecords: Vector[EncryptedImportedKey] = Vector.empty
+
+  def isLocked: Boolean = unlockedKek.isEmpty
+
+  def secrets: Option[IndexedSeq[Array[Byte]]] = unlockedSecrets
+
+  /**
+    * Decrypt every record using the given KEK and populate the in-memory list.
+    * If the file does not exist yet the storage unlocks with an empty list.
+    */
+  def unlock(kek: Array[Byte]): Try[Unit] = Try {
+    val (records, decrypted) = if (Files.exists(path)) {
+      val raw = new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+      decode[Vector[EncryptedImportedKey]](raw) match {
+        case Right(rs) =>
+          val ds = rs.map(r => decryptRecord(r, kek).get)
+          (rs, ds)
+        case Left(err) =>
+          throw new Exception(s"Failed to parse imported secrets file: $err")
+      }
+    } else {
+      (Vector.empty[EncryptedImportedKey], Vector.empty[Array[Byte]])
+    }
+    encryptedRecords = records
+    unlockedSecrets = Some(decrypted)
+    unlockedKek = Some(kek.clone())
+  }
+
+  /**
+    * Encrypt a new scalar and persist it. Requires the storage to be unlocked.
+    * `publicKey` is stored alongside in plaintext so the lookup-on-export path
+    * does not have to decrypt every record to find one by address.
+    */
+  def append(scalar: Array[Byte], publicKey: Array[Byte]): Try[Unit] = Try {
+    require(scalar.length == Wif.SecretLength, "imported scalar must be 32 bytes")
+    val kek = unlockedKek.getOrElse(
+      throw new IllegalStateException("imported-secrets storage is locked")
+    )
+    val salt = scorex.utils.Random.randomBytes(32)
+    val iv = scorex.utils.Random.randomBytes(12)
+    val (cipherText, authTag) = encryptRaw(scalar, kek, iv)
+    val record = EncryptedImportedKey(cipherText, salt, iv, authTag, publicKey)
+    encryptedRecords = encryptedRecords :+ record
+    unlockedSecrets = Some(unlockedSecrets.getOrElse(Vector.empty) :+ scalar.clone())
+    writeFile()
+  }
+
+  /** Zero the plaintext list and the KEK. Encrypted-on-disk records are untouched. */
+  def lock(): Unit = {
+    unlockedSecrets.foreach(_.foreach(util.Arrays.fill(_, 0: Byte)))
+    unlockedSecrets = None
+    unlockedKek.foreach(util.Arrays.fill(_, 0: Byte))
+    unlockedKek = None
+  }
+
+  /** Public-keys (compressed sec1 encoding) of all imported records, decrypted or not. */
+  def publicKeys: IndexedSeq[Array[Byte]] =
+    encryptedRecords.map(r => Base16.decode(r.publicKey).get)
+
+  private def writeFile(): Unit = {
+    Files.createDirectories(path.getParent)
+    val tmp = path.resolveSibling(path.getFileName.toString + ".tmp")
+    Files.write(tmp, encryptedRecords.asJson.noSpaces.getBytes(StandardCharsets.UTF_8))
+    Files.move(
+      tmp, path,
+      StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
+    )
+  }
+
+  private def decryptRecord(r: EncryptedImportedKey, kek: Array[Byte]): Try[Array[Byte]] =
+    for {
+      ct  <- Base16.decode(r.cipherText)
+      iv  <- Base16.decode(r.iv)
+      tag <- Base16.decode(r.authTag)
+      pt  <- decryptRaw(ct, kek, iv, tag)
+    } yield pt
+
+  private def encryptRaw(
+    data: Array[Byte],
+    key: Array[Byte],
+    iv: Array[Byte]
+  ): (Array[Byte], Array[Byte]) = {
+    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+    cipher.init(
+      Cipher.ENCRYPT_MODE,
+      new SecretKeySpec(key, "AES"),
+      new GCMParameterSpec(GcmTagBits, iv)
+    )
+    val out = cipher.doFinal(data)
+    val tagLen = GcmTagBits / 8
+    val cipherText = util.Arrays.copyOfRange(out, 0, out.length - tagLen)
+    val tag = util.Arrays.copyOfRange(out, out.length - tagLen, out.length)
+    (cipherText, tag)
+  }
+
+  private def decryptRaw(
+    cipherText: Array[Byte],
+    key: Array[Byte],
+    iv: Array[Byte],
+    authTag: Array[Byte]
+  ): Try[Array[Byte]] = {
+    val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+    cipher.init(
+      Cipher.DECRYPT_MODE,
+      new SecretKeySpec(key, "AES"),
+      new GCMParameterSpec(GcmTagBits, iv)
+    )
+    Try(cipher.doFinal(cipherText ++ authTag)).recoverWith {
+      case _: AEADBadTagException =>
+        Failure(new Throwable("Imported-secret decryption failed (wrong key or tampered file)"))
+      case e: Throwable =>
+        Failure(e)
+    }
+  }
+
+}
+
+object ImportedSecretsStorage {
+
+  /**
+    * Sentinel BIP-32 path component used to mark imported (non-HD) public keys
+    * inside the wallet's tracked-key cache. Picked far out of the practical
+    * derivation space so it cannot collide with anything a user might derive.
+    */
+  val ImportedKeyPathTag: Int = Index.hardIndex(0x7FFFFFFE)
+
+  /** Path used to identify imported key `idx`: `m/2147483646'/idx`. */
+  def importedPathAt(idx: Int): DerivationPath =
+    DerivationPath(List(0, ImportedKeyPathTag, idx), publicBranch = false)
+
+  /** True iff the given path was created by `importedPathAt`. */
+  def isImportedPath(path: DerivationPath): Boolean =
+    path.decodedPath.length == 3 && path.decodedPath(1) == ImportedKeyPathTag
+
+  /**
+    * Build a fake `ExtendedPublicKey` for a non-HD secret. The chain code is
+    * filled with zeroes since imported keys are never further derived from.
+    */
+  def fakeExtendedPubKey(scalar: Array[Byte], idx: Int): ExtendedPublicKey = {
+    val input = DLogProverInput(BigIntegers.fromUnsignedByteArray(scalar))
+    val pkBytes = CryptoFacade.getASN1Encoding(input.publicImage.value, true)
+    new ExtendedPublicKey(pkBytes, Array.fill(32)(0: Byte), importedPathAt(idx))
+  }
+
+  /**
+    * Default location: a subdirectory of the master-seed directory. The
+    * subdirectory keeps `imported/keys.json` out of `JsonSecretStorage.readFile`'s
+    * top-level `*.json` lookup so the master-seed picker is unaffected.
+    */
+  def pathAt(secretDir: String): Path = Paths.get(secretDir, "imported", "keys.json")
+
+  /**
+    * Derive a 32-byte KEK from the unlocked master seed bytes. Uses HMAC-SHA256
+    * with a fixed label, so changing the label deliberately invalidates older
+    * stored imported keys (future migration knob).
+    */
+  def deriveKek(masterSeed: Array[Byte]): Array[Byte] = {
+    val label = "ergo-wif-import-v1".getBytes(StandardCharsets.UTF_8)
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(masterSeed, "HmacSHA256"))
+    mac.doFinal(label)
+  }
+
+}

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/Wif.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/Wif.scala
@@ -1,0 +1,88 @@
+package org.ergoplatform.wallet.secrets
+
+import scorex.crypto.hash.Sha256
+import scorex.util.encode.Base58
+
+import java.util
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Wallet Import Format (WIF) codec for secp256k1 private keys.
+  *
+  * Layout (pre-Base58): version(1) || key(32) || [0x01] || checksum(4)
+  * where checksum = first 4 bytes of SHA256(SHA256(version || key || [0x01])).
+  *
+  * On decode we accept WIFs that carry either the standard Bitcoin version bytes
+  * (0x80 mainnet, 0xEF testnet) or the Ergo-specific bytes defined here.
+  * The optional 0x01 "compressed pubkey" flag is accepted but not required.
+  * On encode we always emit the Ergo-specific version byte and include the flag.
+  */
+object Wif {
+
+  val MainnetByte: Byte = 0x88.toByte
+  val TestnetByte: Byte = 0xC8.toByte
+
+  val BitcoinMainnetByte: Byte = 0x80.toByte
+  val BitcoinTestnetByte: Byte = 0xEF.toByte
+
+  val AcceptedVersionBytes: Set[Byte] =
+    Set(MainnetByte, TestnetByte, BitcoinMainnetByte, BitcoinTestnetByte)
+
+  val CompressionFlag: Byte = 0x01
+
+  val SecretLength: Int = 32
+  val ChecksumLength: Int = 4
+
+  /**
+    * Encode a 32-byte secp256k1 scalar as a WIF string with the compression flag set.
+    */
+  def encode(keyBytes: Array[Byte], mainnet: Boolean): String = {
+    require(
+      keyBytes.length == SecretLength,
+      s"WIF expects $SecretLength-byte secret, got ${keyBytes.length}"
+    )
+    val version = if (mainnet) MainnetByte else TestnetByte
+    val payload = (version +: keyBytes) :+ CompressionFlag
+    val checksum = doubleSha256(payload).take(ChecksumLength)
+    Base58.encode(payload ++ checksum)
+  }
+
+  /**
+    * Decode a WIF string into a 32-byte scalar. Validates Base58, length, version
+    * byte and checksum. The optional compression flag (0x01) is accepted whether
+    * present or absent.
+    */
+  def decode(wif: String): Try[Array[Byte]] =
+    Base58.decode(wif).flatMap { bytes =>
+      val expectedWithFlag = 1 + SecretLength + 1 + ChecksumLength
+      val expectedNoFlag   = 1 + SecretLength + ChecksumLength
+      if (bytes.length != expectedWithFlag && bytes.length != expectedNoFlag) {
+        Failure(new IllegalArgumentException(
+          s"WIF payload of unexpected length: ${bytes.length}"
+        ))
+      } else if (!AcceptedVersionBytes.contains(bytes(0))) {
+        Failure(new IllegalArgumentException(
+          f"WIF version byte 0x${bytes(0) & 0xff}%02x not accepted"
+        ))
+      } else {
+        val (payload, checksum) = bytes.splitAt(bytes.length - ChecksumLength)
+        val expectedChecksum = doubleSha256(payload).take(ChecksumLength)
+        if (!util.Arrays.equals(checksum, expectedChecksum)) {
+          Failure(new IllegalArgumentException("WIF checksum mismatch"))
+        } else if (bytes.length == expectedWithFlag &&
+                   payload(payload.length - 1) != CompressionFlag) {
+          Failure(new IllegalArgumentException(
+            "WIF trailing byte must be 0x01 (compression flag)"
+          ))
+        } else {
+          val secretEnd = if (bytes.length == expectedWithFlag) payload.length - 1
+                          else payload.length
+          Success(util.Arrays.copyOfRange(payload, 1, secretEnd))
+        }
+      }
+    }
+
+  private def doubleSha256(data: Array[Byte]): Array[Byte] =
+    Sha256.hash(Sha256.hash(data))
+
+}

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/ImportedSecretsStorageSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/ImportedSecretsStorageSpec.scala
@@ -1,0 +1,98 @@
+package org.ergoplatform.wallet.secrets
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import java.nio.file.{Files, Path}
+import java.util
+
+class ImportedSecretsStorageSpec
+  extends AnyPropSpec
+    with Matchers {
+
+  private def tmpPath(): Path = {
+    val dir = Files.createTempDirectory("imported-secrets-test")
+    dir.toFile.deleteOnExit() // best-effort JVM-shutdown cleanup; only File exposes this hook
+    ImportedSecretsStorage.pathAt(dir.toString)
+  }
+
+  private def randomScalar(): Array[Byte] = scorex.utils.Random.randomBytes(32)
+  private def randomPubkey(): Array[Byte] = scorex.utils.Random.randomBytes(33)
+  private def randomKek(): Array[Byte] = scorex.utils.Random.randomBytes(32)
+
+  property("empty storage unlocks to an empty list") {
+    val storage = new ImportedSecretsStorage(tmpPath())
+    storage.unlock(randomKek()).get
+    storage.isLocked shouldBe false
+    storage.secrets shouldBe Some(IndexedSeq.empty)
+    storage.publicKeys shouldBe IndexedSeq.empty
+  }
+
+  property("append round-trips through file + unlock") {
+    val path = tmpPath()
+    val kek = randomKek()
+    val s1 = randomScalar()
+    val s2 = randomScalar()
+    val p1 = randomPubkey()
+    val p2 = randomPubkey()
+
+    val a = new ImportedSecretsStorage(path)
+    a.unlock(kek).get
+    a.append(s1, p1).get
+    a.append(s2, p2).get
+    a.secrets.get.length shouldBe 2
+    util.Arrays.equals(a.secrets.get(0), s1) shouldBe true
+    util.Arrays.equals(a.secrets.get(1), s2) shouldBe true
+
+    val b = new ImportedSecretsStorage(path)
+    b.unlock(kek).get
+    b.secrets.get.length shouldBe 2
+    util.Arrays.equals(b.secrets.get(0), s1) shouldBe true
+    util.Arrays.equals(b.secrets.get(1), s2) shouldBe true
+    util.Arrays.equals(b.publicKeys(0), p1) shouldBe true
+    util.Arrays.equals(b.publicKeys(1), p2) shouldBe true
+  }
+
+  property("decrypt fails with wrong KEK") {
+    val path = tmpPath()
+    val storage = new ImportedSecretsStorage(path)
+    storage.unlock(randomKek()).get
+    storage.append(randomScalar(), randomPubkey()).get
+
+    val other = new ImportedSecretsStorage(path)
+    other.unlock(randomKek()).isFailure shouldBe true
+  }
+
+  property("lock zeroes plaintext and clears the in-memory list") {
+    val storage = new ImportedSecretsStorage(tmpPath())
+    val kek = randomKek()
+    storage.unlock(kek).get
+    val scalar = randomScalar()
+    val pubkey = randomPubkey()
+    storage.append(scalar, pubkey).get
+
+    val handle = storage.secrets.get.head
+    storage.lock()
+    storage.isLocked shouldBe true
+    storage.secrets shouldBe None
+    handle.forall(_ == 0.toByte) shouldBe true
+  }
+
+  property("append before unlock is rejected") {
+    val storage = new ImportedSecretsStorage(tmpPath())
+    storage.append(randomScalar(), randomPubkey()).isFailure shouldBe true
+  }
+
+  property("KEK derivation is deterministic and depends on seed") {
+    val seed = randomScalar()
+    val k1 = ImportedSecretsStorage.deriveKek(seed)
+    val k2 = ImportedSecretsStorage.deriveKek(seed)
+    util.Arrays.equals(k1, k2) shouldBe true
+
+    val differentSeed = randomScalar()
+    val k3 = ImportedSecretsStorage.deriveKek(differentSeed)
+    util.Arrays.equals(k1, k3) shouldBe false
+    k1.length shouldBe 32
+  }
+
+}

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/WifSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/WifSpec.scala
@@ -1,0 +1,99 @@
+package org.ergoplatform.wallet.secrets
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scorex.crypto.hash.Sha256
+import scorex.util.encode.Base58
+
+import java.util
+
+class WifSpec
+  extends AnyPropSpec
+    with Matchers
+    with ScalaCheckPropertyChecks {
+
+  private val scalarGen = org.scalacheck.Gen
+    .containerOfN[Array, Byte](Wif.SecretLength, org.scalacheck.Arbitrary.arbByte.arbitrary)
+
+  property("round-trips random 32-byte scalars on mainnet and testnet") {
+    forAll(scalarGen) { scalar =>
+      val mainnetWif = Wif.encode(scalar, mainnet = true)
+      util.Arrays.equals(Wif.decode(mainnetWif).get, scalar) shouldBe true
+
+      val testnetWif = Wif.encode(scalar, mainnet = false)
+      util.Arrays.equals(Wif.decode(testnetWif).get, scalar) shouldBe true
+    }
+  }
+
+  property("emits the chosen Ergo version byte") {
+    forAll(scalarGen) { scalar =>
+      val main = Base58.decode(Wif.encode(scalar, mainnet = true)).get
+      main(0) shouldBe Wif.MainnetByte
+      val test = Base58.decode(Wif.encode(scalar, mainnet = false)).get
+      test(0) shouldBe Wif.TestnetByte
+    }
+  }
+
+  property("emits the 0x01 compression flag") {
+    forAll(scalarGen) { scalar =>
+      val raw = Base58.decode(Wif.encode(scalar, mainnet = true)).get
+      // last 4 bytes are checksum; byte before that is the flag
+      raw(raw.length - Wif.ChecksumLength - 1) shouldBe Wif.CompressionFlag
+    }
+  }
+
+  property("accepts a Bitcoin-prefixed WIF (no Ergo prefix required)") {
+    // Known Bitcoin test vector: compressed mainnet WIF starting with 'K'/'L'.
+    // Private key (hex): 0c28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d
+    val knownWif = "KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
+    val expectedHex = "0c28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d"
+    val decoded = Wif.decode(knownWif).get
+    decoded.map("%02x".format(_)).mkString shouldBe expectedHex
+  }
+
+  property("accepts both flag-present and flag-absent payloads") {
+    forAll(scalarGen) { scalar =>
+      val withFlag = Wif.encode(scalar, mainnet = true)
+      // Construct a flag-absent WIF by hand to make sure decode tolerates it.
+      val noFlag = buildWifWithoutFlag(scalar, Wif.MainnetByte)
+      util.Arrays.equals(Wif.decode(withFlag).get, scalar) shouldBe true
+      util.Arrays.equals(Wif.decode(noFlag).get, scalar) shouldBe true
+    }
+  }
+
+  property("rejects mutated checksum") {
+    forAll(scalarGen) { scalar =>
+      val wif = Wif.encode(scalar, mainnet = true)
+      val bytes = Base58.decode(wif).get
+      bytes(bytes.length - 1) = (bytes(bytes.length - 1) ^ 0xff).toByte
+      Wif.decode(Base58.encode(bytes)).isFailure shouldBe true
+    }
+  }
+
+  property("rejects unknown version byte") {
+    forAll(scalarGen) { scalar =>
+      val bytes = Base58.decode(Wif.encode(scalar, mainnet = true)).get
+      bytes(0) = 0x42.toByte
+      // re-checksum so only the version byte is the problem
+      val payload = bytes.dropRight(Wif.ChecksumLength)
+      val newChecksum = Sha256.hash(Sha256.hash(payload)).take(Wif.ChecksumLength)
+      val rebuilt = payload ++ newChecksum
+      Wif.decode(Base58.encode(rebuilt)).isFailure shouldBe true
+    }
+  }
+
+  property("rejects garbage input") {
+    Wif.decode("not_base58!!!").isFailure shouldBe true
+    Wif.decode("").isFailure shouldBe true
+    // Valid Base58 but wrong length
+    Wif.decode("abc").isFailure shouldBe true
+  }
+
+  private def buildWifWithoutFlag(scalar: Array[Byte], version: Byte): String = {
+    val payload = version +: scalar
+    val checksum = Sha256.hash(Sha256.hash(payload)).take(Wif.ChecksumLength)
+    Base58.encode(payload ++ checksum)
+  }
+
+}

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -5091,6 +5091,98 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
+  /wallet/getPrivateKeyWif:
+    post:
+      security:
+        - ApiKeyAuth: [api_key]
+      summary: Get the private key for a known address in Wallet Import Format
+      description: >
+        Looks up the secret for a P2PK address (HD-derived or previously imported)
+        and returns it Base58-encoded with the Ergo WIF version byte and the
+        standard 0x01 compressed-pubkey flag.
+      operationId: walletGetPrivateKeyWif
+      tags:
+        - wallet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PrivateKeyRequest"
+      responses:
+        '200':
+          description: Successfully retrieved WIF-encoded secret
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - wif
+                properties:
+                  wif:
+                    type: string
+                    description: Base58-encoded WIF private key
+                    example: "PJq..."
+        '404':
+          description: Address not found in wallet database
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /wallet/importWif:
+    post:
+      security:
+        - ApiKeyAuth: [api_key]
+      summary: Import a private key from a Wallet Import Format string
+      description: >
+        Decode a WIF-encoded secp256k1 private key (Bitcoin-compatible 0x80/0xEF
+        prefixes are accepted in addition to the Ergo-specific bytes) and add it
+        as a non-HD signing key in the wallet. The imported key persists across
+        lock/unlock cycles, encrypted at rest under a KEK derived from the
+        wallet's master seed. Requires the wallet to be unlocked.
+      operationId: walletImportWif
+      tags:
+        - wallet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - wif
+              properties:
+                wif:
+                  type: string
+                  description: WIF-encoded private key
+                  example: "PJq..."
+      responses:
+        '200':
+          description: Imported private key, returning the resulting P2PK address
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - address
+                properties:
+                  address:
+                    type: string
+                    description: Encoded P2PK address of the imported key
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
   /mining/candidate:
     get:
       security:

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -67,7 +67,9 @@ case class WalletApiRoute(readersHolder: ActorRef,
         checkSeedR ~
         rescanWalletR ~
         extractHintsR ~
-        getPrivateKeyR
+        getPrivateKeyR ~
+        importWifR ~
+        getPrivateKeyWifR
     }
   }
 
@@ -496,6 +498,24 @@ case class WalletApiRoute(readersHolder: ActorRef,
           }
         case None => NotExists("Address not found in wallet database.")
       }
+    }
+  }
+
+  private val wifString: Directive1[String] = entity(as[Json]).flatMap { p =>
+    p.hcursor.downField("wif").as[String].fold(_ => reject, provide)
+  }
+
+  def importWifR: Route = (path("importWif") & post & wifString) { wif =>
+    withWalletOp(_.importPrivateKeyWif(wif)) {
+      case Success(address) => ApiResponse(Json.obj("address" -> address.toString.asJson))
+      case Failure(t)       => BadRequest(t.getMessage)
+    }
+  }
+
+  def getPrivateKeyWifR: Route = (path("getPrivateKeyWif") & post & p2pkAddress) { p2pk =>
+    withWalletOp(_.exportPrivateKeyWif(p2pk)) {
+      case Success(wif) => ApiResponse(Json.obj("wif" -> wif.asJson))
+      case Failure(t)   => BadRequest(t.getMessage)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -149,6 +149,18 @@ class ErgoWalletActor(settings: ErgoSettings,
     case GetPrivateKeyFromPath(path: DerivationPath) =>
       sender() ! ergoWalletService.getPrivateKeyFromPath(state, path)
 
+    case ImportPrivateKeyWif(wif) =>
+      ergoWalletService.importPrivateKeyWif(state, wif) match {
+        case Success((address, newState)) =>
+          context.become(loadedWallet(newState))
+          sender() ! Success(address)
+        case f @ Failure(_) =>
+          sender() ! f
+      }
+
+    case ExportPrivateKeyWif(p2pk) =>
+      sender() ! ergoWalletService.exportPrivateKeyWif(state, p2pk)
+
     case GetMiningPubKey =>
       state.walletVars.trackedPubKeys.headOption match {
         case Some(pk) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -131,6 +131,18 @@ object ErgoWalletActorMessages {
   final case class GetPrivateKeyFromPath(path: DerivationPath)
 
   /**
+   * Decode a WIF-encoded private key and add it to the wallet as an imported
+   * (non-HD) secret. Returns the resulting P2PK address.
+   */
+  final case class ImportPrivateKeyWif(wif: String)
+
+  /**
+   * Look up the secret associated with the given P2PK address (HD or imported)
+   * and return it WIF-encoded.
+   */
+  final case class ExportPrivateKeyWif(p2pk: P2PKAddress)
+
+  /**
    * Read wallet either from mnemonic or from secret storage
    */
   final case class ReadWallet(state: ErgoWalletState)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -79,6 +79,12 @@ trait ErgoWalletReader extends NodeViewComponent {
   def getPrivateKeyFromPath(path: DerivationPath): Future[Try[DLogProverInput]] =
     (walletActor ? GetPrivateKeyFromPath(path)).mapTo[Try[DLogProverInput]]
 
+  def importPrivateKeyWif(wif: String): Future[Try[P2PKAddress]] =
+    (walletActor ? ImportPrivateKeyWif(wif)).mapTo[Try[P2PKAddress]]
+
+  def exportPrivateKeyWif(p2pk: P2PKAddress): Future[Try[String]] =
+    (walletActor ? ExportPrivateKeyWif(p2pk)).mapTo[Try[String]]
+
   def walletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean): Future[Seq[WalletBox]] =
     (walletActor ? GetWalletBoxes(unspentOnly, considerUnconfirmed)).mapTo[Seq[WalletBox]]
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -18,15 +18,17 @@ import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.{BoxSelector, TrackedBox}
 import org.ergoplatform.wallet.interpreter.{ErgoProvingInterpreter, TransactionHintsBag}
 import org.ergoplatform.wallet.mnemonic.Mnemonic
-import org.ergoplatform.wallet.secrets.JsonSecretStorage
+import org.ergoplatform.wallet.secrets.{ImportedSecretsStorage, JsonSecretStorage, Wif}
 import org.ergoplatform.wallet.settings.SecretStorageSettings
 import org.ergoplatform.wallet.utils.FileUtils
 import scorex.util.ModifierId
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigma.Extensions.CollBytesOps
-import sigma.data.SigmaBoolean
+import sigma.crypto.{BigIntegers, CryptoConstants}
+import sigma.data.{ProveDlog, SigmaBoolean}
 
 import java.io.FileNotFoundException
+import java.nio.file.Files
 import scala.collection.compat.immutable.ArraySeq
 import scala.util.{Failure, Success, Try}
 
@@ -180,6 +182,18 @@ trait ErgoWalletService {
   def deriveNextKey(state: ErgoWalletState, usePreEip3Derivation: Boolean): Try[(DeriveNextKeyResult, ErgoWalletState)]
 
   /**
+    * Decode a WIF-encoded secp256k1 private key and add it to the wallet as a
+    * non-HD (imported) signing key. Requires the wallet to be unlocked.
+    */
+  def importPrivateKeyWif(state: ErgoWalletState, wif: String): Try[(P2PKAddress, ErgoWalletState)]
+
+  /**
+    * Look up the secret for a P2PK address in either the HD set or the imported
+    * set, and return it WIF-encoded (Ergo mainnet/testnet version byte).
+    */
+  def exportPrivateKeyWif(state: ErgoWalletState, p2pk: P2PKAddress): Try[String]
+
+  /**
     * Get unconfirmed transactions from mempool that are associated with given scan id
     * @param state current wallet state
     * @param scanId to get transactions for
@@ -291,10 +305,30 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
           },
           secretStorage => {
             log.info("Wallet loaded successfully and locked")
-            state.copy(secretStorageOpt = Some(secretStorage))
+            state.copy(
+              secretStorageOpt = Some(secretStorage),
+              importedSecretsOpt = Some(importedStorageFor(secretStorage))
+            )
           }
         )
     }
+  }
+
+  private def importedStorageFor(secretStorage: JsonSecretStorage): ImportedSecretsStorage = {
+    // secretStorage.secretFile is a java.io.File from the SDK; bridge to NIO at this boundary only.
+    val parent = secretStorage.secretFile.toPath.toAbsolutePath.getParent.toString
+    new ImportedSecretsStorage(ImportedSecretsStorage.pathAt(parent))
+  }
+
+  /**
+    * Delete any imported-keys file that may be left over in the secret directory
+    * from a previous wallet. Used by init/restore so a fresh master seed never
+    * inherits encrypted records it can no longer decrypt.
+    */
+  private def freshImportedStorage(secretStorage: JsonSecretStorage): ImportedSecretsStorage = {
+    val storage = importedStorageFor(secretStorage)
+    Files.deleteIfExists(storage.path)
+    storage
   }
 
   override def initWallet(state: ErgoWalletState,
@@ -317,7 +351,11 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
             // remove old wallet state, see https://github.com/ergoplatform/ergo/issues/1313
             recreateRegistry(state, settings).flatMap { stateV1 =>
               recreateStorage(stateV1, settings).map { stateV2 =>
-                mnemonic -> stateV2.copy(secretStorageOpt = Some(newSecretStorage), walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings))
+                mnemonic -> stateV2.copy(
+                  secretStorageOpt = Some(newSecretStorage),
+                  importedSecretsOpt = Some(freshImportedStorage(newSecretStorage)),
+                  walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings)
+                )
               }
             }
           }
@@ -341,7 +379,11 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
           // remove old wallet state, see https://github.com/ergoplatform/ergo/issues/1313
           recreateRegistry(state, settings).flatMap { stateV1 =>
             recreateStorage(stateV1, settings).map { stateV2 =>
-              stateV2.copy(secretStorageOpt = Some(secretStorage), walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings))
+              stateV2.copy(
+                secretStorageOpt = Some(secretStorage),
+                importedSecretsOpt = Some(freshImportedStorage(secretStorage)),
+                walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings)
+              )
             }
           }
         }
@@ -373,6 +415,7 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
 
   override def lockWallet(state: ErgoWalletState): ErgoWalletState = {
     state.secretStorageOpt.foreach(_.lock())
+    state.importedSecretsOpt.foreach(_.lock())
     state.copy(walletVars = state.walletVars.resetProver())
   }
 
@@ -583,6 +626,49 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       case None =>
         Failure(new Exception("Unable to derive key, wallet is not initialized"))
     }
+
+  override def importPrivateKeyWif(state: ErgoWalletState, wif: String): Try[(P2PKAddress, ErgoWalletState)] =
+    state.secretStorageOpt match {
+      case Some(secretStorage) if !secretStorage.isLocked =>
+        Wif.decode(wif).flatMap(addImportedSecret(state, _))
+      case Some(_) =>
+        Failure(new Exception("Unable to import key, wallet is locked"))
+      case None =>
+        Failure(new Exception("Unable to import key, wallet is not initialized"))
+    }
+
+  override def exportPrivateKeyWif(state: ErgoWalletState, p2pk: P2PKAddress): Try[String] = {
+    val mainnet = ergoSettings.chainSettings.isMainnet
+    val targetPk = p2pk.pubkey.value
+
+    // Try HD first: walletVars.trackedPubKeys covers HD-derived keys with real paths.
+    state.walletVars.trackedPubKeys.find { pk =>
+      pk.key.value == targetPk && !ImportedSecretsStorage.isImportedPath(pk.path)
+    } match {
+      case Some(hdPk) =>
+        getPrivateKeyFromPath(state, hdPk.path.toPrivateBranch).map { sk =>
+          Wif.encode(BigIntegers.asUnsignedByteArray(Wif.SecretLength, sk.w), mainnet)
+        }
+      case None =>
+        state.importedSecretsOpt match {
+          case Some(iss) if !iss.isLocked =>
+            val pubKeys = iss.publicKeys
+            val secrets = iss.secrets.getOrElse(IndexedSeq.empty)
+            val idx = pubKeys.indexWhere { encoded =>
+              Try(
+                ProveDlog(CryptoConstants.dlogGroup.ctx.decodePoint(encoded)).value == targetPk
+              ).getOrElse(false)
+            }
+            if (idx >= 0 && idx < secrets.length) {
+              Success(Wif.encode(secrets(idx), mainnet))
+            } else {
+              Failure(new Exception("Address not found in wallet database."))
+            }
+          case _ =>
+            Failure(new Exception("Address not found in wallet database."))
+        }
+    }
+  }
 
   override def scanBlockUpdate(state: ErgoWalletState, block: ErgoFullBlock, dustLimit: Option[Long]): Try[ErgoWalletState] =
       WalletScanLogic.scanBlockTransactions(

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -10,7 +10,7 @@ import org.ergoplatform.nodeView.wallet.ErgoWalletState.FilterFn
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.boxes.{BoxSelector, TrackedBox}
-import org.ergoplatform.wallet.secrets.JsonSecretStorage
+import org.ergoplatform.wallet.secrets.{ImportedSecretsStorage, JsonSecretStorage}
 import scorex.util.ScorexLogging
 
 import scala.util.Try
@@ -18,6 +18,7 @@ import scala.util.Try
 case class ErgoWalletState(
     storage: WalletStorage,
     secretStorageOpt: Option[JsonSecretStorage],
+    importedSecretsOpt: Option[ImportedSecretsStorage],
     registry: WalletRegistry,
     offChainRegistry: OffChainRegistry,
     outputsFilter: Option[BloomFilter[Array[Byte]]], // Bloom filter for boxes not being spent to the moment
@@ -144,6 +145,7 @@ object ErgoWalletState {
       ErgoWalletState(
         ergoStorage,
         secretStorageOpt = None,
+        importedSecretsOpt = None,
         registry,
         offChainRegistry,
         outputsFilter = None,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -9,7 +9,7 @@ import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResu
 import org.ergoplatform.nodeView.wallet.persistence.WalletStorage
 import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.sdk.SecretString
-import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey, ExtendedSecretKey}
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DlogSecretKey, ExtendedPublicKey, ExtendedSecretKey}
 import org.ergoplatform.sdk.wallet.{AssetUtils, TokensMap}
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.utils.BoxUtils
@@ -18,11 +18,14 @@ import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
 import org.ergoplatform.wallet.boxes.{BoxSelector, TrackedBox}
 import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.wallet.mnemonic.Mnemonic
+import org.ergoplatform.wallet.secrets.ImportedSecretsStorage
 import org.ergoplatform.wallet.transactions.TransactionBuilder
 import scorex.util.ScorexLogging
 import sigma.Colls
 import sigma.ast.{ByteArrayConstant, ErgoTree}
+import sigma.crypto.BigIntegers
 import sigma.data.ProveDlog
+import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigmastate.eval.Extensions._
 import sigma.Extensions.ArrayOps
 import sigmastate.utils.Extensions._
@@ -50,6 +53,40 @@ trait ErgoWalletSupport extends ScorexLogging {
         }
       }
     }
+
+  /**
+    * Persist an imported (non-HD) secret to disk, register it with the prover, and
+    * surface its address through the wallet's scan cache so the wallet starts
+    * tracking incoming payments to it.
+    */
+  protected def addImportedSecret(state: ErgoWalletState,
+                                  scalar: Array[Byte]): Try[(P2PKAddress, ErgoWalletState)] = {
+    state.importedSecretsOpt match {
+      case None =>
+        Failure(new IllegalStateException("Imported-secrets storage not initialized"))
+      case Some(iss) if iss.isLocked =>
+        Failure(new IllegalStateException("Imported-secrets storage is locked"))
+      case Some(iss) =>
+        val secretKey = DlogSecretKey(DLogProverInput(BigIntegers.fromUnsignedByteArray(scalar)))
+        val newIdx = iss.secrets.fold(0)(_.length)
+        val sentinelPk = ImportedSecretsStorage.fakeExtendedPubKey(scalar, newIdx)
+        val newAddress = P2PKAddress(sentinelPk.key)(addressEncoder)
+
+        val alreadyImported = iss.publicKeys.exists(java.util.Arrays.equals(_, sentinelPk.keyBytes))
+        val hdConflict = state.walletVars.trackedPubKeys.exists(_.key.value == sentinelPk.key.value)
+        if (alreadyImported || hdConflict) {
+          Failure(new IllegalArgumentException(s"Address $newAddress is already in the wallet"))
+        } else {
+          iss.append(scalar, sentinelPk.keyBytes).flatMap { _ =>
+            val newWalletVars = state.walletVars.withImportedKey(secretKey)
+            newWalletVars.stateCacheOpt.get.withNewPubkey(sentinelPk).map { updCache =>
+              val newVars = newWalletVars.copy(stateCacheProvided = Some(updCache))(newWalletVars.settings)
+              newAddress -> state.copy(walletVars = newVars)
+            }
+          }
+        }
+    }
+  }
 
   // call nextPath and derive next key from it
   protected def deriveNextKeyForMasterKey(state: ErgoWalletState,
@@ -123,11 +160,34 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
   }
 
+  /**
+    * Decrypt the wallet's imported (non-HD) secrets with a KEK derived from the
+    * master seed and register them with the in-memory prover and scan cache.
+    * No-op if there is no imported-secrets storage or no imported keys yet.
+    */
+  protected def loadImportedSecrets(state: ErgoWalletState,
+                                    masterKey: ExtendedSecretKey): Try[ErgoWalletState] = Try {
+    state.importedSecretsOpt match {
+      case None => state
+      case Some(iss) =>
+        val kek = ImportedSecretsStorage.deriveKek(masterKey.keyBytes)
+        iss.unlock(kek).get
+        val scalars = iss.secrets.getOrElse(IndexedSeq.empty)
+        scalars.zipWithIndex.foldLeft(state) { case (st, (scalar, idx)) =>
+          val secretKey = DlogSecretKey(DLogProverInput(BigIntegers.fromUnsignedByteArray(scalar)))
+          val sentinelPk = ImportedSecretsStorage.fakeExtendedPubKey(scalar, idx)
+          val newVars = st.walletVars.withImportedKey(secretKey)
+          val newCache = newVars.stateCacheOpt.get.withNewPubkey(sentinelPk).get
+          st.copy(walletVars = newVars.copy(stateCacheProvided = Some(newCache))(newVars.settings))
+        }
+    }
+  }
+
   protected def processUnlock(state: ErgoWalletState,
                               masterKey: ExtendedSecretKey,
                               usePreEip3Derivation: Boolean): Try[ErgoWalletState] = {
     log.info("Starting wallet unlock")
-    convertLegacyClientPaths(state.storage, masterKey).flatMap { _ =>
+    val hdReady = convertLegacyClientPaths(state.storage, masterKey).flatMap { _ =>
       // Now we read previously stored, or just stored during the conversion procedure above, public keys
       // If no public keys in the database yet, add master's public key into it
       val pubKeys = state.storage.readAllKeys().toIndexedSeq
@@ -175,6 +235,7 @@ trait ErgoWalletSupport extends ScorexLogging {
         Try(updatePublicKeys(state, masterKey, pubKeys))
       }
     }
+    hdReady.flatMap(loadImportedSecrets(_, masterKey))
   }
 
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.wallet
 import com.google.common.hash.BloomFilter
 import org.ergoplatform.nodeView.wallet.persistence.WalletStorage
 import org.ergoplatform.nodeView.wallet.scanning.Scan
-import org.ergoplatform.sdk.wallet.secrets.{ExtendedPublicKey, ExtendedSecretKey}
+import org.ergoplatform.sdk.wallet.secrets.{DlogSecretKey, ExtendedPublicKey, ExtendedSecretKey}
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
@@ -82,6 +82,20 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
         this
     }
   }
+
+  /**
+    * Add a non-HD primitive secret to the prover. Mirrors [[withExtendedKey]]
+    * but skips updating the cached HD pubkey list, since imported keys do not
+    * participate in HD derivation.
+    */
+  def withImportedKey(secret: DlogSecretKey): WalletVars =
+    proverOpt match {
+      case Some(prover) =>
+        this.copy(proverOpt = Some(prover.withNewImportedSecret(secret)))
+      case None =>
+        log.warn("Trying to add imported secret, but prover is not initialized")
+        this
+    }
 
   /**
     * Updates parameters of the prover

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -203,6 +203,26 @@ class WalletApiRouteSpec extends AnyFlatSpec
     }
   }
 
+  it should "import a WIF-encoded private key" in {
+    Post(prefix + "/importWif", Json.obj("wif" -> WalletActorStub.exampleWif.asJson)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(WalletActorStub.address.toString)
+    }
+  }
+
+  it should "reject importWif when wif field is missing" in {
+    Post(prefix + "/importWif", Json.obj("notWif" -> "x".asJson)) ~> route ~> check {
+      handled shouldBe false
+    }
+  }
+
+  it should "export a private key as WIF" in {
+    Post(prefix + "/getPrivateKeyWif", Json.obj("address" -> WalletActorStub.address.toString.asJson)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("wif").as[String] shouldEqual Right(WalletActorStub.exampleWif)
+    }
+  }
+
   it should "return wallet boxes" in {
     Get(prefix + "/boxes") ~> route ~> check {
       status shouldBe StatusCodes.OK

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -10,7 +10,7 @@ import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletReg
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, PaymentRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{EqualsScanningPredicate, ScanRequest, ScanWalletInteraction}
 import org.ergoplatform.sdk.SecretString
-import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedSecretKey}
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DlogSecretKey, ExtendedSecretKey}
 import org.ergoplatform.settings.Constants.TrueTree
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.utils.fixtures.WalletFixture
@@ -20,18 +20,22 @@ import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
 import org.ergoplatform.wallet.boxes.{ErgoBoxSerializer, ReplaceCompactCollectBoxSelector, TrackedBox}
 import org.ergoplatform.wallet.crypto.ErgoSignature
-import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
+import org.ergoplatform.wallet.interpreter.{ErgoProvingInterpreter, TransactionHintsBag}
 import org.ergoplatform.wallet.mnemonic.Mnemonic
+import org.ergoplatform.wallet.secrets.Wif
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterAll
 import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
-import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, SType}
+import sigma.crypto.BigIntegers
+import sigma.ast.{ByteArrayConstant, ErgoTree, EvaluatedValue, FalseLeaf, SType}
+import sigma.interpreter.ContextExtension
 import sigmastate.helpers.TestingHelpers.testBox
+import scorex.util.ModifierId
 
 import scala.collection.compat.immutable.ArraySeq
-import scala.util.Random
+import scala.util.{Random, Try}
 
 class ErgoWalletServiceSpec
   extends ErgoCorePropertyTest
@@ -60,6 +64,7 @@ class ErgoWalletServiceSpec
     ErgoWalletState(
       new WalletStorage(store, settings),
       secretStorageOpt = Option.empty,
+      importedSecretsOpt = Option.empty,
       new WalletRegistry(versionedStore)(settings.walletSettings),
       OffChainRegistry.empty,
       outputsFilter = Option.empty,
@@ -328,6 +333,121 @@ class ErgoWalletServiceSpec
     }
   }
 
+  property("WIF import survives lock/unlock and round-trips through export") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val pass = SecretString.create(Random.nextString(10))
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val ws0 = initialState(store, versionedStore)
+
+        // initWallet only creates the encrypted file; we have to unlock to get
+        // a usable in-memory master + prover.
+        val initialized = walletService.initWallet(ws0, settings, pass, Option.empty).get._2
+        val ready = walletService.unlockWallet(
+          walletService.lockWallet(initialized), pass, usePreEip3Derivation = false
+        ).get
+
+        // Use a fixed scalar so the test is deterministic
+        val scalar: Array[Byte] = Base16.decode(
+          "0c28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d"
+        ).get
+        val inputWif = Wif.encode(scalar, mainnet = settings.chainSettings.isMainnet)
+
+        val (importedAddr, afterImport) = walletService.importPrivateKeyWif(ready, inputWif).get
+        afterImport.importedSecretsOpt.get.secrets.get.length shouldBe 1
+        afterImport.walletVars.publicKeyAddresses should contain(importedAddr)
+
+        // Re-export must produce the same WIF (since we encoded with the wallet's network byte)
+        walletService.exportPrivateKeyWif(afterImport, importedAddr).get shouldBe inputWif
+
+        // Lock: imported plaintext is zeroed
+        val locked = walletService.lockWallet(afterImport)
+        locked.importedSecretsOpt.get.isLocked shouldBe true
+        locked.walletVars.proverOpt shouldBe empty
+
+        // Unlock again: imported key reappears with the same address
+        val unlocked = walletService.unlockWallet(locked, pass, usePreEip3Derivation = false).get
+        unlocked.importedSecretsOpt.get.isLocked shouldBe false
+        unlocked.walletVars.publicKeyAddresses should contain(importedAddr)
+        walletService.exportPrivateKeyWif(unlocked, importedAddr).get shouldBe inputWif
+
+        // The prover holds the imported scalar so it can sign with it
+        val proverSecrets = unlocked.walletVars.proverOpt.get.secretKeys
+        val hasImported = proverSecrets.exists {
+          case dlog: DlogSecretKey =>
+            BigIntegers.asUnsignedByteArray(Wif.SecretLength, dlog.privateInput.w).sameElements(scalar)
+          case _ => false
+        }
+        hasImported shouldBe true
+      }
+    }
+  }
+
+  property("imported WIF key can sign a transaction before and after lock/unlock") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val pass = SecretString.create(Random.nextString(10))
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val initialized = walletService.initWallet(
+          initialState(store, versionedStore), settings, pass, Option.empty
+        ).get._2
+        val unlocked = walletService.unlockWallet(
+          walletService.lockWallet(initialized), pass, usePreEip3Derivation = false
+        ).get
+
+        val scalar = Base16.decode(
+          "0c28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d"
+        ).get
+        val wif = Wif.encode(scalar, mainnet = settings.chainSettings.isMainnet)
+        val (importedAddr, withImported) = walletService.importPrivateKeyWif(unlocked, wif).get
+
+        // Build a tx that spends a box locked to the imported P2PK and sends it to itself.
+        val value = 100000000L
+        val height = 10000
+        val box = new ErgoBoxCandidate(value, ErgoTree.fromSigmaBoolean(importedAddr.pubkey), height)
+        val fakeTxId = ModifierId @@ Base16.encode(Array.fill(32)(5: Byte))
+        val inputBox = box.toBox(fakeTxId, 0.toShort)
+        val unsignedInput = new UnsignedInput(inputBox.id, ContextExtension.empty)
+        val utx = new UnsignedErgoLikeTransaction(IndexedSeq(unsignedInput), IndexedSeq.empty, IndexedSeq(box))
+
+        def signWith(state: ErgoWalletState): Try[_] = state.walletVars.proverOpt.get.sign(
+          utx, IndexedSeq(inputBox), IndexedSeq.empty, state.stateContext, TransactionHintsBag.empty
+        )
+
+        signWith(withImported).isSuccess shouldBe true
+
+        // Lock and unlock; the imported key must still sign the same tx.
+        val reUnlocked = walletService.unlockWallet(
+          walletService.lockWallet(withImported), pass, usePreEip3Derivation = false
+        ).get
+        signWith(reUnlocked).isSuccess shouldBe true
+      }
+    }
+  }
+
+  property("WIF import rejects duplicate scalar") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val pass = SecretString.create(Random.nextString(10))
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val initialized = walletService.initWallet(
+          initialState(store, versionedStore), settings, pass, Option.empty
+        ).get._2
+        val ready = walletService.unlockWallet(
+          walletService.lockWallet(initialized), pass, usePreEip3Derivation = false
+        ).get
+
+        val scalar = Base16.decode(
+          "11d28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72ab2"
+        ).get
+        val wif = Wif.encode(scalar, mainnet = settings.chainSettings.isMainnet)
+
+        val afterFirst = walletService.importPrivateKeyWif(ready, wif).get._2
+        walletService.importPrivateKeyWif(afterFirst, wif).isFailure shouldBe true
+      }
+    }
+  }
+
   property("it should derive private key correctly") {
     withVersionedStore(2) { versionedStore =>
       withStore { store =>
@@ -357,6 +477,7 @@ class ErgoWalletServiceSpec
         val walletState = ErgoWalletState(
           new WalletStorage(store, settings),
           secretStorageOpt = Option.empty,
+          importedSecretsOpt = Option.empty,
           new WalletRegistry(versionedStore)(settings.walletSettings),
           OffChainRegistry.empty,
           outputsFilter = Option.empty,
@@ -398,6 +519,7 @@ class ErgoWalletServiceSpec
         val walletState = ErgoWalletState(
           new WalletStorage(store, settings),
           secretStorageOpt = Option.empty,
+          importedSecretsOpt = Option.empty,
           new WalletRegistry(versionedStore)(settings.walletSettings),
           OffChainRegistry.empty,
           outputsFilter = Option.empty,

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -215,6 +215,10 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
 
       case DeriveKey(_) => sender() ! Success(WalletActorStub.address)
 
+      case ImportPrivateKeyWif(_) => sender() ! Success(WalletActorStub.address)
+
+      case ExportPrivateKeyWif(_) => sender() ! Success(WalletActorStub.exampleWif)
+
       case DeriveNextKey => sender() !
         DeriveNextKeyResult(Success((WalletActorStub.path, WalletActorStub.address, WalletActorStub.secretKey)))
 
@@ -278,6 +282,9 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
     val path = DerivationPath(List(0, 1, 2), publicBranch = false)
     val secretKey = ExtendedSecretKey.deriveMasterKey(Mnemonic.toSeed(SecretString.create(mnemonic)), usePre1627KeyDerivation = false).derive(path)
     val address = P2PKAddress(proveDlogGen.sample.get)
+    val exampleWif: String = org.ergoplatform.wallet.secrets.Wif.encode(
+      Array.fill(32)(7: Byte), mainnet = settings.chainSettings.isMainnet
+    )
 
     val walletBoxN_N: WalletBox = WalletBox(
       TrackedBox(


### PR DESCRIPTION
Closes #848

## Summary

Adds Wallet Import Format (WIF) support to the wallet API:

- **`POST /wallet/getPrivateKeyWif`** — return any wallet address's private key as a Base58 WIF string.
- **`POST /wallet/importWif`** — import a raw secp256k1 scalar from a WIF string as a non-HD signing key. Persists across lock/unlock, encrypted at rest.

## Design notes

- **WIF layout**: `version(1) || key(32) || 0x01 || checksum(4)`, Base58. `0x01` matches Bitcoin's compressed-WIF convention.
- **Network bytes**: emit `0x88` mainnet / `0xC8` testnet; accept `0x80`/`0xEF` on import too, so Bitcoin paper WIFs round-trip (both chains share secp256k1).
- **Persistence**: imported scalars are AES-256-GCM-encrypted under a KEK derived from the unlocked master seed via HMAC-SHA256. Stored as a JSON array at `<secretDir>/imported/keys.json`, rewritten atomically on each append. Locking zeroes both the KEK and the plaintexts; `initWallet`/`restoreWallet` wipe stale files so a new seed never inherits blobs it can't decrypt.
- **HD compatibility**: imported keys live in the prover's `secretKeys` as `DlogSecretKey`, never as `ExtendedSecretKey`, so HD derivation is untouched. They're plumbed through `WalletCache` (scan filter, balance, mining scripts) via a sentinel `ExtendedPublicKey` with zero chain code and path `m/2147483646'/idx`, well outside the practical derivation space.

~30 new test cases across `WifSpec`, `ImportedSecretsStorageSpec`, `ErgoWalletServiceSpec`, and `WalletApiRouteSpec` — codec, encrypted storage, end-to-end signing across lock/unlock, and HTTP routes.

## Deliberately out of scope

- HD derivation off an imported key (chain code unknown).
- Removing imported keys / bulk import / CLI tool.