### PR TITLE
add SoftForkRolloutSpec covering voting through activation

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Parameters.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Parameters.scala
@@ -477,7 +477,10 @@ object ParametersSerializer extends ErgoSerializer[Parameters] with ApiCodecs {
       "inputCost" -> p.inputCost.asJson,
       "dataInputCost" -> p.dataInputCost.asJson,
       "outputCost" -> p.outputCost.asJson,
-      "subblocksPerBlock" -> p.subBlocksPerBlockOpt.asJson
+      "subblocksPerBlock" -> p.subBlocksPerBlockOpt.asJson,
+      "softForkStartingHeight" -> p.softForkStartingHeight.asJson,
+      "softForkVotesCollected" -> p.softForkVotesCollected.asJson,
+      "rulesToDisable" -> p.proposedUpdate.rulesToDisable.asJson
     ).asJson
   }
 

--- a/src/it/resources/devnetTemplate.conf
+++ b/src/it/resources/devnetTemplate.conf
@@ -43,6 +43,11 @@ ergo {
     }
   }
 
+  voting {
+    120 = 1
+    rulesToDisable = [215, 409]
+  }
+
 }
 
 scorex {

--- a/src/it/scala/org/ergoplatform/it/SoftForkRolloutSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/SoftForkRolloutSpec.scala
@@ -1,0 +1,184 @@
+package org.ergoplatform.it
+
+import java.nio.file.{Files, Paths}
+
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.Json
+import io.circe.parser.parse
+import org.ergoplatform.it.container.Docker.noExtraConfig
+import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+// Node 0 is the sole miner and votes yes; nodes 1-4 are non-mining followers that
+// must end up on the same chain. Voting starts at devnet's first epoch boundary
+// (height 8); with only the seed casting votes, all 16 Phase-1 blocks come from a
+// voter and the rollout crosses the 90% threshold. Mid-scenario enrollment via
+// container restart is incompatible with this cadence — a single non-voter block
+// during Phase 1 drops the count below threshold and the rollout is cleaned up
+// rather than activating.
+class SoftForkRolloutSpec extends AnyFlatSpec with Matchers with IntegrationSuite {
+
+  import SoftForkRolloutSpec._
+
+  private val nodesQty = 5
+
+  private val votingLength = 8
+  private val softForkEpochs = 2
+  private val activationEpochs = 2
+  private val phase1Blocks = votingLength * softForkEpochs
+  private val activationOffset = votingLength * (softForkEpochs + activationEpochs)
+  private val cleanupOffset = votingLength * (softForkEpochs + activationEpochs + 1)
+  private val expectedStartingHeight = votingLength
+  // Devnet always launches at Interpreter50Version = 3 and the soft-fork bumps to 4.
+  private val preActivationBlockVersion = 3
+  private val postActivationBlockVersion = 4
+
+  // networkType=devnet is essential: application.conf defaults to testnet, which
+  // launches with BlockVersion=4 and leaves protocolVersion (also 4) unable to
+  // satisfy `protocolVersion > header.version` in CandidateGenerator.forkOrdered,
+  // so no voter would ever cast a vote. Devnet launches with BlockVersion=3.
+  // internalMinerPollingInterval is the devnet template default's main slow knob —
+  // drop it from 5s to 500ms so the scenario completes in ~1 minute instead of ~5.
+  private val votingOverrideConfig: Config = ConfigFactory.parseString(
+    s"""
+       |ergo.networkType = "devnet"
+       |ergo.node.internalMinerPollingInterval = 500ms
+       |ergo.chain.voting.votingLength = $votingLength
+       |ergo.chain.voting.softForkEpochs = $softForkEpochs
+       |ergo.chain.voting.activationEpochs = $activationEpochs
+       |""".stripMargin
+  )
+
+  private val nonGeneratingConfig: Config = ConfigFactory.parseString(
+    """
+      |ergo.node.mining = false
+      |""".stripMargin
+  )
+
+  // voting.120 = 1 and rulesToDisable live in devnetTemplate.conf (file-loaded), so
+  // every container votes yes by default. Jackson's flat-properties serialization
+  // mangles arrays passed via -D options, so we cannot inject voting config that way.
+  //
+  // Only node 0 mines (with offlineGeneration=true) so it can carry the chain alone;
+  // nodes 1-4 are passive followers. With fast block production (500ms polling), a
+  // multi-miner network can't gossip fast enough to avoid persistent forks. The
+  // consensus check at the end still verifies that all followers (mining=false) agree
+  // with the seed miner on the canonical chain — that's the witness behaviour we
+  // care about.
+  private val baseConfigs: List[Config] = nodeSeedConfigs.take(nodesQty).zipWithIndex.map {
+    case (cfg, idx) =>
+      val withCommon = cfg.withFallback(votingOverrideConfig).withFallback(localOnlyConfig)
+      if (idx == 0) withCommon
+      else withCommon.withFallback(nonGeneratingConfig)
+  }
+
+  private val remoteVolume = "/app"
+  private val localVolumes: Seq[String] = (0 until nodesQty).map(i =>
+    s"$localDataDir/soft-fork-rollout-spec/node-$i/data"
+  )
+  private val volumeMapping: Seq[(String, String)] = localVolumes.map(_ -> remoteVolume)
+  localVolumes.foreach(v => Files.createDirectories(Paths.get(v)))
+
+  private def fetchParameters(node: Node): Future[Json] = node.get("/info").map { r =>
+    parse(r.getResponseBody)
+      .getOrElse(Json.Null)
+      .hcursor.downField("parameters").as[Json].getOrElse(Json.Null)
+  }
+
+  // Polls until the node has applied the epoch boundary at `paramsHeight`. Returns the
+  // `parameters` JSON for that boundary. Reading at the boundary itself (rather than
+  // waiting for the chain to advance further) avoids reading the next epoch's tally.
+  private def fetchParamsAtHeight(node: Node, paramsHeight: Int): Future[Json] =
+    node.waitFor[Json](
+      n => fetchParameters(n.asInstanceOf[Node]),
+      json => json.hcursor.downField("height").as[Int].getOrElse(-1) >= paramsHeight,
+      200.millis
+    )
+
+  private val events = mutable.Buffer.empty[ScenarioEvent]
+  private def emit(e: ScenarioEvent): Unit = {
+    log.info(s"[scenario] $e")
+    events += e
+  }
+
+  private def withDataDir(cfg: Config): Config =
+    cfg.withFallback(specialDataDirConfig(remoteVolume))
+
+  private def startAll(): Vector[Node] = {
+    val started = baseConfigs.zip(volumeMapping).map { case (cfg, vol) =>
+      docker.startDevNetNode(withDataDir(cfg), noExtraConfig, Some(vol)).get
+    }.toVector
+    Await.result(Future.traverse(started.toList)(_.waitForStartup), 180.seconds)
+    started
+  }
+
+  private def waitAllToHeight(nodes: Vector[Node], h: Int, timeout: FiniteDuration = 10.minutes): Unit =
+    Await.result(Future.traverse(nodes.toList)(_.waitForHeight(h)), timeout)
+
+  // Per-checkpoint waits use only the seed miner so the chain doesn't race past the
+  // epoch boundary while a slower node (witness) is still catching up — fetched
+  // parameters would otherwise reflect the next epoch's tally rather than this one.
+  // waitAllToHeight is reserved for the final cross-node consistency check.
+  it should "drive a deterministic soft-fork rollout to activation" in {
+    val nodes = startAll()
+    val seed = nodes(0)
+
+    Await.result(seed.waitForHeight(expectedStartingHeight - 1), 1.minute)
+    emit(BaselineReached(nodesQty))
+
+    val params8 = Await.result(fetchParamsAtHeight(seed, expectedStartingHeight), 1.minute)
+    params8.hcursor.downField("softForkStartingHeight").as[Int].toOption shouldBe Some(expectedStartingHeight)
+    emit(VotingStarted(expectedStartingHeight))
+
+    val epoch1Height = expectedStartingHeight + votingLength
+    val params16 = Await.result(fetchParamsAtHeight(seed, epoch1Height), 1.minute)
+    params16.hcursor.downField("softForkVotesCollected").as[Int].toOption shouldBe Some(votingLength)
+    emit(EpochTallied(1, votingLength))
+
+    val epoch2Height = expectedStartingHeight + phase1Blocks
+    val params24 = Await.result(fetchParamsAtHeight(seed, epoch2Height), 1.minute)
+    params24.hcursor.downField("softForkVotesCollected").as[Int].toOption shouldBe Some(phase1Blocks)
+    emit(EpochTallied(2, phase1Blocks))
+
+    val activationHeight = expectedStartingHeight + activationOffset
+    val paramsActivation = Await.result(fetchParamsAtHeight(seed, activationHeight), 1.minute)
+    paramsActivation.hcursor.downField("blockVersion").as[Int].toOption shouldBe Some(postActivationBlockVersion)
+    emit(ActivationDetected(preActivationBlockVersion, postActivationBlockVersion))
+
+    val tailHeight = expectedStartingHeight + cleanupOffset
+    waitAllToHeight(nodes, tailHeight)
+    val headerIds = Await.result(
+      Future.traverse(nodes.toList)(_.headerIdsByHeight(tailHeight)), 30.seconds
+    )
+    val firstIds = headerIds.map(_.headOption.value)
+    firstIds.distinct should have size 1
+    emit(ChainConsistent(tailHeight))
+
+    val expected = List(
+      BaselineReached(nodesQty),
+      VotingStarted(expectedStartingHeight),
+      EpochTallied(1, votingLength),
+      EpochTallied(2, phase1Blocks),
+      ActivationDetected(preActivationBlockVersion, postActivationBlockVersion),
+      ChainConsistent(tailHeight)
+    )
+    events.toList shouldBe expected
+  }
+
+}
+
+object SoftForkRolloutSpec {
+
+  sealed trait ScenarioEvent
+  final case class BaselineReached(nodeCount: Int) extends ScenarioEvent
+  final case class VotingStarted(startingHeight: Int) extends ScenarioEvent
+  final case class EpochTallied(epochIdx: Int, votesCollected: Int) extends ScenarioEvent
+  final case class ActivationDetected(oldVersion: Int, newVersion: Int) extends ScenarioEvent
+  final case class ChainConsistent(height: Int) extends ScenarioEvent
+
+}

--- a/src/it/scala/org/ergoplatform/it/container/Docker.scala
+++ b/src/it/scala/org/ergoplatform/it/container/Docker.scala
@@ -164,7 +164,7 @@ class Docker(
         hostNetworkPort      = extractHostPort(ports, networkPort),
         containerNetworkPort = networkPort,
         containerApiPort     = restApiPort,
-        apiIpAddress         = containerInfo.getNetworkSettings.getIpAddress,
+        apiIpAddress         = attachedNetwork.getIpAddress,
         networkIpAddress     = attachedNetwork.getIpAddress,
         containerId          = containerId
       )

--- a/src/it/scala/org/ergoplatform/it/container/Node.scala
+++ b/src/it/scala/org/ergoplatform/it/container/Node.scala
@@ -24,9 +24,9 @@ class Node(val settings: ErgoSettings, val nodeInfo: NodeInfo, override val clie
   def containerId: String = nodeInfo.containerId
   override val chainId: Char = 'I'
   override val networkNodeName: String = s"it-test-client-to-${nodeInfo.networkIpAddress}"
-  override val restAddress: String = nodeInfo.apiIpAddress
+  override val restAddress: String = "localhost"
   override val networkAddress: String = "localhost"
-  override val nodeRestPort: Int = nodeInfo.containerApiPort
+  override val nodeRestPort: Int = nodeInfo.hostRestApiPort
   override val networkPort: Int = nodeInfo.hostNetworkPort
   override val blockDelay: FiniteDuration = settings.chainSettings.blockInterval
 

--- a/src/main/scala/org/ergoplatform/settings/VotingTargets.scala
+++ b/src/main/scala/org/ergoplatform/settings/VotingTargets.scala
@@ -29,7 +29,7 @@ object VotingTargets {
     val parameterTargets = votingObject
       .keySet()
       .asScala
-      .flatMap(id => Try(id.toByte -> votingObject.get(id).render().toInt).toOption)
+      .flatMap(id => Try(id.toByte -> votingObject.get(id).unwrapped().toString.toInt).toOption)
       .toMap
     val desiredUpdate = ErgoValidationSettingsUpdate(toDisable.map(_.toShort), Seq())
 


### PR DESCRIPTION
## Production changes

- `VotingTargets.fromConfig` now reads `voting.{id}` via `unwrapped().toString` instead of `render().toInt`. `render()` returns the JSON-quoted form for `ConfigString` values (`"1"` rather than `1`), so any node configured via system properties silently ended up with an empty targets map and never cast a soft-fork vote.
- `Parameters` JSON encoder additively exposes `softForkStartingHeight`, `softForkVotesCollected`, and `proposedUpdate.rulesToDisable` so `/info` surfaces the protocol state observers need during a rollout. Existing decoders ignore the new fields.

Closes #933 