### PR TITLE
replace primitive wallet messages with case-class wrappers

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
@@ -75,7 +75,7 @@ case class MiningApiRoute(miner: ActorRef,
 
   def solutionR: Route = (path("solution") & post & entity(as[AutolykosSolution])) { solution =>
     val result = if (ergoSettings.nodeSettings.useExternalMiner) {
-      miner.askWithStatus(solution).mapTo[Unit]
+      miner.askWithStatus(solution).mapTo[CandidateGenerator.SolutionAck.type].map(_ => ())
     } else {
       Future.failed(new Exception("External miner support is inactive"))
     }

--- a/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
@@ -69,8 +69,9 @@ case class ScanApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
       val scanId = ScanId @@ scanIdInt.toShort
       val considerUnconfirmed = minConfNum == -1
       withWallet(_.scanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight).map {
-        _.filter(boxConfirmationFilter(_, minConfNum, maxConfNum))
-        .slice(offset, offset + limit)
+        _.boxes
+          .filter(boxConfirmationFilter(_, minConfNum, maxConfNum))
+          .slice(offset, offset + limit)
       })
   }
 
@@ -78,8 +79,9 @@ case class ScanApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
     (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
       val scanId = ScanId @@ scanIdInt.toShort
       withWallet(_.scanSpentBoxes(scanId).map {
-        _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
-        .slice(offset, offset + limit)
+        _.boxes
+          .filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+          .slice(offset, offset + limit)
       })
   }
 

