### PR TITLE
default network to mainnet, pick up ~/.ergo/ergo.conf if present

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -24,6 +24,7 @@ import org.ergoplatform.network.peer.PeerManagerRef
 import scorex.util.ScorexLogging
 
 import java.net.InetSocketAddress
+import java.nio.file.{Files, Paths}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.{Codec, Source}
 
@@ -263,11 +264,13 @@ class ErgoApp(args: Args) extends ScorexLogging {
 object ErgoApp extends ScorexLogging {
   val ApplicationNameLimit: Int = 50
 
+  val DefaultConfigFileName: String = "ergo.conf"
+
   val argParser = new scopt.OptionParser[Args]("ergo") {
     opt[String]("config")
       .abbr("c")
       .action((x, c) => c.copy(userConfigPathOpt = Some(x)))
-      .text("location of ergo node configuration")
+      .text(s"location of ergo node configuration (default: ~/.ergo/$DefaultConfigFileName)")
       .optional()
     opt[Unit]("devnet")
       .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.DevNet)))
@@ -279,7 +282,7 @@ object ErgoApp extends ScorexLogging {
       .optional()
     opt[Unit]("mainnet")
       .action((_, c) => c.copy(networkTypeOpt = Some(NetworkType.MainNet)))
-      .text("set network to mainnet")
+      .text("set network to mainnet (default if no network flag is given)")
       .optional()
     help("help").text("prints this usage text")
   }
@@ -303,7 +306,39 @@ object ErgoApp extends ScorexLogging {
 
   def main(args: Array[String]): Unit = {
     argParser.parse(args, Args()).foreach { argsParsed =>
-      new ErgoApp(argsParsed).run()
+      new ErgoApp(applyDefaults(argsParsed)).run()
+    }
+  }
+
+  /**
+    * Fill in defaults for arguments not explicitly provided on the command line:
+    *  - `--config` defaults to `~/.ergo/ergo.conf` if that file exists
+    *  - network defaults to mainnet if no `--mainnet`/`--testnet`/`--devnet` was given
+    */
+  private[ergoplatform] def applyDefaults(args: Args): Args = {
+    val withConfig = args.userConfigPathOpt match {
+      case Some(_) => args
+      case None =>
+        defaultUserConfigPath(System.getProperty("user.home")) match {
+          case Some(path) =>
+            log.info(s"Using default user config: $path")
+            args.copy(userConfigPathOpt = Some(path))
+          case None => args
+        }
+    }
+    withConfig.networkTypeOpt match {
+      case Some(_) => withConfig
+      case None =>
+        log.info("No network flag provided; defaulting to mainnet")
+        withConfig.copy(networkTypeOpt = Some(NetworkType.MainNet))
+    }
+  }
+
+  /** Absolute path to `<baseDir>/.ergo/<DefaultConfigFileName>` if that file exists. */
+  private[ergoplatform] def defaultUserConfigPath(baseDir: String): Option[String] = {
+    Option(baseDir).flatMap { dir =>
+      val candidate = Paths.get(dir, ".ergo", DefaultConfigFileName)
+      if (Files.isRegularFile(candidate)) Some(candidate.toAbsolutePath.toString) else None
     }
   }
 

--- a/src/test/scala/org/ergoplatform/ErgoAppSpec.scala
+++ b/src/test/scala/org/ergoplatform/ErgoAppSpec.scala
@@ -1,0 +1,78 @@
+package org.ergoplatform
+
+import org.ergoplatform.settings.{Args, NetworkType}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.IOException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+class ErgoAppSpec extends AnyFlatSpec with Matchers {
+
+  "applyDefaults" should "default networkTypeOpt to MainNet when no network flag is given" in {
+    val args = Args(userConfigPathOpt = Some("/some/explicit/path"), networkTypeOpt = None)
+    ErgoApp.applyDefaults(args).networkTypeOpt shouldBe Some(NetworkType.MainNet)
+  }
+
+  it should "preserve an explicit --testnet flag" in {
+    val args = Args(Some("/x"), Some(NetworkType.TestNet))
+    ErgoApp.applyDefaults(args).networkTypeOpt shouldBe Some(NetworkType.TestNet)
+  }
+
+  it should "preserve an explicit --devnet flag" in {
+    val args = Args(Some("/x"), Some(NetworkType.DevNet))
+    ErgoApp.applyDefaults(args).networkTypeOpt shouldBe Some(NetworkType.DevNet)
+  }
+
+  it should "preserve an explicit --mainnet flag" in {
+    val args = Args(Some("/x"), Some(NetworkType.MainNet))
+    ErgoApp.applyDefaults(args).networkTypeOpt shouldBe Some(NetworkType.MainNet)
+  }
+
+  it should "preserve an explicit user config path" in {
+    val args = Args(Some("/explicit/path.conf"), Some(NetworkType.MainNet))
+    ErgoApp.applyDefaults(args).userConfigPathOpt shouldBe Some("/explicit/path.conf")
+  }
+
+  "defaultUserConfigPath" should "return the path when <baseDir>/.ergo/ergo.conf exists" in {
+    val tmpHome = Files.createTempDirectory("ergo-app-spec-home")
+    try {
+      val ergoDir = Files.createDirectories(tmpHome.resolve(".ergo"))
+      val confFile = Files.write(ergoDir.resolve(ErgoApp.DefaultConfigFileName), "ergo {}".getBytes)
+      ErgoApp.defaultUserConfigPath(tmpHome.toAbsolutePath.toString) shouldBe
+        Some(confFile.toAbsolutePath.toString)
+    } finally {
+      deleteRecursively(tmpHome)
+    }
+  }
+
+  it should "return None when ergo.conf is absent" in {
+    val tmpHome = Files.createTempDirectory("ergo-app-spec-empty")
+    try {
+      ErgoApp.defaultUserConfigPath(tmpHome.toAbsolutePath.toString) shouldBe None
+    } finally {
+      deleteRecursively(tmpHome)
+    }
+  }
+
+  it should "return None for a null baseDir" in {
+    ErgoApp.defaultUserConfigPath(null) shouldBe None
+  }
+
+  private def deleteRecursively(root: Path): Unit = {
+    if (Files.exists(root)) {
+      Files.walkFileTree(root, new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
+        }
+        override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
+          Files.delete(dir)
+          FileVisitResult.CONTINUE
+        }
+      })
+      ()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`java -jar ergo-*.jar` with no flags currently produces a broken hybrid: testnet `networkType` paired with non-network-specific ports/peers/genesis, so the node connects nowhere and stays at `null` height. Two defaults are now applied in `ErgoApp.main` before constructing the app:

- **Default network is mainnet.** When `--mainnet`/`--testnet`/`--devnet` is absent, `networkTypeOpt` is set to `MainNet`, so the no-flag path takes the same route as `--mainnet` and `mainnet.conf` is layered as the base configuration.
- **`~/.ergo/ergo.conf` is auto-loaded.** When `-c` is absent and that file exists, it's used as the user config (Bitcoin-style). Pass `-c <path>` to override.

Explicit `--mainnet`/`--testnet`/`--devnet` and `-c <path>` are preserved unchanged. If a user's default config declares a conflicting `networkType`, the existing `consistentSettings` check fails fast with a clear error instead of silently producing another broken hybrid.

Closes #973 
