### PR TITLE
add Bitcoin-style getblocktemplate mining endpoint

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/mining/BlockTemplate.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/mining/BlockTemplate.scala
@@ -1,0 +1,61 @@
+package org.ergoplatform.mining
+
+import io.circe.Encoder
+import io.circe.syntax._
+import org.ergoplatform.http.api.ApiCodecs
+import org.ergoplatform.modifiers.history.extension.ExtensionCandidate
+import org.ergoplatform.modifiers.history.header.HeaderWithoutPow
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.settings.Algos
+import scorex.crypto.authds.SerializedAdProof
+import sigma.data.ProveDlog
+
+/**
+  * Block template for external miners and block-building extensions.
+  *
+  * Exposes the pre-PoW header (with all roots already computed by the node) together with the
+  * block's transactions, extension and AD proofs, so callers can reassemble the header bytes
+  * themselves and either mine it as-is or modify the components before mining. Solutions are
+  * submitted back through `POST /mining/solution`.
+  *
+  * `b` is the PoW target derived from `header.nBits`; `msg` is `Blake2b256(bytesWithoutPow)`
+  * over the header — the same value an external GPU miner works on.
+  */
+case class BlockTemplate(header: HeaderWithoutPow,
+                         transactions: Seq[ErgoTransaction],
+                         extension: ExtensionCandidate,
+                         adProofBytes: SerializedAdProof,
+                         pk: ProveDlog,
+                         b: BigInt,
+                         msg: Array[Byte])
+
+object BlockTemplate extends ApiCodecs {
+
+  def fromCandidateBlock(cb: CandidateBlock,
+                         pk: ProveDlog,
+                         powScheme: AutolykosPowScheme): BlockTemplate = {
+    val header = CandidateUtils.deriveUnprovenHeader(cb)
+    BlockTemplate(
+      header       = header,
+      transactions = cb.transactions,
+      extension    = cb.extension,
+      adProofBytes = cb.adProofBytes,
+      pk           = pk,
+      b            = powScheme.getB(cb.nBits),
+      msg          = powScheme.msgByHeader(header)
+    )
+  }
+
+  implicit val encoder: Encoder[BlockTemplate] = Encoder.instance { t: BlockTemplate =>
+    Map(
+      "header"       -> t.header.asJson,
+      "transactions" -> t.transactions.asJson,
+      "extension"    -> t.extension.asJson,
+      "adProofBytes" -> Algos.encode(t.adProofBytes).asJson,
+      "pk"           -> t.pk.asJson,
+      "b"            -> t.b.asJson(bigIntEncoder),
+      "msg"          -> Algos.encode(t.msg).asJson
+    ).asJson
+  }
+
+}

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionCandidate.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionCandidate.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.modifiers.history.extension
 
+import io.circe.Encoder
+import io.circe.syntax._
 import org.ergoplatform.modifiers.history.extension.Extension.InterlinksVectorPrefix
 import org.ergoplatform.settings.Algos
 import scorex.crypto.authds.LeafData
