### PR TITLE
Stabilize P2P test coverage and IT harness

### DIFF
--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -1,12 +1,14 @@
 package org.ergoplatform.it
 
 import java.io.File
+import java.util.concurrent.TimeoutException
 import com.typesafe.config.Config
+import org.ergoplatform.it.api.NodeApi.NodeInfo
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
 import org.scalatest.freespec.AnyFreeSpec
 import scala.async.Async
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, Future, blocking}
 import scala.concurrent.duration._
 
 class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
@@ -42,6 +44,43 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
   val minerBConfigNonGen: Config = minerBConfig
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(localOnlyConfig)
+
+  private def waitForSameBestBlock(
+    nodeA: Node,
+    nodeB: Node,
+    minHeight: Int,
+    timeout: FiniteDuration
+  ): Future[(NodeInfo, NodeInfo)] = {
+    def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo): Boolean = {
+      val sameHeight =
+        infoA.bestBlockHeightOpt.nonEmpty &&
+          infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+      val sameBlock =
+        infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+      val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+      sameHeight && sameBlock && highEnough
+    }
+
+    def retryAfterDelay(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
+      Future {
+        blocking(Thread.sleep(1000))
+      }.flatMap(_ => loop(deadline))
+
+    def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
+      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
+        if (sameBestBlock(infoA, infoB)) {
+          Future.successful((infoA, infoB))
+        } else if (deadline.isOverdue()) {
+          Future.failed(new TimeoutException(
+            s"Nodes did not converge to the same best full block at height >= $minHeight"
+          ))
+        } else {
+          retryAfterDelay(deadline)
+        }
+      }
+
+    loop(timeout.fromNow)
+  }
 
   "Deep rollback handling" in {
 
@@ -83,7 +122,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
-      Async.await(minerBIsolated.waitForHeight(chainLength))
+      Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
 
       log.info("Mining phase done")
 
@@ -115,14 +154,12 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       isMiningBOpt map (_ shouldBe false)
 
       // 5. Wait until it switches to the better chain
-      Async.await(minerB.waitForHeight(minerABestHeight))
+      val (minerAInfo, minerBInfo) =
+        Async.await(waitForSameBestBlock(minerA, minerB, minerABestHeight, 5.minutes))
 
       log.info("Chain switching done")
 
-      val minerABestBlock = Async.await(minerA.headerIdsByHeight(minerABestHeight)).head
-      val minerBBestBlock = Async.await(minerB.headerIdsByHeight(minerABestHeight)).head
-
-      minerBBestBlock shouldEqual minerABestBlock
+      minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
     Await.result(result, 15.minutes)

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
@@ -30,14 +30,24 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
   val dirs: Seq[File] = localVolumes.map(vol => new File(vol))
   dirs.foreach(_.mkdirs())
 
-  val nodeConfigs: List[Config] = nodeSeedConfigs.take(4).map(_.withFallback(localOnlyConfig))
+  val miningTimingConfig: Config = shortInternalMinerPollingInterval
+    .withFallback(blockIntervalConfig(500))
+
+  val nodeConfigs: List[Config] = nodeSeedConfigs.take(4)
+    .map(_.withFallback(localOnlyConfig).withFallback(miningTimingConfig))
 
   val minerConfig: Config = nodeConfigs.head
-  val onlineMiningNodesConfig: List[Config] = nodeConfigs.slice(1, nodesQty)
-    .map(_.withFallback(onlineGeneratingPeerConfig))
+  val onlineSyncNodesConfig: List[Config] = nodeConfigs.slice(1, nodesQty)
+    .map(_.withFallback(nonGeneratingPeerConfig))
   val offlineMiningNodesConfig: List[Config] = nodeConfigs.slice(1, nodesQty)
 
   def localVolume(n: Int): String = s"$localDataDir/fork-resolution-spec/node-$n/data"
+
+  def clearPeerDatabases(): Unit = {
+    volumesMapping.foreach { case (localVolume, remoteVolume) =>
+      docker.removeFromMountedVolume(localVolume, remoteVolume, "peers")
+    }
+  }
 
   def startNodesWithBinds(nodeConfigs: List[Config],
                           configEnrich: ExtraConfig = noExtraConfig): List[Node] = {
@@ -56,36 +66,40 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
 
   // Testing scenario:
   // 1. Start up {nodesQty} nodes and let them mine common chain of length {initialCommonChainLength};
-  // 2. Kill all nodes when they are done, make them offline generating, clear `knownPeers` and restart them;
+  // 2. Kill all nodes when they are done, make them offline generating, clear known peers and restart them;
   // 3. Let them mine another {forkLength} blocks offline in order to create {nodesQty} forks;
   // 4. Kill all nodes again and restart with `knownPeers` filled, wait another {syncLength} blocks;
   // 5. Check that nodes reached consensus on created forks;
   it should "Fork resolution after isolated mining" in {
 
     log.info(minerConfig.toString)
-    onlineMiningNodesConfig.foreach(x => log.info(x.toString))
+    onlineSyncNodesConfig.foreach(x => log.info(x.toString))
 
-    val nodes: List[Node] = startNodesWithBinds(minerConfig +: onlineMiningNodesConfig)
+    val nodes: List[Node] = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig)
 
     val result = Async.async {
       val initMaxHeight = Async.await(Future.traverse(nodes)(_.fullHeight).map(_.max))
-      Async.await(Future.traverse(nodes)(_.waitForHeight(initMaxHeight + commonChainLength)))
+      Async.await(Future.traverse(nodes)(_.waitForHeight(initMaxHeight + commonChainLength, 100.millis)))
       val isolatedNodes = Async.await {
         nodes.foreach(node => docker.stopNode(node.containerId))
+        clearPeerDatabases()
         Future.successful(startNodesWithBinds(minerConfig +: offlineMiningNodesConfig, isolatedPeersConfig))
       }
       val forkHeight = initMaxHeight + commonChainLength + forkLength
-      Async.await(Future.traverse(isolatedNodes)(_.waitForHeight(forkHeight)))
+      Async.await(Future.traverse(isolatedNodes)(_.waitForHeight(forkHeight, 100.millis)))
       val regularNodes = Async.await {
         isolatedNodes.foreach(node => docker.stopNode(node.containerId))
-        Future.successful(startNodesWithBinds(minerConfig +: onlineMiningNodesConfig))
+        clearPeerDatabases()
+        Future.successful(startNodesWithBinds(minerConfig +: onlineSyncNodesConfig))
       }
-      Async.await(Future.traverse(regularNodes)(_.waitForHeight(forkHeight + syncLength)))
-      val headers = Async.await(Future.traverse(regularNodes)(_.headerIdsByHeight(forkHeight)))
+      Async.await(Future.traverse(regularNodes)(_.waitForHeight(forkHeight + syncLength, 100.millis)))
+      val sample = Async.await(regularNodes.head.headerIdsByHeight(forkHeight)).headOption.value
+      val headers = Async.await(Future.traverse(regularNodes) { node =>
+        node.waitFor[Seq[String]](_.headerIdsByHeight(forkHeight), _.headOption.contains(sample), 100.millis)
+      })
 
-      log.debug(s"Headers at height $initMaxHeight: ${headers.mkString(",")}")
+      log.debug(s"Headers at height $forkHeight: ${headers.mkString(",")}")
       val headerIdsAtSameHeight = headers.map(_.headOption.value)
-      val sample = headerIdsAtSameHeight.head
       headerIdsAtSameHeight should contain only sample
     }
 

--- a/src/it/scala/org/ergoplatform/it/container/Docker.scala
+++ b/src/it/scala/org/ergoplatform/it/container/Docker.scala
@@ -3,15 +3,17 @@ package org.ergoplatform.it.container
 import java.io.{File, FileOutputStream}
 import java.net.InetAddress
 import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Properties, UUID}
 import cats.implicits._
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper
 import com.github.dockerjava.api.DockerClient
+import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.command.{CreateContainerCmd, WaitContainerResultCallback}
 import com.github.dockerjava.api.exception.NotFoundException
-import com.github.dockerjava.api.model.{Bind, ContainerNetwork, ExposedPort, HostConfig, Network, PortBinding, Ports, Volume}
+import com.github.dockerjava.api.model.{Bind, ContainerNetwork, ExposedPort, Frame, HostConfig, Network, PortBinding, Ports, Volume}
 import com.github.dockerjava.api.model.Network.Ipam
 import com.google.common.primitives.Ints
 import com.github.dockerjava.core.{DefaultDockerClientConfig, DockerClientImpl}
@@ -392,13 +394,55 @@ class Docker(
     stopNode(node.containerId, secondsToWait)
 
   def stopNode(containerId: String, secondsToWait: Int = 5): Unit = {
+    nodeRepository.find(_.containerId == containerId).foreach(_.close())
     nodeRepository = nodeRepository.filterNot(_.containerId == containerId)
     client.stopContainerCmd(containerId).withTimeout(secondsToWait).exec()
   }
 
   def forceStopNode(containerId: String): Unit = {
+    nodeRepository.find(_.containerId == containerId).foreach(_.close())
     nodeRepository = nodeRepository.filterNot(_.containerId == containerId)
     client.removeContainerCmd(containerId).withForce(true).exec()
+  }
+
+  def removeFromMountedVolume(
+    localVolume: String,
+    remoteVolume: String,
+    relativePath: String
+  ): Unit = {
+    require(relativePath.nonEmpty, "Relative path to remove must be non-empty")
+    require(
+      !relativePath.startsWith("/"),
+      s"Relative path must not be absolute: $relativePath"
+    )
+    require(
+      !relativePath.split("/").contains(".."),
+      s"Relative path must not escape the volume: $relativePath"
+    )
+
+    val targetPath = s"$remoteVolume/$relativePath"
+    val hostConfig =
+      new HostConfig().withBinds(new Bind(localVolume, new Volume(remoteVolume)))
+    val cleanupContainerId = client
+      .createContainerCmd(ErgoImageLatest)
+      .withHostConfig(hostConfig)
+      .withEntrypoint("rm", "-rf", targetPath)
+      .exec()
+      .getId
+
+    val waitCallback = waitContainer(cleanupContainerId)
+    try {
+      client.startContainerCmd(cleanupContainerId).exec()
+      val exitCode = waitCallback.awaitStatusCode()
+      if (exitCode != 0) {
+        throw new IllegalStateException(
+          s"Volume cleanup failed for $targetPath with exit code $exitCode"
+        )
+      }
+    } finally {
+      waitCallback.close()
+      client.removeContainerCmd(cleanupContainerId).withForce(true).exec()
+    }
   }
 
   override def close(): Unit = {
@@ -434,41 +478,37 @@ class Docker(
     val logDir: Path = Paths.get(System.getProperty("user.dir"), "target", "logs")
     Files.createDirectories(logDir)
 
-    val fileName: String = s"$tag-$containerId"
+    val fileName: String = if (tag.isEmpty) containerId else s"$tag-$containerId"
     val logFile: File    = logDir.resolve(s"$fileName.log").toFile
-    log.info(s"Writing logs of $tag-$containerId to ${logFile.getAbsolutePath}")
+    log.info(s"Writing logs of $fileName to ${logFile.getAbsolutePath}")
 
-    val fileStream: FileOutputStream = new FileOutputStream(logFile, false)
-    client
-      .logContainerCmd(containerId)
-      .withTimestamps(true)
-      .withFollowStream(true)
-      .withStdOut(true)
-      .withStdErr(true)
-      .start()
-      .onStart(fileStream)
+    val fileStream = new FileOutputStream(logFile, false)
+    val callback = new ResultCallback.Adapter[Frame] {
+      override def onNext(frame: Frame): Unit = {
+        fileStream.write(frame.getPayload)
+      }
+    }
+    try {
+      val completed = client
+        .logContainerCmd(containerId)
+        .withTimestamps(true)
+        .withStdOut(true)
+        .withStdErr(true)
+        .exec(callback)
+        .awaitCompletion(10, TimeUnit.SECONDS)
+      if (!completed) {
+        log.warn(s"Timed out while writing logs for $fileName")
+      }
+    } finally {
+      callback.close()
+      fileStream.close()
+    }
   }
 
   private def saveNodeLogs(): Unit = {
-    val logDir = Paths.get(System.getProperty("user.dir"), "target", "logs")
-    Files.createDirectories(logDir)
     nodeRepository.foreach { node =>
       import node.nodeInfo.containerId
-
-      val fileName = if (tag.isEmpty) containerId else s"$tag-$containerId"
-      val logFile  = logDir.resolve(s"$fileName.log").toFile
-      log.info(s"Writing logs of $containerId to ${logFile.getAbsolutePath}")
-
-      val fileStream = new FileOutputStream(logFile, false)
-      client
-        .logContainerCmd(containerId)
-        .withTimestamps(true)
-        .withFollowStream(true)
-        .withStdOut(true)
-        .withStdErr(true)
-        .start()
-        .onStart(fileStream)
-
+      saveLogs(containerId, tag)
     }
   }
 

--- a/src/it/scala/org/ergoplatform/it/container/IntegrationSuite.scala
+++ b/src/it/scala/org/ergoplatform/it/container/IntegrationSuite.scala
@@ -20,7 +20,9 @@ trait IntegrationSuite
 
   implicit def executionContext: ExecutionContext = ErgoTestHelpers.defaultExecutionContext
 
-  val tempDir: String = System.getenv("TMPDIR")
+  val tempDir: String = Option(System.getenv("TMPDIR"))
+    .filter(_.nonEmpty)
+    .getOrElse(System.getProperty("java.io.tmpdir"))
 
   protected val localDataDir: String = s"$tempDir/ergo-${Random.nextInt(Int.MaxValue)}"
 

--- a/src/it/scala/org/ergoplatform/it/container/Node.scala
+++ b/src/it/scala/org/ergoplatform/it/container/Node.scala
@@ -24,9 +24,10 @@ class Node(val settings: ErgoSettings, val nodeInfo: NodeInfo, override val clie
   def containerId: String = nodeInfo.containerId
   override val chainId: Char = 'I'
   override val networkNodeName: String = s"it-test-client-to-${nodeInfo.networkIpAddress}"
-  override val restAddress: String = nodeInfo.apiIpAddress
+  override val restAddress: String = Option(nodeInfo.apiIpAddress).filter(_.nonEmpty).getOrElse("localhost")
   override val networkAddress: String = "localhost"
-  override val nodeRestPort: Int = nodeInfo.containerApiPort
+  override val nodeRestPort: Int =
+    if (restAddress == "localhost") nodeInfo.hostRestApiPort else nodeInfo.containerApiPort
   override val networkPort: Int = nodeInfo.hostNetworkPort
   override val blockDelay: FiniteDuration = settings.chainSettings.blockInterval
 

--- a/src/main/scala/org/ergoplatform/network/peer/PeerManager.scala
+++ b/src/main/scala/org/ergoplatform/network/peer/PeerManager.scala
@@ -25,12 +25,13 @@ class PeerManager(settings: ErgoSettings, scorexContext: ScorexContext) extends 
     // fill database with peers from config file if empty
     log.info("No peers in database, seeding peers database with nodes from config")
     settings.scorexSettings.network.knownPeers.foreach { address =>
-      if (!isSelf(address)) {
+      if (shouldKeep(address)) {
         peerDatabase.addOrUpdateKnownPeer(PeerInfo.fromAddress(address))
       }
     }
   } else {
     log.info(s"${peerDatabase.knownPeers.size} peers read from the database")
+    purgeRejectedPeers()
   }
 
   override def receive: Receive = peersManagement orElse apiInterface orElse {
@@ -50,8 +51,10 @@ class PeerManager(settings: ErgoSettings, scorexContext: ScorexContext) extends 
 
     case AddOrUpdatePeer(peerInfo) =>
       // We have connected to a peer and got his peerInfo from him
-      if (!isSelf(peerInfo.peerSpec) && !peerInfo.peerSpec.address.exists(checkLocalOnly(_))) {
+      if (shouldKeep(peerInfo.peerSpec)) {
         peerDatabase.addOrUpdateKnownPeer(peerInfo)
+      } else {
+        removePeer(peerInfo.peerSpec)
       }
 
     case Penalize(peer, penaltyType) =>
@@ -64,10 +67,13 @@ class PeerManager(settings: ErgoSettings, scorexContext: ScorexContext) extends 
 
     case AddPeerIfEmpty(peerSpec) =>
       // We have received peer data from other peers. It might be modified and should not affect existing data if any
-      if (peerSpec.address.forall(a => peerDatabase.get(a).isEmpty) && !isSelf(peerSpec) && !peerSpec.address.exists(checkLocalOnly(_))) {
+      val keepPeer = shouldKeep(peerSpec)
+      if (keepPeer && peerSpec.address.forall(a => peerDatabase.get(a).isEmpty)) {
         val peerInfo: PeerInfo = PeerInfo(peerSpec, 0, None)
         log.info(s"New discovered peer: $peerInfo")
         peerDatabase.addOrUpdateKnownPeer(peerInfo)
+      } else if (!keepPeer) {
+        removePeer(peerSpec)
       }
 
     case RemovePeer(address) =>
@@ -101,6 +107,22 @@ class PeerManager(settings: ErgoSettings, scorexContext: ScorexContext) extends 
 
   private def checkLocalOnly(address: InetSocketAddress): Boolean =
     NetworkUtils.checkLocalOnly(address, settings.scorexSettings.network.localOnly)
+
+  private def shouldKeep(address: InetSocketAddress): Boolean =
+    !isSelf(address) && !checkLocalOnly(address)
+
+  private def shouldKeep(peerSpec: PeerSpec): Boolean =
+    !isSelf(peerSpec) && !peerSpec.address.exists(checkLocalOnly)
+
+  private def removePeer(peerSpec: PeerSpec): Unit =
+    peerSpec.address.foreach(peerDatabase.remove)
+
+  private def purgeRejectedPeers(): Unit =
+    peerDatabase.knownPeers.values.toSeq.foreach { peerInfo =>
+      if (!shouldKeep(peerInfo.peerSpec)) {
+        removePeer(peerInfo.peerSpec)
+      }
+    }
 
 }
 

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -63,6 +63,7 @@ class NetworkController(ergoSettings: ErgoSettings,
 
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]
   private var unconfirmedConnections = Set.empty[InetSocketAddress]
+  private var unconfirmedIncomingConnections = Map.empty[InetSocketAddress, ActorRef]
 
   private val mySessionIdFeature = SessionIdPeerFeature(networkSettings.magicBytes)
   /**
@@ -72,7 +73,7 @@ class NetworkController(ergoSettings: ErgoSettings,
   private var lastIncomingMessageTime: Time = 0L
   private val activityDelta: Long = 60 * 1000 // 1 min
 
-  // incoming connections limit (number oof incoming connections should be strictly less than the limit)
+  // incoming connections limit (number of incoming connections should be strictly less than the limit)
   private val incomingLimit = Math.max(networkSettings.maxConnections / 2, networkSettings.maxConnections - OutgoingConnections)
 
   //check own declared address for validity
@@ -179,12 +180,16 @@ class NetworkController(ergoSettings: ErgoSettings,
       log.info(s"Unconfirmed connection: ($remoteAddress, $localAddress) => $connectionId")
       if (connectionDirection.isOutgoing) {
         createPeerConnectionHandler(connectionId, sender())
+      } else if (unconfirmedIncomingConnections.contains(remoteAddress)) {
+        log.warn(s"Connection to peer $remoteAddress is already pending")
+        sender() ! Close
       } else {
-        val incomingCount = connections.values.count(_.connectionId.direction.isIncoming)
+        val incomingCount = connections.values.count(_.connectionId.direction.isIncoming) + unconfirmedIncomingConnections.size
         if (incomingCount >= incomingLimit) {
           log.info(s"Incoming connection from $remoteAddress denied: too many incoming connections ($incomingCount)")
           sender() ! Close
         } else {
+          unconfirmedIncomingConnections += remoteAddress -> sender()
           peerManagerRef ! ConfirmConnection(connectionId, sender())
         }
       }
@@ -195,10 +200,35 @@ class NetworkController(ergoSettings: ErgoSettings,
 
     case ConnectionConfirmed(connectionId, handlerRef) =>
       log.info(s"Connection confirmed to $connectionId")
-      createPeerConnectionHandler(connectionId, handlerRef)
+      if (connectionId.direction.isIncoming) {
+        val remoteAddress = connectionId.remoteAddress
+        if (!unconfirmedIncomingConnections.get(remoteAddress).contains(handlerRef)) {
+          log.info(s"Ignoring stale incoming connection confirmation from $remoteAddress")
+          handlerRef ! Close
+        } else {
+          unconfirmedIncomingConnections -= remoteAddress
+          val incomingCount = connections.values.count(_.connectionId.direction.isIncoming)
+          if (incomingCount >= incomingLimit) {
+            log.info(s"Incoming connection from ${connectionId.remoteAddress} denied: too many incoming connections ($incomingCount)")
+            handlerRef ! Close
+          } else {
+            createPeerConnectionHandler(connectionId, handlerRef)
+          }
+        }
+      } else {
+        createPeerConnectionHandler(connectionId, handlerRef)
+      }
 
     case ConnectionDenied(connectionId, handlerRef) =>
       log.info(s"Incoming connection from ${connectionId.remoteAddress} denied")
+      if (connectionId.direction.isIncoming) {
+        val remoteAddress = connectionId.remoteAddress
+        if (unconfirmedIncomingConnections.get(remoteAddress).contains(handlerRef)) {
+          unconfirmedIncomingConnections -= remoteAddress
+        } else {
+          log.info(s"Ignoring stale incoming connection denial from $remoteAddress")
+        }
+      }
       handlerRef ! Close
 
     case Handshaked(connectedPeer) =>
@@ -228,12 +258,14 @@ class NetworkController(ergoSettings: ErgoSettings,
           val remoteAddress = connectedPeer.connectionId.remoteAddress
           connections -= remoteAddress
           unconfirmedConnections -= remoteAddress
+          unconfirmedIncomingConnections -= remoteAddress
           context.system.eventStream.publish(DisconnectedPeer(connectedPeer))
         case None =>
           log.warn(s"No connection found for $ref during termination")
       }
 
     case _: ConnectionClosed =>
+      unconfirmedIncomingConnections = unconfirmedIncomingConnections.filterNot(_._2 == sender())
       log.info("Denied connection has been closed")
   }
 

--- a/src/main/scala/scorex/core/utils/NetworkUtils.scala
+++ b/src/main/scala/scorex/core/utils/NetworkUtils.scala
@@ -30,8 +30,9 @@ object NetworkUtils {
     */
   def checkLocalOnly(address: InetSocketAddress, localOnly: Boolean): Boolean = {
     if (!localOnly) {
-      val addr = address.getAddress
-      addr.isSiteLocalAddress || addr.isLinkLocalAddress || addr.isLoopbackAddress
+      Option(address.getAddress).exists { addr =>
+        addr.isSiteLocalAddress || addr.isLinkLocalAddress || addr.isLoopbackAddress
+      }
     } else {
       false
     }

--- a/src/test/scala/org/ergoplatform/network/MessageSerializerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/MessageSerializerSpecification.scala
@@ -1,0 +1,51 @@
+package org.ergoplatform.network
+
+import akka.util.ByteString
+import org.ergoplatform.network.message.MessageConstants.{HeaderLength, MaxMessageSize}
+import org.ergoplatform.network.message.{MessageSerializer, ModifiersSpec}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.core.network.MaliciousBehaviorException
+
+import java.nio.ByteOrder
+
+class MessageSerializerSpecification extends ErgoCorePropertyTest {
+
+  private implicit val byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
+
+  private val magic = Array(1: Byte, 0: Byte, 2: Byte, 4: Byte)
+  private val serializer = new MessageSerializer(Seq(ModifiersSpec), magic)
+
+  private def headerWithLength(length: Int): ByteString = {
+    ByteString.createBuilder
+      .putBytes(magic)
+      .putByte(ModifiersSpec.messageCode)
+      .putInt(length)
+      .result()
+  }
+
+  property("message serializer rejects negative payload length") {
+    val result = serializer.deserialize(headerWithLength(-1), None)
+
+    result.isFailure shouldBe true
+    result.failed.get shouldBe a[MaliciousBehaviorException]
+    result.failed.get.getMessage should include("negative")
+  }
+
+  property("message serializer accepts max payload length as an incomplete message") {
+    val result = serializer.deserialize(headerWithLength(MaxMessageSize), None)
+
+    result.get shouldBe None
+  }
+
+  property("message serializer rejects payload length above max") {
+    val result = serializer.deserialize(headerWithLength(MaxMessageSize + 1), None)
+
+    result.isFailure shouldBe true
+    result.failed.get shouldBe a[MaliciousBehaviorException]
+    result.failed.get.getMessage should include("above limit")
+  }
+
+  property("message serializer waits for header before checking payload length") {
+    serializer.deserialize(ByteString(Array.fill(HeaderLength - 1)(0.toByte)), None).get shouldBe None
+  }
+}

--- a/src/test/scala/org/ergoplatform/network/peer/LocalPeerFilteringSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/peer/LocalPeerFilteringSpecification.scala
@@ -1,8 +1,19 @@
 package org.ergoplatform.network.peer
 
+import akka.testkit.TestProbe
+import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.{AddOrUpdatePeer, AddPeerIfEmpty, GetAllPeers}
+import org.ergoplatform.network.{PeerSpec, Version}
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoNodeTestConstants
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.core.app.ScorexContext
+import scorex.core.utils.NetworkUtils
+import scorex.testkit.utils.AkkaFixture
 
+import java.nio.file.Files
 import java.net.InetSocketAddress
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class LocalPeerFilteringSpecification extends ErgoCorePropertyTest {
 
@@ -11,15 +22,85 @@ class LocalPeerFilteringSpecification extends ErgoCorePropertyTest {
   private val linkLocalAddress = new InetSocketAddress("169.254.1.1", 9003)
   private val loopbackAddress = new InetSocketAddress("127.0.0.1", 9004)
 
-  property("local addresses are correctly classified") {
-    // Verify that the addresses we test with are indeed classified correctly
-    remoteAddress.getAddress.isSiteLocalAddress shouldBe false
-    remoteAddress.getAddress.isLinkLocalAddress shouldBe false
-    remoteAddress.getAddress.isLoopbackAddress shouldBe false
+  private def settingsWith(knownPeers: Seq[InetSocketAddress], localOnly: Boolean): ErgoSettings = {
+    val base = ErgoNodeTestConstants.settings
+    val networkSettings = base.scorexSettings.network.copy(
+      knownPeers = knownPeers,
+      localOnly = localOnly
+    )
+    base.copy(
+      directory = Files.createTempDirectory("ergo-peer-filtering").toFile.getAbsolutePath,
+      scorexSettings = base.scorexSettings.copy(network = networkSettings)
+    )
+  }
 
-    siteLocalAddress.getAddress.isSiteLocalAddress shouldBe true
-    linkLocalAddress.getAddress.isLinkLocalAddress shouldBe true
-    loopbackAddress.getAddress.isLoopbackAddress shouldBe true
+  private class PeerManagerFixture(ergoSettings: ErgoSettings) extends AkkaFixture {
+    val probe: TestProbe = TestProbe()
+    val scorexContext: ScorexContext = ScorexContext(Seq.empty, None, None)
+    val peerManager = system.actorOf(PeerManagerRef.props(ergoSettings, scorexContext))
+
+    def peers: Map[InetSocketAddress, PeerInfo] = {
+      probe.send(peerManager, GetAllPeers)
+      probe.expectMsgPF() {
+        case peers: Map[_, _] => peers.asInstanceOf[Map[InetSocketAddress, PeerInfo]]
+      }
+    }
+  }
+
+  private def withPeerManager(ergoSettings: ErgoSettings)(testCode: PeerManagerFixture => Any): Unit = {
+    val fixture = new PeerManagerFixture(ergoSettings)
+    try {
+      testCode(fixture)
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  private def peerSpec(address: InetSocketAddress): PeerSpec =
+    PeerSpec("test", Version(6, 0, 0), "test", Some(address), Seq.empty)
+
+  property("local addresses are correctly classified") {
+    NetworkUtils.checkLocalOnly(remoteAddress, localOnly = false) shouldBe false
+
+    NetworkUtils.checkLocalOnly(siteLocalAddress, localOnly = false) shouldBe true
+    NetworkUtils.checkLocalOnly(linkLocalAddress, localOnly = false) shouldBe true
+    NetworkUtils.checkLocalOnly(loopbackAddress, localOnly = false) shouldBe true
+
+    NetworkUtils.checkLocalOnly(siteLocalAddress, localOnly = true) shouldBe false
+  }
+
+  property("peer manager does not seed local known peers when localOnly is disabled") {
+    val ergoSettings = settingsWith(
+      knownPeers = Seq(remoteAddress, siteLocalAddress, linkLocalAddress, loopbackAddress),
+      localOnly = false
+    )
+
+    withPeerManager(ergoSettings) { fixture =>
+      fixture.peers.keySet shouldBe Set(remoteAddress)
+    }
+  }
+
+  property("peer manager purges local peers already stored in the database") {
+    val ergoSettings = settingsWith(knownPeers = Seq.empty, localOnly = false)
+    val peerDatabase = new PeerDatabase(ergoSettings)
+    peerDatabase.addOrUpdateKnownPeer(PeerInfo.fromAddress(remoteAddress))
+    peerDatabase.addOrUpdateKnownPeer(PeerInfo.fromAddress(siteLocalAddress))
+    peerDatabase.addOrUpdateKnownPeer(PeerInfo.fromAddress(loopbackAddress))
+
+    withPeerManager(ergoSettings) { fixture =>
+      fixture.peers.keySet shouldBe Set(remoteAddress)
+    }
+  }
+
+  property("peer manager rejects local peers received from peer messages") {
+    val ergoSettings = settingsWith(knownPeers = Seq(remoteAddress), localOnly = false)
+
+    withPeerManager(ergoSettings) { fixture =>
+      fixture.probe.send(fixture.peerManager, AddOrUpdatePeer(PeerInfo.fromAddress(siteLocalAddress)))
+      fixture.probe.send(fixture.peerManager, AddPeerIfEmpty(peerSpec(loopbackAddress)))
+
+      fixture.peers.keySet shouldBe Set(remoteAddress)
+    }
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/OffChainRegistrySpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/OffChainRegistrySpec.scala
@@ -42,7 +42,7 @@ class OffChainRegistrySpec
 
 
       //check remove-offchain flag
-      boxes.filter(_.scans.size > 1).flatMap(_.scans).find(_ != Constants.PaymentsScanId).map { scanId =>
+      boxes.filter(_.scans.size > 1).flatMap(_.scans).find(_ > Constants.PaymentsScanId).map { scanId =>
         val p = EqualsScanningPredicate(ErgoBox.R1, ByteArrayConstant(TrueTree.bytes))
         val scan = Scan(scanId, "_", p, ScanWalletInteraction.Off, removeOffchain = false)
         val filtered = boxes.filter(tb => tb.scans.contains(scanId))

--- a/src/test/scala/scorex/core/network/NetworkControllerSpecification.scala
+++ b/src/test/scala/scorex/core/network/NetworkControllerSpecification.scala
@@ -1,0 +1,168 @@
+package scorex.core.network
+
+import akka.io.Tcp.{Bind, Close, Connected, PeerClosed}
+import akka.testkit.TestProbe
+import org.ergoplatform.network.message.MessageConstants.MessageCode
+import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.{ConfirmConnection, ConnectionConfirmed, ConnectionDenied}
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoNodeTestConstants
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.app.ScorexContext
+import scorex.testkit.utils.AkkaFixture
+
+import java.net.InetSocketAddress
+import java.nio.file.Files
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class NetworkControllerSpecification extends AnyFlatSpec with Matchers {
+
+  private class NetworkControllerFixture(maxConnections: Int) extends AkkaFixture {
+    implicit val ec = system.dispatcher
+
+    val peerManagerProbe: TestProbe = TestProbe()
+    val tcpManagerProbe: TestProbe = TestProbe()
+    val scorexContext: ScorexContext = ScorexContext(Seq.empty, None, None)
+
+    val ergoSettings: ErgoSettings = {
+      val base = ErgoNodeTestConstants.settings
+      val networkSettings = base.scorexSettings.network.copy(
+        maxConnections = maxConnections,
+        bindAddress = new InetSocketAddress("127.0.0.1", 0),
+        declaredAddress = None
+      )
+      base.copy(
+        directory = Files.createTempDirectory("ergo-network-controller").toFile.getAbsolutePath,
+        scorexSettings = base.scorexSettings.copy(network = networkSettings)
+      )
+    }
+
+    val networkController = system.actorOf(
+      NetworkControllerRef.props(
+        ergoSettings,
+        peerManagerProbe.ref,
+        scorexContext,
+        tcpManagerProbe.ref,
+        _ => Map.empty[MessageCode, akka.actor.ActorRef]
+      )
+    )
+
+    tcpManagerProbe.expectMsgType[Bind]
+
+    def incomingLimit: Int =
+      Math.max(maxConnections / 2, maxConnections - NetworkController.OutgoingConnections)
+
+    def remote(i: Int): InetSocketAddress =
+      new InetSocketAddress(s"203.0.113.$i", 9000 + i)
+
+    val local: InetSocketAddress = new InetSocketAddress("127.0.0.1", 9000)
+  }
+
+  private def withNetworkController(maxConnections: Int)(testCode: NetworkControllerFixture => Any): Unit = {
+    val fixture = new NetworkControllerFixture(maxConnections)
+    try {
+      testCode(fixture)
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  it should "count pending inbound confirmations against the incoming connection limit" in {
+    withNetworkController(maxConnections = 10) { fixture =>
+      import fixture._
+
+      (1 to incomingLimit).foreach { i =>
+        val connection = TestProbe()
+        connection.send(networkController, Connected(remote(i), local))
+        peerManagerProbe.expectMsgType[ConfirmConnection]
+      }
+
+      val overflowConnection = TestProbe()
+      overflowConnection.send(networkController, Connected(remote(99), local))
+      overflowConnection.expectMsg(Close)
+      peerManagerProbe.expectNoMessage(300.millis)
+    }
+  }
+
+  it should "release a pending inbound slot when peer manager denies the connection" in {
+    withNetworkController(maxConnections = 10) { fixture =>
+      import fixture._
+
+      (1 to incomingLimit).foreach { i =>
+        val connection = TestProbe()
+        connection.send(networkController, Connected(remote(i), local))
+        val confirm = peerManagerProbe.expectMsgType[ConfirmConnection]
+        if (i == 1) {
+          peerManagerProbe.send(networkController, ConnectionDenied(confirm.connectionId, confirm.handlerRef))
+          connection.expectMsg(Close)
+        }
+      }
+
+      val replacementConnection = TestProbe()
+      replacementConnection.send(networkController, Connected(remote(99), local))
+      peerManagerProbe.expectMsgType[ConfirmConnection]
+    }
+  }
+
+  it should "close duplicate inbound connections while confirmation is pending" in {
+    withNetworkController(maxConnections = 10) { fixture =>
+      import fixture._
+
+      val firstConnection = TestProbe()
+      firstConnection.send(networkController, Connected(remote(1), local))
+      peerManagerProbe.expectMsgType[ConfirmConnection]
+
+      val duplicateConnection = TestProbe()
+      duplicateConnection.send(networkController, Connected(remote(1), local))
+      duplicateConnection.expectMsg(Close)
+      peerManagerProbe.expectNoMessage(300.millis)
+    }
+  }
+
+  it should "ignore stale inbound confirmations after the raw connection has closed" in {
+    withNetworkController(maxConnections = 10) { fixture =>
+      import fixture._
+
+      val firstConnection = TestProbe()
+      firstConnection.send(networkController, Connected(remote(1), local))
+      val firstConfirm = peerManagerProbe.expectMsgType[ConfirmConnection]
+      firstConnection.send(networkController, PeerClosed)
+
+      val secondConnection = TestProbe()
+      secondConnection.send(networkController, Connected(remote(1), local))
+      peerManagerProbe.expectMsgType[ConfirmConnection]
+
+      peerManagerProbe.send(networkController, ConnectionConfirmed(firstConfirm.connectionId, firstConfirm.handlerRef))
+      firstConnection.expectMsg(Close)
+
+      val duplicateConnection = TestProbe()
+      duplicateConnection.send(networkController, Connected(remote(1), local))
+      duplicateConnection.expectMsg(Close)
+      peerManagerProbe.expectNoMessage(300.millis)
+    }
+  }
+
+  it should "ignore stale inbound denials after the raw connection has closed" in {
+    withNetworkController(maxConnections = 10) { fixture =>
+      import fixture._
+
+      val firstConnection = TestProbe()
+      firstConnection.send(networkController, Connected(remote(1), local))
+      val firstConfirm = peerManagerProbe.expectMsgType[ConfirmConnection]
+      firstConnection.send(networkController, PeerClosed)
+
+      val secondConnection = TestProbe()
+      secondConnection.send(networkController, Connected(remote(1), local))
+      peerManagerProbe.expectMsgType[ConfirmConnection]
+
+      peerManagerProbe.send(networkController, ConnectionDenied(firstConfirm.connectionId, firstConfirm.handlerRef))
+      firstConnection.expectMsg(Close)
+
+      val duplicateConnection = TestProbe()
+      duplicateConnection.send(networkController, Connected(remote(1), local))
+      duplicateConnection.expectMsg(Close)
+      peerManagerProbe.expectNoMessage(300.millis)
+    }
+  }
+}


### PR DESCRIPTION
Follow-up patch for #2306.

## Summary
- Count pending inbound confirmations against the incoming connection limit.
- Close duplicate/stale inbound confirmations and denials deterministically.
- Keep local/self peers out of the persisted peer database when local peer discovery is disabled.
- Add message payload length boundary coverage for negative, max-size, and over-limit frames.
- Make the Docker IT harness more stable around host REST fallback, temp directory fallback, and bounded log capture.
- Make the fork-resolution and deep-rollback specs verify actual convergence instead of relying only on height progress.
- Fix the off-chain registry test so generated data cannot select a reserved scan id.

## Checks
- `sbt -Denv=test ++2.12.20 "testOnly scorex.core.network.NetworkControllerSpecification org.ergoplatform.network.peer.LocalPeerFilteringSpecification org.ergoplatform.network.MessageSerializerSpecification org.ergoplatform.nodeView.wallet.persistence.OffChainRegistrySpec"`
- `sbt -Denv=test ++2.12.20 "it:testOnly org.ergoplatform.it.ForkResolutionSpec org.ergoplatform.it.DeepRollBackSpec"`