### PR TITLE
add /node/config endpoints for voting + mempool settings

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2634,6 +2634,53 @@ components:
         error:
           type: string
 
+    NodeConfig:
+      description: |
+        Mutable subset of node configuration. All fields are optional in PUT
+        bodies; only specified fields are updated.
+      type: object
+      properties:
+        voting:
+          type: object
+          properties:
+            targets:
+              type: object
+              additionalProperties:
+                type: integer
+                format: int32
+              description: |
+                Map of voting parameter byte-id (as a string key in 0..255) to
+                the integer target value the miner wants to vote for.
+              example:
+                "1": 1000000
+                "120": 1
+            rulesToDisable:
+              type: array
+              description: Validation rule ids the node would like to disable in a soft-fork.
+              items:
+                type: integer
+                format: int32
+              example: [215, 409]
+        mempool:
+          type: object
+          properties:
+            capacity:
+              type: integer
+              format: int32
+              description: Maximum number of transactions kept in the mempool.
+              example: 100000
+            minimalFeeAmount:
+              type: integer
+              format: int64
+              description: Minimum fee (nanoERG) required for a transaction to enter the mempool.
+              example: 1000000
+            cleanupDuration:
+              type: string
+              description: |
+                Mempool cleanup interval as a duration string (e.g. '10s',
+                '500ms'). A transaction can be rechecked only after this delay.
+              example: "10s"
+
     ApiError:
       description: Error response from API
       type: object
@@ -6065,6 +6112,78 @@ paths:
       responses:
         '200':
           description: The node will be shut down in 5 seconds
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /node/config:
+    get:
+      security:
+        - ApiKeyAuth: [ api_key ]
+      summary: Get the mutable subset of the node configuration
+      description: |
+        Returns the subset of node settings that can be updated at runtime via
+        PUT /node/config: voting targets, rulesToDisable, and selected mempool
+        parameters. Other settings (state type, network bindings, paths) are
+        not exposed here.
+      operationId: getNodeConfig
+      tags:
+        - node
+      responses:
+        '200':
+          description: Current mutable configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeConfig'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+    put:
+      security:
+        - ApiKeyAuth: [ api_key ]
+      summary: Update one or more mutable node settings at runtime
+      description: |
+        Accepts a partial NodeConfig body. Validation is all-or-nothing: if any
+        field is invalid the entire patch is rejected with 400 and no state
+        changes. On success, changes are persisted to the user's HOCON config
+        file (appended in a sentinel-delimited block) and applied in memory.
+        Returns 409 if the node was started without a writable user config
+        file.
+      operationId: updateNodeConfig
+      tags:
+        - node
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeConfig'
+      responses:
+        '200':
+          description: Updated configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeConfig'
+        '400':
+          description: Invalid patch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '409':
+          description: Node has no writable user config file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         default:
           description: Error
           content:

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -13,7 +13,7 @@ import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ErgoSyncTracker}
 import org.ergoplatform.nodeView.history.ErgoSyncInfoMessageSpec
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
-import org.ergoplatform.settings.{Args, ErgoSettings, ErgoSettingsReader, NetworkType, ScorexSettings}
+import org.ergoplatform.settings.{Args, ErgoSettings, ErgoSettingsReader, HoconConfigRewriter, NetworkType, PersistError, ScorexSettings, SettingsHolder}
 import scorex.core.api.http._
 import scorex.core.app.ScorexContext
 import scorex.core.network.NetworkController.ReceivableMessages.ShutdownNetwork
@@ -24,6 +24,7 @@ import org.ergoplatform.network.peer.PeerManagerRef
 import scorex.util.ScorexLogging
 
 import java.net.InetSocketAddress
+import java.nio.file.Paths
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.{Codec, Source}
 
@@ -51,6 +52,22 @@ class ErgoApp(args: Args) extends ScorexLogging {
   )
 
   implicit private val executionContext: ExecutionContext = actorSystem.dispatcher
+
+  /** Holds the current settings and (when the node was started with a user config) persists API-driven changes. */
+  private val settingsHolder: SettingsHolder = {
+    val persister: ErgoSettings => Either[PersistError, Unit] = args.userConfigPathOpt match {
+      case Some(path) =>
+        val rewriter = new HoconConfigRewriter(Paths.get(path))
+        rewriter.writeOverrides
+      case None =>
+        _ => Left(PersistError.NoWritableConfig)
+    }
+    new SettingsHolder(
+      ergoSettings,
+      persister,
+      (prev, curr) => actorSystem.eventStream.publish(SettingsHolder.SettingsUpdated(prev, curr))
+    )
+  }
 
   private val upnpGateway: Option[UPnPGateway] =
     if (scorexSettings.network.upnpEnabled) UPnP.getValidGateway(scorexSettings.network)
@@ -94,7 +111,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   private val peerManagerRef = PeerManagerRef(ergoSettings, scorexContext)
 
-  private val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings)
+  private val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings, settingsHolder)
 
   private val readersHolderRef: ActorRef = ErgoReadersHolderRef(nodeViewHolderRef)
 
@@ -199,7 +216,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
     UtxoApiRoute(readersHolderRef, scorexSettings.restApi),
     ScriptApiRoute(readersHolderRef, ergoSettings),
     ScanApiRoute(readersHolderRef, ergoSettings),
-    NodeApiRoute(ergoSettings)
+    NodeApiRoute(ergoSettings, settingsHolder)
   ) ++ minerRefOpt.map(minerRef => MiningApiRoute(minerRef, ergoSettings)).toSeq
 
   private val swaggerRoute = SwaggerRoute(scorexSettings.restApi, swaggerConfig)
@@ -232,7 +249,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
   }
 
   if (!ergoSettings.nodeSettings.stateType.requireProofs) {
-    MempoolAuditorRef(nodeViewHolderRef, networkControllerRef, ergoSettings)
+    MempoolAuditorRef(nodeViewHolderRef, networkControllerRef, ergoSettings, settingsHolder)
   }
 
   private def swaggerConfig: String =

--- a/src/main/scala/org/ergoplatform/http/api/NodeApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/NodeApiRoute.scala
@@ -1,26 +1,49 @@
 package org.ergoplatform.http.api
 
 import akka.actor.{ActorRefFactory, ActorSystem}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
+import io.circe.syntax._
 import org.ergoplatform.ErgoApp
 import org.ergoplatform.ErgoApp.RemoteShutdown
-import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
+import org.ergoplatform.http.api.NodeConfigCodecs._
+import org.ergoplatform.settings.{ErgoSettings, PersistError, RESTApiSettings, SettingsHolder}
 import scorex.core.api.http.ApiResponse
 
 import scala.concurrent.duration._
 