@@ -57,4 +59,11 @@ class ExtensionCandidate(val fields: Seq[(Array[Byte], Array[Byte])]) {
 
 object ExtensionCandidate {
   def apply(fields: Seq[(Array[Byte], Array[Byte])]): ExtensionCandidate = new ExtensionCandidate(fields)
+
+  implicit val jsonEncoder: Encoder[ExtensionCandidate] = Encoder.instance { e: ExtensionCandidate =>
+    Map(
+      "digest" -> Algos.encode(e.digest).asJson,
+      "fields" -> e.fields.map(kv => Algos.encode(kv._1) -> Algos.encode(kv._2).asJson).asJson
+    ).asJson
+  }
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/header/HeaderWithoutPow.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/header/HeaderWithoutPow.scala
@@ -1,6 +1,10 @@
 package org.ergoplatform.modifiers.history.header
 
+import io.circe.Encoder
+import io.circe.syntax._
+import org.ergoplatform.http.api.ApiCodecs
 import org.ergoplatform.mining.AutolykosSolution
+import org.ergoplatform.settings.Algos
 import scorex.crypto.authds.ADDigest
 import scorex.crypto.hash.Digest32
 import scorex.util.ModifierId
@@ -24,13 +28,29 @@ class HeaderWithoutPow(val version: Header.Version, // 1 byte
       nBits, height, extensionRoot, powSolution, votes, unparsedBytes, headerSize)
 }
 
-object HeaderWithoutPow {
+object HeaderWithoutPow extends ApiCodecs {
 
   def apply(version: Header.Version, parentId: ModifierId, ADProofsRoot: Digest32, stateRoot: ADDigest,
             transactionsRoot: Digest32, timestamp: Header.Timestamp, nBits: Long, height: Int,
             extensionRoot: Digest32, votes: Array[Byte], unparsedBytes: Array[Byte]): HeaderWithoutPow = {
     new HeaderWithoutPow(version, parentId, ADProofsRoot, stateRoot, transactionsRoot, timestamp,
       nBits, height, extensionRoot, votes, unparsedBytes)
+  }
+
+  implicit val jsonEncoder: Encoder[HeaderWithoutPow] = Encoder.instance { h: HeaderWithoutPow =>
+    Map(
+      "version" -> h.version.asJson,
+      "parentId" -> Algos.encode(h.parentId).asJson,
+      "adProofsRoot" -> Algos.encode(h.ADProofsRoot).asJson,
+      "stateRoot" -> Algos.encode(h.stateRoot).asJson,
+      "transactionsRoot" -> Algos.encode(h.transactionsRoot).asJson,
+      "timestamp" -> h.timestamp.asJson,
+      "nBits" -> h.nBits.asJson,
+      "height" -> h.height.asJson,
+      "extensionRoot" -> Algos.encode(h.extensionRoot).asJson,
+      "votes" -> Algos.encode(h.votes).asJson,
+      "unparsedBytes" -> Algos.encode(h.unparsedBytes).asJson
+    ).asJson
   }
 
 }

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2021,6 +2021,118 @@ components:
           type: object
           $ref: '#/components/schemas/ProofOfUpcomingTransactions'
 
+    HeaderWithoutPow:
+      description: Block header fields without the Proof-of-Work solution, with all Merkle roots already computed
+      type: object
+      required:
+        - version
+        - parentId
+        - adProofsRoot
+        - stateRoot
+        - transactionsRoot
+        - timestamp
+        - nBits
+        - height
+        - extensionRoot
+        - votes
+        - unparsedBytes
+      properties:
+        version:
+          type: integer
+          format: int32
+          description: Block version
+          example: 3
+        parentId:
+          $ref: '#/components/schemas/ModifierId'
+        adProofsRoot:
+          $ref: '#/components/schemas/Digest32'
+        stateRoot:
+          $ref: '#/components/schemas/ADDigest'
+        transactionsRoot:
+          $ref: '#/components/schemas/Digest32'
+        timestamp:
+          $ref: '#/components/schemas/Timestamp'
+        nBits:
+          type: integer
+          format: int64
+          description: Encoded difficulty (unsigned int)
+          example: 100734821
+        height:
+          type: integer
+          format: int32
+          description: Block height
+          example: 1234567
+        extensionRoot:
+          $ref: '#/components/schemas/Digest32'
+        votes:
+          type: string
+          description: Base16-encoded parameter votes (3 bytes)
+          example: '000000'
+        unparsedBytes:
+          type: string
+          description: Base16-encoded bytes reserved for future protocol versions (may be empty)
+          example: ''
+
+    ExtensionCandidate:
+      description: Extension block section without an assigned header id
+      type: object
+      required:
+        - digest
+        - fields
+      properties:
+        digest:
+          $ref: '#/components/schemas/Digest32'
+        fields:
+          type: array
+          description: Extension key-value pairs (each entry is a 2-tuple of Base16-encoded key and value)
+          items:
+            type: array
+            items:
+              type: string
+            minItems: 2
+            maxItems: 2
+
+    BlockTemplate:
+      description: |
+        Bitcoin-style `getblocktemplate` response. Returns the pre-PoW header (with all
+        Merkle roots already computed), the block transactions, extension and AD proofs,
+        along with the PoW work parameters returned by `/mining/candidate`. Callers can
+        reassemble or modify the components and submit a solved block via
+        `POST /mining/solution`.
+      type: object
+      required:
+        - header
+        - transactions
+        - extension
+        - adProofBytes
+        - pk
+        - b
+        - msg
+      properties:
+        header:
+          $ref: '#/components/schemas/HeaderWithoutPow'
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErgoTransaction'
+        extension:
+          $ref: '#/components/schemas/ExtensionCandidate'
+        adProofBytes:
+          type: string
+          description: Base16-encoded serialized AD proofs
+        pk:
+          type: string
+          description: Base16-encoded miner public key
+          example: '0350e25cee8562697d55275c96bb01b34228f9bd68fd9933f2a25ff195526864f5'
+        b:
+          type: integer
+          description: PoW target value (q / difficulty)
+          example: 987654321
+        msg:
+          type: string
+          description: Base16-encoded Blake2b256 hash of the pre-PoW header bytes — what GPU miners work on
+          example: '0350e25cee8562697d55275c96bb01b34228f9bd68fd9933f2a25ff195526864f5'
+
     Peer:
       type: object
       required:
@@ -5134,6 +5246,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkMessage'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /mining/blockTemplate:
+    get:
+      security:
+        - ApiKeyAuth: [api_key]
+      summary: Request full block template
+      description: |
+        Bitcoin-style `getblocktemplate` analogue. Returns the components of the current block
+        candidate — pre-PoW header (with computed Merkle roots), transactions, extension and AD
+        proofs — together with the PoW work parameters. Useful for external miners and
+        block-building extensions that need to inspect or reassemble the header bytes themselves.
+        Solutions are submitted via `POST /mining/solution`.
+      operationId: miningRequestBlockTemplate
+      tags:
+        - mining
+      responses:
+        '200':
+          description: Full block template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockTemplate'
         default:
           description: Error
           content:

--- a/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
@@ -6,7 +6,7 @@ import akka.pattern.ask
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import org.ergoplatform.mining.CandidateGenerator.Candidate
-import org.ergoplatform.mining.{AutolykosSolution, CandidateGenerator, ErgoMiner}
+import org.ergoplatform.mining.{AutolykosSolution, BlockTemplate, CandidateGenerator, ErgoMiner}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.ErgoAddressJsonEncoder
 import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
@@ -27,6 +27,7 @@ case class MiningApiRoute(miner: ActorRef,
   override val route: Route = pathPrefix("mining") {
     candidateR ~
       candidateWithTxsR ~
+      blockTemplateR ~
       solutionR ~
       rewardAddressR ~
       rewardPublicKeyR
@@ -39,6 +40,23 @@ case class MiningApiRoute(miner: ActorRef,
     val prepareCmd = CandidateGenerator.GenerateCandidate(Seq.empty, reply = true, forced = false)
     val candidateF = miner.askWithStatus(prepareCmd).mapTo[Candidate].map(_.externalVersion)
     ApiResponse(candidateF)
+  }
+
+  /**
+    * Get full block template — pre-PoW header (with computed roots), transactions, extension and
+    * AD proofs, plus the same `pk`/`b`/`msg` work parameters returned by `/mining/candidate`.
+    *
+    * Analogue of Bitcoin's `getblocktemplate`: lets external miners and block-building extensions
+    * inspect or modify the components and assemble the header bytes themselves, then submit a
+    * solved block via `POST /mining/solution`.
+    */
+  def blockTemplateR: Route = (path("blockTemplate") & pathEndOrSingleSlash & get) {
+    val prepareCmd = CandidateGenerator.GenerateCandidate(Seq.empty, reply = true, forced = false)
+    val powScheme  = ergoSettings.chainSettings.powScheme
+    val templateF = miner.askWithStatus(prepareCmd).mapTo[Candidate].map { c =>
+      BlockTemplate.fromCandidateBlock(c.candidateBlock, c.externalVersion.pk, powScheme)
+    }
+    ApiResponse(templateF)
   }
 
   /**

--- a/src/test/scala/org/ergoplatform/http/routes/MiningApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/MiningApiRouteSpec.scala
@@ -6,14 +6,19 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.Json
 import io.circe.syntax._
+import org.bouncycastle.util.encoders.Hex
 import org.ergoplatform.http.api.MiningApiRoute
 import org.ergoplatform.mining.AutolykosSolution
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.modifiers.history.header.HeaderWithoutPow
+import org.ergoplatform.settings.{Algos, ErgoSettings}
 import org.ergoplatform.utils.Stubs
 import org.ergoplatform.utils.generators.ErgoCoreGenerators.genECPoint
 import org.ergoplatform.{ErgoTreePredef, Pay2SAddress}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scorex.crypto.authds.ADDigest
+import scorex.crypto.hash.Digest32
+import scorex.util.bytesToId
 
 import scala.util.Try
 
@@ -53,6 +58,47 @@ class MiningApiRouteSpec
       val script = ErgoTreePredef.rewardOutputScript(settings.chainSettings.monetary.minerRewardDelay, pk)
       val addressStr = Pay2SAddress(script)(settings.addressEncoder).toString()
       responseAs[Json].hcursor.downField("rewardAddress").as[String] shouldEqual Right(addressStr)
+    }
+  }
+
+  it should "return a self-consistent block template" in {
+    Get(prefix + "/blockTemplate") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val json = responseAs[Json]
+      val cur  = json.hcursor
+
+      // top-level fields are all present
+      cur.downField("header").focus       shouldBe defined
+      cur.downField("transactions").focus shouldBe defined
+      cur.downField("extension").focus    shouldBe defined
+      cur.downField("adProofBytes").focus shouldBe defined
+      cur.downField("pk").focus           shouldBe defined
+      cur.downField("b").focus            shouldBe defined
+      cur.downField("msg").focus          shouldBe defined
+
+      // header roots are populated (CandidateBlock JSON wouldn't have these directly)
+      val header = cur.downField("header")
+      header.downField("transactionsRoot").as[String].toOption.get should have length 64
+      header.downField("adProofsRoot").as[String].toOption.get    should have length 64
+      header.downField("extensionRoot").as[String].toOption.get   should have length 64
+
+      // reconstructing HeaderWithoutPow from the JSON and hashing must reproduce `msg`
+      val reconstructed = HeaderWithoutPow(
+        version          = header.downField("version").as[Byte].toOption.get,
+        parentId         = bytesToId(Algos.decode(header.downField("parentId").as[String].toOption.get).get),
+        ADProofsRoot     = Digest32 @@ Algos.decode(header.downField("adProofsRoot").as[String].toOption.get).get,
+        stateRoot        = ADDigest @@ Algos.decode(header.downField("stateRoot").as[String].toOption.get).get,
+        transactionsRoot = Digest32 @@ Algos.decode(header.downField("transactionsRoot").as[String].toOption.get).get,
+        timestamp        = header.downField("timestamp").as[Long].toOption.get,
+        nBits            = header.downField("nBits").as[Long].toOption.get,
+        height           = header.downField("height").as[Int].toOption.get,
+        extensionRoot    = Digest32 @@ Algos.decode(header.downField("extensionRoot").as[String].toOption.get).get,
+        votes            = Algos.decode(header.downField("votes").as[String].toOption.get).get,
+        unparsedBytes    = Algos.decode(header.downField("unparsedBytes").as[String].toOption.get).get
+      )
+      val expectedMsg = settings.chainSettings.powScheme.msgByHeader(reconstructed)
+      val returnedMsg = Algos.decode(cur.downField("msg").as[String].toOption.get).get
+      Hex.toHexString(returnedMsg) shouldEqual Hex.toHexString(expectedMsg)
     }
   }
 

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -5,9 +5,11 @@ import akka.pattern.StatusReply
 import org.bouncycastle.util.BigIntegers
 import org.ergoplatform.P2PKAddress
 import org.ergoplatform.mining.CandidateGenerator.Candidate
-import org.ergoplatform.mining.{AutolykosSolution, CandidateGenerator, ErgoMiner, WorkMessage}
+import org.ergoplatform.mining.{AutolykosSolution, CandidateBlock, CandidateGenerator, ErgoMiner, WorkMessage}
 import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.history.extension.ExtensionCandidate
 import org.ergoplatform.modifiers.history.header.Header
+import scorex.crypto.authds.SerializedAdProof
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.{GetAllPeers, GetBlacklistedPeers}
 import org.ergoplatform.network.{Handshake, PeerSpec, Version}
@@ -99,6 +101,18 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
   val pk: ProveDlog = DLogProverInput(BigIntegers.fromUnsignedByteArray(Random.randomBytes(32))).publicImage
   val externalWorkMessage = WorkMessage(Array.fill(32)(2: Byte), BigInt(9999), None, pk, None)
 
+  val stubCandidateBlock: CandidateBlock = CandidateBlock(
+    parentOpt    = None,
+    version      = Header.InitialVersion,
+    nBits        = settings.chainSettings.initialNBits,
+    stateRoot    = ADDigest @@ Array.fill(HashLength + 1)(0: Byte),
+    adProofBytes = SerializedAdProof @@ Array.emptyByteArray,
+    transactions = Seq.empty,
+    timestamp    = 0L,
+    extension    = ExtensionCandidate(Seq.empty),
+    votes        = Array.fill(3)(0: Byte)
+  )
+
   class PeersManagerStub extends Actor {
     def receive: Receive = {
       case GetAllPeers => sender() ! peers
@@ -114,7 +128,7 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
     def receive: Receive = {
       case CandidateGenerator.GenerateCandidate(_, reply, _) =>
         if (reply) {
-          val candidate = Candidate(null, externalWorkMessage, Seq.empty) // API does not use CandidateBlock
+          val candidate = Candidate(stubCandidateBlock, externalWorkMessage, Seq.empty)
           sender() ! StatusReply.success(candidate)
         }
       case _: AutolykosSolution => sender() ! StatusReply.success(())


### PR DESCRIPTION
## Summary

Adds `GET /mining/blockTemplate`, a Bitcoin-style `getblocktemplate` analogue. The existing `/mining/candidate` returns only a pre-hashed `WorkMessage`, which is opaque to anything that wants to inspect or modify block contents before mining. The new endpoint exposes:

- the pre-PoW header (`HeaderWithoutPow`) with all Merkle roots already computed by the node
- transactions, extension fields, and AD proof bytes
- the same `pk` / `b` / `msg` work parameters returned by `/mining/candidate`

Callers can reassemble the header bytes themselves (or modify components) and submit a solved block via the existing `POST /mining/solution` — no changes to the solution path.

## Notes

- `BlockTemplate` lives in `ergo-core` and takes primitive types (`CandidateBlock`, `ProveDlog`, `AutolykosPowScheme`) so it stays free of the actor-layer `Candidate` wrapper.
- Added Circe encoders for `HeaderWithoutPow` and `ExtensionCandidate` — neither had one before.
- The existing `MinerStub` returned `Candidate(null, …)` ("API does not use CandidateBlock"); replaced with a real minimal `CandidateBlock` since the new route does dereference it.
- OpenAPI spec updated with the new path and three new schemas (`BlockTemplate`, `HeaderWithoutPow`, `ExtensionCandidate`).
- `MiningApiRouteSpec` reconstructs `HeaderWithoutPow` from the returned JSON and asserts `Blake2b256(bytesWithoutPow) == msg`, so the template is verified mining-equivalent to `/mining/candidate`.

Closes #1030  