### PR TITLE
Add wallet scan support after UTXO snapshot bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
            key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
        - name: Runs it node tests
+         env:
+           DOCKER_BUILDKIT: "0"
          run: |
            cd it
            mkdir tmp

--- a/avldb/src/main/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorage.scala
+++ b/avldb/src/main/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorage.scala
@@ -12,7 +12,7 @@ import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.ScorexLogging
 
 import scala.collection.mutable
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
   * Persistent versioned authenticated AVL+ tree implementation on top of versioned LevelDB storage
@@ -151,6 +151,127 @@ class VersionedLDBAVLStorage(store: LDBVersionedStore)
       dumpStorage.insert(rootNodeLabel, manifestBytes)
 
       rootNodeLabel
+    }
+  }
+
+  /**
+    * Iterates current AVL+ tree subtrees using the same manifest cut as [[dumpSnapshot]].
+    *
+    * @param fromIndex      - zero-based subtree index to start from
+    * @param depth          - manifest cut depth
+    * @param handleSubtree  - callback invoked for every subtree at or after `fromIndex`
+    * @return index after the last successfully iterated subtree
+    */
+  def iterateSubtrees(fromIndex: Int, depth: Int)
+                     (handleSubtree: (Int, BatchAVLProverSubtree[DigestType]) => Try[Unit]): Try[Int] =
+    iterateSubtrees(fromIndex, depth, Int.MaxValue)(handleSubtree)
+
+  /**
+    * Iterates a bounded number of current AVL+ tree subtrees using the same manifest cut as [[dumpSnapshot]].
+    *
+    * @param fromIndex      - zero-based subtree index to start from
+    * @param depth          - manifest cut depth
+    * @param limit          - maximal number of subtrees to handle
+    * @param handleSubtree  - callback invoked for every subtree at or after `fromIndex`
+    * @return index after the last successfully iterated subtree
+    */
+  def iterateSubtrees(fromIndex: Int, depth: Int, limit: Int)
+                     (handleSubtree: (Int, BatchAVLProverSubtree[DigestType]) => Try[Unit]): Try[Int] = {
+    Try {
+      require(fromIndex >= 0, "fromIndex should be non-negative")
+      require(depth > 0, "depth should be positive")
+      require(limit > 0, "limit should be positive")
+    }.flatMap { _ =>
+      store.processSnapshot { dbReader =>
+        def readNode(nodeDbKey: Array[Byte]): ProverNodes[DigestType] = {
+          val nodeBytes = dbReader.get(nodeDbKey)
+          VersionedLDBAVLStorage.noStoreSerializer.parseBytes(nodeBytes)
+        }
+
+        def readSubtree(sid: DigestType): Try[BatchAVLProverSubtree[DigestType]] = Try {
+          def subtreeLoop(nodeDbKey: Array[Byte]): ProverNodes[DigestType] = {
+            readNode(nodeDbKey) match {
+              case in: ProxyInternalNode[DigestType] =>
+                val left = subtreeLoop(in.leftLabel)
+                val right = subtreeLoop(in.rightLabel)
+                in.getNew(newLeft = left, newRight = right)
+              case node =>
+                node
+            }
+          }
+
+          new BatchAVLProverSubtree[DigestType](subtreeLoop(sid))
+        }
+
+        var nextIndex = 0
+        var handled = 0
+
+        def handleSubtreeId(sid: DigestType): Try[Unit] = {
+          val currentIndex = nextIndex
+          if (currentIndex < fromIndex) {
+            nextIndex += 1
+            Success(())
+          } else if (handled >= limit) {
+            Success(())
+          } else {
+            readSubtree(sid).flatMap(handleSubtree(currentIndex, _)).map { _ =>
+              nextIndex += 1
+              handled += 1
+            }
+          }
+        }
+
+        def manifestLoop(nodeDbKey: Array[Byte], level: Int): Try[Unit] = {
+          if (handled >= limit) {
+            Success(())
+          } else readNode(nodeDbKey) match {
+            case in: ProxyInternalNode[DigestType] if level == depth =>
+              handleSubtreeId(Digest32 @@@ in.leftLabel)
+                .flatMap(_ => handleSubtreeId(Digest32 @@@ in.rightLabel))
+            case in: ProxyInternalNode[DigestType] =>
+              manifestLoop(in.leftLabel, level + 1)
+                .flatMap(_ => manifestLoop(in.rightLabel, level + 1))
+            case _ =>
+              Success(())
+          }
+        }
+
+        val rootNodeLabel = dbReader.get(topNodeHashKey)
+        manifestLoop(rootNodeLabel, level = 1).map(_ => nextIndex)
+      }.flatMap(identity)
+    }
+  }
+
+  /**
+    * Counts current AVL+ tree subtrees using the same manifest cut as [[dumpSnapshot]].
+    */
+  def countSubtrees(depth: Int): Try[Int] = {
+    Try {
+      require(depth > 0, "depth should be positive")
+    }.flatMap { _ =>
+      store.processSnapshot { dbReader =>
+        def readNode(nodeDbKey: Array[Byte]): ProverNodes[DigestType] = {
+          val nodeBytes = dbReader.get(nodeDbKey)
+          VersionedLDBAVLStorage.noStoreSerializer.parseBytes(nodeBytes)
+        }
+
+        var count = 0
+
+        def manifestLoop(nodeDbKey: Array[Byte], level: Int): Unit = {
+          readNode(nodeDbKey) match {
+            case _: ProxyInternalNode[DigestType] if level == depth =>
+              count += 2
+            case in: ProxyInternalNode[DigestType] =>
+              manifestLoop(in.leftLabel, level + 1)
+              manifestLoop(in.rightLabel, level + 1)
+            case _ =>
+          }
+        }
+
+        val rootNodeLabel = dbReader.get(topNodeHashKey)
+        manifestLoop(rootNodeLabel, level = 1)
+        count
+      }
     }
   }
 }

--- a/avldb/src/test/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorageSpecification.scala
+++ b/avldb/src/test/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorageSpecification.scala
@@ -19,7 +19,7 @@ import scorex.utils.{Random => RandomBytes}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 class VersionedLDBAVLStorageSpecification
   extends AnyPropSpec
@@ -368,6 +368,78 @@ class VersionedLDBAVLStorageSpecification
       val chunkBytes = store.get(sid).get
       SubtreeSerializer.parseBytesTry(chunkBytes).get.id.sameElements(sid) shouldBe true
     }