-case class NodeApiRoute(ergoSettings: ErgoSettings)(implicit system: ActorSystem, val context: ActorRefFactory) extends ErgoBaseApiRoute {
+case class NodeApiRoute(ergoSettings: ErgoSettings,
+                        settingsHolder: SettingsHolder)
+                       (implicit system: ActorSystem, val context: ActorRefFactory) extends ErgoBaseApiRoute {
 
   val settings: RESTApiSettings = ergoSettings.scorexSettings.restApi
 
   override val route: Route = (pathPrefix("node") & withAuth) {
-      shutdown
-    }
+    shutdown ~ getConfig ~ putConfig
+  }
 
   private val shutdownDelay = 5.seconds
 
-  private def shutdown: Route = (pathPrefix("shutdown") & post) {
+  private def shutdown: Route = (path("shutdown") & post) {
     system.scheduler.scheduleOnce(shutdownDelay)(ErgoApp.shutdownSystem(RemoteShutdown))
     ApiResponse(s"The node will be shut down in $shutdownDelay")
+  }
+
+  private def getConfig: Route = (path("config") & get) {
+    ApiResponse(NodeConfigView.from(settingsHolder.current).asJson)
+  }
+
+  private def putConfig: Route = (path("config") & put & entity(as[NodeConfigPatch])) { patch =>
+    val candidate = applyPatch(settingsHolder.current, patch)
+    settingsHolder.trySwap(candidate) match {
+      case Right(updated) =>
+        ApiResponse(NodeConfigView.from(updated).asJson)
+      case Left(PersistError.NoWritableConfig) =>
+        ApiError(StatusCodes.Conflict, "no.writable.config")(PersistError.NoWritableConfig.message)
+      case Left(e: PersistError.ConfigFileUnsupported) =>
+        ApiError(StatusCodes.Conflict, "config.file.unsupported")(e.message)
+      case Left(e: PersistError.IoFailure) =>
+        ApiError.InternalError(e.message)
+    }
   }
 }

--- a/src/main/scala/org/ergoplatform/http/api/NodeConfigCodecs.scala
+++ b/src/main/scala/org/ergoplatform/http/api/NodeConfigCodecs.scala
@@ -1,0 +1,139 @@
+package org.ergoplatform.http.api
+
+import io.circe._
+import io.circe.generic.semiauto._
+import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, VotingTargets}
+
+import scala.concurrent.duration._
+import scala.util.Try
+
+/**
+  * JSON codecs and DTOs for the `/node/config` API endpoint.
+  *
+  * Request:  [[NodeConfigPatch]] — all fields are optional; only fields that are
+  *           present in the JSON body are applied. Type and range validation is
+  *           performed in the decoders' `emap` calls so a single bad field fails
+  *           the whole decode (all-or-nothing semantics).
+  *
+  * Response: [[NodeConfigView]] — the full mutable subset of `ErgoSettings`.
+  */
+object NodeConfigCodecs {
+
+  // ---------- Request DTOs ----------
+
+  final case class MempoolPatch(
+    capacity: Option[Int] = None,
+    minimalFeeAmount: Option[Long] = None,
+    cleanupDuration: Option[FiniteDuration] = None
+  )
+
+  final case class VotingPatch(
+    targets: Option[Map[Byte, Int]] = None,
+    rulesToDisable: Option[Seq[Short]] = None
+  )
+
+  final case class NodeConfigPatch(
+    voting: Option[VotingPatch] = None,
+    mempool: Option[MempoolPatch] = None
+  )
+
+  // ---------- Response DTO ----------
+
+  final case class MempoolView(
+    capacity: Int,
+    minimalFeeAmount: Long,
+    cleanupDuration: FiniteDuration
+  )
+
+  final case class VotingView(
+    targets: Map[Byte, Int],
+    rulesToDisable: Seq[Short]
+  )
+
+  final case class NodeConfigView(
+    voting: VotingView,
+    mempool: MempoolView
+  )
+
+  object NodeConfigView {
+    def from(s: ErgoSettings): NodeConfigView =
+      NodeConfigView(
+        voting = VotingView(
+          targets = s.votingTargets.targets,
+          rulesToDisable = s.votingTargets.desiredUpdate.rulesToDisable
+        ),
+        mempool = MempoolView(
+          capacity = s.nodeSettings.mempoolCapacity,
+          minimalFeeAmount = s.nodeSettings.minimalFeeAmount,
+          cleanupDuration = s.nodeSettings.mempoolCleanupDuration
+        )
+      )
+  }
+
+  // ---------- Helper codecs (used implicitly by derivation) ----------
+
+  /** Voting parameter ids are 0..255 expressed as quoted JSON object keys. */
+  implicit val byteKeyDecoder: KeyDecoder[Byte] = (key: String) =>
+    Try(key.toInt).toOption.filter(i => i >= 0 && i <= 255).map(i => (i & 0xFF).toByte)
+
+  implicit val byteKeyEncoder: KeyEncoder[Byte] =
+    (b: Byte) => (b.toInt & 0xFF).toString
+
+  /** HOCON-style duration strings, e.g. "15s", "500ms", "2 minutes". */
+  implicit val finiteDurationDecoder: Decoder[FiniteDuration] = Decoder.decodeString.emap { str =>
+    Try(Duration(str)).toEither.left.map(_.getMessage).flatMap {
+      case fd: FiniteDuration if fd.toMillis > 0 => Right(fd)
+      case fd: FiniteDuration => Left(s"duration must be positive (got $fd)")
+      case d => Left(s"expected finite duration, got $d")
+    }
+  }
+
+  implicit val finiteDurationEncoder: Encoder[FiniteDuration] =
+    Encoder.encodeString.contramap(fd => s"${fd.toMillis}ms")
+
+  /** Rule ids are non-negative shorts. */
+  implicit val rangedShortDecoder: Decoder[Short] = Decoder.decodeInt.emap { i =>
+    if (i >= 0 && i <= Short.MaxValue) Right(i.toShort)
+    else Left(s"value $i out of range 0..${Short.MaxValue}")
+  }
+
+  // ---------- Patch decoders ----------
+
+  implicit val mempoolPatchDecoder: Decoder[MempoolPatch] = deriveDecoder[MempoolPatch].emap { p =>
+    if (p.capacity.exists(_ <= 0)) Left("mempool.capacity must be > 0")
+    else if (p.minimalFeeAmount.exists(_ < 0)) Left("mempool.minimalFeeAmount must be >= 0")
+    else Right(p)
+  }
+
+  implicit val votingPatchDecoder: Decoder[VotingPatch] = deriveDecoder[VotingPatch]
+  implicit val nodeConfigPatchDecoder: Decoder[NodeConfigPatch] = deriveDecoder[NodeConfigPatch]
+
+  // ---------- View encoders ----------
+
+  implicit val mempoolViewEncoder: Encoder[MempoolView] = deriveEncoder[MempoolView]
+  implicit val votingViewEncoder: Encoder[VotingView] = deriveEncoder[VotingView]
+  implicit val nodeConfigViewEncoder: Encoder[NodeConfigView] = deriveEncoder[NodeConfigView]
+
+  // ---------- Merge logic ----------
+
+  /** Returns `current` with any fields present in `patch` overlaid. Validation
+    * already happened in the decoder, so this is pure structural merging. */
+  def applyPatch(current: ErgoSettings, patch: NodeConfigPatch): ErgoSettings = {
+    val withVoting = patch.voting.fold(current) { vp =>
+      val newTargets = vp.targets.getOrElse(current.votingTargets.targets)
+      val newRules = vp.rulesToDisable.getOrElse(current.votingTargets.desiredUpdate.rulesToDisable)
+      current.copy(votingTargets = VotingTargets(
+        targets = newTargets,
+        desiredUpdate = ErgoValidationSettingsUpdate(newRules, Seq())
+      ))
+    }
+    patch.mempool.fold(withVoting) { mp =>
+      val ns = withVoting.nodeSettings.copy(
+        mempoolCapacity = mp.capacity.getOrElse(withVoting.nodeSettings.mempoolCapacity),
+        minimalFeeAmount = mp.minimalFeeAmount.getOrElse(withVoting.nodeSettings.minimalFeeAmount),
+        mempoolCleanupDuration = mp.cleanupDuration.getOrElse(withVoting.nodeSettings.mempoolCleanupDuration)
+      )
+      withVoting.copy(nodeSettings = ns)
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
+++ b/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.local.MempoolAuditor.CleanupDone
 import org.ergoplatform.modifiers.mempool.UnconfirmedTransaction
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.UtxoStateReader
-import org.ergoplatform.settings.NodeConfigurationSettings
+import org.ergoplatform.settings.{NodeConfigurationSettings, SettingsHolder}
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{EliminateTransactions, RecheckedTransactions}
 import scorex.util.{ModifierId, ScorexLogging}
 
@@ -21,13 +21,15 @@ import scala.concurrent.ExecutionContext.Implicits.global
   * Validation results sent directly to `NodeViewHolder`.
   */
 class CleanupWorker(nodeViewHolderRef: ActorRef,
-                    nodeSettings: NodeConfigurationSettings) extends Actor with ScorexLogging {
+                    holder: SettingsHolder) extends Actor with ScorexLogging {
 
   // Limit for total cost of transactions to be re-checked. Hard-coded for now.
   private val CostLimit = 7000000
 
-  // Transaction can be re-checked only after this delay
-  private val TimeLimit = nodeSettings.mempoolCleanupDuration.toMillis
+  private def nodeSettings: NodeConfigurationSettings = holder.current.nodeSettings
+
+  // Transaction can be re-checked only after this delay (read live so runtime config changes apply).
+  private def TimeLimit: Long = nodeSettings.mempoolCleanupDuration.toMillis
 
   override def preStart(): Unit = {
     log.info("Cleanup worker started")

--- a/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
+++ b/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.local.CleanupWorker.RunCleanup
 import org.ergoplatform.local.MempoolAuditor.CleanupDone
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, SettingsHolder}
 import scorex.core.network.Broadcast
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.RecheckMempool
@@ -22,7 +22,8 @@ import scala.concurrent.duration._
   */
 class MempoolAuditor(nodeViewHolderRef: ActorRef,
                      networkControllerRef: ActorRef,
-                     settings: ErgoSettings) extends Actor with ScorexLogging {
+                     settings: ErgoSettings,
+                     settingsHolder: SettingsHolder) extends Actor with ScorexLogging {
 
   override def postRestart(reason: Throwable): Unit = {
     log.error(s"Mempool auditor actor restarted due to ${reason.getMessage}", reason)
@@ -52,7 +53,7 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
   private var stateReaderOpt: Option[ErgoStateReader] = None
 
   private val worker: ActorRef =
-    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings.nodeSettings)))
+    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settingsHolder)))
 
   override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[RecheckMempool])
