### PR TITLE
make NipopowAlgos.log2 total, add level-boundary canary

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
@@ -68,8 +68,8 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
   def maxLevelOf(header: Header): Int =
     if (!header.isGenesis) {
       val requiredTarget = org.ergoplatform.mining.q / DifficultySerializer.decodeCompactBits(header.nBits)
-      val realTarget = powScheme.powHit(header).doubleValue
-      val level = log2(requiredTarget.doubleValue) - log2(realTarget.doubleValue)
+      val realTarget = powScheme.powHit(header)
+      val level = log2(requiredTarget) - log2(realTarget)
       level.toInt
     } else {
       Int.MaxValue
@@ -163,7 +163,21 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
 
 object NipopowAlgos {
 
-  private def log2(x: Double): Double = math.log(x) / math.log(2)
+  // Bit-length threshold above which BigInt -> Double would overflow Double's exponent (max ~1023).
+  // ~ MAX_DIGITS_10 * LN(10)/LN(2)
+  private val Log2BigIntShiftThreshold = 977
+
+  private val Ln2: Double = math.log(2)
+
+  /** log2(BigInt) without losing precision when `x` exceeds Double's representable range. */
+  private[history] def log2(x: BigInt): Double =
+    if (x.signum == 0) Double.NegativeInfinity
+    else if (x.signum < 0) Double.NaN
+    else {
+      val blex = x.bitLength - Log2BigIntShiftThreshold
+      if (blex > 0) math.log((x >> blex).doubleValue) / Ln2 + blex
+      else math.log(x.doubleValue) / Ln2
+    }
 
   /**
     * Packs interlinks into key-value format of the block extension.

--- a/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
@@ -83,6 +83,18 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
     chain.foreach(x => nipopowAlgos.maxLevelOf(x.header) >= 0 shouldBe true)
   }
 
+  property("log2 - precise and overflow-safe") {
+    NipopowAlgos.log2(BigInt(1)) shouldEqual 0.0
+    NipopowAlgos.log2(BigInt(2)) shouldEqual 1.0
+    NipopowAlgos.log2(BigInt(1) << 256) shouldEqual 256.0
+    // Beyond Double's exponent range: doubleValue alone would yield +Infinity.
+    val large = NipopowAlgos.log2(BigInt(1) << 1024)
+    large.isInfinite shouldBe false
+    math.abs(large - 1024.0) should be < 1e-9
+    NipopowAlgos.log2(BigInt(0)) shouldEqual Double.NegativeInfinity
+    NipopowAlgos.log2(BigInt(-1)).isNaN shouldBe true
+  }
+
   property("lowestCommonAncestor - diverging") {
     val sizes = Seq(10, 100, 1000)
     sizes.foreach { size =>


### PR DESCRIPTION
Refs #1039, #2556. Does **not** close #1039.

Moves the `Double` conversion inside a total `log2(BigInt)`: negative → `NaN`, zero → `-Infinity`, oversized values shifted down first.

**No behavioural change** — the overflow branch is unreachable, both operands being bounded by the group order (256 bits) against a 977-bit threshold. µ and interlinks are unchanged for every header. The value is that `log2` is now total and testable.

The original description was wrong twice: #1039 is about rounding, not overflow, and "cannot flip µ in practice" is false — see #2556. `log2` still bottoms out in `math.log`, so that stands. Fixing it needs `StrictMath.log` or an integer form, both consensus changes → #1380.

Second commit adds the boundary test #2556 says is missing. It asserts the triple is one of three recorded classes rather than pinning a value, which would fail on arm64 while passing CI's x86_64 JDK 8.

Rebased onto master; was on `v6.0.3-RC1`, 207 commits behind.