+  }
+
+  property("iterating snapshot subtrees follows manifest order and supports resume") {
+    val manifestDepth: Byte = 6
+    val manifestSerializer = new ManifestSerializer(manifestDepth)
+    val prover = createPersistentProver()
+    blockchainWorkflowTest(prover)
+
+    val storage = prover.storage.asInstanceOf[VersionedLDBAVLStorage]
+    val dumpStore = LDBFactory.createKvDb(getRandomTempDir.getAbsolutePath)
+
+    val rootNodeLabel = storage.dumpSnapshot(dumpStore, manifestDepth, prover.digest.dropRight(1)).get
+    val manifest = manifestSerializer.parseBytesTry(dumpStore.get(rootNodeLabel).get).get
+
+    val iteratedIds = scala.collection.mutable.ArrayBuffer.empty[Digest32]
+    val nextIndex = storage.iterateSubtrees(0, manifestDepth) { case (_, subtree) =>
+      iteratedIds += subtree.id
+      Success(())
+    }.get
+
+    nextIndex shouldBe manifest.subtreesIds.size
+    iteratedIds.toSeq.map(Base16.encode) shouldBe manifest.subtreesIds.map(Base16.encode)
+    storage.countSubtrees(manifestDepth).get shouldBe manifest.subtreesIds.size
+
+    val resumeFrom = manifest.subtreesIds.size / 2
+    val resumedIds = scala.collection.mutable.ArrayBuffer.empty[Digest32]
+    val resumedNextIndex = storage.iterateSubtrees(resumeFrom, manifestDepth) { case (_, subtree) =>
+      resumedIds += subtree.id
+      Success(())
+    }.get
+
+    resumedNextIndex shouldBe manifest.subtreesIds.size
+    resumedIds.toSeq.map(Base16.encode) shouldBe manifest.subtreesIds.drop(resumeFrom).map(Base16.encode)
+
+    val limitedIds = scala.collection.mutable.ArrayBuffer.empty[Digest32]
+    val limitedNextIndex = storage.iterateSubtrees(resumeFrom, manifestDepth, limit = 2) { case (_, subtree) =>
+      limitedIds += subtree.id
+      Success(())
+    }.get
+
+    limitedNextIndex shouldBe resumeFrom + 2
+    limitedIds.toSeq.map(Base16.encode) shouldBe manifest.subtreesIds.slice(resumeFrom, resumeFrom + 2).map(Base16.encode)
+  }
+
+  property("iterating snapshot subtrees stops on handler failure") {
+    val manifestDepth: Byte = 6
+    val prover = createPersistentProver()
+    blockchainWorkflowTest(prover)
+
+    val storage = prover.storage.asInstanceOf[VersionedLDBAVLStorage]
+    val visited = scala.collection.mutable.ArrayBuffer.empty[Int]
+    val failure = new IllegalStateException("stop")
+
+    val result = storage.iterateSubtrees(0, manifestDepth) { case (index, _) =>
+      visited += index
+      if (index == 2) Failure(failure) else Success(())
+    }
+
+    result.failed.get shouldBe failure
+    visited.toSeq shouldBe Seq(0, 1, 2)
+  }
+
+  property("iterating snapshot subtrees validates arguments") {
+    val prover = createPersistentProver()
+    blockchainWorkflowTest(prover)
+
+    val storage = prover.storage.asInstanceOf[VersionedLDBAVLStorage]
+
+    storage.iterateSubtrees(-1, 6) { case (_, _) => Success(()) }.isFailure shouldBe true
+    storage.iterateSubtrees(0, 0) { case (_, _) => Success(()) }.isFailure shouldBe true
+    storage.iterateSubtrees(0, 6, 0) { case (_, _) => Success(()) }.isFailure shouldBe true
+    storage.countSubtrees(0).isFailure shouldBe true
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ docker / dockerfile := {
   val configMainNet = (IntegrationTest / resourceDirectory).value / "mainnetTemplate.conf"
 
   new Dockerfile {
-    from("openjdk:11-jre-slim")
+    from("eclipse-temurin:11-jre-jammy")
     label("ergo-integration-tests", "ergo-integration-tests")
     add(assembly.value, "/opt/ergo/ergo.jar")
     add(Seq(configDevNet), "/opt/ergo")

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -50,6 +50,13 @@ object ErgoNodeViewSynchronizerMessages {
     case class ChangedState(reader: ErgoStateReader) extends NodeViewChange
 
     /**
+     * Event emitted after UTXO state has been reconstructed from a local UTXO set snapshot.
+     */
+    case class UtxoSnapshotAppliedToState(blockHeight: Height,
+                                          blockId: ModifierId,
+                                          stateReader: UtxoStateReader) extends NodeViewHolderEvent
+
+    /**
      * Event which is published when rollback happened (on finding a better chain)
      *
      * @param branchPoint - block id which is last in the chain after rollback (before applying blocks from a fork)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -288,6 +288,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
             history().onUtxoSnapshotApplied(height)
             val newState = new UtxoState(pp, version = VersionTag @@@ blockId, store, settings)
             updateNodeView(updatedState = Some(newState.asInstanceOf[State]))
+            context.system.eventStream.publish(UtxoSnapshotAppliedToState(height, blockId, newState))
           case Failure(t) =>
             log.error("UTXO set snapshot application failed: ", t)
         }

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
@@ -11,6 +11,8 @@ import org.ergoplatform.settings.Algos.HF
 import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.validation.MalformedModifierError
+import scorex.crypto.authds.avltree.batch.Constants.DigestType
+import scorex.crypto.authds.avltree.batch.serialization.BatchAVLProverSubtree
 import scorex.crypto.authds.avltree.batch.{Lookup, PersistentBatchAVLProver, VersionedLDBAVLStorage}
 import scorex.crypto.authds.{ADDigest, ADKey, SerializedAdProof}
 import scorex.crypto.hash.Digest32
@@ -190,5 +192,13 @@ trait UtxoStateReader extends ErgoStateReader with UtxoSetSnapshotPersistence {
     * Useful when checking mempool transactions.
     */
   def withMempool(mp: ErgoMemPoolReader): UtxoState = withUnconfirmedTransactions(mp.getAll)
+
+  def countSnapshotSubtrees(depth: Int): Try[Int] =
+    persistentProver.storage.asInstanceOf[VersionedLDBAVLStorage].countSubtrees(depth)
+
+  def iterateSnapshotSubtrees(fromIndex: Int, depth: Int, limit: Int)
+                             (handleSubtree: (Int, BatchAVLProverSubtree[DigestType]) => Try[Unit]): Try[Int] =
+    persistentProver.storage.asInstanceOf[VersionedLDBAVLStorage]
+      .iterateSubtrees(fromIndex, depth, limit)(handleSubtree)
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -4,21 +4,23 @@ import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor._
 import akka.pattern.StatusReply
 import org.ergoplatform.ErgoBox._
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState, UtxoSnapshotAppliedToState}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
+import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
-import org.ergoplatform.nodeView.state.ErgoStateReader
+import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
+import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, UtxoSnapshotScanStatus}
 import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.settings._
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.BoxSelector
 import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages._
 import org.ergoplatform._
-import org.ergoplatform.core.VersionTag
+import org.ergoplatform.core.{VersionTag, versionToId}
 import org.ergoplatform.sdk.SecretString
 import org.ergoplatform.utils.ScorexEncoding
-import scorex.util.ScorexLogging
+import scorex.util.{ModifierId, ScorexLogging}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -31,6 +33,7 @@ class ErgoWalletActor(settings: ErgoSettings,
   extends Actor with Stash with ScorexLogging with ScorexEncoding {
 
   private val ergoAddressEncoder: ErgoAddressEncoder = settings.addressEncoder
+  private var utxoSnapshotScanner: ActorRef = _
 
   override val supervisorStrategy: OneForOneStrategy =
     OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
@@ -62,8 +65,13 @@ class ErgoWalletActor(settings: ErgoSettings,
     log.info("Initializing wallet actor")
     ErgoWalletState.initial(settings, parameters) match {
       case Success(state) =>
+        utxoSnapshotScanner = context.actorOf(
+          UtxoSnapshotWalletScanner.props(self, settings).withDispatcher(GlobalConstants.ApiDispatcher),
+          "utxo-snapshot-wallet-scanner"
+        )
         context.system.eventStream.subscribe(self, classOf[ChangedState])
         context.system.eventStream.subscribe(self, classOf[ChangedMempool])
+        context.system.eventStream.subscribe(self, classOf[UtxoSnapshotAppliedToState])
         self ! ReadWallet(state)
       case Failure(ex) =>
         log.error("Unable to initialize wallet", ex)
@@ -77,10 +85,55 @@ class ErgoWalletActor(settings: ErgoSettings,
       // Try to read wallet from json file or test mnemonic provided in a config file
       val newState = ergoWalletService.readWallet(state, ws.testMnemonic.map(SecretString.create(_)), ws.testKeysQty, ws.secretStorage)
       context.become(loadedWallet(newState))
+      maybeStartAvailableUtxoSnapshotScan(newState)
       unstashAll()
     case _ => // stashing all messages until wallet is setup
       stash()
   }
+
+  private def pendingUtxoSnapshotScan(state: ErgoWalletState): Option[UtxoSnapshotScanStatus] =
+    if (settings.nodeSettings.utxoSettings.utxoBootstrap) {
+      state.storage.readUtxoSnapshotScanStatus().filterNot(_.completed)
+    } else {
+      None
+    }
+
+  private def matchingUtxoSnapshotReader(status: UtxoSnapshotScanStatus,
+                                         reader: UtxoStateReader): Boolean =
+    status.snapshotHeight == reader.stateContext.currentHeight &&
+      status.snapshotBlockId == versionToId(reader.version)
+
+  private def startUtxoSnapshotScan(snapshotHeight: Height,
+                                    snapshotBlockId: ModifierId,
+                                    stateReader: UtxoStateReader,
+                                    forceRestart: Boolean): Unit = {
+    if (settings.nodeSettings.utxoSettings.utxoBootstrap) {
+      utxoSnapshotScanner ! StartUtxoSnapshotScan(snapshotHeight, snapshotBlockId, stateReader, forceRestart)
+    }
+  }
+
+  private def canScanUtxoSnapshot(state: ErgoWalletState): Boolean =
+    state.walletVars.trackedBytes.nonEmpty || state.walletVars.externalScans.nonEmpty
+
+  private def maybeStartAvailableUtxoSnapshotScan(state: ErgoWalletState): Unit = {
+    val shouldStart =
+      settings.nodeSettings.utxoSettings.utxoBootstrap &&
+        settings.nodeSettings.isFullBlocksPruned &&
+        canScanUtxoSnapshot(state) &&
+        state.getWalletHeight == 0 &&
+        state.storage.readUtxoSnapshotScanStatus().isEmpty
+
+    if (shouldStart) {
+      state.utxoStateReaderOpt
+        .orElse(state.stateReaderOpt.collect { case reader: UtxoStateReader => reader })
+        .foreach { reader =>
+          startUtxoSnapshotScan(reader.stateContext.currentHeight, versionToId(reader.version), reader, forceRestart = false)
+        }
+    }
+  }
+
+  private def fail[T](message: String): Failure[T] =
+    Failure(new IllegalStateException(message))
 
   private def loadedWallet(state: ErgoWalletState): Receive = {
     // Init wallet (w. mnemonic generation) if secret is not set yet
@@ -214,13 +267,100 @@ class ErgoWalletActor(settings: ErgoSettings,
           val updState = state.copy(stateReaderOpt = Some(s), parameters = cp, walletVars = newWalletVars)
           val newState = ergoWalletService.updateUtxoState(updState)
           context.become(loadedWallet(newState))
+          (pendingUtxoSnapshotScan(newState), s) match {
+            case (Some(status), reader: UtxoStateReader) if matchingUtxoSnapshotReader(status, reader) =>
+              startUtxoSnapshotScan(status.snapshotHeight, status.snapshotBlockId, reader, forceRestart = false)
+            case (None, _: UtxoStateReader) =>
+              maybeStartAvailableUtxoSnapshotScan(newState)
+            case _ =>
+          }
         case Failure(t) =>
           val errorMsg = s"Updating wallet state context failed : ${t.getMessage}"
           log.error(errorMsg, t)
           context.become(loadedWallet(state.copy(error = Some(errorMsg))))
       }
 
+    case UtxoSnapshotAppliedToState(height, blockId, reader) =>
+      if (canScanUtxoSnapshot(state)) {
+        startUtxoSnapshotScan(height, blockId, reader, forceRestart = false)
+      } else {
+        log.debug("Skipping UTXO snapshot wallet scan because wallet scan variables are not initialized")
+      }
+
     /* SCAN COMMANDS */
+    case GetOrInitUtxoSnapshotScanStatus(snapshotHeight, snapshotBlockId, manifestDepth, totalSubtrees) =>
+      val statusTry = state.storage.readUtxoSnapshotScanStatus() match {
+        case Some(status)
+          if status.snapshotHeight == snapshotHeight &&
+            status.snapshotBlockId == snapshotBlockId &&
+            status.manifestDepth == manifestDepth &&
+            status.totalSubtrees == totalSubtrees =>
+          Success(status)
+        case _ =>
+          val status = UtxoSnapshotScanStatus(
+            snapshotHeight,
+            snapshotBlockId,
+            manifestDepth,
+            nextSubtreeIndex = 0,
+            totalSubtrees,
+            completed = false
+          )
+          state.storage.writeUtxoSnapshotScanStatus(status).map(_ => status)
+      }
+      sender() ! statusTry
+
+    case ApplyUtxoSnapshotScanBatch(snapshotHeight, snapshotBlockId, subtreeIndex, nextSubtreeIndex, completed, boxes) =>
+      val replyTo = sender()
+      val updateTry = state.storage.readUtxoSnapshotScanStatus() match {
+        case Some(status)
+          if status.snapshotHeight == snapshotHeight &&
+            status.snapshotBlockId == snapshotBlockId &&
+            !status.completed &&
+            status.nextSubtreeIndex == subtreeIndex &&
+            nextSubtreeIndex >= subtreeIndex =>
+          val updatedStatus = status.copy(nextSubtreeIndex = nextSubtreeIndex, completed = completed)
+          ergoWalletService
+            .scanUtxoSnapshotChunk(
+              state,
+              boxes,
+              snapshotBlockId,
+              snapshotHeight,
+              subtreeIndex,
+              finalChunk = completed,
+              settings.walletSettings.dustLimit
+            )
+            .flatMap { updatedState =>
+              updatedState.storage.writeUtxoSnapshotScanStatus(updatedStatus).map { _ =>
+                updatedState -> updatedStatus
+              }
+            }
+        case Some(status) if status.completed =>
+          fail(s"UTXO snapshot wallet scan is already completed at height ${status.snapshotHeight}")
+        case Some(status) =>
+          fail(s"Unexpected UTXO snapshot wallet scan batch, expected subtree ${status.nextSubtreeIndex}")
+        case None =>
+          fail("UTXO snapshot wallet scan status is missing")
+      }
+
+      updateTry match {
+        case Success((updatedState, updatedStatus)) =>
+          val finalState = if (updatedStatus.completed) {
+            updatedState.copy(rescanInProgress = false)
+          } else {
+            updatedState
+          }
+          context.become(loadedWallet(finalState))
+          if (updatedStatus.completed) {
+            self ! ScanInThePast(updatedStatus.snapshotHeight + 1, rescan = false)
+          }
+          replyTo ! Success(updatedStatus)
+        case Failure(t) =>
+          val errorMsg = s"UTXO snapshot wallet scan batch failed : ${t.getMessage}"
+          log.error(errorMsg, t)
+          context.become(loadedWallet(state.copy(error = Some(errorMsg))))
+          replyTo ! Failure(t)
+      }
+
     //scan mempool transaction
     case ScanOffChain(tx) =>
       val dustLimit = settings.walletSettings.dustLimit
@@ -233,54 +373,62 @@ class ErgoWalletActor(settings: ErgoSettings,
 
     // rescan=true means we serve a user request for rescan from arbitrary height
     case ScanInThePast(blockHeight, rescan) =>
-      val nextBlockHeight = state.expectedNextBlockHeight(blockHeight, settings.nodeSettings.isFullBlocksPruned)
-      if (nextBlockHeight == blockHeight || rescan) {
-        val newState =
-          historyReader.bestFullBlockAt(blockHeight) match {
-            case Some(block) =>
-              val operation = if (rescan) "rescanning" else "scanning"
-              log.info(s"Wallet is $operation a block ${block.id} in the past at height ${block.height}")
-              ergoWalletService.scanBlockUpdate(state, block, settings.walletSettings.dustLimit) match {
-                case Failure(ex) =>
-                  val errorMsg = s"Block ${block.id} $operation at height $blockHeight failed : ${ex.getMessage}"
-                  log.error(errorMsg, ex)
-                  state.copy(error = Some(errorMsg))
-                case Success(updatedState) =>
-                  updatedState
-              }
-            case None =>
-              state // We may do not have a block if, for example, the blockchain is pruned. This is okay, just skip it.
-        }
-        context.become(loadedWallet(newState))
-        if (blockHeight < newState.fullHeight) {
-          self ! ScanInThePast(blockHeight + 1, rescan)
-        } else if (rescan) {
-          log.info(s"Rescanning finished at height $blockHeight")
-          context.become(loadedWallet(newState.copy(rescanInProgress = false)))
+      if (pendingUtxoSnapshotScan(state).nonEmpty) {
+        log.debug(s"Delaying wallet scan from height $blockHeight until UTXO snapshot scan is completed")
+      } else {
+        val nextBlockHeight = state.expectedNextBlockHeight(blockHeight, settings.nodeSettings.isFullBlocksPruned)
+        if (nextBlockHeight == blockHeight || rescan) {
+          val newState =
+            historyReader.bestFullBlockAt(blockHeight) match {
+              case Some(block) =>
+                val operation = if (rescan) "rescanning" else "scanning"
+                log.info(s"Wallet is $operation a block ${block.id} in the past at height ${block.height}")
+                ergoWalletService.scanBlockUpdate(state, block, settings.walletSettings.dustLimit) match {
+                  case Failure(ex) =>
+                    val errorMsg = s"Block ${block.id} $operation at height $blockHeight failed : ${ex.getMessage}"
+                    log.error(errorMsg, ex)
+                    state.copy(error = Some(errorMsg))
+                  case Success(updatedState) =>
+                    updatedState
+                }
+              case None =>
+                state // We may do not have a block if, for example, the blockchain is pruned. This is okay, just skip it.
+            }
+          context.become(loadedWallet(newState))
+          if (blockHeight < newState.fullHeight) {
+            self ! ScanInThePast(blockHeight + 1, rescan)
+          } else if (rescan) {
+            log.info(s"Rescanning finished at height $blockHeight")
+            context.become(loadedWallet(newState.copy(rescanInProgress = false)))
+          }
         }
       }
 
     //scan block transactions
     case ScanOnChain(newBlock) =>
       if (state.secretIsSet(settings.walletSettings.testMnemonic)) { // scan blocks only if wallet is initialized
-        val nextBlockHeight = state.expectedNextBlockHeight(newBlock.height, settings.nodeSettings.isFullBlocksPruned)
-        if (nextBlockHeight == newBlock.height) {
-          log.info(s"Wallet is going to scan a block ${newBlock.id} on chain at height ${newBlock.height}")
-          val newState =
-            ergoWalletService.scanBlockUpdate(state, newBlock, settings.walletSettings.dustLimit) match {
-              case Failure(ex) =>
-                val errorMsg = s"Scanning new block ${newBlock.id} on chain at height ${newBlock.height} failed : ${ex.getMessage}"
-                log.error(errorMsg, ex)
-                state.copy(error = Some(errorMsg))
-              case Success(updatedState) =>
-                updatedState
-            }
-          context.become(loadedWallet(newState))
-        } else if (nextBlockHeight < newBlock.height) {
-          log.warn(s"Wallet: skipped blocks found starting from $nextBlockHeight, going back to scan them")
-          self ! ScanInThePast(nextBlockHeight, false)
+        if (pendingUtxoSnapshotScan(state).nonEmpty) {
+          log.debug(s"Delaying wallet scan of block ${newBlock.id} until UTXO snapshot scan is completed")
         } else {
-          log.warn(s"Wallet: block in the past reported at ${newBlock.height}, blockId: ${newBlock.id}")
+          val nextBlockHeight = state.expectedNextBlockHeight(newBlock.height, settings.nodeSettings.isFullBlocksPruned)
+          if (nextBlockHeight == newBlock.height) {
+            log.info(s"Wallet is going to scan a block ${newBlock.id} on chain at height ${newBlock.height}")
+            val newState =
+              ergoWalletService.scanBlockUpdate(state, newBlock, settings.walletSettings.dustLimit) match {
+                case Failure(ex) =>
+                  val errorMsg = s"Scanning new block ${newBlock.id} on chain at height ${newBlock.height} failed : ${ex.getMessage}"
+                  log.error(errorMsg, ex)
+                  state.copy(error = Some(errorMsg))
+                case Success(updatedState) =>
+                  updatedState
+              }
+            context.become(loadedWallet(newState))
+          } else if (nextBlockHeight < newBlock.height) {
+            log.warn(s"Wallet: skipped blocks found starting from $nextBlockHeight, going back to scan them")
+            self ! ScanInThePast(nextBlockHeight, false)
+          } else {
+            log.warn(s"Wallet: block in the past reported at ${newBlock.height}, blockId: ${newBlock.id}")
+          }
         }
       }
 
@@ -318,6 +466,7 @@ class ErgoWalletActor(settings: ErgoSettings,
           log.info("Wallet successfully unlocked")
           walletPass.erase()
           context.become(loadedWallet(newState))
+          maybeStartAvailableUtxoSnapshotScan(newState)
           sender() ! Success(())
         case f@Failure(t) =>
           walletPass.erase()
@@ -341,10 +490,39 @@ class ErgoWalletActor(settings: ErgoSettings,
         log.info(s"Rescanning the wallet from height: $fromHeight")
         ergoWalletService.recreateRegistry(state, settings) match {
           case Success(newState) =>
-            context.become(loadedWallet(newState.copy(rescanInProgress = true)))
-            val heightToScanFrom = Math.min(newState.fullHeight, fromHeight)
-            self ! ScanInThePast(heightToScanFrom, rescan = true)
-            sender() ! Success(())
+            val resetState = newState.copy(
+              offChainRegistry = OffChainRegistry.init(newState.registry),
+              outputsFilter = None,
+              rescanInProgress = true
+            )
+            if (settings.nodeSettings.utxoSettings.utxoBootstrap && settings.nodeSettings.isFullBlocksPruned) {
+              resetState.storage.removeUtxoSnapshotScanStatus() match {
+                case Success(_) =>
+                  val utxoReaderOpt = resetState.utxoStateReaderOpt
+                    .orElse(resetState.stateReaderOpt.collect { case reader: UtxoStateReader => reader })
+                  utxoReaderOpt match {
+                    case Some(reader) =>
+                      val snapshotHeight = reader.stateContext.currentHeight
+                      val snapshotBlockId = versionToId(reader.version)
+                      context.become(loadedWallet(resetState))
+                      startUtxoSnapshotScan(snapshotHeight, snapshotBlockId, reader, forceRestart = true)
+                      sender() ! Success(())
+                    case None =>
+                      val err = new IllegalStateException("Unable to restart UTXO snapshot wallet scan: UTXO state reader is unavailable")
+                      context.become(loadedWallet(resetState.copy(error = Some(err.getMessage), rescanInProgress = false)))
+                      sender() ! Failure(err)
+                  }
+                case Failure(t) =>
+                  log.error("Error during UTXO snapshot wallet scan reset: ", t)
+                  context.become(loadedWallet(resetState.copy(error = Some(t.getMessage), rescanInProgress = false)))
+                  sender() ! Failure(t)
+              }
+            } else {
+              context.become(loadedWallet(resetState))
+              val heightToScanFrom = Math.min(resetState.fullHeight, fromHeight)
+              self ! ScanInThePast(heightToScanFrom, rescan = true)
+              sender() ! Success(())
+            }
           case f@Failure(t) =>
             log.error("Error during rescan attempt: ", t)
             sender() ! f

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -4,6 +4,7 @@ import org.ergoplatform.ErgoBox._
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
+import org.ergoplatform.nodeView.state.UtxoStateReader
 import org.ergoplatform.nodeView.wallet.models.CollectedBoxes
 import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, TransactionGenerationRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest}
@@ -50,6 +51,23 @@ object ErgoWalletActorMessages {
    * @param block - block to scan
    */
   final case class ScanOnChain(block: ErgoFullBlock)
+
+  private[wallet] final case class GetOrInitUtxoSnapshotScanStatus(snapshotHeight: Height,
+                                                                   snapshotBlockId: ModifierId,
+                                                                   manifestDepth: Int,
+                                                                   totalSubtrees: Int)
+
+  private[wallet] final case class ApplyUtxoSnapshotScanBatch(snapshotHeight: Height,
+                                                              snapshotBlockId: ModifierId,
+                                                              subtreeIndex: Int,
+                                                              nextSubtreeIndex: Int,
+                                                              completed: Boolean,
+                                                              boxes: IndexedSeq[ErgoBox])
+
+  private[wallet] final case class StartUtxoSnapshotScan(snapshotHeight: Height,
+                                                         snapshotBlockId: ModifierId,
+                                                         stateReader: UtxoStateReader,
+                                                         forceRestart: Boolean)
 
   /**
    * Rollback to previous version of the wallet, by throwing away effects of blocks after the version

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -6,6 +6,7 @@ import org.ergoplatform._
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.state.{ErgoStateContext, UtxoStateReader}
+import org.ergoplatform.nodeView.wallet.IdUtils.encodedBoxId
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
 import org.ergoplatform.nodeView.wallet.models.{ChangeBox, CollectedBoxes}
 import org.ergoplatform.nodeView.wallet.persistence.{WalletRegistry, WalletStorage}
@@ -28,6 +29,7 @@ import sigma.data.SigmaBoolean
 
 import java.io.FileNotFoundException
 import scala.collection.compat.immutable.ArraySeq
+import scala.collection.immutable.TreeSet
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -219,6 +221,14 @@ trait ErgoWalletService {
     * @param dustLimit - Boxes with value smaller than dustLimit are disregarded in wallet scan logic
     */
   def scanBlockUpdate(state: ErgoWalletState, block: ErgoFullBlock, dustLimit: Option[Long]): Try[ErgoWalletState]
+
+  def scanUtxoSnapshotChunk(state: ErgoWalletState,
+                            boxes: Seq[ErgoBox],
+                            snapshotBlockId: ModifierId,
+                            snapshotHeight: Int,
+                            subtreeIndex: Int,
+                            finalChunk: Boolean,
+                            dustLimit: Option[Long]): Try[ErgoWalletState]
 
   /**
     * Sign a transaction
@@ -595,6 +605,23 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
         ergoSettings.walletSettings.walletProfile).map { case (reg, offReg, updatedOutputsFilter) =>
         state.copy(registry = reg, offChainRegistry = offReg, outputsFilter = Some(updatedOutputsFilter))
       }
+
+  override def scanUtxoSnapshotChunk(state: ErgoWalletState,
+                                     boxes: Seq[ErgoBox],
+                                     snapshotBlockId: ModifierId,
+                                     snapshotHeight: Int,
+                                     subtreeIndex: Int,
+                                     finalChunk: Boolean,
+                                     dustLimit: Option[Long]): Try[ErgoWalletState] = {
+    val scanResults = WalletScanLogic.scanSnapshotBoxes(boxes, state.walletVars, dustLimit)
+    state.registry.updateOnSnapshotChunk(scanResults, snapshotBlockId, snapshotHeight, subtreeIndex, finalChunk).map { _ =>
+      val walletUnspent = state.registry.walletUnspentBoxes()
+      val newOnChainIds = scanResults.outputs.map(x => encodedBoxId(x.box.id)).to[TreeSet]
+      val offChainHeight = if (finalChunk) snapshotHeight else state.offChainRegistry.height
+      val offChainRegistry = state.offChainRegistry.updateOnBlock(offChainHeight, walletUnspent, newOnChainIds)
+      state.copy(registry = state.registry, offChainRegistry = offChainRegistry, outputsFilter = None)
+    }
+  }
 
   override def updateUtxoState(state: ErgoWalletState): ErgoWalletState = {
     (state.mempoolReaderOpt, state.stateReaderOpt) match {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/UtxoSnapshotWalletScanner.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/UtxoSnapshotWalletScanner.scala
@@ -1,0 +1,192 @@
+package org.ergoplatform.nodeView.wallet
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.pattern.{ask, pipe}
+import akka.util.Timeout
+import org.ergoplatform.ErgoBox
+import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
+import org.ergoplatform.nodeView.state.UtxoStateReader
+import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages._
+import org.ergoplatform.nodeView.wallet.persistence.UtxoSnapshotScanStatus
+import org.ergoplatform.serialization.ManifestSerializer
+import org.ergoplatform.settings.{Algos, ErgoSettings}
+import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
+import org.ergoplatform.GlobalConstants
+import scorex.crypto.authds.avltree.batch.Constants.DigestType
+import scorex.crypto.authds.avltree.batch.serialization.{BatchAVLProverSubtree, ProxyInternalNode}
+import scorex.crypto.authds.avltree.batch.{InternalProverNode, ProverLeaf, ProverNodes}
+import scorex.util.{ModifierId, ScorexLogging}
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+private[wallet] class UtxoSnapshotWalletScanner(walletActor: ActorRef,
+                                                settings: ErgoSettings)
+  extends Actor with ScorexLogging {
+
+  import UtxoSnapshotWalletScanner._
+
+  private implicit val timeout: Timeout = Timeout(5.minutes)
+  private implicit val callbackDispatcher = context.dispatcher
+  private val snapshotDispatcher = context.system.dispatchers.lookup(GlobalConstants.IndexerDispatcher)
+
+  private var runId: Long = 0L
+  private var activeSnapshot: Option[(Height, ModifierId)] = None
+
+  override def receive: Receive = {
+    case StartUtxoSnapshotScan(snapshotHeight, snapshotBlockId, stateReader, forceRestart) =>
+      val snapshot = snapshotHeight -> snapshotBlockId
+      if (!forceRestart && activeSnapshot.contains(snapshot)) {
+        log.debug(s"UTXO snapshot wallet scan is already running for height $snapshotHeight")
+      } else if (!settings.nodeSettings.utxoSettings.utxoBootstrap) {
+        log.debug("Ignoring UTXO snapshot wallet scan request because utxoBootstrap is disabled")
+      } else {
+        runId += 1
+        activeSnapshot = Some(snapshot)
+        start(runId, snapshotHeight, snapshotBlockId, stateReader)
+      }
+
+    case Initialized(id, stateReader, Success(status)) if isCurrent(id) =>
+      if (status.completed) {
+        activeSnapshot = None
+        log.info(s"UTXO snapshot wallet scan is already completed at height ${status.snapshotHeight}")
+      } else {
+        readBatch(id, stateReader, status)
+      }
+
+    case Initialized(id, _, Failure(t)) if isCurrent(id) =>
+      activeSnapshot = None
+      log.error("Failed to initialize UTXO snapshot wallet scan", t)
+
+    case BatchRead(id, stateReader, Success(batch)) if isCurrent(id) =>
+      val applyResult = (walletActor ? ApplyUtxoSnapshotScanBatch(
+        batch.snapshotHeight,
+        batch.snapshotBlockId,
+        batch.subtreeIndex,
+        batch.nextSubtreeIndex,
+        batch.completed,
+        batch.boxes
+      )).mapTo[Try[UtxoSnapshotScanStatus]]
+
+      applyResult.map(Applied(id, stateReader, _)).pipeTo(self)
+
+    case BatchRead(id, _, Failure(t)) if isCurrent(id) =>
+      activeSnapshot = None
+      log.error("Failed to read UTXO snapshot wallet scan batch", t)
+
+    case Applied(id, stateReader, Success(status)) if isCurrent(id) =>
+      if (status.completed) {
+        activeSnapshot = None
+        log.info(s"UTXO snapshot wallet scan completed at height ${status.snapshotHeight}")
+      } else {
+        readBatch(id, stateReader, status)
+      }
+
+    case Applied(id, _, Failure(t)) if isCurrent(id) =>
+      activeSnapshot = None
+      log.error("Failed to apply UTXO snapshot wallet scan batch", t)
+
+    case _: Initialized | _: BatchRead | _: Applied =>
+      log.debug("Ignoring stale UTXO snapshot wallet scan message")
+  }
+
+  private def isCurrent(id: Long): Boolean =
+    id == runId
+
+  private def start(id: Long,
+                    snapshotHeight: Height,
+                    snapshotBlockId: ModifierId,
+                    stateReader: UtxoStateReader): Unit = {
+    val manifestDepth = ManifestSerializer.MainnetManifestDepth.toInt
+    val init = Future {
+      stateReader.countSnapshotSubtrees(manifestDepth)
+    }(snapshotDispatcher).flatMap {
+      case Success(totalSubtrees) =>
+        (walletActor ? GetOrInitUtxoSnapshotScanStatus(
+          snapshotHeight,
+          snapshotBlockId,
+          manifestDepth,
+          totalSubtrees
+        )).mapTo[Try[UtxoSnapshotScanStatus]]
+      case Failure(t) =>
+        Future.successful(Failure(t))
+    }
+
+    init.map(Initialized(id, stateReader, _)).pipeTo(self)
+  }
+
+  private def readBatch(id: Long,
+                        stateReader: UtxoStateReader,
+                        status: UtxoSnapshotScanStatus): Unit = {
+    Future {
+      readSnapshotBatch(stateReader, status)
+    }(snapshotDispatcher).map(BatchRead(id, stateReader, _)).pipeTo(self)
+  }
+}
+
+private[wallet] object UtxoSnapshotWalletScanner {
+
+  val SnapshotScanBatchSize: Int = 32
+
+  def props(walletActor: ActorRef, settings: ErgoSettings): Props =
+    Props(classOf[UtxoSnapshotWalletScanner], walletActor, settings)
+
+  private[wallet] final case class SnapshotBatch(snapshotHeight: Height,
+                                                 snapshotBlockId: ModifierId,
+                                                 subtreeIndex: Int,
+                                                 nextSubtreeIndex: Int,
+                                                 completed: Boolean,
+                                                 boxes: IndexedSeq[ErgoBox])
+
+  private final case class Initialized(runId: Long,
+                                       stateReader: UtxoStateReader,
+                                       result: Try[UtxoSnapshotScanStatus])
+
+  private final case class BatchRead(runId: Long,
+                                     stateReader: UtxoStateReader,
+                                     result: Try[SnapshotBatch])
+
+  private final case class Applied(runId: Long,
+                                   stateReader: UtxoStateReader,
+                                   result: Try[UtxoSnapshotScanStatus])
+
+  private[wallet] def readSnapshotBatch(stateReader: UtxoStateReader,
+                                        status: UtxoSnapshotScanStatus): Try[SnapshotBatch] = {
+    val boxesBuilder = Vector.newBuilder[ErgoBox]
+    val nextIndex = stateReader.iterateSnapshotSubtrees(
+      status.nextSubtreeIndex,
+      status.manifestDepth,
+      SnapshotScanBatchSize
+    ) { case (_, subtree) =>
+      collectBoxes(subtree).map(boxesBuilder ++= _)
+    }
+
+    nextIndex.map { next =>
+      SnapshotBatch(
+        status.snapshotHeight,
+        status.snapshotBlockId,
+        status.nextSubtreeIndex,
+        next,
+        completed = next >= status.totalSubtrees,
+        boxesBuilder.result()
+      )
+    }
+  }
+
+  private[wallet] def collectBoxes(subtree: BatchAVLProverSubtree[DigestType]): Try[IndexedSeq[ErgoBox]] = {
+    val boxes = mutable.ArrayBuffer.empty[ErgoBox]
+
+    def loop(node: ProverNodes[DigestType]): Try[Unit] = node match {
+      case leaf: ProverLeaf[DigestType] =>
+        ErgoBoxSerializer.parseBytesTry(leaf.value).map(box => boxes += box)
+      case proxy: ProxyInternalNode[DigestType] =>
+        Failure(new IllegalStateException(s"Unexpected proxy node in UTXO snapshot subtree ${Algos.encode(proxy.label)}"))
+      case in: InternalProverNode[DigestType] =>
+        loop(in.left).flatMap(_ => loop(in.right))
+    }
+
+    loop(subtree.subtreeTop).map(_ => boxes.toVector)
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletScanLogic.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletScanLogic.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.nodeView.wallet
 
 import com.google.common.hash.BloomFilter
+import org.ergoplatform.ErgoBox
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.IdUtils.{EncodedBoxId, encodedBoxId}
@@ -184,78 +185,101 @@ object WalletScanLogic extends ScorexLogging {
                            inclusionHeight: Option[Int],
                            walletVars: WalletVars,
                            dustLimit: Option[Long]): Seq[TrackedBox] = {
+    tx.outputs.flatMap { bx =>
+      filterWalletOutput(bx, inclusionHeight, walletVars, dustLimit)
+    }
+  }
 
+  /**
+    * Extracts all tracked boxes from a UTXO set snapshot chunk.
+    */
+  def scanSnapshotBoxes(boxes: Seq[ErgoBox],
+                        walletVars: WalletVars,
+                        dustLimit: Option[Long]): ScanResults = {
+    ScanResults(
+      boxes.flatMap { bx =>
+        filterWalletOutput(bx, Some(bx.creationHeight), walletVars, dustLimit)
+      },
+      inputsSpent = ArraySeq.empty,
+      relatedTransactions = ArraySeq.empty
+    )
+  }
+
+  /**
+    * Checks whether a box belongs to wallet keys or registered scans.
+    */
+  def filterWalletOutput(bx: ErgoBox,
+                         inclusionHeight: Option[Int],
+                         walletVars: WalletVars,
+                         dustLimit: Option[Long]): Option[TrackedBox] = {
     val trackedBytes: Seq[Array[Byte]] = walletVars.trackedBytes
     val miningScriptsBytes: Seq[Array[Byte]] = walletVars.miningScriptsBytes
     val externalScans: Seq[Scan] = walletVars.externalScans
 
-    tx.outputs.flatMap { bx  =>
+    // First, we check apps triggered by the tx output
+    val appsTriggered =
+      externalScans
+        .filter(_.trackingRule.filter(bx))
+        .map(app => app.scanId -> app.walletInteraction)
 
-      // First, we check apps triggered by the tx output
-      val appsTriggered =
-        externalScans
-          .filter(_.trackingRule.filter(bx))
-          .map(app => app.scanId -> app.walletInteraction)
+    val boxScript = bx.propositionBytes
 
-      val boxScript = bx.propositionBytes
+    // then check whether Bloom filter built on top of payment & mining scripts of the p2pk-wallet
+    val statuses: Set[ScanId] = if (walletVars.scriptsFilter.mightContain(boxScript)) {
 
-      // then check whether Bloom filter built on top of payment & mining scripts of the p2pk-wallet
-      val statuses: Set[ScanId] = if (walletVars.scriptsFilter.mightContain(boxScript)) {
+      // first, we are checking mining script
+      val miningIncomeTriggered = miningScriptsBytes.exists(ms => boxScript.sameElements(ms))
 
-        // first, we are checking mining script
-        val miningIncomeTriggered = miningScriptsBytes.exists(ms => boxScript.sameElements(ms))
-
-        val prePaymentStatuses = if (miningIncomeTriggered) {
-          val miningStatus: (ScanId, ScanWalletInteraction.Value) = if (walletVars.settings.miningRewardDelay > 0) {
-            MiningScanId -> ScanWalletInteraction.Off // scripts are different, so off is kinda overkill
-          } else {
-            //tweak for tests
-            PaymentsScanId -> ScanWalletInteraction.Off
-          }
-          appsTriggered :+ miningStatus
+      val prePaymentStatuses = if (miningIncomeTriggered) {
+        val miningStatus: (ScanId, ScanWalletInteraction.Value) = if (walletVars.settings.miningRewardDelay > 0) {
+          MiningScanId -> ScanWalletInteraction.Off // scripts are different, so off is kinda overkill
         } else {
-          appsTriggered
+          //tweak for tests
+          PaymentsScanId -> ScanWalletInteraction.Off
         }
-
-        if (prePaymentStatuses.nonEmpty &&
-          !prePaymentStatuses.exists(t => ScanWalletInteraction.interactingWithWallet(t._2))) {
-          // if other scans intercept the box, and the scans are not sharing the box,
-          // then the box is not being tracked by the p2pk-wallet
-          prePaymentStatuses.map(_._1).toSet
-        } else {
-          //check whether payment is triggered (Bloom filter has false positives)
-          val paymentsTriggered = trackedBytes.exists(bs => boxScript.sameElements(bs))
-
-          val otherIds = prePaymentStatuses.map(_._1).toSet
-          if (paymentsTriggered) {
-            Set(PaymentsScanId) ++ otherIds
-          } else {
-            otherIds
-          }
-        }
+        appsTriggered :+ miningStatus
       } else {
-        val appScans = appsTriggered.map(_._1).toSet
-
-        // Add p2pk-wallet if there's a scan enforcing that
-        if (appsTriggered.exists(_._2 == ScanWalletInteraction.Forced)) {
-          appScans ++ Set(PaymentsScanId)
-        } else {
-          appScans
-        }
+        appsTriggered
       }
 
-      if (statuses.nonEmpty) {
-        if (dustLimit.exists(bx.value <= _)){
-          // filter out boxes with value that is considered dust
-          None
-        } else {
-          val tb = TrackedBox(tx.id, bx.index, inclusionHeight, None, None, bx, statuses)
-          log.debug("New tracked box: " + tb.boxId, " scans: " + tb.scans)
-          Some(tb)
-        }
+      if (prePaymentStatuses.nonEmpty &&
+        !prePaymentStatuses.exists(t => ScanWalletInteraction.interactingWithWallet(t._2))) {
+        // if other scans intercept the box, and the scans are not sharing the box,
+        // then the box is not being tracked by the p2pk-wallet
+        prePaymentStatuses.map(_._1).toSet
       } else {
+        //check whether payment is triggered (Bloom filter has false positives)
+        val paymentsTriggered = trackedBytes.exists(bs => boxScript.sameElements(bs))
+
+        val otherIds = prePaymentStatuses.map(_._1).toSet
+        if (paymentsTriggered) {
+          Set(PaymentsScanId) ++ otherIds
+        } else {
+          otherIds
+        }
+      }
+    } else {
+      val appScans = appsTriggered.map(_._1).toSet
+
+      // Add p2pk-wallet if there's a scan enforcing that
+      if (appsTriggered.exists(_._2 == ScanWalletInteraction.Forced)) {
+        appScans ++ Set(PaymentsScanId)
+      } else {
+        appScans
+      }
+    }
+
+    if (statuses.nonEmpty) {
+      if (dustLimit.exists(bx.value <= _)){
+        // filter out boxes with value that is considered dust
         None
+      } else {
+        val tb = TrackedBox(bx.transactionId, bx.index, inclusionHeight, None, None, bx, statuses)
+        log.debug("New tracked box: " + tb.boxId, " scans: " + tb.scans)
+        Some(tb)
       }
+    } else {
+      None
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/UtxoSnapshotScanStatus.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/UtxoSnapshotScanStatus.scala
@@ -1,0 +1,40 @@
+package org.ergoplatform.nodeView.wallet.persistence
+
+import org.ergoplatform.serialization.ErgoSerializer
+import org.ergoplatform.settings.Constants
+import scorex.util.Extensions._
+import scorex.util.serialization.{Reader, Writer}
+import scorex.util.{ModifierId, bytesToId, idToBytes}
+
+/**
+  * Version-agnostic wallet progress for scanning a bootstrapped UTXO snapshot.
+  */
+final case class UtxoSnapshotScanStatus(snapshotHeight: Int,
+                                        snapshotBlockId: ModifierId,
+                                        manifestDepth: Int,
+                                        nextSubtreeIndex: Int,
+                                        totalSubtrees: Int,
+                                        completed: Boolean)
+
+object UtxoSnapshotScanStatusSerializer extends ErgoSerializer[UtxoSnapshotScanStatus] {
+
+  override def serialize(obj: UtxoSnapshotScanStatus, w: Writer): Unit = {
+    w.putUInt(obj.snapshotHeight)
+    w.putBytes(idToBytes(obj.snapshotBlockId))
+    w.putUInt(obj.manifestDepth)
+    w.putUInt(obj.nextSubtreeIndex)
+    w.putUInt(obj.totalSubtrees)
+    w.putBoolean(obj.completed)
+  }
+
+  override def parse(r: Reader): UtxoSnapshotScanStatus = {
+    UtxoSnapshotScanStatus(
+      snapshotHeight = r.getUInt().toIntExact,
+      snapshotBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize)),
+      manifestDepth = r.getUInt().toIntExact,
+      nextSubtreeIndex = r.getUInt().toIntExact,
+      totalSubtrees = r.getUInt().toIntExact,
+      completed = r.getByte() != 0
+    )
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.wallet.persistence
 
+import com.google.common.primitives.Ints
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.ErgoBox.BoxId
 import org.ergoplatform.ErgoLikeContext.Height
@@ -15,6 +16,7 @@ import org.ergoplatform.wallet.boxes.{TrackedBox, TrackedBoxSerializer}
 import org.ergoplatform.wallet.transactions.TransactionBuilder
 import org.ergoplatform.core.VersionTag
 import scorex.crypto.authds.ADKey
+import scorex.crypto.hash.Blake2b256
 import scorex.db.LDBVersionedStore
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
@@ -273,44 +275,81 @@ class WalletRegistry(private val store: LDBVersionedStore)(ws: WalletSettings) e
         log.error(s"Blocks were skipped during wallet scanning, from $height until $blockHeight")
       }
       val spentWalletBoxes = spentBoxesWithTx.map(_._2).filter(_.scans.contains(PaymentsScanId))
-      val spentAmt = spentWalletBoxes.map(_.box.value).sum
-      val spentTokensAmt = spentWalletBoxes
-        .flatMap(_.box.additionalTokens.toArray)
-        .foldLeft(Map.empty[EncodedTokenId, Long]) { case (acc, (id, amt)) =>
-          acc.updated(encodedTokenId(id), acc.getOrElse(encodedTokenId(id), 0L) + amt)
-        }
-      val receivedTokensAmt = scanResults.outputs.filter(_.scans.contains(PaymentsScanId))
-        .flatMap(_.box.additionalTokens.toArray)
-        .foldLeft(Map.empty[EncodedTokenId, Long]) { case (acc, (id, amt)) =>
-          acc.updated(encodedTokenId(id), acc.getOrElse(encodedTokenId(id), 0L) + amt)
-        }
-
-      val wTokens = mutable.LinkedHashMap(wTokensSeq: _*)
-
-      val increasedTokenBalances = receivedTokensAmt.foldLeft(wTokens) { case (acc, (encodedId, amt)) =>
-        acc += encodedId -> (acc.getOrElse(encodedId, 0L) + amt)
-      }
-
-      val newTokensBalance = spentTokensAmt
-        .foldLeft(increasedTokenBalances) { case (acc, (encodedId, amt)) =>
-          val decreasedAmt = acc.getOrElse(encodedId, 0L) - amt
-          if (decreasedAmt > 0) {
-            acc += encodedId -> decreasedAmt
-          } else {
-            acc -= encodedId
-          }
-        }
-
-      val receivedAmt = scanResults.outputs.filter(_.scans.contains(PaymentsScanId)).map(_.box.value).sum
-      val newBalance = wBalance + receivedAmt - spentAmt
-      if ((newBalance >= 0 && newTokensBalance.forall(_._2 >= 0)) || ws.testMnemonic.isDefined)
-        Success(WalletDigest(blockHeight, newBalance, newTokensBalance.toSeq))
-      else
-        Failure(new IllegalStateException("Balance could not be negative"))
+      updateWalletDigest(WalletDigest(height, wBalance, wTokensSeq), scanResults.outputs, spentWalletBoxes, blockHeight)
     }.flatMap { bag4 =>
       bag4.transact(store, idToBytes(blockId))
     }
   }
+
+  /**
+    * Updates wallet indexes from a UTXO snapshot chunk without inventing pre-snapshot transactions.
+    */
+  def updateOnSnapshotChunk(scanResults: ScanResults,
+                            snapshotBlockId: ModifierId,
+                            snapshotHeight: Int,
+                            subtreeIndex: Int,
+                            finalChunk: Boolean): Try[Unit] = {
+    if (scanResults.inputsSpent.nonEmpty || scanResults.relatedTransactions.nonEmpty) {
+      Failure(new IllegalArgumentException("Snapshot chunk scan data must contain only outputs"))
+    } else {
+      cache ++= scanResults.outputs.map(b => b.boxId -> b)
+      val bag1 = putBoxes(KeyValuePairsBag.empty, scanResults.outputs)
+      updateDigest(bag1) { digest =>
+        val nextHeight = if (finalChunk) snapshotHeight else digest.height
+        updateWalletDigest(digest, scanResults.outputs, Seq.empty, nextHeight)
+      }.flatMap { bag2 =>
+        bag2.transact(store, snapshotChunkVersion(snapshotBlockId, subtreeIndex, finalChunk))
+      }
+    }
+  }
+
+  private def updateWalletDigest(currentDigest: WalletDigest,
+                                 receivedBoxes: Seq[TrackedBox],
+                                 spentWalletBoxes: Seq[TrackedBox],
+                                 nextHeight: Int): Try[WalletDigest] = {
+    val receivedWalletBoxes = receivedBoxes.filter(_.scans.contains(PaymentsScanId))
+    val spentAmt = spentWalletBoxes.map(_.box.value).sum
+    val spentTokensAmt = tokenAmounts(spentWalletBoxes)
+    val receivedTokensAmt = tokenAmounts(receivedWalletBoxes)
+
+    val wTokens = mutable.LinkedHashMap(currentDigest.walletAssetBalances: _*)
+
+    val increasedTokenBalances = receivedTokensAmt.foldLeft(wTokens) { case (acc, (encodedId, amt)) =>
+      acc += encodedId -> (acc.getOrElse(encodedId, 0L) + amt)
+    }
+
+    val newTokensBalance = spentTokensAmt
+      .foldLeft(increasedTokenBalances) { case (acc, (encodedId, amt)) =>
+        val decreasedAmt = acc.getOrElse(encodedId, 0L) - amt
+        if (decreasedAmt > 0) {
+          acc += encodedId -> decreasedAmt
+        } else {
+          acc -= encodedId
+        }
+      }
+
+    val receivedAmt = receivedWalletBoxes.map(_.box.value).sum
+    val newBalance = currentDigest.walletBalance + receivedAmt - spentAmt
+    if ((newBalance >= 0 && newTokensBalance.forall(_._2 >= 0)) || ws.testMnemonic.isDefined)
+      Success(WalletDigest(nextHeight, newBalance, newTokensBalance.toSeq))
+    else
+      Failure(new IllegalStateException("Balance could not be negative"))
+  }
+
+  private def tokenAmounts(boxes: Seq[TrackedBox]): Map[EncodedTokenId, Long] =
+    boxes
+      .flatMap(_.box.additionalTokens.toArray)
+      .foldLeft(Map.empty[EncodedTokenId, Long]) { case (acc, (id, amt)) =>
+        val encodedId = encodedTokenId(id)
+        acc.updated(encodedId, acc.getOrElse(encodedId, 0L) + amt)
+      }
+
+  private def snapshotChunkVersion(snapshotBlockId: ModifierId, subtreeIndex: Int, finalChunk: Boolean): Array[Byte] =
+    if (finalChunk) {
+      idToBytes(snapshotBlockId)
+    } else {
+      Blake2b256.hash(idToBytes(snapshotBlockId) ++ Ints.toByteArray(subtreeIndex))
+    }
 
   def rollback(version: VersionTag): Try[Unit] = {
     cache.clear()

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
@@ -194,6 +194,23 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings) extends Sco
       .getOrElse(PaymentsScanId)
   }
 
+  def readUtxoSnapshotScanStatus(): Option[UtxoSnapshotScanStatus] =
+    store.get(UtxoSnapshotScanStatusKey).flatMap { bytes =>
+      UtxoSnapshotScanStatusSerializer.parseBytesTry(bytes) match {
+        case Success(status) =>
+          Some(status)
+        case Failure(t) =>
+          log.error("Corrupted UTXO snapshot scan status", t)
+          None
+      }
+    }
+
+  def writeUtxoSnapshotScanStatus(status: UtxoSnapshotScanStatus): Try[Unit] =
+    store.insert(UtxoSnapshotScanStatusKey, UtxoSnapshotScanStatusSerializer.toBytes(status))
+
+  def removeUtxoSnapshotScanStatus(): Try[Unit] =
+    store.remove(Array(UtxoSnapshotScanStatusKey))
+
   /**
     * Close wallet storage database
     */
@@ -243,6 +260,7 @@ object WalletStorage {
   val SecretPathsKey: Array[Byte] = noPrefixKey("secret_paths")
   val ChangeAddressKey: Array[Byte] = noPrefixKey("change_address")
   val lastUsedScanIdKey: Array[Byte] = noPrefixKey("last_scan_id")
+  val UtxoSnapshotScanStatusKey: Array[Byte] = noPrefixKey("utxo_snapshot_scan_status")
 
 
   /**

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -243,6 +243,34 @@ class ErgoWalletServiceSpec
     }
   }
 
+  property("it should scan UTXO snapshot chunks without creating wallet transactions") {
+    forAll(modifierIdGen) { snapshotBlockId =>
+      withVersionedStore(10) { versionedStore =>
+        withStore { store =>
+          val walletService = new ErgoWalletServiceImpl(settings)
+          val wState = initialState(store, versionedStore)
+          val boxes = boxesAvailable(makeGenesisBlock(pks.head.pubkey, randomNewAsset), pks.head.pubkey)
+          val scanResults = WalletScanLogic.scanSnapshotBoxes(boxes, wState.walletVars, None)
+
+          val updatedState = walletService.scanUtxoSnapshotChunk(
+            wState,
+            boxes,
+            snapshotBlockId,
+            snapshotHeight = 100,
+            subtreeIndex = 0,
+            finalChunk = true,
+            dustLimit = None
+          ).get
+
+          updatedState.registry.walletUnspentBoxes().toList should contain theSameElementsAs scanResults.outputs
+          updatedState.registry.allWalletTxs() shouldBe empty
+          updatedState.registry.fetchDigest().height shouldBe 100
+          updatedState.outputsFilter shouldBe empty
+        }
+      }
+    }
+  }
+
   property("it should generate signed and unsigned transaction") {
     withVersionedStore(2) { versionedStore =>
       withStore { store =>

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -1,12 +1,16 @@
 package org.ergoplatform.nodeView.wallet
 
+import akka.pattern.ask
+import akka.util.Timeout
 import org.ergoplatform._
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
+import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages.{ApplyUtxoSnapshotScanBatch, GetOrInitUtxoSnapshotScanStatus}
 import org.ergoplatform.nodeView.wallet.IdUtils._
 import org.ergoplatform.nodeView.wallet.persistence.{WalletDigest, WalletDigestSerializer}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, BurnTokensRequest, ExternalSecret, PaymentRequest}
 import org.ergoplatform.sdk.wallet.secrets.PrimitiveSecretKey
+import org.ergoplatform.serialization.ManifestSerializer
 import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils._
 import org.ergoplatform.utils.fixtures.WalletFixture
@@ -25,6 +29,7 @@ import sigmastate.eval.Extensions._
 import org.ergoplatform.settings.Constants.TrueTree
 
 import scala.concurrent.duration._
+import scala.util.Success
 
 class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventually {
   import org.ergoplatform.utils.ErgoCoreTestConstants._
@@ -34,6 +39,7 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
   import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators._
 
   private implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
+  private implicit val timeout: Timeout = Timeout(5.seconds)
 
   property("assets in WalletDigest are deterministic against serialization") {
     forAll(Gen.listOfN(5, assetGen)) { preAssets =>
@@ -91,6 +97,55 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         tx3.inputs.foreach { in =>
           tx2.inputs.exists(tx2In => tx2In.boxId sameElements in.boxId) shouldBe false
         }
+      }
+    }
+  }
+
+  property("skip on-chain block scan while UTXO snapshot scan is pending") {
+    val bootstrapSettings = settings.copy(
+      nodeSettings = settings.nodeSettings.copy(
+        utxoSettings = settings.nodeSettings.utxoSettings.copy(utxoBootstrap = true)
+      )
+    )
+    new WalletFixture(bootstrapSettings, parameters, getCurrentView(_).vault).apply { implicit w =>
+      val address = getPublicKeys.head
+      val genesisBlock = makeGenesisBlock(address.pubkey)
+      val initialBoxes = boxesAvailable(genesisBlock, address.pubkey)
+      val initialBalance = balanceAmount(initialBoxes)
+      applyBlock(genesisBlock) shouldBe 'success
+
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
+      eventually {
+        getConfirmedBalances.walletBalance shouldBe initialBalance
+      }
+
+      val returnBalance = initialBalance / 2
+      val spendingTx = makeSpendingTx(initialBoxes, address, returnBalance)
+      val nextBlock = makeNextBlock(getUtxoState, Seq(spendingTx))
+
+      await(wallet.walletActor ? GetOrInitUtxoSnapshotScanStatus(
+        genesisBlock.height,
+        genesisBlock.id,
+        ManifestSerializer.MainnetManifestDepth.toInt,
+        totalSubtrees = 1
+      )) shouldBe a[Success[_]]
+
+      wallet.scanPersistent(nextBlock)
+      Thread.sleep(500)
+      getConfirmedBalances.walletBalance shouldBe initialBalance
+
+      await(wallet.walletActor ? ApplyUtxoSnapshotScanBatch(
+        genesisBlock.height,
+        genesisBlock.id,
+        subtreeIndex = 0,
+        nextSubtreeIndex = 1,
+        completed = true,
+        boxes = IndexedSeq.empty
+      )) shouldBe a[Success[_]]
+
+      wallet.scanPersistent(nextBlock)
+      eventually {
+        getConfirmedBalances.walletBalance shouldBe returnBalance
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/UtxoSnapshotWalletScannerSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/UtxoSnapshotWalletScannerSpec.scala
@@ -1,0 +1,21 @@
+package org.ergoplatform.nodeView.wallet
+
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.crypto.authds.avltree.batch.Constants.{DigestType, hashFn}
+import scorex.crypto.authds.avltree.batch.ProverLeaf
+import scorex.crypto.authds.avltree.batch.serialization.BatchAVLProverSubtree
+import scorex.crypto.authds.{ADKey, ADValue}
+
+class UtxoSnapshotWalletScannerSpec extends ErgoCorePropertyTest {
+
+  property("UTXO snapshot collectBoxes fails on malformed box bytes") {
+    val leaf = new ProverLeaf[DigestType](
+      ADKey @@ Array.fill(32)(1: Byte),
+      ADValue @@ Array[Byte](1, 2, 3),
+      ADKey @@ Array.fill(32)(2: Byte)
+    )(hashFn)
+    val subtree = new BatchAVLProverSubtree[DigestType](leaf)
+
+    UtxoSnapshotWalletScanner.collectBoxes(subtree).isFailure shouldBe true
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletScanLogicSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletScanLogicSpec.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.wallet
 
 import org.ergoplatform.utils.{ErgoCorePropertyTest, WalletTestOps}
-import WalletScanLogic.{extractWalletOutputs, scanBlockTransactions}
+import WalletScanLogic.{extractWalletOutputs, filterWalletOutput, scanBlockTransactions, scanSnapshotBoxes}
 import org.ergoplatform.db.DBSpec
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry}
@@ -118,6 +118,39 @@ class WalletScanLogicSpec extends ErgoCorePropertyTest with DBSpec with WalletTe
       val lowDustLimit = Some(1L)
       val foundBoxes2 = extractWalletOutputs(trackedTransaction.tx, inclusionHeightOpt, walletVars, lowDustLimit)
       foundBoxes2.forall(_.value > 1) shouldBe true
+    }
+  }
+
+  property("filterWalletOutput preserves extractWalletOutputs behavior") {
+    val height = Random.nextInt(200) - 100
+    val inclusionHeightOpt = if (height <= 0) None else Some(height)
+
+    forAll(trackedTransactionGen, walletVarsGen) { case (trackedTransaction, walletVars) =>
+      val extracted = extractWalletOutputs(trackedTransaction.tx, inclusionHeightOpt, walletVars, None)
+      val filtered = trackedTransaction.tx.outputs.flatMap { box =>
+        filterWalletOutput(box, inclusionHeightOpt, walletVars, None)
+      }
+
+      filtered shouldBe extracted
+    }
+  }
+
+  property("scanSnapshotBoxes extracts tracked boxes without wallet transactions") {
+    forAll(trackedTransactionGen, walletVarsGen) { case (trackedTransaction, walletVars) =>
+      val scanResults = scanSnapshotBoxes(trackedTransaction.tx.outputs, walletVars, None)
+
+      scanResults.outputs.length shouldBe trackedTransaction.scriptsCount
+      scanResults.inputsSpent shouldBe empty
+      scanResults.relatedTransactions shouldBe empty
+      scanResults.outputs.map(_.inclusionHeightOpt).forall(_ == Some(1)) shouldBe true
+      scanResults.outputs.map(_.value).sum shouldBe trackedTransaction.valuesSum
+    }
+  }
+
+  property("scanSnapshotBoxes applies dust limit") {
+    forAll(trackedTransactionGen, walletVarsGen) { case (trackedTransaction, walletVars) =>
+      scanSnapshotBoxes(trackedTransaction.tx.outputs, walletVars, Some(Long.MaxValue)).outputs shouldBe empty
+      scanSnapshotBoxes(trackedTransaction.tx.outputs, walletVars, Some(1L)).outputs.forall(_.value > 1) shouldBe true
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistrySpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistrySpec.scala
@@ -1,11 +1,13 @@
 package org.ergoplatform.nodeView.wallet.persistence
 
 import com.google.common.primitives.{Ints, Shorts}
+import org.ergoplatform.core.{VersionTag, idToVersion}
+import org.ergoplatform.nodeView.history.ErgoHistoryUtils.EmptyHistoryHeight
+import org.ergoplatform.nodeView.wallet.IdUtils.{EncodedTokenId, encodedTokenId}
 import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.db.DBSpec
 import org.ergoplatform.nodeView.wallet.WalletScanLogic.{ScanResults, SpentInputData}
 import org.ergoplatform.wallet.boxes.TrackedBox
-import org.ergoplatform.core.VersionTag
 import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,6 +33,17 @@ class WalletRegistrySpec
   private val walletBoxStatus = Set(PaymentsScanId)
 
   private val ws = settings.walletSettings
+
+  private def unspentWalletBox(box: TrackedBox): TrackedBox =
+    box.copy(spendingHeightOpt = None, spendingTxIdOpt = None, scans = walletBoxStatus)
+
+  private def walletTokenBalances(boxes: Seq[TrackedBox]): Map[EncodedTokenId, Long] =
+    boxes
+      .flatMap(_.box.additionalTokens.toArray)
+      .foldLeft(Map.empty[EncodedTokenId, Long]) { case (acc, (id, amount)) =>
+        val encodedId = encodedTokenId(id)
+        acc.updated(encodedId, acc.getOrElse(encodedId, 0L) + amount)
+      }
 
   it should "read unspent wallet boxes" in {
     forAll(trackedBoxGen) { box =>
@@ -110,10 +123,83 @@ class WalletRegistrySpec
       withVersionedStore(10) { store =>
         val registry = new WalletRegistry(store)(settings.walletSettings)
         val blockId = modifierIdGen.sample.get
-        val unspentBoxes = boxes.map(bx => bx.copy(spendingHeightOpt = None, spendingTxIdOpt = None, scans = walletBoxStatus))
+        val unspentBoxes = boxes.map(unspentWalletBox)
         registry.updateOnBlock(ScanResults(unspentBoxes, ArraySeq.empty, ArraySeq.empty), blockId, 100).get
         registry.walletUnspentBoxes().toList should contain theSameElementsAs unspentBoxes
       }
+    }
+  }
+
+  it should "updateOnSnapshotChunk accumulates balances and tokens until final snapshot chunk" in {
+    withVersionedStore(10) { store =>
+      val registry = new WalletRegistry(store)(settings.walletSettings)
+      val snapshotBlockId = modifierIdGen.sample.get
+      val box1 = unspentWalletBox(trackedBoxGen.sample.get)
+      val box2 = unspentWalletBox(trackedBoxGen.sample.get)
+
+      registry.fetchDigest().height shouldBe EmptyHistoryHeight
+      registry.updateOnSnapshotChunk(
+        ScanResults(Seq(box1), ArraySeq.empty, ArraySeq.empty),
+        snapshotBlockId,
+        snapshotHeight = 100,
+        subtreeIndex = 0,
+        finalChunk = false
+      ).get
+
+      registry.walletUnspentBoxes().toList should contain theSameElementsAs Seq(box1)
+      registry.fetchDigest().height shouldBe EmptyHistoryHeight
+      registry.fetchDigest().walletBalance shouldBe box1.box.value
+      registry.fetchDigest().walletAssetBalances.toMap shouldBe walletTokenBalances(Seq(box1))
+
+      registry.updateOnSnapshotChunk(
+        ScanResults(Seq(box2), ArraySeq.empty, ArraySeq.empty),
+        snapshotBlockId,
+        snapshotHeight = 100,
+        subtreeIndex = 1,
+        finalChunk = true
+      ).get
+
+      val allBoxes = Seq(box1, box2)
+      registry.walletUnspentBoxes().toList should contain theSameElementsAs allBoxes
+      registry.fetchDigest().height shouldBe 100
+      registry.fetchDigest().walletBalance shouldBe allBoxes.map(_.box.value).sum
+      registry.fetchDigest().walletAssetBalances.toMap shouldBe walletTokenBalances(allBoxes)
+    }
+  }
+
+  it should "updateOnSnapshotChunk writes a final snapshot version even if no wallet boxes are found" in {
+    withVersionedStore(10) { store =>
+      val registry = new WalletRegistry(store)(settings.walletSettings)
+      val snapshotBlockId = modifierIdGen.sample.get
+
+      registry.updateOnSnapshotChunk(
+        ScanResults(ArraySeq.empty, ArraySeq.empty, ArraySeq.empty),
+        snapshotBlockId,
+        snapshotHeight = 100,
+        subtreeIndex = 0,
+        finalChunk = true
+      ).get
+
+      registry.fetchDigest().height shouldBe 100
+      registry.rollback(idToVersion(snapshotBlockId)).isSuccess shouldBe true
+      registry.fetchDigest().height shouldBe 100
+    }
+  }
+
+  it should "updateOnSnapshotChunk rejects block scan data" in {
+    withVersionedStore(10) { store =>
+      val registry = new WalletRegistry(store)(settings.walletSettings)
+      val snapshotBlockId = modifierIdGen.sample.get
+      val box = unspentWalletBox(trackedBoxGen.sample.get)
+      val spent = SpentInputData(modifierIdGen.sample.get, box)
+
+      registry.updateOnSnapshotChunk(
+        ScanResults(Seq(box), Seq(spent), ArraySeq.empty),
+        snapshotBlockId,
+        snapshotHeight = 100,
+        subtreeIndex = 0,
+        finalChunk = false
+      ).isFailure shouldBe true
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
@@ -5,6 +5,7 @@ import org.ergoplatform.db.DBSpec
 import org.ergoplatform.nodeView.wallet.persistence.WalletStorage.SecretPathsKey
 import org.ergoplatform.nodeView.wallet.scanning.{ScanRequest, ScanWalletInteraction}
 import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DerivationPathSerializer}
+import org.ergoplatform.utils.generators.CoreObjectGenerators._
 import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -82,6 +83,33 @@ class WalletStorageSpec
         val scan2 = storage.addScan(externalScanReq).get
         storage.lastUsedScanId shouldBe scan2.scanId
         storage.lastUsedScanId shouldBe (scan.scanId +1)
+      }
+    }
+  }
+
+  it should "store, update and remove UTXO snapshot scan status" in {
+    forAll(modifierIdGen) { snapshotBlockId =>
+      withStore { store =>
+        val storage = new WalletStorage(store, settings)
+        val status = UtxoSnapshotScanStatus(
+          snapshotHeight = 100,
+          snapshotBlockId = snapshotBlockId,
+          manifestDepth = 6,
+          nextSubtreeIndex = 3,
+          totalSubtrees = 64,
+          completed = false
+        )
+
+        storage.readUtxoSnapshotScanStatus() shouldBe None
+        storage.writeUtxoSnapshotScanStatus(status).get
+        storage.readUtxoSnapshotScanStatus() shouldBe Some(status)
+
+        val completedStatus = status.copy(nextSubtreeIndex = status.totalSubtrees, completed = true)
+        storage.writeUtxoSnapshotScanStatus(completedStatus).get
+        storage.readUtxoSnapshotScanStatus() shouldBe Some(completedStatus)
+
+        storage.removeUtxoSnapshotScanStatus().get
+        storage.readUtxoSnapshotScanStatus() shouldBe None
       }
     }
   }


### PR DESCRIPTION
﻿Closes #2034.

This adds wallet-side UTXO snapshot scanning for nodes bootstrapped from a UTXO set snapshot. PR #2072 was useful historical reference; this is a fresh implementation.

Summary:
- add safe AVL subtree iteration matching snapshot manifest order, with resume, bounded batch reads, and immediate error propagation
- persist wallet-local UTXO snapshot scan status and scan snapshot chunks into the wallet registry without inventing pre-snapshot wallet transactions
- run snapshot scanning asynchronously via a scanner actor, pause normal full-block wallet scans while the snapshot scan is pending, then resume from snapshotHeight + 1
- make wallet rescan under utxoBootstrap reset the snapshot scan instead of trying to rescan pruned blocks
- add targeted coverage for AVL iteration, scan logic, status storage, registry chunks, service integration, scanner failure handling, and actor catch-up behavior

Checks run:
- sbt compile
- sbt "avldb/testOnly scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorageSpecification"
- sbt "testOnly org.ergoplatform.nodeView.history.UtxoSetSnapshotProcessorSpecification"
- sbt "testOnly org.ergoplatform.nodeView.wallet.WalletScanLogicSpec org.ergoplatform.nodeView.wallet.ErgoWalletServiceSpec org.ergoplatform.nodeView.wallet.ErgoWalletSpec org.ergoplatform.nodeView.wallet.UtxoSnapshotWalletScannerSpec org.ergoplatform.nodeView.wallet.persistence.WalletStorageSpec org.ergoplatform.nodeView.wallet.persistence.WalletRegistrySpec"
- publication guard on staged content, final diff range, and commit history range