@@ -127,13 +128,15 @@ object MempoolAuditorRef {
 
   def props(nodeViewHolderRef: ActorRef,
             networkControllerRef: ActorRef,
-            settings: ErgoSettings): Props =
-    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings))
+            settings: ErgoSettings,
+            settingsHolder: SettingsHolder): Props =
+    Props(new MempoolAuditor(nodeViewHolderRef, networkControllerRef, settings, settingsHolder))
 
   def apply(nodeViewHolderRef: ActorRef,
             networkControllerRef: ActorRef,
-            settings: ErgoSettings)
+            settings: ErgoSettings,
+            settingsHolder: SettingsHolder)
            (implicit context: ActorRefFactory): ActorRef =
-    context.actorOf(props(nodeViewHolderRef, networkControllerRef, settings))
+    context.actorOf(props(nodeViewHolderRef, networkControllerRef, settings, settingsHolder))
 
 }

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -20,7 +20,7 @@ import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.history.{ErgoHistoryReader, ErgoHistoryUtils}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateType, UtxoStateReader}
-import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
+import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters, SettingsHolder}
 import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
@@ -46,18 +46,27 @@ class CandidateGenerator(
   minerPk: ProveDlog,
   readersHolderRef: ActorRef,
   viewHolderRef: ActorRef,
-  ergoSettings: ErgoSettings
+  initialErgoSettings: ErgoSettings
 ) extends Actor
   with ScorexLogging {
 
   import org.ergoplatform.mining.CandidateGenerator._
 
+  // Tracks the latest settings; updated on SettingsHolder.SettingsUpdated events so
+  // voting targets and soft-fork preferences picked up at runtime take effect on the
+  // next candidate generation.
+  private var ergoSettings: ErgoSettings = initialErgoSettings
+
+  // Intentionally captured: live updates to blockCandidateGenerationInterval would
+  // require recreating the scheduler that drives candidate regeneration, which this
+  // actor doesn't do. Operators wanting a new interval must restart the node.
   private val candidateGenInterval =
     ergoSettings.nodeSettings.blockCandidateGenerationInterval
 
   /** retrieve Readers once on start and then get updated by events */
   override def preStart(): Unit = {
     log.info("CandidateGenerator is starting")
+    context.system.eventStream.subscribe(self, classOf[SettingsHolder.SettingsUpdated])
     readersHolderRef ! GetReaders
   }
 
@@ -142,6 +151,11 @@ class CandidateGenerator(
       }
     case _: NodeViewChange =>
     // Just ignore all other NodeView Changes
+
+    case SettingsHolder.SettingsUpdated(_, current) =>
+      // Pick up new voting targets / soft-fork preference on the next candidate generation.
+      ergoSettings = current
+      log.info("CandidateGenerator picked up updated settings")
 
     /*
      * When new block is applied, either one mined by us or received from peers isn't equal to our candidate's parent,

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -13,7 +13,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.wallet.ErgoWallet
 import org.ergoplatform.wallet.utils.FileUtils
-import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, NetworkType, ScorexSettings}
+import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, NetworkType, ScorexSettings, SettingsHolder}
 import org.ergoplatform.core._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.{BlockAppliedTransactions, CurrentView, DownloadRequest}
@@ -39,8 +39,13 @@ import scala.util.{Failure, Success, Try}
   * Updates of the composite view instances are to be performed atomically.
   *
   */
-abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSettings)
-  extends Actor with ScorexLogging with ScorexEncoding with FileUtils {
+abstract class ErgoNodeViewHolder[State <: ErgoState[State]](
+  settings: ErgoSettings,
+  settingsHolder: SettingsHolder
+) extends Actor 
+  with ScorexLogging
+  with ScorexEncoding
+  with FileUtils {
 
   private implicit lazy val actorSystem: ActorSystem = context.system
 
@@ -424,7 +429,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
     val wallet = ErgoWallet.readOrGenerate(history.getReader, settings, settings.launchParameters)
 
-    val memPool = ErgoMemPool.empty(settings)
+    val memPool = ErgoMemPool.empty(settingsHolder)
 
     (history, state, wallet, memPool)
   }
@@ -439,7 +444,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
   } else {
     val history = ErgoHistory.readOrGenerate(settings)
     log.info("History database read")
-    val memPool = ErgoMemPool.empty(settings)
+    val memPool = ErgoMemPool.empty(settingsHolder)
     restoreConsistentState(ErgoState.readOrGenerate(settings).asInstanceOf[State], history) match {
       case Success(state) =>
         log.info(s"State database read, state synchronized")
@@ -793,29 +798,33 @@ object ErgoNodeViewHolder {
   }
 }
 
-private[nodeView] class DigestNodeViewHolder(settings: ErgoSettings)
-  extends ErgoNodeViewHolder[DigestState](settings)
+private[nodeView] class DigestNodeViewHolder(settings: ErgoSettings, settingsHolder: SettingsHolder)
+  extends ErgoNodeViewHolder[DigestState](settings, settingsHolder)
 
-private[nodeView] class UtxoNodeViewHolder(settings: ErgoSettings)
-  extends ErgoNodeViewHolder[UtxoState](settings)
+private[nodeView] class UtxoNodeViewHolder(settings: ErgoSettings, settingsHolder: SettingsHolder)
+  extends ErgoNodeViewHolder[UtxoState](settings, settingsHolder)
 
 
 
 object ErgoNodeViewRef {
 
-  private def digestProps(settings: ErgoSettings): Props =
-    Props.create(classOf[DigestNodeViewHolder], settings)
+  private def digestProps(settings: ErgoSettings, holder: SettingsHolder): Props =
+    Props.create(classOf[DigestNodeViewHolder], settings, holder)
 
-  private def utxoProps(settings: ErgoSettings): Props =
-    Props.create(classOf[UtxoNodeViewHolder], settings)
+  private def utxoProps(settings: ErgoSettings, holder: SettingsHolder): Props =
+    Props.create(classOf[UtxoNodeViewHolder], settings, holder)
 
-  private def props(settings: ErgoSettings): Props =
+  private def props(settings: ErgoSettings, holder: SettingsHolder): Props =
     (settings.nodeSettings.stateType match {
-      case StateType.Digest => digestProps(settings)
-      case StateType.Utxo => utxoProps(settings)
+      case StateType.Digest => digestProps(settings, holder)
+      case StateType.Utxo => utxoProps(settings, holder)
     }).withDispatcher("critical-dispatcher")
 
+  /** Backward-compatible entry: creates a read-only holder so tests don't have to thread one through. */
   def apply(settings: ErgoSettings)(implicit system: ActorSystem): ActorRef =
-    system.actorOf(props(settings))
-  
+    apply(settings, SettingsHolder.readonly(settings))
+
+  def apply(settings: ErgoSettings, holder: SettingsHolder)(implicit system: ActorSystem): ActorRef =
+    system.actorOf(props(settings, holder))
+
 }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -5,7 +5,7 @@ import org.ergoplatform.mining.emission.EmissionRules
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.OrderedTxPool.WeightedTxId
 import org.ergoplatform.nodeView.state.{ErgoState, UtxoState}
-import org.ergoplatform.settings.{ErgoSettings, MonetarySettings, NodeConfigurationSettings}
+import org.ergoplatform.settings.{ErgoSettings, MonetarySettings, NodeConfigurationSettings, SettingsHolder}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import OrderedTxPool.weighted
 import org.ergoplatform.modifiers.history.header.Header
@@ -30,7 +30,7 @@ import scala.util.{Failure, Success, Try}
 class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
                                    private[mempool] val stats: MemPoolStatistics,
                                    private[mempool] val sortingOption: SortingOption)