--- a/src/main/scala/org/ergoplatform/http/api/ScriptApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScriptApiRoute.scala
@@ -72,7 +72,7 @@ case class ScriptApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
 
   // todo: unite p2sAddress and p2shAddress, https://github.com/ergoplatform/ergo/issues/2213
   private def p2sAddressR: Route = (path("p2sAddress") & post & entity(as[CompileRequest])) { compileRequest =>
-    withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
+    withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys).map(_.addresses), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
       onSuccess(addrsF) { addrs =>
         val scriptVersion = Header.scriptFromBlockVersion(bv)
         val treeVersion = compileRequest.treeVersion
@@ -88,7 +88,7 @@ case class ScriptApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
 
 
   private def p2shAddressR: Route = (path("p2shAddress") & post & entity(as[CompileRequest])) { compileRequest =>
-    withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
+    withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys).map(_.addresses), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
       onSuccess(addrsF) { addrs =>
         val scriptVersion = Header.scriptFromBlockVersion(bv)
         val treeVersion = compileRequest.treeVersion

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -24,6 +24,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import akka.http.scaladsl.server.MissingQueryParamRejection
 import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 
 case class WalletApiRoute(readersHolder: ActorRef,
                           nodeViewActorRef: ActorRef,
@@ -76,9 +77,9 @@ case class WalletApiRoute(readersHolder: ActorRef,
       .fold(_ => reject, s => provide(s))
   }
 
-  private val derivationPath: Directive1[String] = entity(as[Json]).flatMap { p =>
+  private val derivationPath: Directive1[DerivationPath] = entity(as[Json]).flatMap { p =>
     p.hcursor.downField("derivationPath").as[String]
-      .fold(_ => reject, s => provide(s))
+      .fold(_ => reject, s => DerivationPath.fromEncoded(s).fold(_ => reject, provide))
   }
 
   private val restoreRequest: Directive1[(Boolean, String, String, Option[String])] = entity(as[Json]).flatMap { p =>
@@ -160,7 +161,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
                                             dataInputsRaw: Seq[String],
                                             verifyFn: ErgoTransaction => Future[Try[UnconfirmedTransaction]],
                                             processFn: UnconfirmedTransaction => Route): Route = {
-    withWalletOp(_.generateTransaction(requests, inputsRaw, dataInputsRaw).flatMap(txTry => txTry match {
+    withWalletOp(_.generateTransaction(requests, inputsRaw, dataInputsRaw).flatMap(_.tx match {
       case Success(tx) => verifyFn(tx)
       case Failure(e) => Future(Failure[UnconfirmedTransaction](e))
     })) {
@@ -185,8 +186,10 @@ case class WalletApiRoute(readersHolder: ActorRef,
                                           inputsRaw: Seq[String],
                                           dataInputsRaw: Seq[String]): Route = {
     withWalletOp(_.generateUnsignedTransaction(requests, inputsRaw, dataInputsRaw)) {
-      case Failure(e) => BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
-      case Success(utx) => ApiResponse(utx)
+      _.tx match {
+        case Failure(e) => BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
+        case Success(utx) => ApiResponse(utx)
+      }
     }
   }
 
@@ -244,12 +247,12 @@ case class WalletApiRoute(readersHolder: ActorRef,
           .flatMap(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry).toOption)
 
         if (boxesToSpend.size == tx.inputs.size && dataBoxes.size == tx.dataInputs.size) {
-          r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes))
+          r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes)).map(_.tx)
         } else {
           Future(Failure(new Exception("Can't parse input boxes provided")))
         }
       } else {
-        r.w.signTransaction(tx, secrets, hints, None, None)
+        r.w.signTransaction(tx, secrets, hints, None, None).map(_.tx)
       }
     }
 
@@ -281,7 +284,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def balancesR: Route = (path("balances") & get) {
-    withWallet(_.confirmedBalances)
+    withWallet(_.confirmedBalances.map(_.digest))
   }
 
   def getWalletStatusR: Route = (path("status") & get) {
@@ -297,11 +300,11 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def unconfirmedBalanceR: Route = (path("balances" / "withUnconfirmed") & get) {
-    withWallet(_.balancesWithUnconfirmed)
+    withWallet(_.balancesWithUnconfirmed.map(_.digest))
   }
 
   def addressesR: Route = (path("addresses") & get) {
-    withWallet(_.publicKeys(0, Int.MaxValue): Future[Seq[ErgoAddress]])
+    withWallet(_.publicKeys(0, Int.MaxValue).map(_.addresses): Future[Seq[ErgoAddress]])
   }
 
   def unspentBoxesR: Route = (path("boxes" / "unspent") & get & boxParams) {
@@ -309,8 +312,8 @@ case class WalletApiRoute(readersHolder: ActorRef,
       val considerUnconfirmed = minConfNum == -1
       withWallet { wallet =>
         wallet.walletBoxes(unspentOnly = true, considerUnconfirmed)
-          .map { boxes =>
-            boxes
+          .map { resp =>
+            resp.boxes
               .filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
               .slice(offset, offset + limit)
           }
@@ -323,8 +326,9 @@ case class WalletApiRoute(readersHolder: ActorRef,
       withWallet {
         _.walletBoxes(unspentOnly = false, considerUnconfirmed = considerUnconfirmed)
           .map {
-            _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
-            .slice(offset, offset + limit)
+            _.boxes
+              .filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+              .slice(offset, offset + limit)
           }
       }
   }
@@ -340,7 +344,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
         withWallet {
           _.transactions
             .map {
-              _.filter(tx =>
+              _.txs.filter(tx =>
                 tx.wtx.scanIds.exists(scanId => scanId <= Constants.PaymentsScanId)
               )
             }
@@ -354,14 +358,14 @@ case class WalletApiRoute(readersHolder: ActorRef,
             minConfNum,
             maxConfNum,
             includeUnconfirmed = false
-          )
+          ).map(_.txs)
         }
       }
   }
 
   def getTransactionR: Route = (path("transactionById") & modifierIdGet & get) { id =>
     withWalletOp(_.transactionById(id)) {
-      _.fold[Route](NotExists)(tx => ApiResponse(tx.asJson))
+      _.tx.fold[Route](NotExists)(tx => ApiResponse(tx.asJson))
     }
   }
 
@@ -383,7 +387,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
           maxConfNum,
           includeUnconfirmed)
         ) {
-          resp => ApiResponse(resp.asJson)
+          resp => ApiResponse(resp.txs.asJson)
         }
       }
   }
@@ -391,7 +395,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
   def initWalletR: Route = (path("init") & post & initRequest) {
     case (pass, mnemonicPassOpt) =>
       withWalletOp(_.initWallet(SecretString.create(pass), mnemonicPassOpt.map(SecretString.create(_)))) {
-        _.fold(
+        _.result.fold(
           e => BadRequest(e.getMessage),
           mnemonic => {
             val responseJson = Json.obj("mnemonic" -> mnemonic.asJson)
@@ -405,7 +409,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
   def restoreWalletR: Route = (path("restore") & post & restoreRequest) {
     case (usePre1627KeyDerivation, pass, mnemo, mnemoPassOpt) =>
       withWalletOp(_.restoreWallet(SecretString.create(pass), SecretString.create(mnemo), mnemoPassOpt.map(SecretString.create(_)), usePre1627KeyDerivation)) {
-        _.fold(
+        _.result.fold(
           e => BadRequest(e.getMessage),
           _ => ApiResponse.toRoute(ApiResponse.OK)
         )
@@ -414,7 +418,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def unlockWalletR: Route = (path("unlock") & post & password) { pass =>
     withWalletOp(_.unlockWallet(SecretString.create(pass))) {
-      _.fold(
+      _.result.fold(
         e => BadRequest(e.getMessage),
         _ => ApiResponse.toRoute(ApiResponse.OK)
       )
@@ -423,11 +427,10 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def checkSeedR: Route = (path("check") & post & checkRequest) {
     case (mnemo, mnemoPassOpt) =>
-      withWalletOp(_.checkSeed(SecretString.create(mnemo), mnemoPassOpt.map(SecretString.create(_)))) { matched =>
-        ApiResponse(
-          Json.obj(
-            "matched" -> matched.asJson
-          )
+      withWalletOp(_.checkSeed(SecretString.create(mnemo), mnemoPassOpt.map(SecretString.create(_)))) {
+        _.matched.fold(
+          e => BadRequest(e.getMessage),
+          matched => ApiResponse(Json.obj("matched" -> matched.asJson))
         )
       }
   }
@@ -441,7 +444,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def deriveKeyR: Route = (path("deriveKey") & post & derivationPath) { path =>
     withWalletOp(_.deriveKey(path)) {
-      _.fold(
+      _.address.fold(
         e => BadRequest(e.getMessage),
         address => ApiResponse(Json.obj("address" -> address.toString.asJson))
       )
@@ -470,7 +473,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def rescanWalletR: Route = (path("rescan") & post & heightEntityField) { fromHeight =>
     withWalletOp(_.rescanWallet(fromHeight)) {
-      _.fold(
+      _.result.fold(
         e => BadRequest(e.getMessage),
         _ => ApiResponse.toRoute(ApiResponse.OK)
       )
@@ -487,12 +490,14 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def getPrivateKeyR: Route = (path("getPrivateKey") & post & p2pkAddress) { p2pk =>
-    withWalletOp(_.allExtendedPublicKeys()) { extKeys =>
-      extKeys.find(_.key.value.equals(p2pk.pubkey.value)).map(_.path) match {
+    withWalletOp(_.allExtendedPublicKeys()) { resp =>
+      resp.keys.find(_.key.value.equals(p2pk.pubkey.value)).map(_.path) match {
         case Some(path) =>
           withWalletOp(_.getPrivateKeyFromPath(path)) {
-            case Success(secret) => ApiResponse(secret.w)
-            case Failure(f) => BadRequest(f.getMessage)
+            _.key match {
+              case Success(secret) => ApiResponse(secret.w)
+              case Failure(f) => BadRequest(f.getMessage)
+            }
           }
         case None => NotExists("Address not found in wallet database.")
       }

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -214,7 +214,7 @@ class CandidateGenerator(
         } else {
           preSolution
         }
-      val result: StatusReply[Unit] = {
+      val result: StatusReply[SolutionAck.type] = {
         val newBlock = state.cachedCandidate
           .map(candidate => completeBlock(candidate.candidateBlock, solution))
           .filter(block => ergoSettings.chainSettings.powScheme.validate(block.header).isSuccess)
@@ -229,7 +229,7 @@ class CandidateGenerator(
           case Success(newBlock) =>
             sendToNodeView(newBlock)
             context.become(initialized(state.copy(solvedBlock = Some(newBlock))))
-            StatusReply.success(())
+            StatusReply.success(SolutionAck)
           case Failure(exception) =>
             log.warn(s"Removing candidates due to invalid block", exception)
             context.become(initialized(state.copy(cachedCandidate = None, cachedPreviousCandidate = None)))
@@ -272,6 +272,9 @@ object CandidateGenerator extends ScorexLogging {
     forced: Boolean,
     optPk: Option[ProveDlog] = None
   )
+
+  /** Acknowledgement that a mined solution was accepted by the candidate generator. */
+  case object SolutionAck
 
   /** Local state of candidate generator to avoid mutable vars */
   case class CandidateGeneratorState(

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -5,6 +5,7 @@ import akka.actor._
 import akka.pattern.StatusReply
 import org.ergoplatform.ErgoBox._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState}
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.ErgoStateReader
@@ -90,12 +91,12 @@ class ErgoWalletActor(settings: ErgoSettings,
           log.info("Wallet is initialized")
           context.become(loadedWallet(newState))
           self ! UnlockWallet(walletPass)
-          sender() ! Success(mnemonic)
+          sender() ! InitWalletResponse(Success(mnemonic))
         case Failure(t) =>
           walletPass.erase()
           val f = wrapLegalExc(t) // getting nicer message for illegal key size exception
           log.error(s"Wallet initialization is failed, details: ${f.exception.getMessage}")
-          sender() ! f
+          sender() ! InitWalletResponse(f)
       }
 
     // Restore wallet with mnemonic if secret is not set yet
@@ -105,17 +106,20 @@ class ErgoWalletActor(settings: ErgoSettings,
           log.info("Wallet is restored")
           context.become(loadedWallet(newState))
           self ! UnlockWallet(walletPass)
-          sender() ! Success(())
+          sender() ! RestoreWalletResponse(Success(()))
         case Failure(t) =>
           walletPass.erase()
           val f = wrapLegalExc(t) //getting nicer message for illegal key size exception
           log.error(s"Wallet restoration is failed, details: ${f.exception.getMessage}")
-          sender() ! f
+          sender() ! RestoreWalletResponse(f)
       }
 
     // branch for key already being set
-    case _: RestoreWallet | _: InitWallet =>
-      sender() ! Failure(new Exception("Wallet is already initialized or testMnemonic is set. Clear current secret to re-init it."))
+    case _: InitWallet =>
+      sender() ! InitWalletResponse(Failure(new Exception("Wallet is already initialized or testMnemonic is set. Clear current secret to re-init it.")))
+
+    case _: RestoreWallet =>
+      sender() ! RestoreWalletResponse(Failure(new Exception("Wallet is already initialized or testMnemonic is set. Clear current secret to re-init it.")))
 
     /* READERS */
     case ReadBalances(chainStatus) =>
@@ -138,16 +142,16 @@ class ErgoWalletActor(settings: ErgoSettings,
       } else {
         walletDigest
       }
-      sender() ! res
+      sender() ! BalancesResponse(res)
 
     case ReadPublicKeys(from, until) =>
-      sender() ! state.walletVars.publicKeyAddresses.slice(from, until)
+      sender() ! PublicKeysResponse(state.walletVars.publicKeyAddresses.slice(from, until))
 
     case ReadExtendedPublicKeys() =>
-      sender() ! state.storage.readAllKeys()
+      sender() ! ExtendedPublicKeysResponse(state.storage.readAllKeys())
 
     case GetPrivateKeyFromPath(path: DerivationPath) =>
-      sender() ! ergoWalletService.getPrivateKeyFromPath(state, path)
+      sender() ! PrivateKeyFromPathResponse(ergoWalletService.getPrivateKeyFromPath(state, path))
 
     case GetMiningPubKey =>
       state.walletVars.trackedPubKeys.headOption match {
@@ -176,21 +180,21 @@ class ErgoWalletActor(settings: ErgoSettings,
      */
     case GetWalletBoxes(unspent, considerUnconfirmed) =>
       val boxes = ergoWalletService.getWalletBoxes(state, unspent, considerUnconfirmed)
-      sender() ! boxes
+      sender() ! WalletBoxesResponse(boxes)
 
     case GetScanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight) =>
       val boxes = ergoWalletService.getScanUnspentBoxes(state, scanId, considerUnconfirmed, minHeight, maxHeight)
-      sender() ! boxes
+      sender() ! ScanBoxesResponse(boxes)
 
     case GetScanSpentBoxes(scanId) =>
       val boxes = ergoWalletService.getScanSpentBoxes(state, scanId)
-      sender() ! boxes
+      sender() ! ScanBoxesResponse(boxes)
 
     case GetTransactions =>
-      sender() ! ergoWalletService.getTransactions(state.registry, state.fullHeight)
+      sender() ! WalletTransactionsResponse(ergoWalletService.getTransactions(state.registry, state.fullHeight))
 
     case GetTransaction(txId) =>
-      sender() ! ergoWalletService.getTransactionsByTxId(txId, state.registry, state.fullHeight)
+      sender() ! WalletTransactionResponse(ergoWalletService.getTransactionsByTxId(txId, state.registry, state.fullHeight))
 
     case ReadScans =>
       sender() ! ReadScansResponse(state.walletVars.externalScans)
@@ -306,9 +310,9 @@ class ErgoWalletActor(settings: ErgoSettings,
       state.secretStorageOpt match {
         case Some(secretStorage) =>
           val checkResult = secretStorage.checkSeed(mnemonic, passOpt)
-          sender() ! checkResult
+          sender() ! CheckSeedResponse(Success(checkResult))
         case None =>
-          sender() ! Failure(new Exception("Wallet not initialized"))
+          sender() ! CheckSeedResponse(Failure(new Exception("Wallet not initialized")))
       }
 
     case UnlockWallet(walletPass) =>
@@ -318,11 +322,11 @@ class ErgoWalletActor(settings: ErgoSettings,
           log.info("Wallet successfully unlocked")
           walletPass.erase()
           context.become(loadedWallet(newState))
-          sender() ! Success(())
-        case f@Failure(t) =>
+          sender() ! UnlockWalletResponse(Success(()))
+        case Failure(t) =>
           walletPass.erase()
           log.warn("Wallet unlock failed with: ", t)
-          sender() ! f
+          sender() ! UnlockWalletResponse(Failure(t))
       }
 
     case LockWallet =>
@@ -344,14 +348,14 @@ class ErgoWalletActor(settings: ErgoSettings,
             context.become(loadedWallet(newState.copy(rescanInProgress = true)))
             val heightToScanFrom = Math.min(newState.fullHeight, fromHeight)
             self ! ScanInThePast(heightToScanFrom, rescan = true)
-            sender() ! Success(())
-          case f@Failure(t) =>
+            sender() ! RescanWalletResponse(Success(()))
+          case Failure(t) =>
             log.error("Error during rescan attempt: ", t)
-            sender() ! f
+            sender() ! RescanWalletResponse(Failure(t))
         }
       } else {
         log.info(s"Skipping rescan request from height: $fromHeight as one is already in progress")
-        sender() ! Failure(new IllegalStateException("Rescan already in progress"))
+        sender() ! RescanWalletResponse(Failure(new IllegalStateException("Rescan already in progress")))
       }
 
     case GetWalletStatus =>
@@ -365,7 +369,11 @@ class ErgoWalletActor(settings: ErgoSettings,
 
     case GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign) =>
       val txTry = ergoWalletService.generateTransaction(state, boxSelector, requests, inputsRaw, dataInputsRaw, sign)
-      sender() ! txTry
+      if (sign) {
+        sender() ! SignedTransactionResponse(txTry.map(_.asInstanceOf[ErgoTransaction]))
+      } else {
+        sender() ! UnsignedTransactionResponse(txTry.map(_.asInstanceOf[UnsignedErgoTransaction]))
+      }
 
     case GenerateCommitmentsFor(unsignedTx, externalSecretsOpt, externalInputsOpt, externalDataInputsOpt) =>
       val resultTry = ergoWalletService.generateCommitments(state, unsignedTx, externalSecretsOpt, externalInputsOpt, externalDataInputsOpt)
@@ -383,19 +391,19 @@ class ErgoWalletActor(settings: ErgoSettings,
           state.parameters,
           state.stateContext
         )(state.readBoxFromUtxoWithWalletFallback)
-      sender() ! txTry
+      sender() ! SignedTransactionResponse(txTry)
 
     case ExtractHints(tx, real, simulated, boxesToSpendOpt, dataBoxesOpt) =>
       val bag = ergoWalletService.extractHints(state, tx, real, simulated, boxesToSpendOpt, dataBoxesOpt)
       sender() ! ExtractHintsResult(bag)
 
-    case DeriveKey(encodedPath) =>
-      ergoWalletService.deriveKeyFromPath(state, encodedPath, ergoAddressEncoder) match {
+    case DeriveKey(path) =>
+      ergoWalletService.deriveKeyFromPath(state, path, ergoAddressEncoder) match {
         case Success((p2pkAddress, newState)) =>
           context.become(loadedWallet(newState))
-          sender() ! Success(p2pkAddress)
-        case f@Failure(_) =>
-          sender() ! f
+          sender() ! DeriveKeyResponse(Success(p2pkAddress))
+        case Failure(t) =>
+          sender() ! DeriveKeyResponse(Failure(t))
       }
 
     case DeriveNextKey =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -5,9 +5,10 @@ import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.wallet.models.CollectedBoxes
+import org.ergoplatform.nodeView.wallet.persistence.WalletDigest
 import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, TransactionGenerationRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest}
-import org.ergoplatform.sdk.wallet.secrets.DerivationPath
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.ChainStatus
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
@@ -164,7 +165,7 @@ object ErgoWalletActorMessages {
    *
    * @param path
    */
-  final case class DeriveKey(path: String)
+  final case class DeriveKey(path: DerivationPath)
 
   /**
    * Get boxes related to P2PK payments
@@ -213,7 +214,7 @@ object ErgoWalletActorMessages {
    * @param minHeight - min inclusion height of unspent boxes
    * @param maxHeight - max inclusion height of unspent boxes
    */
-  final case class GetScanUnspentBoxes(scanId: ScanId, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int)
+  final case class GetScanUnspentBoxes(scanId: ScanId, considerUnconfirmed: Boolean, minHeight: Height, maxHeight: Height)
 
   /**
    * Get spent boxes related to a scan
@@ -281,8 +282,8 @@ object ErgoWalletActorMessages {
    * @param includeUnconfirmed - whether to include transactions from mempool that match given scanId
    */
   case class GetFilteredScanTxs(scanIds: List[ScanId],
-                                minHeight: Int,
-                                maxHeight: Int,
+                                minHeight: Height,
+                                maxHeight: Height,
                                 minConfNum: Int,
                                 maxConfNum: Int,
                                 includeUnconfirmed: Boolean)
@@ -306,7 +307,7 @@ object ErgoWalletActorMessages {
   /**
    * Rescan wallet
    */
-  case class RescanWallet(fromHeight: Int)
+  case class RescanWallet(fromHeight: Height)
 
   /**
    * Get wallet status
@@ -411,5 +412,85 @@ object ErgoWalletActorMessages {
    * @param status
    */
   case class AddBoxResponse(status: Try[Unit])
+
+  /**
+   * Wallet's response to [[InitWallet]] containing the generated mnemonic phrase.
+   */
+  final case class InitWalletResponse(result: Try[SecretString])
+
+  /**
+   * Wallet's response to [[RestoreWallet]].
+   */
+  final case class RestoreWalletResponse(result: Try[Unit])
+
+  /**
+   * Wallet's response to [[UnlockWallet]].
+   */
+  final case class UnlockWalletResponse(result: Try[Unit])
+
+  /**
+   * Wallet's response to [[RescanWallet]].
+   */
+  final case class RescanWalletResponse(result: Try[Unit])
+
+  /**
+   * Wallet's response to [[CheckSeed]] — whether the supplied mnemonic matches stored secret.
+   */
+  final case class CheckSeedResponse(matched: Try[Boolean])
+
+  /**
+   * Wallet's response to [[DeriveKey]] containing the derived address.
+   */
+  final case class DeriveKeyResponse(address: Try[P2PKAddress])
+
+  /**
+   * Wallet's response to [[GetPrivateKeyFromPath]].
+   */
+  final case class PrivateKeyFromPathResponse(key: Try[DLogProverInput])
+
+  /**
+   * Wallet's response to [[ReadPublicKeys]].
+   */
+  final case class PublicKeysResponse(addresses: Seq[P2PKAddress])
+
+  /**
+   * Wallet's response to [[ReadExtendedPublicKeys]].
+   */
+  final case class ExtendedPublicKeysResponse(keys: Seq[ExtendedPublicKey])
+
+  /**
+   * Wallet's response to [[GetWalletBoxes]].
+   */
+  final case class WalletBoxesResponse(boxes: Seq[WalletBox])
+
+  /**
+   * Wallet's response to [[GetScanUnspentBoxes]] / [[GetScanSpentBoxes]].
+   */
+  final case class ScanBoxesResponse(boxes: Seq[WalletBox])
+
+  /**
+   * Wallet's response to [[GetTransactions]].
+   */
+  final case class WalletTransactionsResponse(txs: Seq[AugWalletTransaction])
+
+  /**
+   * Wallet's response to [[GetTransaction]].
+   */
+  final case class WalletTransactionResponse(tx: Option[AugWalletTransaction])
+
+  /**
+   * Wallet's response to [[ReadBalances]].
+   */
+  final case class BalancesResponse(digest: WalletDigest)
+
+  /**
+   * Wallet's response to a signed-transaction [[GenerateTransaction]] request.
+   */
+  final case class SignedTransactionResponse(tx: Try[ErgoTransaction])
+
+  /**
+   * Wallet's response to an unsigned-transaction [[GenerateTransaction]] request.
+   */
+  final case class UnsignedTransactionResponse(tx: Try[UnsignedErgoTransaction])
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -5,13 +5,13 @@ import akka.pattern.ask
 import akka.util.Timeout
 import org.ergoplatform.ErgoBox.BoxId
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
+import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages._
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
-import org.ergoplatform.nodeView.wallet.persistence.WalletDigest
 import org.ergoplatform.nodeView.wallet.requests.{BoxesRequest, ExternalSecret, TransactionGenerationRequest}
 import org.ergoplatform.nodeView.wallet.scanning.ScanRequest
 import org.ergoplatform.sdk.SecretString
-import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey}
+import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.ChainStatus
 import org.ergoplatform.wallet.boxes.ChainStatus.{OffChain, OnChain}
@@ -19,11 +19,9 @@ import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.{ErgoBox, NodeViewComponent, P2PKAddress}
 import scorex.util.ModifierId
 import sigma.data.SigmaBoolean
-import sigmastate.crypto.DLogProtocol.DLogProverInput
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
-import scala.util.Try
 
 trait ErgoWalletReader extends NodeViewComponent {
 
@@ -36,72 +34,72 @@ trait ErgoWalletReader extends NodeViewComponent {
     * @param mnemonicPassOpt  mnemonic encription password
     * @return  menmonic phrase for the new wallet
     */
-  def initWallet(pass: SecretString, mnemonicPassOpt: Option[SecretString]): Future[Try[SecretString]] =
-    (walletActor ? InitWallet(pass, mnemonicPassOpt)).mapTo[Try[SecretString]]
+  def initWallet(pass: SecretString, mnemonicPassOpt: Option[SecretString]): Future[InitWalletResponse] =
+    (walletActor ? InitWallet(pass, mnemonicPassOpt)).mapTo[InitWalletResponse]
 
   def restoreWallet(encryptionPass: SecretString, mnemonic: SecretString,
-                    mnemonicPassOpt: Option[SecretString] = None, usePre1627KeyDerivation: Boolean): Future[Try[Unit]] =
-    (walletActor ? RestoreWallet(mnemonic, mnemonicPassOpt, encryptionPass, usePre1627KeyDerivation)).mapTo[Try[Unit]]
+                    mnemonicPassOpt: Option[SecretString] = None, usePre1627KeyDerivation: Boolean): Future[RestoreWalletResponse] =
+    (walletActor ? RestoreWallet(mnemonic, mnemonicPassOpt, encryptionPass, usePre1627KeyDerivation)).mapTo[RestoreWalletResponse]
 
-  def unlockWallet(pass: SecretString): Future[Try[Unit]] =
-    (walletActor ? UnlockWallet(pass)).mapTo[Try[Unit]]
+  def unlockWallet(pass: SecretString): Future[UnlockWalletResponse] =
+    (walletActor ? UnlockWallet(pass)).mapTo[UnlockWalletResponse]
 
   def lockWallet(): Unit = walletActor ! LockWallet
 
-  def rescanWallet(fromHeight: Int): Future[Try[Unit]] = (walletActor ? RescanWallet(fromHeight)).mapTo[Try[Unit]]
+  def rescanWallet(fromHeight: Height): Future[RescanWalletResponse] =
+    (walletActor ? RescanWallet(fromHeight)).mapTo[RescanWalletResponse]
 
   def getWalletStatus: Future[WalletStatus] =
     (walletActor ? GetWalletStatus).mapTo[WalletStatus]
 
-  def checkSeed(mnemonic: SecretString, mnemonicPassOpt: Option[SecretString] = None): Future[Boolean] = {
-    (walletActor ? CheckSeed(mnemonic, mnemonicPassOpt)).mapTo[Boolean]
-  }
+  def checkSeed(mnemonic: SecretString, mnemonicPassOpt: Option[SecretString] = None): Future[CheckSeedResponse] =
+    (walletActor ? CheckSeed(mnemonic, mnemonicPassOpt)).mapTo[CheckSeedResponse]
 
-  def deriveKey(path: String): Future[Try[P2PKAddress]] =
-    (walletActor ? DeriveKey(path)).mapTo[Try[P2PKAddress]]
+  def deriveKey(path: DerivationPath): Future[DeriveKeyResponse] =
+    (walletActor ? DeriveKey(path)).mapTo[DeriveKeyResponse]
 
   def deriveNextKey: Future[DeriveNextKeyResult] =
     (walletActor ? DeriveNextKey).mapTo[DeriveNextKeyResult]
 
-  def balances(chainStatus: ChainStatus): Future[WalletDigest] =
-    (walletActor ? ReadBalances(chainStatus)).mapTo[WalletDigest]
+  def balances(chainStatus: ChainStatus): Future[BalancesResponse] =
+    (walletActor ? ReadBalances(chainStatus)).mapTo[BalancesResponse]
 
-  def confirmedBalances: Future[WalletDigest] = balances(OnChain)
+  def confirmedBalances: Future[BalancesResponse] = balances(OnChain)
 
-  def balancesWithUnconfirmed: Future[WalletDigest] = balances(OffChain)
+  def balancesWithUnconfirmed: Future[BalancesResponse] = balances(OffChain)
 
-  def publicKeys(from: Int, to: Int): Future[Seq[P2PKAddress]] =
-    (walletActor ? ReadPublicKeys(from, to)).mapTo[Seq[P2PKAddress]]
+  def publicKeys(from: Int, to: Int): Future[PublicKeysResponse] =
+    (walletActor ? ReadPublicKeys(from, to)).mapTo[PublicKeysResponse]
 
-  def allExtendedPublicKeys(): Future[Seq[ExtendedPublicKey]] =
-    (walletActor ? ReadExtendedPublicKeys()).mapTo[Seq[ExtendedPublicKey]]
+  def allExtendedPublicKeys(): Future[ExtendedPublicKeysResponse] =
+    (walletActor ? ReadExtendedPublicKeys()).mapTo[ExtendedPublicKeysResponse]
 
-  def getPrivateKeyFromPath(path: DerivationPath): Future[Try[DLogProverInput]] =
-    (walletActor ? GetPrivateKeyFromPath(path)).mapTo[Try[DLogProverInput]]
+  def getPrivateKeyFromPath(path: DerivationPath): Future[PrivateKeyFromPathResponse] =
+    (walletActor ? GetPrivateKeyFromPath(path)).mapTo[PrivateKeyFromPathResponse]
 
-  def walletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean): Future[Seq[WalletBox]] =
-    (walletActor ? GetWalletBoxes(unspentOnly, considerUnconfirmed)).mapTo[Seq[WalletBox]]
+  def walletBoxes(unspentOnly: Boolean, considerUnconfirmed: Boolean): Future[WalletBoxesResponse] =
+    (walletActor ? GetWalletBoxes(unspentOnly, considerUnconfirmed)).mapTo[WalletBoxesResponse]
 
-  def scanUnspentBoxes(scanId: ScanId, considerUnconfirmed: Boolean, minHeight: Int, maxHeight: Int): Future[Seq[WalletBox]] =
-    (walletActor ? GetScanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight)).mapTo[Seq[WalletBox]]
+  def scanUnspentBoxes(scanId: ScanId, considerUnconfirmed: Boolean, minHeight: Height, maxHeight: Height): Future[ScanBoxesResponse] =
+    (walletActor ? GetScanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight)).mapTo[ScanBoxesResponse]
 
-  def scanSpentBoxes(scanId: ScanId): Future[Seq[WalletBox]] =
-    (walletActor ? GetScanSpentBoxes(scanId)).mapTo[Seq[WalletBox]]
+  def scanSpentBoxes(scanId: ScanId): Future[ScanBoxesResponse] =
+    (walletActor ? GetScanSpentBoxes(scanId)).mapTo[ScanBoxesResponse]
 
   def updateChangeAddress(address: P2PKAddress): Future[Unit] =
     walletActor.askWithStatus(UpdateChangeAddress(address)).mapTo[Unit]
 
-  def transactions: Future[Seq[AugWalletTransaction]] =
-    (walletActor ? GetTransactions).mapTo[Seq[AugWalletTransaction]]
+  def transactions: Future[WalletTransactionsResponse] =
+    (walletActor ? GetTransactions).mapTo[WalletTransactionsResponse]
 
-  def transactionById(id: ModifierId): Future[Option[AugWalletTransaction]] =
-    (walletActor ? GetTransaction(id)).mapTo[Option[AugWalletTransaction]]
+  def transactionById(id: ModifierId): Future[WalletTransactionResponse] =
+    (walletActor ? GetTransaction(id)).mapTo[WalletTransactionResponse]
 
   def generateTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
-                          dataInputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
+                          dataInputsRaw: Seq[String] = Seq.empty): Future[SignedTransactionResponse] =
     (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = true))
-      .mapTo[Try[ErgoTransaction]]
+      .mapTo[SignedTransactionResponse]
 
   def generateCommitmentsFor(unsignedErgoTransaction: UnsignedErgoTransaction,
                              externalSecretsOpt: Option[Seq[ExternalSecret]],
@@ -113,16 +111,16 @@ trait ErgoWalletReader extends NodeViewComponent {
 
   def generateUnsignedTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
-                          dataInputsRaw: Seq[String] = Seq.empty): Future[Try[UnsignedErgoTransaction]] =
-    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = false)).mapTo[Try[UnsignedErgoTransaction]]
+                          dataInputsRaw: Seq[String] = Seq.empty): Future[UnsignedTransactionResponse] =
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = false)).mapTo[UnsignedTransactionResponse]
 
 
   def signTransaction(tx: UnsignedErgoTransaction,
                       secrets: Seq[ExternalSecret],
                       hints: TransactionHintsBag,
                       boxesToSpend: Option[Seq[ErgoBox]],
-                      dataBoxes: Option[Seq[ErgoBox]]): Future[Try[ErgoTransaction]] =
-    (walletActor ? SignTransaction(tx, secrets, hints, boxesToSpend, dataBoxes)).mapTo[Try[ErgoTransaction]]
+                      dataBoxes: Option[Seq[ErgoBox]]): Future[SignedTransactionResponse] =
+    (walletActor ? SignTransaction(tx, secrets, hints, boxesToSpend, dataBoxes)).mapTo[SignedTransactionResponse]
 
   def extractHints(tx: ErgoTransaction,
                    real: Seq[SigmaBoolean],
@@ -162,11 +160,11 @@ trait ErgoWalletReader extends NodeViewComponent {
     * @param includeUnconfirmed - whether to include transactions from mempool that match given scanId
     */
   def filteredScanTransactions(scanIds: List[ScanId],
-                               minHeight: Int,
-                               maxHeight: Int,
+                               minHeight: Height,
+                               maxHeight: Height,
                                minConfNum: Int,
                                maxConfNum: Int,
-                               includeUnconfirmed: Boolean): Future[Seq[AugWalletTransaction]] =
-    (walletActor ? GetFilteredScanTxs(scanIds, minHeight, maxHeight, minConfNum, maxConfNum, includeUnconfirmed)).mapTo[Seq[AugWalletTransaction]]
+                               includeUnconfirmed: Boolean): Future[WalletTransactionsResponse] =
+    (walletActor ? GetFilteredScanTxs(scanIds, minHeight, maxHeight, minConfNum, maxConfNum, includeUnconfirmed)).mapTo[WalletTransactionsResponse]
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -158,10 +158,10 @@ trait ErgoWalletService {
   /**
     * Derive key from given encoded path according to BIP-32
     * @param state current wallet state
-    * @param encodedPath derivation path from the master key
+    * @param path derivation path from the master key
     * @return Try of pay-to-public-key-address and new wallet state
     */
-  def deriveKeyFromPath(state: ErgoWalletState, encodedPath: String, addrEncoder: ErgoAddressEncoder): Try[(P2PKAddress, ErgoWalletState)]
+  def deriveKeyFromPath(state: ErgoWalletState, path: DerivationPath, addrEncoder: ErgoAddressEncoder): Try[(P2PKAddress, ErgoWalletState)]
 
   /**
    * Get the secret key for a give derivation path.
@@ -537,23 +537,20 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
     prover.bagForTransaction(tx, inputBoxes, dataBoxes, state.stateContext, real, simulated)
   }
 
-  override def deriveKeyFromPath(state: ErgoWalletState, encodedPath: String, addrEncoder: ErgoAddressEncoder): Try[(P2PKAddress, ErgoWalletState)] =
+  override def deriveKeyFromPath(state: ErgoWalletState, path: DerivationPath, addrEncoder: ErgoAddressEncoder): Try[(P2PKAddress, ErgoWalletState)] =
     state.secretStorageOpt match {
       case Some(secretStorage) if !secretStorage.isLocked =>
         val rootSecret = secretStorage.secret.get // unlocked means Some(secret)
-        DerivationPath.fromEncoded(encodedPath) match {
-          case Success(path) if !path.publicBranch =>
-            val secret = rootSecret.derive(path)
-            addSecretToStorage(state, secret) match {
-              case Success(newState) =>
-                Success(P2PKAddress(secret.publicKey.key)(addrEncoder) -> newState)
-              case Failure(t) =>
-                Failure(t)
-            }
-          case Success(path) =>
-            Failure(new Exception(s"A private path is expected, but the public one given: $path"))
-          case Failure(t) =>
-            Failure(t)
+        if (path.publicBranch) {
+          Failure(new Exception(s"A private path is expected, but the public one given: $path"))
+        } else {
+          val secret = rootSecret.derive(path)
+          addSecretToStorage(state, secret) match {
+            case Success(newState) =>
+              Success(P2PKAddress(secret.publicKey.key)(addrEncoder) -> newState)
+            case Failure(t) =>
+              Failure(t)
+          }
         }
       case Some(_) =>
         Failure(new Exception("Unable to derive key from path, wallet is locked"))

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -5,7 +5,7 @@ import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
-import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
+import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate, SolutionAck}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
@@ -157,13 +157,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(block.header.powSolution, testProbe.ref)
     // we fish either for ack or SSM as the order is non-deterministic
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) =>
+      case StatusReply.Success(SolutionAck) =>
         testProbe.expectMsgPF(candidateGenDelay) {
           case FullBlockApplied(header) if header.id != block.header.parentId =>
         }
         true
       case FullBlockApplied(header) if header.id != block.header.parentId =>
-        testProbe.expectMsg(StatusReply.Success(()))
+        testProbe.expectMsg(StatusReply.Success(SolutionAck))
         true
     }
 
@@ -209,13 +209,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         candidateGenerator.tell(block.header.powSolution, testProbe.ref)
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -299,13 +299,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         candidateGenerator.tell(block.header.powSolution, testProbe.ref)
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -358,13 +358,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         candidateGenerator.tell(block.header.powSolution, testProbe.ref)
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -405,13 +405,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -450,13 +450,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -510,13 +510,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -565,13 +565,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -788,7 +788,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       .get
     candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
+      case StatusReply.Success(SolutionAck) => true
       case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
       case _ => false
     }
@@ -861,7 +861,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
     // Wait for block application - can receive either StatusReply or FullBlockApplied first
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
+      case StatusReply.Success(SolutionAck) => true
       case _: FullBlockApplied => true
       case _ => false
     }
@@ -894,7 +894,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     // Should successfully apply the block
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
+      case StatusReply.Success(SolutionAck) => true
       case _: FullBlockApplied => true
       case _ => false
     }
@@ -942,7 +942,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
     // Wait for both StatusReply and FullBlockApplied messages
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
+      case StatusReply.Success(SolutionAck) => true
       case _: FullBlockApplied => true
       case _ => false
     }
@@ -990,7 +990,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     // Should successfully apply the block
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
+      case StatusReply.Success(SolutionAck) => true
       case _: FullBlockApplied => true
       case _ => false
     }
@@ -1077,13 +1077,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           .get
         candidateGenerator.tell(block.header.powSolution, testProbe.ref)
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }
@@ -1135,7 +1135,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     // Should successfully apply the block
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
+      case StatusReply.Success(SolutionAck) => true
       case FullBlockApplied(header) if header.id != solvedBlock.header.parentId => true
       case _ => false
     }

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -5,7 +5,7 @@ import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
-import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
+import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate, SolutionAck}
 import org.ergoplatform.mining.ErgoMiner.StartMining
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
@@ -165,7 +165,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     def loop(toSend: Int): Unit = {
       val toSpend: Seq[ErgoBox] = await(
         wallet.walletBoxes(unspentOnly = false, considerUnconfirmed = false)
-      ).map(_.trackedBox.box).toList
+      ).boxes.map(_.trackedBox.box).toList
       log.debug(s"Generate more transactions from ${toSpend.length} boxes. $toSend remains," +
         s"pool size: ${requestReaders.m.size}")
       val txs: Seq[ErgoTransaction] = toSpend.take(toSend) map { boxToSend =>
@@ -269,13 +269,13 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
+          case StatusReply.Success(SolutionAck) =>
             testProbe.expectMsgPF(candidateGenDelay) {
               case FullBlockApplied(header) if header.id != block.header.parentId =>
             }
             true
           case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
+            testProbe.expectMsg(StatusReply.Success(SolutionAck))
             true
         }
     }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -62,7 +62,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
           val req = (0 until inputsToCreate).map(_ => PaymentRequest(addresses.head, sumToSpend, Array.empty, Map.empty))
           log.info(s"Confirmed balance $snap")
           log.info(s"Payment request $req")
-          val tx = await(wallet.generateTransaction(req)).get
+          val tx = await(wallet.generateTransaction(req)).tx.get
           log.info(s"Generated transaction $tx")
           val context = new ErgoStateContext(Seq(genesisBlock.header), Some(genesisBlock.extension), startDigest, parameters, validationSettingsNoIl, VotingData.empty)(settings.chainSettings)
           val boxesToSpend = tx.inputs.map(i => genesisTx.outputs.find(o => java.util.Arrays.equals(o.id, i.boxId)).get)
@@ -77,7 +77,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
           val newSumToSpend = tx.outputs.head.value
           val req2 = Seq(PaymentRequest(addresses.head, newSumToSpend, Array.empty, Map.empty))
           log.info(s"Payment requests 2 $req2")
-          val tx2 = await(wallet.generateTransaction(req2)).get
+          val tx2 = await(wallet.generateTransaction(req2)).tx.get
           (req2, tx2)
         }
       log.info(s"Generated transaction $tx2")
@@ -86,7 +86,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
       eventually {
         tx2.inputs.size should be < tx.outputs.size
         // trying to create a new transaction
-        val tx3 = await(wallet.generateTransaction(req2)).get
+        val tx3 = await(wallet.generateTransaction(req2)).tx.get
         // check that tx3 has inputs different from tx2
         tx3.inputs.foreach { in =>
           tx2.inputs.exists(tx2In => tx2In.boxId sameElements in.boxId) shouldBe false
@@ -111,7 +111,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val feeAmount = availableAmount / 4
         val feeReq = PaymentRequest(Pay2SAddress(TrueTree), feeAmount, Array.empty, Map.empty)
         val req = AssetIssueRequest(address, None, emissionAmount, tokenName, tokenDescription, tokenDecimals)
-        val tx = await(wallet.generateTransaction(Seq(feeReq, req))).get
+        val tx = await(wallet.generateTransaction(Seq(feeReq, req))).tx.get
         log.info(s"Generated transaction $tx")
         val context = new ErgoStateContext(
           Seq(genesisBlock.header),
@@ -146,7 +146,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         assetToSpend should not be empty
         val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance, assetToSpend, Map.empty)
 
-        val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).get
+        val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).tx.get
         tx1.outputs.size shouldBe 1
         tx1.outputs.head.value shouldBe confirmedBalance
         toAssetMap(tx1.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend)
@@ -156,7 +156,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val assetToReturn = assetToSpend.map { case (tokenId, _) => (tokenId, 1L) }
         val req2 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance - MinBoxValue, assetToSpend2, Map.empty)
 
-        val tx2 = await(wallet.generateTransaction(Seq(req2))).get
+        val tx2 = await(wallet.generateTransaction(Seq(req2))).tx.get
         tx2.outputs.size shouldBe 2
         tx2.outputs.head.value shouldBe confirmedBalance - MinBoxValue
         toAssetMap(tx2.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend2)
@@ -186,7 +186,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         assetToSpend should not be empty
         val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance, assetToSpend, Map.empty)
 
-        val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).get
+        val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).tx.get
         tx1.outputs.size shouldBe 1
         tx1.outputs.head.value shouldBe confirmedBalance
         toAssetMap(tx1.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend)
@@ -196,7 +196,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val assetToReturn = assetToSpend.map { case (tokenId, _) => (tokenId, 1L) }
         val req2 = Seq(BurnTokensRequest(assetToSpend2))
 
-        val tx2 = await(wallet.generateTransaction(req2)).get
+        val tx2 = await(wallet.generateTransaction(req2)).tx.get
         tx2.outputs.size shouldBe 1
         tx2.outputs.head.value shouldBe confirmedBalance
         toAssetMap(tx2.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToReturn)
@@ -224,7 +224,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         assetToSpend should not be empty
         val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance, assetToSpend, Map.empty)
 
-        val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).get
+        val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).tx.get
         tx1.outputs.size shouldBe 1
         tx1.outputs.head.value shouldBe confirmedBalance
         toAssetMap(tx1.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend)
@@ -234,7 +234,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val assetToReturn = assetToSpend.map { case (tokenId, _) => (tokenId, 1L) }
         val req2 = Seq(BurnTokensRequest(assetToSpend2), PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance - MinBoxValue, Array.empty, Map.empty))
 
-        val tx2 = await(wallet.generateTransaction(req2)).get
+        val tx2 = await(wallet.generateTransaction(req2)).tx.get
         tx2.outputs.size shouldBe 2
         tx2.outputs.head.value shouldBe confirmedBalance - MinBoxValue
         toAssetMap(tx2.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(Seq.empty)
@@ -276,7 +276,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
 
       val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance / 2, Array.empty, Map.empty)
 
-      val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).get
+      val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).tx.get
       tx1.outputs.size shouldBe 2
       tx1.outputs.head.value shouldBe (confirmedBalance / 2)
       tx1.outputs.head.additionalTokens.toArray shouldBe Seq.empty
@@ -308,7 +308,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
 
       val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance / 2, Array.empty, Map.empty)
 
-      val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).get
+      val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).tx.get
       tx1.outputs.size shouldBe 2
       tx1.outputs.head.value shouldBe (confirmedBalance / 2)
       tx1.outputs.head.additionalTokens.toArray shouldBe Seq.empty
@@ -340,7 +340,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
 
       val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance / 2, Array.empty, Map.empty)
 
-      val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).get
+      val tx1 = await(wallet.generateTransaction(Seq(req1), boxesToUseEncoded)).tx.get
       tx1.outputs.size shouldBe 2
       tx1.outputs.head.value shouldBe (confirmedBalance / 2)
       tx1.outputs.head.additionalTokens.toArray shouldBe Seq.empty
@@ -370,7 +370,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
               addresses.tail.map(a => PaymentRequest(a, sumToSpend, Array.empty, Map.empty))
           log.info(s"Confirmed balance $snap")
           log.info(s"Payment request $req")
-          val tx = await(wallet.generateTransaction(req)).get
+          val tx = await(wallet.generateTransaction(req)).tx.get
           log.info(s"Generated transaction $tx")
           val context = new ErgoStateContext(
             Seq(genesisBlock.header),
@@ -393,7 +393,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
           addresses.tail.map(a => PaymentRequest(a, newSumToSpend, Array.empty, Map.empty))
         log.info(s"New balance $newSnap")
         log.info(s"Payment requests 2 $req2")
-        val tx2 = await(wallet.generateTransaction(req2)).get
+        val tx2 = await(wallet.generateTransaction(req2)).tx.get
         log.info(s"Generated transaction $tx2")
         val context2 = new ErgoStateContext(Seq(block.header), Some(block.extension), startDigest, parameters, validationSettingsNoIl, VotingData.empty)(settings.chainSettings)
         val knownBoxes = tx.outputs ++ genesisTx.outputs
@@ -999,7 +999,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         assetToSpend should not be empty
         val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance, assetToSpend, Map.empty)
 
-        val tx1 = await(wallet.generateTransaction(Seq(req1))).get
+        val tx1 = await(wallet.generateTransaction(Seq(req1))).tx.get
         tx1.outputs.size shouldBe 1
         tx1.outputs.head.value shouldBe confirmedBalance
         toAssetMap(tx1.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend)
@@ -1009,7 +1009,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val assetToReturn = assetToSpend.map { case (tokenId, _) => (tokenId, 1L) }
         val req2 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance - MinBoxValue, assetToSpend2, Map.empty)
 
-        val tx2 = await(wallet.generateTransaction(Seq(req2))).get
+        val tx2 = await(wallet.generateTransaction(Seq(req2))).tx.get
         tx2.outputs.size shouldBe 2
         tx2.outputs.head.value shouldBe confirmedBalance - MinBoxValue
         toAssetMap(tx2.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend2)
@@ -1033,12 +1033,12 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         assetToSpend should not be empty
         val req1 = PaymentRequest(Pay2SAddress(TrueTree), confirmedBalance, assetToSpend, Map.empty)
 
-        val utx = await(wallet.generateUnsignedTransaction(Seq(req1))).get
+        val utx = await(wallet.generateUnsignedTransaction(Seq(req1))).tx.get
         utx.outputs.size shouldBe 1
         utx.outputs.head.value shouldBe confirmedBalance
         toAssetMap(utx.outputs.head.additionalTokens.toArray) shouldBe toAssetMap(assetToSpend)
 
-        val tx = await(wallet.signTransaction(utx, Seq.empty, TransactionHintsBag.empty, None, None)).get
+        val tx = await(wallet.signTransaction(utx, Seq.empty, TransactionHintsBag.empty, None, None)).tx.get
         tx.id shouldBe utx.id // signing preserves transaction id
       }
     }
@@ -1065,7 +1065,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         assetToSpend should not be empty
         val req1 = PaymentRequest(Pay2SAddress(ErgoTree.fromSigmaBoolean(CAND(Seq(secret1.publicImage, secret2.publicImage)))), confirmedBalance, assetToSpend, Map.empty)
 
-        val tx = await(wallet.generateTransaction(Seq(req1))).get
+        val tx = await(wallet.generateTransaction(Seq(req1))).tx.get
 
         val in = tx.outputs.head
 
@@ -1073,7 +1073,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
 
         val hints1 = await(wallet.generateCommitmentsFor(utx, Some(Seq(es1)), Some(Seq(in)), None)).response.get
 
-        val txSigned = await(wallet.signTransaction(utx, Seq(es2), hints1, Some(Seq(in)), None)).get
+        val txSigned = await(wallet.signTransaction(utx, Seq(es2), hints1, Some(Seq(in)), None)).tx.get
 
         txSigned.statelessValidity().isSuccess shouldBe true
       }
@@ -1103,7 +1103,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val addr = Pay2SAddress(ErgoTree.fromSigmaBoolean(CTHRESHOLD(2, Seq(secret1.publicImage, secret2.publicImage, secret3.publicImage))))
         val req1 = PaymentRequest(addr, confirmedBalance, assetToSpend, Map.empty)
 
-        val tx = await(wallet.generateTransaction(Seq(req1))).get
+        val tx = await(wallet.generateTransaction(Seq(req1))).tx.get
 
         val in = tx.outputs.head
 
@@ -1114,14 +1114,14 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
 
         val pubCmts1 = TransactionHintsBag(cmts1.publicHints)
 
-        val ptx = await(wallet.signTransaction(utx, Seq(es2), pubCmts1, Some(Seq(in)), None)).get
+        val ptx = await(wallet.signTransaction(utx, Seq(es2), pubCmts1, Some(Seq(in)), None)).tx.get
 
         val eh = wallet.extractHints(ptx, Seq(secret1.publicImage, secret2.publicImage), Seq(secret3.publicImage), Some(Seq(in)), None)
         val hintsExtracted = await(eh).transactionHintsBag
 
         val hints = hintsExtracted.addHintsForInput(0, cmts1.allHintsForInput(0))
 
-        val txSigned = await(wallet.signTransaction(utx, Seq(es1), hints, Some(Seq(in)), None)).get
+        val txSigned = await(wallet.signTransaction(utx, Seq(es1), hints, Some(Seq(in)), None)).tx.get
         txSigned.statelessValidity().isSuccess shouldBe true
       }
     }

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -117,7 +117,7 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
           val candidate = Candidate(null, externalWorkMessage, Seq.empty) // API does not use CandidateBlock
           sender() ! StatusReply.success(candidate)
         }
-      case _: AutolykosSolution => sender() ! StatusReply.success(())
+      case _: AutolykosSolution => sender() ! StatusReply.success(CandidateGenerator.SolutionAck)
       case ErgoMiner.ReadMinerPk => sender() ! StatusReply.success(pk)
     }
   }
@@ -181,19 +181,19 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
 
     def receive: Receive = {
 
-      case _: InitWallet => sender() ! Success(SecretString.create(WalletActorStub.mnemonic))
+      case _: InitWallet => sender() ! InitWalletResponse(Success(SecretString.create(WalletActorStub.mnemonic)))
 
-      case _: RestoreWallet => sender() ! Success(())
+      case _: RestoreWallet => sender() ! RestoreWalletResponse(Success(()))
 
-      case _: UnlockWallet => sender() ! Success(())
+      case _: UnlockWallet => sender() ! UnlockWalletResponse(Success(()))
 
       case LockWallet => ()
 
-      case RescanWallet(_) => sender ! Success(())
+      case RescanWallet(_) => sender() ! RescanWalletResponse(Success(()))
 
       case GetWalletStatus => sender() ! WalletStatus(true, true, None, ErgoHistoryUtils.GenesisHeight, error = None)
 
-      case _: CheckSeed => sender() ! true
+      case _: CheckSeed => sender() ! CheckSeedResponse(Success(true))
 
       case GetWalletBoxes(unspentOnly, _) =>
         val boxes = if (unspentOnly) {
@@ -201,7 +201,7 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
         } else {
           Seq(walletBox10_10, walletBox20_30, walletBoxSpent21_31)
         }
-        sender() ! boxes.sortBy(_.trackedBox.inclusionHeightOpt)
+        sender() ! WalletBoxesResponse(boxes.sortBy(_.trackedBox.inclusionHeightOpt))
 
       case GetScanTransactions(scanId, includeUnconfirmed) =>
         if (includeUnconfirmed) {
@@ -211,18 +211,18 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
         }
 
       case GetTransactions =>
-        sender() ! walletTxs
+        sender() ! WalletTransactionsResponse(walletTxs)
 
-      case DeriveKey(_) => sender() ! Success(WalletActorStub.address)
+      case DeriveKey(_) => sender() ! DeriveKeyResponse(Success(WalletActorStub.address))
 
       case DeriveNextKey => sender() !
         DeriveNextKeyResult(Success((WalletActorStub.path, WalletActorStub.address, WalletActorStub.secretKey)))
 
       case ReadPublicKeys(from, until) =>
-        sender() ! trackedAddresses.slice(from, until)
+        sender() ! PublicKeysResponse(trackedAddresses.slice(from, until))
 
       case ReadBalances(chainStatus) =>
-        sender() ! WalletDigest(0, WalletActorStub.balance(chainStatus), mutable.WrappedArray.empty)
+        sender() ! BalancesResponse(WalletDigest(0, WalletActorStub.balance(chainStatus), mutable.WrappedArray.empty))
 
       case AddScan(req) =>
         val scanId = ScanId @@ (apps.lastOption.map(_._1).getOrElse(100: Short) + 1).toShort
@@ -249,10 +249,10 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
           box.trackedBox.inclusionHeightOpt.getOrElse(0) >= minHeight &&
             (maxHeight == -1 || box.trackedBox.inclusionHeightOpt.getOrElse(Int.MaxValue) <= maxHeight)
         }
-        sender() ! res
+        sender() ! ScanBoxesResponse(res)
 
       case GetScanSpentBoxes(_) =>
-        sender() ! Seq(walletBox10_10, walletBox20_30, walletBoxSpent21_31)
+        sender() ! ScanBoxesResponse(Seq(walletBox10_10, walletBox20_30, walletBoxSpent21_31))
 
       case StopTracking(_, _) =>
         sender() ! StopTrackingResponse(Success(()))
@@ -263,13 +263,13 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
       case GenerateTransaction(_, _, _, _) =>
         val input = inputGen.sample.value
         val tx = ErgoTransaction(IndexedSeq(input), IndexedSeq(ergoBoxCandidateGen.sample.value))
-        sender() ! Success(tx)
+        sender() ! SignedTransactionResponse(Success(tx))
 
       case SignTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt) =>
         val sc = ErgoStateContext.empty(settings.chainSettings, parameters)
-        sender() ! ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, parameters, sc) { boxId =>
+        sender() ! SignedTransactionResponse(ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, parameters, sc) { boxId =>
           utxoState.versionedBoxHolder.get(ByteArrayWrapper(boxId))
-        }
+        })
     }
   }
 

--- a/src/test/scala/org/ergoplatform/utils/WalletTestOps.scala
+++ b/src/test/scala/org/ergoplatform/utils/WalletTestOps.scala
@@ -36,13 +36,13 @@ trait WalletTestOps extends NodeViewBaseOps {
   def wallet(implicit w: WalletFixture): ErgoWallet = w.wallet
 
   def getPublicKeys(implicit w: WalletFixture): Seq[P2PKAddress] =
-    await(w.wallet.publicKeys(0, Int.MaxValue))
+    await(w.wallet.publicKeys(0, Int.MaxValue)).addresses
 
   def getConfirmedBalances(implicit w: WalletFixture): WalletDigest =
-    await(w.wallet.confirmedBalances)
+    await(w.wallet.confirmedBalances).digest
 
   def getBalancesWithUnconfirmed(implicit w: WalletFixture): WalletDigest =
-    await(w.wallet.balancesWithUnconfirmed)
+    await(w.wallet.balancesWithUnconfirmed).digest
 
   def offchainScanTime(tx: ErgoTransaction): Long = tx.outputs.size * 100 + 300
 


### PR DESCRIPTION
Replaced bare primitives (`Try[Unit]`, `Future[Boolean]`, raw `Int` heights, raw `String` derivation paths) in `ErgoWalletActor` <-> API communication with named case-class wrappers and existing type aliases.

Wallet actor now replies with `InitWalletResponse`, `RestoreWalletResponse`, `CheckSeedResponse`, `DeriveKeyResponse`, `RescanWalletResponse`, `BalancesResponse`, `WalletBoxesResponse`, `WalletTransactionsResponse`, `SignedTransactionResponse`, etc. instead of unwrapped `Try` / `Future` primitives. Request fields that carried block heights now use the `Height` alias; `DeriveKey` takes a parsed `DerivationPath` instead of a raw string. Mining solution submission gets a `SolutionAck` instead of `Unit`.

Internal-only refactor - public HTTP API JSON shape is unchanged.

Closes #1005 