### PR TITLE
Expose best block and forks at /blocks/chain/at/{height}

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2761,6 +2761,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
+  /blocks/chain/at/{blockHeight}:
+    get:
+      summary: Get best chain block id and fork ids at the given height
+      operationId: getBestAndForkIdsAtHeight
+      tags:
+        - blocks
+      parameters:
+        - in: path
+          name: blockHeight
+          required: true
+          description: Height to retrieve header ids for
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Best chain header id and any fork header ids at the given height
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - best
+                  - forks
+                properties:
+                  best:
+                    type: string
+                    description: Best chain header id at the given height
+                    example: '87a7362f892708a1445d4ddfb17e9176e037bd9db444f1b786c344f5e2ee615a'
+                  forks:
+                    type: array
+                    description: Fork header ids at the given height (empty when there are no forks)
+                    items:
+                      type: string
+                      example: 'cbefbbca647490f9fc1de2da4252d9211ff0ea4c0955d15639bb566f01f95d44'
+        '404':
+          description: No block at this height
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
   /blocks/chainSlice:
     get:
       summary: Get headers in a specified range of heights

--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NonHeaderBlockSe
 import org.ergoplatform.nodeView.ErgoReadersHolder.GetDataFromHistory
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.settings.{Algos, ErgoSettings, RESTApiSettings}
-import org.ergoplatform.http.api.ApiError.BadRequest
+import org.ergoplatform.http.api.ApiError.{BadRequest, NotExists}
 import org.ergoplatform.nodeView.LocallyGeneratedModifier
 import scorex.core.api.http.ApiResponse
 import scorex.crypto.authds.merkle.MerkleProof
@@ -35,6 +35,7 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
       postBlocksR ~
       getLastHeadersR ~
       getChainSliceR ~
+      getBestAndForkIdsAtHeightR ~
       getBlockIdsAtHeightR ~
       getBlockHeaderByHeaderIdR ~
       getFullBlockByHeaderIdsR ~
@@ -50,6 +51,18 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
   private def getHeaderIdsAtHeight(h: Int): Future[Json] =
     getHistory.map { history =>
       history.headerIdsAtHeight(h).map(Algos.encode).asJson
+    }
+
+  private def getBestAndForkIdsAtHeight(h: Int): Future[Option[Json]] =
+    getHistory.map { history =>
+      history.headerIdsAtHeight(h) match {
+        case Seq() => None
+        case best +: forks =>
+          Some(Json.obj(
+            "best"  -> Algos.encode(best).asJson,
+            "forks" -> forks.map(Algos.encode).asJson
+          ))
+      }
     }
 
   private def getLastHeaders(n: Int): Future[Json] =
@@ -166,6 +179,12 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
 
   def getBlockIdsAtHeightR: Route = (pathPrefix("at" / IntNumber) & get) { height =>
     ApiResponse(getHeaderIdsAtHeight(height))
+  }
+
+  def getBestAndForkIdsAtHeightR: Route = (pathPrefix("chain" / "at" / IntNumber) & get) { height =>
+    onSuccess(getBestAndForkIdsAtHeight(height)) {
+      _.fold[Route](NotExists(s"No block at height $height"))(ApiResponse(_))
+    }
   }
 
   def getBlockHeaderByHeaderIdR: Route = (modifierId & pathPrefix("header") & get) { id =>

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -73,6 +73,27 @@ class BlocksApiRouteSpec
     }
   }
 
+  it should "get best and fork ids at height" in {
+    val height = history.lastHeaders(1).headers.head.height
+    Get(prefix + s"/chain/at/$height") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val ids   = history.headerIdsAtHeight(height)
+      val best  = Algos.encode(ids.head)
+      val forks = ids.tail.map(Algos.encode)
+      val expected = Json.obj(
+        "best"  -> best.asJson,
+        "forks" -> forks.asJson
+      )
+      responseAs[Json] shouldEqual expected
+    }
+  }
+
+  it should "return 404 from chain/at when no block exists at height" in {
+    Get(prefix + "/chain/at/1000000") ~> route ~> check {
+      status shouldBe StatusCodes.NotFound
+    }
+  }
+
   it should "get chain slice" in {
     Get(prefix + "/chainSlice?fromHeight=0") ~> route ~> check {
       status shouldBe StatusCodes.OK


### PR DESCRIPTION
## Summary

Adds a new `GET /blocks/chain/at/{height}` endpoint that splits the best-chain header id from forks:

​```json
{ "best": "87a7...", "forks": ["cbef...", ...] }
​```

Previously `/blocks/at/{height}` returned a flat array of ids with no indication which id was on the main chain, forcing callers to guess. The new endpoint makes the distinction explicit.

- Non-breaking: legacy `/blocks/at/{height}` is unchanged.
- Returns `404` with a descriptive message when no block exists at the requested height.

Closes #978 