-                                  (implicit settings: ErgoSettings)
+                                  (implicit val holder: SettingsHolder)
   extends ErgoMemPoolReader with ScorexLogging {
 
   import EmissionRules.CoinsInOneErgo
@@ -40,8 +40,10 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     */
   private val FakeCost = 1000
 
-  private val nodeSettings: NodeConfigurationSettings = settings.nodeSettings
-  private implicit val monetarySettings: MonetarySettings = settings.chainSettings.monetary
+  private def settings: ErgoSettings = holder.current
+  private def nodeSettings: NodeConfigurationSettings = holder.current.nodeSettings
+  // MonetarySettings is chain-config and immutable per chain — safe to capture once.
+  private implicit val monetarySettings: MonetarySettings = holder.current.chainSettings.monetary
 
   override def size: Int = pool.size
 
@@ -366,16 +368,20 @@ object ErgoMemPool extends ScorexLogging {
    * @param settings - node settings (to get mempool settings from)
    * @return empty mempool
    */
-  def empty(settings: ErgoSettings): ErgoMemPool = {
+  def empty(settings: ErgoSettings): ErgoMemPool =
+    empty(SettingsHolder.readonly(settings))
+
+  def empty(holder: SettingsHolder): ErgoMemPool = {
+    val settings = holder.current
     val sortingOption = settings.nodeSettings.mempoolSorting
     sortingOption match {
       case SortingOption.FeePerByte => log.info("Sorting mempool by fee-per-byte")
       case SortingOption.FeePerCycle => log.info("Sorting mempool by fee-per-cycle")
     }
     new ErgoMemPool(
-      OrderedTxPool.empty(settings),
+      OrderedTxPool.empty(holder),
       MemPoolStatistics(System.currentTimeMillis(), 0, System.currentTimeMillis()),
       sortingOption
-    )(settings)
+    )(holder)
   }
 }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.mempool
 import org.ergoplatform.ErgoBox.BoxId
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.OrderedTxPool.WeightedTxId
-import org.ergoplatform.settings.{Algos, ErgoSettings, MonetarySettings}
+import org.ergoplatform.settings.{Algos, ErgoSettings, MonetarySettings, SettingsHolder}
 import scorex.util.{ModifierId, ScorexLogging}
 
 import scala.collection.immutable.TreeMap
@@ -22,7 +22,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
                     val invalidatedTxIds: ApproximateCacheLike[String],
                     val outputs: TreeMap[BoxId, WeightedTxId],
                     val inputs: TreeMap[BoxId, WeightedTxId])
