### PR TITLE
support context variables when spending user-provided input

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -704,6 +704,20 @@ components:
           items:
             type: string
             description: hex-encoded serialized box bytes
+        context:
+          description: |
+            Optional context variables to attach to inputsRaw, one ContextExtension per input in the same order.
+            Length of `context.extension` must equal length of `inputsRaw`.
+          type: object
+          properties:
+            extension:
+              type: array
+              items:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/SValue'
+                example:
+                  '1': 'a2aed72ff1b139f35d1ad2938cb44c9848a34d4dcfd6d8ab717ebde40a7304f2541cf628ffc8b5c496e6161eba3f169c6dd440704b1719e0'
 
     SourceHolder:
       type: object

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -24,6 +24,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import akka.http.scaladsl.server.MissingQueryParamRejection
 import org.ergoplatform.sdk.SecretString
+import sigma.interpreter.ContextExtension
 
 case class WalletApiRoute(readersHolder: ActorRef,
                           nodeViewActorRef: ActorRef,
@@ -158,9 +159,10 @@ case class WalletApiRoute(readersHolder: ActorRef,
   private def generateTransactionAndProcess(requests: Seq[TransactionGenerationRequest],
                                             inputsRaw: Seq[String],
                                             dataInputsRaw: Seq[String],
+                                            extensions: Seq[ContextExtension],
                                             verifyFn: ErgoTransaction => Future[Try[UnconfirmedTransaction]],
                                             processFn: UnconfirmedTransaction => Route): Route = {
-    withWalletOp(_.generateTransaction(requests, inputsRaw, dataInputsRaw).flatMap(txTry => txTry match {
+    withWalletOp(_.generateTransaction(requests, inputsRaw, dataInputsRaw, extensions).flatMap(txTry => txTry match {
       case Success(tx) => verifyFn(tx)
       case Failure(e) => Future(Failure[UnconfirmedTransaction](e))
     })) {
@@ -171,11 +173,13 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   private def generateTransaction(requests: Seq[TransactionGenerationRequest],
                                   inputsRaw: Seq[String],
-                                  dataInputsRaw: Seq[String]): Route = {
+                                  dataInputsRaw: Seq[String],
+                                  extensions: Seq[ContextExtension]): Route = {
     generateTransactionAndProcess(
       requests,
       inputsRaw,
       dataInputsRaw,
+      extensions,
       tx => Future(Success(UnconfirmedTransaction(tx, source = None))),
       utx => ApiResponse(utx.transaction)
     )
@@ -183,8 +187,9 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   private def generateUnsignedTransaction(requests: Seq[TransactionGenerationRequest],
                                           inputsRaw: Seq[String],
-                                          dataInputsRaw: Seq[String]): Route = {
-    withWalletOp(_.generateUnsignedTransaction(requests, inputsRaw, dataInputsRaw)) {
+                                          dataInputsRaw: Seq[String],
+                                          extensions: Seq[ContextExtension]): Route = {
+    withWalletOp(_.generateUnsignedTransaction(requests, inputsRaw, dataInputsRaw, extensions)) {
       case Failure(e) => BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
       case Success(utx) => ApiResponse(utx)
     }
@@ -192,8 +197,9 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   private def sendTransaction(requests: Seq[TransactionGenerationRequest],
                               inputsRaw: Seq[String],
-                              dataInputsRaw: Seq[String]): Route = {
-    generateTransactionAndProcess(requests, inputsRaw, dataInputsRaw,
+                              dataInputsRaw: Seq[String],
+                              extensions: Seq[ContextExtension]): Route = {
+    generateTransactionAndProcess(requests, inputsRaw, dataInputsRaw, extensions,
       tx => verifyTransaction(tx, readersHolder, ergoSettings),
       validTx => sendLocalTransactionRoute(nodeViewActorRef, validTx)
     )
@@ -201,17 +207,17 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def sendTransactionR: Route =
     (path("transaction" / "send") & post & entity(as[RequestsHolder])) { holder =>
-      sendTransaction(holder.withFee(), holder.inputsRaw, holder.dataInputsRaw)
+      sendTransaction(holder.withFee(), holder.inputsRaw, holder.dataInputsRaw, holder.extensions)
     }
 
   def generateTransactionR: Route =
     (path("transaction" / "generate") & post & entity(as[RequestsHolder])) { holder =>
-      generateTransaction(holder.withFee(), holder.inputsRaw, holder.dataInputsRaw)
+      generateTransaction(holder.withFee(), holder.inputsRaw, holder.dataInputsRaw, holder.extensions)
     }
 
   def generateUnsignedTransactionR: Route =
     (path("transaction" / "generateUnsigned") & post & entity(as[RequestsHolder])) { holder =>
-      generateUnsignedTransaction(holder.withFee(), holder.inputsRaw, holder.dataInputsRaw)
+      generateUnsignedTransaction(holder.withFee(), holder.inputsRaw, holder.dataInputsRaw, holder.extensions)
     }
 
   def generateCommitmentsR: Route = (path("generateCommitments")
@@ -267,7 +273,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def sendPaymentTransactionR: Route = (path("payment" / "send") & post
     & entity(as[Seq[PaymentRequest]])) { requests =>
-    sendTransaction(withFee(requests), Seq.empty, Seq.empty)
+    sendTransaction(withFee(requests), Seq.empty, Seq.empty, Seq.empty)
   }
 
   def collectBoxesR: Route = (path("boxes" / "collect") & post

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -363,8 +363,8 @@ class ErgoWalletActor(settings: ErgoSettings,
       val status = WalletStatus(isSecretSet, isUnlocked, changeAddress, height, lastError)
       sender() ! status
 
-    case GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign) =>
-      val txTry = ergoWalletService.generateTransaction(state, boxSelector, requests, inputsRaw, dataInputsRaw, sign)
+    case GenerateTransaction(requests, inputsRaw, dataInputsRaw, extensions, sign) =>
+      val txTry = ergoWalletService.generateTransaction(state, boxSelector, requests, inputsRaw, dataInputsRaw, extensions, sign)
       sender() ! txTry
 
     case GenerateCommitmentsFor(unsignedTx, externalSecretsOpt, externalInputsOpt, externalDataInputsOpt) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -16,6 +16,7 @@ import org.ergoplatform.core.VersionTag
 import org.ergoplatform.sdk.SecretString
 import scorex.util.ModifierId
 import sigma.data.{ProveDlog, SigmaBoolean}
+import sigma.interpreter.ContextExtension
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 
 import scala.util.Try
@@ -64,11 +65,13 @@ object ErgoWalletActorMessages {
    * @param requests
    * @param inputsRaw
    * @param dataInputsRaw
+   * @param extensions   context variables, one ContextExtension per inputsRaw entry (empty for empty extension)
    * @param sign
    */
   final case class GenerateTransaction(requests: Seq[TransactionGenerationRequest],
                                        inputsRaw: Seq[String],
                                        dataInputsRaw: Seq[String],
+                                       extensions: Seq[ContextExtension],
                                        sign: Boolean)
 
   /**

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -19,6 +19,7 @@ import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.{ErgoBox, NodeViewComponent, P2PKAddress}
 import scorex.util.ModifierId
 import sigma.data.SigmaBoolean
+import sigma.interpreter.ContextExtension
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 
 import java.util.concurrent.TimeUnit
@@ -99,8 +100,9 @@ trait ErgoWalletReader extends NodeViewComponent {
 
   def generateTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
-                          dataInputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
-    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = true))
+                          dataInputsRaw: Seq[String] = Seq.empty,
+                          extensions: Seq[ContextExtension] = Seq.empty): Future[Try[ErgoTransaction]] =
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, extensions, sign = true))
       .mapTo[Try[ErgoTransaction]]
 
   def generateCommitmentsFor(unsignedErgoTransaction: UnsignedErgoTransaction,
@@ -113,8 +115,9 @@ trait ErgoWalletReader extends NodeViewComponent {
 
   def generateUnsignedTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
-                          dataInputsRaw: Seq[String] = Seq.empty): Future[Try[UnsignedErgoTransaction]] =
-    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = false)).mapTo[Try[UnsignedErgoTransaction]]
+                          dataInputsRaw: Seq[String] = Seq.empty,
+                          extensions: Seq[ContextExtension] = Seq.empty): Future[Try[UnsignedErgoTransaction]] =
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, extensions, sign = false)).mapTo[Try[UnsignedErgoTransaction]]
 
 
   def signTransaction(tx: UnsignedErgoTransaction,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -25,6 +25,7 @@ import scorex.util.ModifierId
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigma.Extensions.CollBytesOps
 import sigma.data.SigmaBoolean
+import sigma.interpreter.ContextExtension
 
 import java.io.FileNotFoundException
 import scala.collection.compat.immutable.ArraySeq
@@ -234,12 +235,16 @@ trait ErgoWalletService {
 
   /**
     * Generate signed or unsigned transaction.
+    *
+    * @param extensions optional per-input context extensions, matching the order of `inputsRaw`.
+    *                   Pass `Seq.empty` to attach `ContextExtension.empty` to every input.
     */
   def generateTransaction(state: ErgoWalletState,
                           boxSelector: BoxSelector,
                           requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String],
                           dataInputsRaw: Seq[String],
+                          extensions: Seq[ContextExtension],
                           sign: Boolean): Try[ErgoLikeTransactionTemplate[_]]
 
   /**
@@ -471,8 +476,9 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
                           requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String],
                           dataInputsRaw: Seq[String],
+                          extensions: Seq[ContextExtension],
                           sign: Boolean): Try[ErgoLikeTransactionTemplate[_]] = {
-    val tx = generateUnsignedTransaction(state, boxSelector, requests, inputsRaw, dataInputsRaw)
+    val tx = generateUnsignedTransaction(state, boxSelector, requests, inputsRaw, dataInputsRaw, extensions)
     if (sign) {
       tx.flatMap { case (unsignedTx, inputs, dataInputs) =>
         state.walletVars.proverOpt match {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -23,9 +23,11 @@ import scorex.util.ScorexLogging
 import sigma.Colls
 import sigma.ast.{ByteArrayConstant, ErgoTree}
 import sigma.data.ProveDlog
+import sigma.interpreter.ContextExtension
 import sigmastate.eval.Extensions._
 import sigma.Extensions.ArrayOps
 import sigmastate.utils.Extensions._
+import scorex.util.{ModifierId, bytesToId}
 
 import scala.util.{Failure, Success, Try}
 
@@ -236,7 +238,8 @@ trait ErgoWalletSupport extends ScorexLogging {
                                            walletHeight: Int,
                                            selectionResult: BoxSelectionResult[TrackedBox],
                                            dataInputBoxes: IndexedSeq[ErgoBox],
-                                           changeAddressOpt: Option[ProveDlog]): Try[UnsignedErgoTransaction] = Try {
+                                           changeAddressOpt: Option[ProveDlog],
+                                           extensionByBoxId: Map[ModifierId, ContextExtension]): Try[UnsignedErgoTransaction] = Try {
     if (selectionResult.changeBoxes.nonEmpty) {
       require(changeAddressOpt.isDefined, "Does not have change address to send change to")
     }
@@ -259,7 +262,7 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
     val inputBoxes = selectionResult.inputBoxes.toIndexedSeq
     new UnsignedErgoTransaction(
-      inputBoxes.map(tx => new UnsignedInput(tx.box.id)),
+      inputBoxes.map(tx => new UnsignedInput(tx.box.id, extensionByBoxId.getOrElse(bytesToId(tx.box.id), ContextExtension.empty))),
       dataInputs,
       (payTo ++ changeBoxCandidates).toIndexedSeq
     )
@@ -274,16 +277,24 @@ trait ErgoWalletSupport extends ScorexLogging {
     *                      the (sum(inputs) == sum(outputs)) preservation rule for ergs.
     * @param dataInputsRaw - user-provided data (read-only) inputs. Wallet is not able to figure out needed data inputs
     *                      (to spend the spendable inputs).
+    * @param extensions    - optional per-input context extensions, parallel to `inputsRaw`. When non-empty it must have
+    *                      the same length as `inputsRaw`; each entry is attached to the matching input's `UnsignedInput`.
+    *                      Empty means no context variables on any input.
     * @return generated transaction along with its inputs and data-inputs, or an error
     */
   protected def generateUnsignedTransaction(state: ErgoWalletState,
                                             boxSelector: BoxSelector,
                                             requests: Seq[TransactionGenerationRequest],
                                             inputsRaw: Seq[String],
-                                            dataInputsRaw: Seq[String]): Try[(UnsignedErgoTransaction, IndexedSeq[ErgoBox], IndexedSeq[ErgoBox])] = Try {
+                                            dataInputsRaw: Seq[String],
+                                            extensions: Seq[ContextExtension]): Try[(UnsignedErgoTransaction, IndexedSeq[ErgoBox], IndexedSeq[ErgoBox])] = Try {
     require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issuance requests")
+    require(extensions.isEmpty || extensions.size == inputsRaw.size,
+      s"extensions size (${extensions.size}) must match inputsRaw size (${inputsRaw.size})")
 
     val userInputs = ErgoWalletServiceUtils.stringsToBoxes(inputsRaw)
+    val extensionByBoxId: Map[ModifierId, ContextExtension] =
+      userInputs.zip(extensions).map { case (box, ext) => bytesToId(box.id) -> ext }.toMap
 
     val inputBoxes = if (userInputs.nonEmpty) {
       // make TrackedBox sequence out of boxes provided
@@ -340,7 +351,7 @@ trait ErgoWalletSupport extends ScorexLogging {
         val dataInputs = ErgoWalletServiceUtils.stringsToBoxes(dataInputsRaw).toIndexedSeq
         selectionOpt.map { selectionResult =>
           val changeAddressOpt: Option[ProveDlog] = state.getChangeAddress(addressEncoder).map(_.pubkey)
-          prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.inputBoxes
+          prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt, extensionByBoxId) -> selectionResult.inputBoxes
         } match {
           case Right((txTry, inputs)) => txTry.map(tx => (tx, inputs.map(_.box).toIndexedSeq, dataInputs))
           case Left(e) => Failure(

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolder.scala
@@ -1,17 +1,19 @@
 package org.ergoplatform.nodeView.wallet.requests
 
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 import org.ergoplatform.http.api.ApiCodecs
 import org.ergoplatform.nodeView.wallet.ErgoAddressJsonEncoder
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, ErgoTreePredef, Pay2SAddress}
+import sigma.interpreter.ContextExtension
 
 
 case class RequestsHolder(requests: Seq[TransactionGenerationRequest],
                           feeOpt: Option[Long],
                           inputsRaw: Seq[String],
                           dataInputsRaw: Seq[String],
+                          extensions: Seq[ContextExtension],
                           minerRewardDelay: Int)
                          (implicit val addressEncoder: ErgoAddressEncoder) {
 
@@ -32,17 +34,24 @@ class RequestsHolderEncoder(ergoSettings: ErgoSettings) extends Encoder[Requests
   implicit val addressEncoder: Encoder[ErgoAddress] = ErgoAddressJsonEncoder(ergoSettings.chainSettings).encoder
 
   def apply(holder: RequestsHolder): Json = {
-    Json.obj(
+    val base = Json.obj(
       "requests" -> holder.requests.asJson,
       "fee" -> holder.feeOpt.asJson,
       "inputsRaw" -> holder.inputsRaw.asJson,
       "dataInputsRaw" -> holder.dataInputsRaw.asJson
     )
+    if (holder.extensions.nonEmpty) {
+      base.deepMerge(Json.obj(
+        "context" -> Json.obj("extension" -> holder.extensions.asJson)
+      ))
+    } else {
+      base
+    }
   }
 
 }
 
-class RequestsHolderDecoder(settings: ErgoSettings) extends Decoder[RequestsHolder] {
+class RequestsHolderDecoder(settings: ErgoSettings) extends Decoder[RequestsHolder] with ApiCodecs {
 
   implicit val transactionRequestDecoder: TransactionRequestDecoder = new TransactionRequestDecoder(settings)
   implicit val addressEncoder: ErgoAddressEncoder = new ErgoAddressEncoder(settings.chainSettings.addressPrefix)
@@ -55,7 +64,18 @@ class RequestsHolderDecoder(settings: ErgoSettings) extends Decoder[RequestsHold
       fee <- cursor.downField("fee").as[Option[Long]]
       inputs <- cursor.downField("inputsRaw").as[Option[Seq[String]]]
       dataInputs <- cursor.downField("dataInputsRaw").as[Option[Seq[String]]]
-    } yield RequestsHolder(requests, fee, inputs.getOrElse(Seq.empty), dataInputs.getOrElse(Seq.empty), minerRewardDelay)
+      extensions <- cursor.downField("context").downField("extension").as[Option[Seq[ContextExtension]]]
+      inputsSeq = inputs.getOrElse(Seq.empty)
+      extSeq = extensions.getOrElse(Seq.empty)
+      _ <- if (extSeq.nonEmpty && extSeq.size != inputsSeq.size) {
+        Left(DecodingFailure(
+          s"context.extension length (${extSeq.size}) must match inputsRaw length (${inputsSeq.size})",
+          cursor.history
+        ))
+      } else {
+        Right(())
+      }
+    } yield RequestsHolder(requests, fee, inputsSeq, dataInputs.getOrElse(Seq.empty), extSeq, minerRewardDelay)
   }
 
 }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -58,6 +58,7 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Some(10000L),
     Seq.empty,
     Seq.empty,
+    Seq.empty,
     minerRewardDelay = 720
   )(settings.addressEncoder)
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -27,7 +27,8 @@ import org.scalatest.BeforeAndAfterAll
 import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
-import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, SType}
+import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, IntConstant, SType}
+import sigma.interpreter.ContextExtension
 import sigmastate.helpers.TestingHelpers.testBox
 
 import scala.collection.compat.immutable.ArraySeq
@@ -107,14 +108,14 @@ class ErgoWalletServiceSpec
     forAll(ergoBoxCandidateGen, ergoBoxCandidateGen, validErgoTransactionGen, proveDlogGen) {
       case (outputCandidate, outputChangeCandidate, (ergoBoxes, _), proveDlog) =>
         val selectionResult = new BoxSelectionResult(inputBoxes, Seq(outputChangeCandidate), None)
-        val tx = prepareUnsignedTransaction(Seq(outputCandidate), startHeight, selectionResult, ergoBoxes, Option(proveDlog)).get
+        val tx = prepareUnsignedTransaction(Seq(outputCandidate), startHeight, selectionResult, ergoBoxes, Option(proveDlog), Map.empty).get
         tx.inputs shouldBe inputBoxes.map(_.box.id).map(id => new UnsignedInput(id))
         tx.dataInputs shouldBe ergoBoxes.map(dataInputBox => DataInput(dataInputBox.id))
         tx.outputCandidates.size shouldBe 2
         tx.outputCandidates.map(_.value).sum shouldBe outputCandidate.value + outputChangeCandidate.value
 
         val txWithChangeBoxesButNoChangeAddress =
-          prepareUnsignedTransaction(Seq(outputCandidate), startHeight, selectionResult, ergoBoxes, Option.empty)
+          prepareUnsignedTransaction(Seq(outputCandidate), startHeight, selectionResult, ergoBoxes, Option.empty, Map.empty)
         txWithChangeBoxesButNoChangeAddress.isFailure shouldBe true
     }
   }
@@ -185,13 +186,14 @@ class ErgoWalletServiceSpec
               Seq(paymentRequest),
               inputsRaw = encodedBoxes,
               dataInputsRaw = Seq.empty,
+              extensions = Seq.empty,
               sign = true
             ).get.asInstanceOf[ErgoTransaction], None)
 
           // let's create wallet state with an unconfirmed transaction in mempool
           val wState = initialState(store, versionedStore, Some(new FakeMempool(Seq(unconfirmedTx))))
           val signedTx1 =
-            walletService.generateTransaction(wState, boxSelector, Seq(paymentRequest), inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty, sign = true)
+            walletService.generateTransaction(wState, boxSelector, Seq(paymentRequest), inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty, extensions = Seq.empty, sign = true)
               .get.asInstanceOf[ErgoTransaction]
           val walletTx1 = WalletTransaction(signedTx1, 100, Seq(ScanId @@ 0.shortValue()))
 
@@ -256,7 +258,7 @@ class ErgoWalletServiceSpec
         val paymentRequest = PaymentRequest(pks.head, 50000, Array.empty, Map.empty)
         val boxSelector = new ReplaceCompactCollectBoxSelector(settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None)
 
-        val (tx, inputs, dataInputs) = generateUnsignedTransaction(wState, boxSelector, Seq(paymentRequest), inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty).get
+        val (tx, inputs, dataInputs) = generateUnsignedTransaction(wState, boxSelector, Seq(paymentRequest), inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty, extensions = Seq.empty).get
         dataInputs shouldBe empty
         inputs.size shouldBe 1
         tx.inputs.size shouldBe 1
@@ -264,12 +266,70 @@ class ErgoWalletServiceSpec
         tx.outputs.map(_.value).sum shouldBe inputs.map(_.value).sum
 
         val walletService = new ErgoWalletServiceImpl(settings)
-        val signedTx = walletService.generateTransaction(wState, boxSelector, Seq(paymentRequest), inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty, sign = true).get.asInstanceOf[ErgoTransaction]
+        val signedTx = walletService.generateTransaction(wState, boxSelector, Seq(paymentRequest), inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty, extensions = Seq.empty, sign = true).get.asInstanceOf[ErgoTransaction]
 
         ErgoSignature.verify(signedTx.messageToSign, signedTx.inputs.head.spendingProof.proof, pks.head.pubkey.value) shouldBe true
         signedTx.inputs.size shouldBe 1
         signedTx.outputs.size shouldBe 2
 
+      }
+    }
+  }
+
+  property("it should attach context extensions to user-provided inputs") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+
+        val userBoxes = boxesAvailable(makeGenesisBlock(pks.head.pubkey, randomNewAsset), pks.head.pubkey)
+        val encodedBoxes = userBoxes.map(box => Base16.encode(ErgoBoxSerializer.toBytes(box)))
+
+        val ext: ContextExtension = ContextExtension(
+          Map[Byte, EvaluatedValue[SType]](1.toByte -> IntConstant(42))
+        )
+        val extensions = Seq.fill(userBoxes.size)(ext)
+
+        val paymentRequest = PaymentRequest(pks.head, 50000, Array.empty, Map.empty)
+        val boxSelector = new ReplaceCompactCollectBoxSelector(
+          settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None
+        )
+
+        val (utx, inputs, _) = generateUnsignedTransaction(
+          wState, boxSelector, Seq(paymentRequest),
+          inputsRaw = encodedBoxes,
+          dataInputsRaw = Seq.empty,
+          extensions = extensions
+        ).get
+
+        inputs.size shouldBe userBoxes.size
+        utx.inputs.size shouldBe userBoxes.size
+        utx.inputs.foreach(_.extension shouldBe ext)
+      }
+    }
+  }
+
+  property("it should reject extensions whose size does not match inputsRaw") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+
+        val userBoxes = boxesAvailable(makeGenesisBlock(pks.head.pubkey, randomNewAsset), pks.head.pubkey)
+        val encodedBoxes = userBoxes.map(box => Base16.encode(ErgoBoxSerializer.toBytes(box)))
+
+        val paymentRequest = PaymentRequest(pks.head, 50000, Array.empty, Map.empty)
+        val boxSelector = new ReplaceCompactCollectBoxSelector(
+          settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None
+        )
+
+        val result = generateUnsignedTransaction(
+          wState, boxSelector, Seq(paymentRequest),
+          inputsRaw = encodedBoxes,
+          dataInputsRaw = Seq.empty,
+          extensions = Seq(ContextExtension.empty) // length mismatch when encodedBoxes.size > 1
+        )
+
+        // Either length is 1 (matches) or it fails — only check the mismatch case
+        if (encodedBoxes.size != 1) result.isFailure shouldBe true
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/requests/RequestsHolderSpec.scala
@@ -1,0 +1,86 @@
+package org.ergoplatform.nodeView.wallet.requests
+
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.ergoplatform.Pay2SAddress
+import org.ergoplatform.http.api.ApiCodecs
+import org.ergoplatform.settings.Constants.FalseTree
+import org.ergoplatform.utils.ErgoNodeTestConstants
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigma.ast.{EvaluatedValue, IntConstant, SType}
+import sigma.interpreter.ContextExtension
+
+class RequestsHolderSpec extends AnyFlatSpec with Matchers with ApiCodecs {
+
+  private val settings = ErgoNodeTestConstants.settings
+  override implicit val ergoAddressEncoder = settings.addressEncoder
+  private implicit val encoder: RequestsHolderEncoder = new RequestsHolderEncoder(settings)
+  private implicit val decoder: RequestsHolderDecoder = new RequestsHolderDecoder(settings)
+
+  private val paymentRequest = PaymentRequest(
+    Pay2SAddress(FalseTree)(ergoAddressEncoder), 100L, Array.empty, Map.empty
+  )
+
+  private def ext(pairs: (Byte, EvaluatedValue[SType])*): ContextExtension =
+    ContextExtension(pairs.toMap)
+
+  "RequestsHolder" should "round-trip without context extensions" in {
+    val holder = RequestsHolder(
+      Seq(paymentRequest), Some(1000L),
+      inputsRaw = Seq("1a2b"),
+      dataInputsRaw = Seq.empty,
+      extensions = Seq.empty,
+      minerRewardDelay = 720
+    )
+    val decoded = decode[RequestsHolder](holder.asJson.noSpaces)
+    decoded shouldBe 'right
+    decoded.right.get.extensions shouldBe Seq.empty
+    decoded.right.get.inputsRaw shouldBe Seq("1a2b")
+  }
+
+  it should "round-trip a context.extension array matching inputsRaw" in {
+    val e0 = ext(1.toByte -> IntConstant(5).asInstanceOf[EvaluatedValue[SType]])
+    val e1 = ext(
+      2.toByte -> IntConstant(7).asInstanceOf[EvaluatedValue[SType]],
+      3.toByte -> IntConstant(11).asInstanceOf[EvaluatedValue[SType]]
+    )
+    val holder = RequestsHolder(
+      Seq(paymentRequest), Some(1000L),
+      inputsRaw = Seq("1a2b", "2b3c"),
+      dataInputsRaw = Seq.empty,
+      extensions = Seq(e0, e1),
+      minerRewardDelay = 720
+    )
+
+    val json = holder.asJson
+    json.hcursor.downField("context").downField("extension").as[Seq[ContextExtension]] shouldBe Right(Seq(e0, e1))
+
+    val decoded = decode[RequestsHolder](json.noSpaces)
+    decoded shouldBe 'right
+    decoded.right.get.extensions shouldBe Seq(e0, e1)
+  }
+
+  it should "reject a request where context.extension length != inputsRaw length" in {
+    val bad =
+      """{
+        |  "requests": [],
+        |  "fee": 1000,
+        |  "inputsRaw": ["1a2b", "2b3c"],
+        |  "context": { "extension": [ { "1": "0402" } ] }
+        |}""".stripMargin
+    decode[RequestsHolder](bad) shouldBe 'left
+  }
+
+  it should "accept a request that omits the context object entirely" in {
+    val plain =
+      """{
+        |  "requests": [],
+        |  "fee": 1000,
+        |  "inputsRaw": ["1a2b"]
+        |}""".stripMargin
+    val decoded = decode[RequestsHolder](plain)
+    decoded shouldBe 'right
+    decoded.right.get.extensions shouldBe Seq.empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -260,7 +260,7 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
       case ReadScans =>
         sender() ! ReadScansResponse(apps.values.toSeq)
 
-      case GenerateTransaction(_, _, _, _) =>
+      case GenerateTransaction(_, _, _, _, _) =>
         val input = inputGen.sample.value
         val tx = ErgoTransaction(IndexedSeq(input), IndexedSeq(ergoBoxCandidateGen.sample.value))
         sender() ! Success(tx)


### PR DESCRIPTION
Closes #938 

Adds an optional `context.extension` array to the `RequestsHolder` JSON accepted by `/wallet/transaction/generate`, `/wallet/transaction/generateUnsigned`, and `/wallet/transaction/send`. Each entry is a `ContextExtension` paired by index with `inputsRaw`, letting callers spend boxes guarded by scripts that read context variables (`getVar(id)`) without having to assemble and sign the transaction outside the node.

When `context` is absent — the entire previous shape of the request — every input continues to get `ContextExtension.empty`, so the change is fully backwards compatible.

## Request schema

```json
{
  "requests": [...],
  "fee": 1000000,
  "inputsRaw": ["1a2b...", "2b3c..."],
  "context": {
    "extension": [
      { "1": "<base16-serialized EvaluatedValue>", "2": "..." },
      { "1": "..." }
    ]
  }
}