-                   (implicit settings: ErgoSettings) extends ScorexLogging {
+                   (implicit val holder: SettingsHolder) extends ScorexLogging {
 
   import OrderedTxPool.weighted
 
@@ -37,9 +37,13 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
     */
   private val MaxParentScanTime = 500
 
+  private def settings: ErgoSettings = holder.current
+
+  // MonetarySettings is part of immutable chain config; safe to read once.
   private implicit val ms: MonetarySettings = settings.chainSettings.monetary
 
-  private val mempoolCapacity = settings.nodeSettings.mempoolCapacity
+  // Read live so runtime config changes take effect on next admission check.
+  private def mempoolCapacity: Int = holder.current.nodeSettings.mempoolCapacity
 
   def size: Int = orderedTransactions.size
 
@@ -246,7 +250,11 @@ object OrderedTxPool {
   private implicit val ordWeight: Ordering[WeightedTxId] = Ordering[(Long, ModifierId)].on(x => (-x.weight, x.id))
   private implicit val ordBoxId: Ordering[BoxId] = Ordering[String].on(b => Algos.encode(b))
 
-  def empty(settings: ErgoSettings): OrderedTxPool = {
+  def empty(settings: ErgoSettings): OrderedTxPool =
+    empty(SettingsHolder.readonly(settings))
+
+  def empty(holder: SettingsHolder): OrderedTxPool = {
+    val settings = holder.current
     val cacheSettings = settings.cacheSettings.mempool
     val frontCacheSize = cacheSettings.invalidModifiersCacheSize
     val frontCacheExpiration = cacheSettings.invalidModifiersCacheExpiration
@@ -255,7 +263,7 @@ object OrderedTxPool {
       TreeMap.empty[ModifierId, WeightedTxId],
       ExpiringApproximateCache.empty(frontCacheSize, frontCacheExpiration),
       TreeMap.empty[BoxId, WeightedTxId],
-      TreeMap.empty[BoxId, WeightedTxId])(settings)
+      TreeMap.empty[BoxId, WeightedTxId])(holder)
   }
 
   def weighted(unconfirmedTx: UnconfirmedTransaction, feeFactor: Int)(implicit ms: MonetarySettings): WeightedTxId = {

--- a/src/main/scala/org/ergoplatform/settings/HoconConfigRewriter.scala
+++ b/src/main/scala/org/ergoplatform/settings/HoconConfigRewriter.scala
@@ -1,0 +1,153 @@
+package org.ergoplatform.settings
+
+import com.typesafe.config.ConfigFactory
+import scorex.util.ScorexLogging
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
+import scala.util.Try
+
+/**
+  * Rewrites the user's HOCON configuration file by appending (or replacing) a
+  * sentinel-delimited "runtime overrides" block at the end of the file. The
+  * block is regenerated from a full [[ErgoSettings]] snapshot on every write,
+  * so the file is always self-consistent with the in-memory state.
+  *
+  * v1 limitations (reported as `Left(PersistError.ConfigFileUnsupported)`):
+  *   - file does not exist or is not writable
+  *   - file contains HOCON `include` directives (scope unclear; not safe to append)
+  */
+class HoconConfigRewriter(configFile: Path) extends ScorexLogging {
+  import HoconConfigRewriter._
+
+  def writeOverrides(settings: ErgoSettings): Either[PersistError, Unit] = {
+    val checks: Either[PersistError, Unit] =
+      if (!Files.exists(configFile))
+        Left(PersistError.ConfigFileUnsupported(s"config file does not exist: $configFile"))
+      else if (!Files.isWritable(configFile))
+        Left(PersistError.ConfigFileUnsupported(s"config file is not writable: $configFile"))
+      else
+        Right(())
+
+    checks.flatMap { _ =>
+      catchIo(readFile(configFile)).flatMap { originalText =>
+        if (containsIncludeDirective(originalText)) {
+          Left(PersistError.ConfigFileUnsupported(
+            "config file contains `include` directives; runtime overrides are not supported in v1"
+          ))
+        } else {
+          val withoutOldBlock = stripOverrideBlock(originalText)
+          val overrideBlock = buildOverrideBlock(settings)
+          val newText = ensureTrailingNewline(withoutOldBlock) + overrideBlock + "\n"
+
+          catchIo {
+            // Post-flight: parse the override block in isolation and verify managed keys round-trip.
+            // verifyOverrideBlock throws IllegalArgumentException via require(); we catch as IoFailure
+            // because reaching this point means the file passed all preconditions.
+            verifyOverrideBlock(overrideBlock, settings)
+            backupOnce(configFile)
+            val tmp = configFile.resolveSibling(configFile.getFileName.toString + ".tmp")
+            Files.write(tmp, newText.getBytes(StandardCharsets.UTF_8))
+            Files.move(
+              tmp,
+              configFile,
+              StandardCopyOption.ATOMIC_MOVE,
+              StandardCopyOption.REPLACE_EXISTING
+            )
+            log.info(s"Wrote runtime-override block to ${configFile.getFileName}")
+          }
+        }
+      }
+    }
+  }
+}
+
+object HoconConfigRewriter {
+  val BlockBegin: String = "# >>> ergo-runtime-overrides v1 BEGIN <<<"
+  val BlockEnd: String = "# >>> ergo-runtime-overrides v1 END <<<"
+
+  /** Convenience for callers that hold a path as a string. */
+  def fromPathString(path: String): HoconConfigRewriter =
+    new HoconConfigRewriter(Paths.get(path))
+
+  private val includeRe = """(?m)^\s*include\b""".r
+
+  def containsIncludeDirective(text: String): Boolean =
+    includeRe.findFirstIn(text).isDefined
+
+  /** Idempotently removes a previously written override block. */
+  def stripOverrideBlock(text: String): String = {
+    val beginIdx = text.indexOf(BlockBegin)
+    if (beginIdx < 0) {
+      text
+    } else {
+      val endIdx = text.indexOf(BlockEnd, beginIdx)
+      val before = text.substring(0, beginIdx).reverse.dropWhile(c => c == ' ' || c == '\t').reverse
+      val trimmedBefore = if (before.endsWith("\n")) before.dropRight(1) else before
+      if (endIdx < 0) {
+        // Malformed: strip from begin marker through end of file.
+        trimmedBefore
+      } else {
+        val after = text.substring(endIdx + BlockEnd.length)
+        val afterTrimmed = if (after.startsWith("\n")) after.drop(1) else after
+        if (afterTrimmed.isEmpty) trimmedBefore else trimmedBefore + "\n" + afterTrimmed
+      }
+    }
+  }
+
+  def buildOverrideBlock(settings: ErgoSettings): String = {
+    val lines = scala.collection.mutable.ArrayBuffer.empty[String]
+    lines += BlockBegin
+    lines += "# Written by the runtime config API. Hand edits will be overwritten."
+    lines += s"ergo.node.mempoolCapacity = ${settings.nodeSettings.mempoolCapacity}"
+    lines += s"ergo.node.minimalFeeAmount = ${settings.nodeSettings.minimalFeeAmount}"
+    lines += s"ergo.node.mempoolCleanupDuration = ${settings.nodeSettings.mempoolCleanupDuration.toMillis}ms"
+
+    settings.votingTargets.targets.toSeq
+      .sortBy { case (id, _) => id.toInt & 0xFF }
+      .foreach { case (id, value) =>
+        lines += s"""ergo.voting."${id.toInt & 0xFF}" = $value"""
+      }
+
+    val rulesToDisable = settings.votingTargets.desiredUpdate.rulesToDisable
+    lines += s"ergo.voting.rulesToDisable = [${rulesToDisable.map(_.toInt).mkString(", ")}]"
+
+    lines += BlockEnd
+    lines.mkString("\n")
+  }
+
+  private def verifyOverrideBlock(blockText: String, expected: ErgoSettings): Unit = {
+    val cfg = ConfigFactory.parseString(blockText)
+    require(
+      cfg.getInt("ergo.node.mempoolCapacity") == expected.nodeSettings.mempoolCapacity,
+      "override round-trip mismatch: mempoolCapacity"
+    )
+    require(
+      cfg.getLong("ergo.node.minimalFeeAmount") == expected.nodeSettings.minimalFeeAmount,
+      "override round-trip mismatch: minimalFeeAmount"
+    )
+    require(
+      cfg.getDuration("ergo.node.mempoolCleanupDuration").toMillis ==
+        expected.nodeSettings.mempoolCleanupDuration.toMillis,
+      "override round-trip mismatch: mempoolCleanupDuration"
+    )
+  }
+
+  private def readFile(path: Path): String =
+    new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+
+  private def ensureTrailingNewline(s: String): String =
+    if (s.isEmpty || s.endsWith("\n")) s else s + "\n"
+
+  private def backupOnce(file: Path): Unit = {
+    val bak = file.resolveSibling(file.getFileName.toString + ".bak")
+    if (!Files.exists(bak)) {
+      val _ = Files.copy(file, bak)
+    }
+  }
+
+  private def catchIo[A](block: => A): Either[PersistError, A] =
+    Try(block).toEither.left.map { e =>
+      PersistError.IoFailure(Option(e.getMessage).getOrElse(e.toString))
+    }
+}

--- a/src/main/scala/org/ergoplatform/settings/SettingsHolder.scala
+++ b/src/main/scala/org/ergoplatform/settings/SettingsHolder.scala
@@ -1,0 +1,93 @@
+package org.ergoplatform.settings
+
+import scorex.util.ScorexLogging
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+  * Holds the current [[ErgoSettings]] in an `AtomicReference` so it can be
+  * swapped at runtime. Reads via [[current]] are lock-free; swaps via
+  * [[trySwap]] are serialized through a write lock so the persister cannot
+  * interleave with another swap.
+  *
+  * On a successful swap the holder invokes the configured `onSwap` callback,
+  * which production code uses to broadcast a `SettingsUpdated` event on the
+  * actor-system event stream. The holder itself has no Akka dependency, so it
+  * can be used in unit tests without an `ActorSystem`.
+  */
+class SettingsHolder(
+  initial: ErgoSettings,
+  persister: ErgoSettings => Either[PersistError, Unit],
+  onSwap: (ErgoSettings, ErgoSettings) => Unit
+) extends ScorexLogging {
+
+  private val ref = new AtomicReference[ErgoSettings](initial)
+  private val writeLock = new Object
+
+  /** @return the latest committed settings snapshot. */
+  def current: ErgoSettings = ref.get()
+
+  /**
+    * Atomically apply a candidate `ErgoSettings`:
+    *   - persists via the configured persister
+    *   - on persister success: swaps the ref and runs `onSwap(previous, current)`
+    *   - on persister failure: leaves state unchanged, returns the `Left`
+    */
+  def trySwap(candidate: ErgoSettings): Either[PersistError, ErgoSettings] = writeLock.synchronized {
+    val previous = ref.get()
+    persister(candidate).map { _ =>
+      ref.set(candidate)
+      log.info("Settings updated via runtime config API")
+      onSwap(previous, candidate)
+      candidate
+    }
+  }
+}
+
+object SettingsHolder {
+
+  /** Published on the actor-system event stream by production code after a successful swap. */
+  final case class SettingsUpdated(previous: ErgoSettings, current: ErgoSettings)
+
+  /**
+    * A holder with no persistence and no notifications. Intended for tests and
+    * any path where runtime swaps are not expected (calling [[trySwap]] returns
+    * `Left(NoWritableConfig)`).
+    */
+  def readonly(initial: ErgoSettings): SettingsHolder =
+    new SettingsHolder(
+      initial,
+      _ => Left(PersistError.NoWritableConfig),
+      (_, _) => ()
+    )
+}
+
+/**
+  * Reasons a [[SettingsHolder]] swap may fail to persist. Sealed so consumers
+  * (notably the REST API) can map each case to an HTTP status code exhaustively.
+  */
+sealed trait PersistError extends Product with Serializable {
+  def message: String
+}
+
+object PersistError {
+
+  /** Node was started without a `--config` / `-c` flag; persistence is unavailable. */
+  case object NoWritableConfig extends PersistError {
+    val message: String =
+      "node was not started with --config / -c pointing to a writable HOCON file"
+  }
+
+  /**
+    * The user's config file is present but cannot be rewritten in place
+    * (does not exist, not writable, contains `include` directives, etc.).
+    */
+  final case class ConfigFileUnsupported(reason: String) extends PersistError {
+    def message: String = reason
+  }
+
+  /** Actual I/O failure during read, write, or atomic move. */
+  final case class IoFailure(detail: String) extends PersistError {
+    def message: String = s"I/O failure while persisting config: $detail"
+  }
+}

--- a/src/test/scala/org/ergoplatform/http/routes/NodeApiRouteConfigSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/NodeApiRouteConfigSpec.scala
@@ -1,0 +1,147 @@
+package org.ergoplatform.http.routes
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.Json
+import org.ergoplatform.http.api.NodeApiRoute
+import org.ergoplatform.settings.{ErgoSettings, PersistError, SettingsHolder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NodeApiRouteConfigSpec
+  extends AnyFlatSpec
+    with Matchers
+    with ScalatestRouteTest
+    with FailFastCirceSupport {
+
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+
+  private val prefix = "/node"
+
+  private def makeRoute(initial: ErgoSettings, holder: SettingsHolder): Route =
+    NodeApiRoute(initial, holder).route
+
+  private def jsonEntity(s: String): HttpEntity.Strict =
+    HttpEntity(ContentTypes.`application/json`, s)
+
+  it should "GET /node/config returns the mutable subset" in {
+    val holder = SettingsHolder.readonly(settings)
+    val route = makeRoute(settings, holder)
+    Get(prefix + "/config") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val j = responseAs[Json]
+      j.hcursor.downField("mempool").downField("capacity").as[Int]
+        .toOption shouldBe Some(settings.nodeSettings.mempoolCapacity)
+      j.hcursor.downField("voting").focus shouldBe defined
+    }
+  }
+
+  it should "PUT /node/config with valid mempool patch updates the holder" in {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val route = makeRoute(settings, holder)
+    val body = """{ "mempool": { "capacity": 7777, "minimalFeeAmount": 12345 } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val j = responseAs[Json]
+      j.hcursor.downField("mempool").downField("capacity").as[Int]
+        .toOption shouldBe Some(7777)
+      holder.current.nodeSettings.mempoolCapacity shouldBe 7777
+      holder.current.nodeSettings.minimalFeeAmount shouldBe 12345L
+    }
+  }
+
+  it should "PUT with invalid capacity (negative) returns 400 and leaves holder unchanged" in {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val before = holder.current.nodeSettings.mempoolCapacity
+    val route = makeRoute(settings, holder)
+    val body = """{ "mempool": { "capacity": -1 } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> Route.seal(route) ~> check {
+      status shouldBe StatusCodes.BadRequest
+      holder.current.nodeSettings.mempoolCapacity shouldBe before
+    }
+  }
+
+  it should "PUT is all-or-nothing: invalid field rejects the whole patch" in {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val before = holder.current.nodeSettings.mempoolCapacity
+    val route = makeRoute(settings, holder)
+    val body = """{ "mempool": { "capacity": 9999, "minimalFeeAmount": -7 } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> Route.seal(route) ~> check {
+      status shouldBe StatusCodes.BadRequest
+      holder.current.nodeSettings.mempoolCapacity shouldBe before
+      holder.current.nodeSettings.minimalFeeAmount should not be (-7L)
+    }
+  }
+
+  it should "PUT with readonly holder (no user config) returns 409" in {
+    val holder = SettingsHolder.readonly(settings)
+    val route = makeRoute(settings, holder)
+    val body = """{ "mempool": { "capacity": 1234 } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> route ~> check {
+      status shouldBe StatusCodes.Conflict
+    }
+  }
+
+  it should "PUT with ConfigFileUnsupported persister returns 409" in {
+    val holder = new SettingsHolder(
+      settings,
+      _ => Left(PersistError.ConfigFileUnsupported("config contains include directive")),
+      (_, _) => ()
+    )
+    val route = makeRoute(settings, holder)
+    val body = """{ "mempool": { "capacity": 1234 } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> route ~> check {
+      status shouldBe StatusCodes.Conflict
+      val response = responseAs[Json]
+      response.hcursor.downField("detail").as[String].toOption.getOrElse("") should include("include")
+    }
+  }
+
+  it should "PUT with IoFailure persister returns 500" in {
+    val holder = new SettingsHolder(
+      settings,
+      _ => Left(PersistError.IoFailure("disk full")),
+      (_, _) => ()
+    )
+    val route = makeRoute(settings, holder)
+    val body = """{ "mempool": { "capacity": 1234 } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> route ~> check {
+      status shouldBe StatusCodes.InternalServerError
+    }
+  }
+
+  it should "PUT with voting patch updates voting targets and rulesToDisable" in {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val route = makeRoute(settings, holder)
+    val body = """{ "voting": { "targets": { "1": 1500000, "120": 1 }, "rulesToDisable": [215, 409] } }"""
+    Put(prefix + "/config", jsonEntity(body)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val targets = holder.current.votingTargets.targets
+      targets((1: Byte)) shouldBe 1500000
+      targets((120: Byte)) shouldBe 1
+      holder.current.votingTargets.desiredUpdate.rulesToDisable should contain allOf (215.toShort, 409.toShort)
+    }
+  }
+
+  it should "PUT with malformed JSON body returns 400" in {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val route = makeRoute(settings, holder)
+    val body = "{ this is not json"
+    Put(prefix + "/config", jsonEntity(body)) ~> Route.seal(route) ~> check {
+      status.intValue() should (be(StatusCodes.BadRequest.intValue) or be(StatusCodes.UnprocessableEntity.intValue))
+    }
+  }
+
+  it should "PUT with empty body is a no-op success" in {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val before = holder.current
+    val route = makeRoute(settings, holder)
+    val body = "{}"
+    Put(prefix + "/config", jsonEntity(body)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      holder.current shouldBe before
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
@@ -9,7 +9,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{LocallyG
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.state.ErgoState
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
-import org.ergoplatform.settings.{Algos, ErgoSettings}
+import org.ergoplatform.settings.{Algos, ErgoSettings, SettingsHolder}
 import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
 import org.ergoplatform.utils.fixtures.NodeViewFixture
 import org.ergoplatform.utils.{ErgoTestHelpers, MempoolTestHelpers, NodeViewTestOps, RandomWrapper}
@@ -82,7 +82,7 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
 
     getPoolSize shouldBe 2
 
-    val _: ActorRef = MempoolAuditorRef(nodeViewHolderRef, nodeViewHolderRef, settingsToTest)
+    val _: ActorRef = MempoolAuditorRef(nodeViewHolderRef, nodeViewHolderRef, settingsToTest, SettingsHolder.readonly(settingsToTest))
 
     Thread.sleep(200) // give transactions in the pool enough time to become candidates for re-checking
 
@@ -110,10 +110,10 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
     val txs = validTransactionsFromBoxes(200000, bxs, new RandomWrapper)._1
       .map(tx => UnconfirmedTransaction(tx, None))
 
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
     val probe = TestProbe()
 
-    val auditor: ActorRef = TestActorRef(new MempoolAuditor(probe.ref, probe.ref, settingsToTest))
+    val auditor: ActorRef = TestActorRef(new MempoolAuditor(probe.ref, probe.ref, settingsToTest, SettingsHolder.readonly(settingsToTest)))
 
 
     auditor ! RecheckMempool(us, new FakeMempool(txs))

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
-import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader, SettingsHolder}
 import org.ergoplatform.validation.{ParentHeaderNotFoundError, RecoverableModifierError}
 import org.ergoplatform.wallet.utils.FileUtils
 import org.scalacheck.Gen
@@ -67,7 +67,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  class NodeViewHolderMock extends ErgoNodeViewHolder[UtxoState](settings)
+  class NodeViewHolderMock extends ErgoNodeViewHolder[UtxoState](settings, SettingsHolder.readonly(settings))
 
   class SynchronizerMock(networkControllerRef: ActorRef,
                          viewHolderRef: ActorRef,

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.{ProcessingOutcome, So
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.settings.Constants.TrueTree
-import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
+import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters, SettingsHolder}
 import org.ergoplatform.utils.{ErgoTestHelpers, RandomWrapper}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -772,14 +772,15 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     // but orderedTransactions stores the tx under wtxActual.
     // This can happen after updateFamily or other weight changes
     // fail to keep the two collections in sync.
-    val emptyPool = OrderedTxPool.empty(settings)
+    val holder = SettingsHolder.readonly(settings)
+    val emptyPool = OrderedTxPool.empty(holder)
     val brokenPool = new OrderedTxPool(
       TreeMap(wtxActual -> utx),
       TreeMap(tx.id -> wtxStale),
       emptyPool.invalidatedTxIds,
       emptyPool.outputs,
       emptyPool.inputs
-    )(settings)
+    )(holder)
 
     // pool.get traverses registry -> wtxStale -> orderedTransactions,
     // but wtxStale is not a key in orderedTransactions, so get returns None.
@@ -792,7 +793,7 @@ class ErgoMemPoolSpec extends AnyFlatSpec
       brokenPool,
       MemPoolStatistics(now, 0, now, 0),
       SortingOption.FeePerByte
-    )(settings)
+    )(holder)
 
     // invalidate() first tries pool.get (returns None), then falls back to
     // scanning orderedTransactions.valuesIterator. It finds the tx and calls

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.SortingOption
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.utils.ErgoCorePropertyTest
 
-import java.net.{InetSocketAddress, URL}
+import java.net.{InetSocketAddress, URI}
 import scala.concurrent.duration._
 
 class ErgoSettingsSpecification extends ErgoCorePropertyTest {
@@ -65,7 +65,7 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
       apiKeyHash = None,
       corsAllowedOrigin = Some("*"),
       timeout = 5.seconds,
-      publicUrl = Some(new URL("https://example.com:80"))
+      publicUrl = Some(new URI("https://example.com:80").toURL)
     )
   }
 
@@ -164,7 +164,7 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
         "http://0.0.0.0",
         "http://example.com/foo/bar",
         "http://example.com?foo=bar"
-      ).map(new URL(_))
+      ).map(new URI(_).toURL)
 
     invalidUrls.forall(ErgoSettingsReader.invalidRestApiUrl) shouldBe true
 
@@ -174,7 +174,7 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
         "http://example.com:80",
         "http://82.90.21.31",
         "http://82.90.21.31:80"
-      ).map(new URL(_))
+      ).map(new URI(_).toURL)
 
     validUrls.forall(url => !ErgoSettingsReader.invalidRestApiUrl(url)) shouldBe true
   }

--- a/src/test/scala/org/ergoplatform/settings/HoconConfigRewriterSpec.scala
+++ b/src/test/scala/org/ergoplatform/settings/HoconConfigRewriterSpec.scala
@@ -1,0 +1,240 @@
+package org.ergoplatform.settings
+
+import com.typesafe.config.ConfigFactory
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.attribute.{PosixFileAttributeView, PosixFilePermissions}
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration._
+
+class HoconConfigRewriterSpec extends ErgoCorePropertyTest {
+
+  private def writeTempConfig(content: String): Path = {
+    val dir: Path = Files.createTempDirectory("ergo-config-test")
+    val file = dir.resolve("ergo.conf")
+    Files.write(file, content.getBytes(StandardCharsets.UTF_8))
+    file
+  }
+
+  private def readFile(f: Path): String =
+    new String(Files.readAllBytes(f), StandardCharsets.UTF_8)
+
+  private def withMempoolCapacity(s: ErgoSettings, cap: Int): ErgoSettings =
+    s.copy(nodeSettings = s.nodeSettings.copy(mempoolCapacity = cap))
+
+  private val baseConfig: String =
+    """# Original user config
+      |ergo {
+      |  node {
+      |    mempoolCapacity = 1000
+      |    minimalFeeAmount = 1000000
+      |    mempoolCleanupDuration = 10s
+      |  }
+      |  voting {
+      |    rulesToDisable = []
+      |  }
+      |}
+      |""".stripMargin
+
+  // Fixtures for the snapshot test. Two literal chunks so a reader can see exactly
+  // what the rewriter is contracted to produce. Update both together if the override
+  // block format changes intentionally.
+  private val snapshotInput: String =
+    """# Original user config — keep this comment
+      |ergo {
+      |  node {
+      |    mempoolCapacity = 100
+      |    minimalFeeAmount = 1000000
+      |    mempoolCleanupDuration = 10s
+      |  }
+      |  voting {
+      |    rulesToDisable = []
+      |  }
+      |}
+      |""".stripMargin
+
+  private val snapshotExpected: String =
+    """# Original user config — keep this comment
+      |ergo {
+      |  node {
+      |    mempoolCapacity = 100
+      |    minimalFeeAmount = 1000000
+      |    mempoolCleanupDuration = 10s
+      |  }
+      |  voting {
+      |    rulesToDisable = []
+      |  }
+      |}
+      |# >>> ergo-runtime-overrides v1 BEGIN <<<
+      |# Written by the runtime config API. Hand edits will be overwritten.
+      |ergo.node.mempoolCapacity = 5000
+      |ergo.node.minimalFeeAmount = 2000000
+      |ergo.node.mempoolCleanupDuration = 30000ms
+      |ergo.voting."1" = 1250000
+      |ergo.voting."4" = 1000000
+      |ergo.voting.rulesToDisable = [215, 409]
+      |# >>> ergo-runtime-overrides v1 END <<<
+      |""".stripMargin
+
+  property("appends override block on first write and is idempotent on second write") {
+    val file = writeTempConfig(baseConfig)
+    val rewriter = new HoconConfigRewriter(file)
+
+    rewriter.writeOverrides(withMempoolCapacity(settings, 4242)) shouldBe Right(())
+    val afterFirst = readFile(file)
+    afterFirst should include(HoconConfigRewriter.BlockBegin)
+    afterFirst should include("ergo.node.mempoolCapacity = 4242")
+    val blockCountFirst = HoconConfigRewriter.BlockBegin.r.findAllIn(afterFirst).size
+    blockCountFirst shouldBe 1
+
+    rewriter.writeOverrides(withMempoolCapacity(settings, 4242)) shouldBe Right(())
+    val afterSecond = readFile(file)
+    val blockCountSecond = HoconConfigRewriter.BlockBegin.r.findAllIn(afterSecond).size
+    blockCountSecond shouldBe 1
+  }
+
+  property("replaces existing override block on subsequent writes") {
+    val file = writeTempConfig(baseConfig)
+    val rewriter = new HoconConfigRewriter(file)
+
+    rewriter.writeOverrides(withMempoolCapacity(settings, 1)) shouldBe Right(())
+    rewriter.writeOverrides(withMempoolCapacity(settings, 2)) shouldBe Right(())
+    val afterSecond = readFile(file)
+
+    afterSecond should not include "ergo.node.mempoolCapacity = 1"
+    afterSecond should include("ergo.node.mempoolCapacity = 2")
+    HoconConfigRewriter.BlockBegin.r.findAllIn(afterSecond).size shouldBe 1
+  }
+
+  property("preserves the original user content above the override block") {
+    val file = writeTempConfig(baseConfig)
+    val rewriter = new HoconConfigRewriter(file)
+    rewriter.writeOverrides(settings) shouldBe Right(())
+
+    val updated = readFile(file)
+    updated should include("# Original user config")
+    updated should include("ergo {")
+    updated.indexOf("# Original user config") should be < updated.indexOf(HoconConfigRewriter.BlockBegin)
+  }
+
+  property("rejects files containing include directives") {
+    val file = writeTempConfig(
+      """include "shared.conf"
+        |ergo.node.mempoolCapacity = 1000
+        |""".stripMargin
+    )
+    val rewriter = new HoconConfigRewriter(file)
+    rewriter.writeOverrides(settings) match {
+      case Left(_: PersistError.ConfigFileUnsupported) => succeed
+      case other => fail(s"expected ConfigFileUnsupported, got $other")
+    }
+  }
+
+  property("creates a .bak file on first write only") {
+    val file = writeTempConfig(baseConfig)
+    val bak = file.resolveSibling(file.getFileName.toString + ".bak")
+    Files.exists(bak) shouldBe false
+
+    val rewriter = new HoconConfigRewriter(file)
+    rewriter.writeOverrides(withMempoolCapacity(settings, 1234)) shouldBe Right(())
+    Files.exists(bak) shouldBe true
+    val bakContent = readFile(bak)
+    bakContent shouldEqual baseConfig
+
+    rewriter.writeOverrides(withMempoolCapacity(settings, 5678)) shouldBe Right(())
+    readFile(bak) shouldEqual baseConfig
+  }
+
+  property("written file parses back to the expected managed values") {
+    val file = writeTempConfig(baseConfig)
+    val updated = settings.copy(
+      nodeSettings = settings.nodeSettings.copy(
+        mempoolCapacity = 7777,
+        minimalFeeAmount = 555000L,
+        mempoolCleanupDuration = 15.seconds
+      ),
+      votingTargets = VotingTargets(
+        targets = Map[Byte, Int]((1.toByte, 1000000), (120.toByte, 1)),
+        desiredUpdate = ErgoValidationSettingsUpdate(Seq(215.toShort, 409.toShort), Seq())
+      )
+    )
+
+    val rewriter = new HoconConfigRewriter(file)
+    rewriter.writeOverrides(updated) shouldBe Right(())
+
+    val cfg = ConfigFactory.parseString(readFile(file)).resolve()
+    cfg.getInt("ergo.node.mempoolCapacity") shouldBe 7777
+    cfg.getLong("ergo.node.minimalFeeAmount") shouldBe 555000L
+    cfg.getDuration("ergo.node.mempoolCleanupDuration").toMillis shouldBe 15000L
+    cfg.getInt("ergo.voting.\"1\"") shouldBe 1000000
+    cfg.getInt("ergo.voting.\"120\"") shouldBe 1
+    cfg.getIntList("ergo.voting.rulesToDisable").size() shouldBe 2
+  }
+
+  property("stripOverrideBlock removes the marked region but leaves surrounding text") {
+    val text =
+      s"""ergo.node.mempoolCapacity = 1000
+         |${HoconConfigRewriter.BlockBegin}
+         |ergo.node.mempoolCapacity = 999
+         |${HoconConfigRewriter.BlockEnd}
+         |""".stripMargin
+    val stripped = HoconConfigRewriter.stripOverrideBlock(text)
+    stripped should not include "999"
+    stripped should include("mempoolCapacity = 1000")
+    HoconConfigRewriter.BlockBegin.r.findAllIn(stripped).size shouldBe 0
+  }
+
+  property("containsIncludeDirective detects top-level include lines") {
+    HoconConfigRewriter.containsIncludeDirective("ergo.node.mempoolCapacity = 1000") shouldBe false
+    HoconConfigRewriter.containsIncludeDirective("include \"a.conf\"\nergo {}") shouldBe true
+    HoconConfigRewriter.containsIncludeDirective("  include classpath(\"foo\")\n") shouldBe true
+  }
+
+  property("reports ConfigFileUnsupported when the config file does not exist") {
+    val absent = Files.createTempDirectory("ergo-config-test").resolve("missing.conf")
+    val rewriter = new HoconConfigRewriter(absent)
+    rewriter.writeOverrides(settings) match {
+      case Left(_: PersistError.ConfigFileUnsupported) => succeed
+      case other => fail(s"expected ConfigFileUnsupported, got $other")
+    }
+  }
+
+  property("produces exactly the expected file contents (snapshot)") {
+    val file = writeTempConfig(snapshotInput)
+    val patched = settings.copy(
+      nodeSettings = settings.nodeSettings.copy(
+        mempoolCapacity = 5000,
+        minimalFeeAmount = 2000000L,
+        mempoolCleanupDuration = 30.seconds
+      ),
+      votingTargets = VotingTargets(
+        targets = Map[Byte, Int]((1.toByte, 1250000), (4.toByte, 1000000)),
+        desiredUpdate = ErgoValidationSettingsUpdate(Seq(215.toShort, 409.toShort), Seq())
+      )
+    )
+
+    val rewriter = new HoconConfigRewriter(file)
+    rewriter.writeOverrides(patched) shouldBe Right(())
+
+    readFile(file) shouldEqual snapshotExpected
+  }
+
+  property("reports ConfigFileUnsupported when the config file is not writable") {
+    val file = writeTempConfig(baseConfig)
+    val posixSupported = Files.getFileStore(file)
+      .supportsFileAttributeView(classOf[PosixFileAttributeView])
+    if (!posixSupported) cancel("requires a POSIX file system")
+
+    Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("r--r--r--"))
+    // Some environments (e.g. root in CI containers) bypass POSIX read-only.
+    if (Files.isWritable(file)) cancel("running as a user that ignores POSIX read-only")
+
+    val rewriter = new HoconConfigRewriter(file)
+    rewriter.writeOverrides(settings) match {
+      case Left(_: PersistError.ConfigFileUnsupported) => succeed
+      case other => fail(s"expected ConfigFileUnsupported, got $other")
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/settings/SettingsHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/settings/SettingsHolderSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.settings
+
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+
+import java.util.concurrent.atomic.AtomicReference
+
+class SettingsHolderSpec extends ErgoCorePropertyTest {
+
+  private def candidate(cap: Int): ErgoSettings =
+    settings.copy(nodeSettings = settings.nodeSettings.copy(mempoolCapacity = cap))
+
+  property("trySwap updates current and invokes onSwap on success") {
+    val captured = new AtomicReference[Option[(ErgoSettings, ErgoSettings)]](None)
+    val holder = new SettingsHolder(
+      settings,
+      _ => Right(()),
+      (prev, curr) => captured.set(Some((prev, curr)))
+    )
+
+    val newSettings = candidate(54321)
+    holder.trySwap(newSettings) shouldBe Right(newSettings)
+    holder.current shouldBe newSettings
+    captured.get() shouldBe Some((settings, newSettings))
+  }
+
+  property("trySwap leaves state unchanged and does not invoke onSwap on persister failure") {
+    val captured = new AtomicReference[Option[(ErgoSettings, ErgoSettings)]](None)
+    val err = PersistError.IoFailure("disk full")
+    val holder = new SettingsHolder(
+      settings,
+      _ => Left(err),
+      (prev, curr) => captured.set(Some((prev, curr)))
+    )
+
+    val result = holder.trySwap(candidate(99))
+    result shouldBe Left(err)
+    holder.current shouldBe settings
+    captured.get() shouldBe None
+  }
+
+  property("concurrent trySwap calls serialize and end on one of the candidates") {
+    val holder = new SettingsHolder(settings, _ => Right(()), (_, _) => ())
+    val N = 50
+    val swaps = (1 to N).map(i => candidate(1000 + i))
+    val threads = swaps.map { s =>
+      new Thread(() => { val _: Either[PersistError, ErgoSettings] = holder.trySwap(s) })
+    }
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+
+    val finalCap = holder.current.nodeSettings.mempoolCapacity
+    finalCap should (be >= 1001 and be <= (1000 + N))
+  }
+
+  property("readonly holder returns initial settings and rejects swaps with NoWritableConfig") {
+    val holder = SettingsHolder.readonly(settings)
+    holder.current shouldBe settings
+    holder.trySwap(candidate(7)) shouldBe Left(PersistError.NoWritableConfig)
+    holder.current shouldBe settings
+  }
+}


### PR DESCRIPTION
## Summary
Adds GET/PUT `/node/config` (closes #963) so operators can change voting targets and selected mempool settings (capacity, minimal fee, cleanup duration) at runtime without restarting the node.

Persistence appends a sentinel-delimited block to the user's HOCON file. Reads stay live via a new `SettingsHolder` threaded into the mempool and `CandidateGenerator`. PUT is all-or-nothing; failures are typed via a `PersistError` ADT and map to 400 / 409 / 500.

N.B `miningPubKeyHex`, `blockCandidateGenerationInterval` - would require restarting the miner / scheduler. Deferred to v2.