### PR TITLE
support optional minerPk override in sign and check endpoints

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -636,6 +636,16 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/DhtSecret'
+        minerPk:
+          description: |-
+            Optional forged miner public key for the upcoming preHeader, hex-encoded
+            (secp256k1 group element). When set, the prover signs against an upcoming
+            state context that uses this pk instead of the placeholder one in
+            `simplifiedUpcoming`. Useful for scripts that depend on
+            `CONTEXT.preHeader.minerPk`. Such transactions only validate inside the
+            forged context and will not be accepted by the real network.
+          type: string
+          example: '02a7955281885bf0f0ca4a48678848cad8dc5b328ce8bc1d4481d041c98e891ff3'
 
     AddressHolder:
       description: Holds encoded ErgoAddress
@@ -3250,6 +3260,18 @@ paths:
       operationId: checkTransaction
       tags:
         - transactions
+      parameters:
+        - in: query
+          name: minerPk
+          required: false
+          schema:
+            type: string
+          description: |-
+            Optional hex-encoded miner public key (secp256k1 group element). When supplied,
+            the transaction is validated against an upcoming state context that uses this pk
+            in the preHeader instead of the placeholder one in `simplifiedUpcoming`. Useful
+            for verifying transactions whose scripts depend on `CONTEXT.preHeader.minerPk`.
+          example: '02a7955281885bf0f0ca4a48678848cad8dc5b328ce8bc1d4481d041c98e891ff3'
       requestBody:
         required: true
         content:

--- a/src/main/scala/org/ergoplatform/http/api/ApiRequestsCodecs.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ApiRequestsCodecs.scala
@@ -9,6 +9,7 @@ import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, GenerateCommit
 import org.ergoplatform.sdk.wallet.secrets.{DhtSecretKey, DlogSecretKey}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import sigma.AnyValue
+import sigma.crypto.EcPointType
 import sigma.data.SigmaBoolean
 
 /**
@@ -67,8 +68,9 @@ trait ApiRequestsCodecs extends ApiCodecs {
       ),
       "hints" -> tsr.hints.asJson,
       "inputsRaw" -> tsr.inputs.asJson,
-      "dataInputsRaw" -> tsr.dataInputs.asJson
-    )
+      "dataInputsRaw" -> tsr.dataInputs.asJson,
+      "minerPk" -> tsr.minerPk.asJson
+    ).dropNullValues
   }
 
   implicit val transactionSigningRequestDecoder: Decoder[TransactionSigningRequest] = { cursor =>
@@ -79,8 +81,9 @@ trait ApiRequestsCodecs extends ApiCodecs {
       hints <- cursor.downField("hints").as[Option[TransactionHintsBag]]
       inputs <- cursor.downField("inputsRaw").as[Option[Seq[String]]]
       dataInputs <- cursor.downField("dataInputsRaw").as[Option[Seq[String]]]
+      minerPk <- cursor.downField("minerPk").as[Option[EcPointType]]
       secrets = (dlogs.getOrElse(Seq.empty) ++ dhts.getOrElse(Seq.empty)).map(ExternalSecret.apply)
-    } yield TransactionSigningRequest(tx, hints.getOrElse(TransactionHintsBag.empty), secrets, inputs, dataInputs)
+    } yield TransactionSigningRequest(tx, hints.getOrElse(TransactionHintsBag.empty), secrets, inputs, dataInputs, minerPk)
   }
 
   implicit val generateCommitmentsRequestEncoder: Encoder[GenerateCommitmentsRequest] = { gcr =>

--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -7,7 +7,9 @@ import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransacti
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
+import org.ergoplatform.nodeView.wallet.ErgoWalletActor
 import org.ergoplatform.settings.{Algos, ErgoSettings}
+import sigma.crypto.EcPointType
 import scorex.core.api.http.ApiRoute
 import scorex.util.{bytesToId, ModifierId}
 import akka.pattern.ask
@@ -116,7 +118,8 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   protected def verifyTransaction(
     tx: ErgoTransaction,
     readersHolder: ActorRef,
-    ergoSettings: ErgoSettings
+    ergoSettings: ErgoSettings,
+    minerPkOverride: Option[EcPointType] = None
   ): Future[Try[UnconfirmedTransaction]] = {
     val now: Long = System.currentTimeMillis()
     val bytes     = Some(tx.bytes)
@@ -125,7 +128,10 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
       .map {
         case (utxo: UtxoStateReader, mp: ErgoMemPoolReader) =>
           val maxTxCost = ergoSettings.nodeSettings.maxTransactionCost
-          val validationContext = utxo.stateContext.simplifiedUpcoming()
+          val validationContext = minerPkOverride match {
+            case Some(pk) => ErgoWalletActor.upcomingWithMinerPk(utxo.stateContext, pk)
+            case None     => utxo.stateContext.simplifiedUpcoming()
+          }
           utxo.withMempool(mp)
             .validateWithCost(tx, validationContext, maxTxCost, None)
             .map(cost => new UnconfirmedTransaction(tx, Some(cost), now, now, bytes, source = None))

--- a/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
@@ -8,6 +8,7 @@ import io.circe.Json
 import io.circe.syntax._
 import org.ergoplatform.{ErgoBox, Input}
 import org.ergoplatform.ErgoBox.{BoxId, NonMandatoryRegisterId, TokenId}
+import org.ergoplatform.mining.groupElemFromBytes
 import org.ergoplatform.http.api.ApiError.BadRequest
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
@@ -20,10 +21,11 @@ import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
 import sigma.VersionContext
 import sigma.ast.{EvaluatedValue, SType}
+import sigma.crypto.EcPointType
 import sigmastate.eval.Extensions.ArrayByteOps
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 case class TransactionsApiRoute(readersHolder: ActorRef,
                                 nodeViewActorRef: ActorRef,
@@ -154,13 +156,14 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
 
   private def getUnconfirmedTransactions(offset: Int, limit: Int): Future[Json] = getUnconfirmedTransactionsWithResolvedInputs(offset, limit)
 
-  private def validateTransactionAndProcess(tx: ErgoTransaction)
+  private def validateTransactionAndProcess(tx: ErgoTransaction,
+                                            minerPkOverride: Option[EcPointType] = None)
                                            (processFn: UnconfirmedTransaction => Route): Route = {
     if (tx.size > ergoSettings.nodeSettings.maxTransactionSize) {
       BadRequest(s"Transaction $tx has too large size ${tx.size}")
     } else {
       onSuccess {
-        verifyTransaction(tx, readersHolder, ergoSettings)
+        verifyTransaction(tx, readersHolder, ergoSettings, minerPkOverride)
       } {
         _.fold(
           e => BadRequest(s"Malformed transaction: ${e.getMessage}"),
@@ -192,9 +195,20 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
     }
   }
 
-  def checkTransactionR: Route = (path("check") & post & entity(as[ErgoTransaction])) { tx =>
-    validateTransactionAndProcess(tx)(validTx => ApiResponse(validTx.transaction.id))
-  }
+  def checkTransactionR: Route =
+    (path("check") & post & parameter("minerPk".as[String].?) & entity(as[ErgoTransaction])) { (minerPkHex, tx) =>
+      minerPkHex.map(parseMinerPk) match {
+        case Some(Failure(e)) =>
+          BadRequest(s"Invalid minerPk hex: ${e.getMessage}")
+        case Some(Success(pk)) =>
+          validateTransactionAndProcess(tx, Some(pk))(validTx => ApiResponse(validTx.transaction.id))
+        case None =>
+          validateTransactionAndProcess(tx, None)(validTx => ApiResponse(validTx.transaction.id))
+      }
+    }
+
+  private def parseMinerPk(hex: String): Try[EcPointType] =
+    Algos.decode(hex).map(groupElemFromBytes)
 
   /**
     * Check transaction given as hex-encoded bytes

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -235,6 +235,7 @@ case class WalletApiRoute(readersHolder: ActorRef,
     val secrets = tsr.externalSecrets
 
     val hints = tsr.hints
+    val minerPkOverride = tsr.minerPk
 
     def signWithReaders(r: Readers): Future[Try[ErgoTransaction]] = {
       if (tsr.inputs.isDefined) {
@@ -244,12 +245,12 @@ case class WalletApiRoute(readersHolder: ActorRef,
           .flatMap(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry).toOption)
 
         if (boxesToSpend.size == tx.inputs.size && dataBoxes.size == tx.dataInputs.size) {
-          r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes))
+          r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes), minerPkOverride)
         } else {
           Future(Failure(new Exception("Can't parse input boxes provided")))
         }
       } else {
-        r.w.signTransaction(tx, secrets, hints, None, None)
+        r.w.signTransaction(tx, secrets, hints, None, None, minerPkOverride)
       }
     }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.ErgoBox._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
-import org.ergoplatform.nodeView.state.ErgoStateReader
+import org.ergoplatform.nodeView.state.{ErgoStateContext, ErgoStateReader, UpcomingStateContext}
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
 import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.settings._
@@ -19,6 +19,7 @@ import org.ergoplatform.core.VersionTag
 import org.ergoplatform.sdk.SecretString
 import org.ergoplatform.utils.ScorexEncoding
 import scorex.util.ScorexLogging
+import sigma.crypto.EcPointType
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -371,7 +372,14 @@ class ErgoWalletActor(settings: ErgoSettings,
       val resultTry = ergoWalletService.generateCommitments(state, unsignedTx, externalSecretsOpt, externalInputsOpt, externalDataInputsOpt)
       sender() ! GenerateCommitmentsResponse(resultTry)
 
-    case SignTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt) =>
+    case SignTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, minerPkOverride) =>
+      val (effectiveContext, effectiveParameters) = minerPkOverride match {
+        case Some(pk) =>
+          val ctx = ErgoWalletActor.upcomingWithMinerPk(state.stateContext, pk)
+          (ctx, ctx.currentParameters)
+        case None =>
+          (state.stateContext, state.parameters)
+      }
       val txTry =
         ergoWalletService.signTransaction(
           state.walletVars.proverOpt,
@@ -380,8 +388,8 @@ class ErgoWalletActor(settings: ErgoSettings,
           hints,
           boxesToSpendOpt,
           dataBoxesOpt,
-          state.parameters,
-          state.stateContext
+          effectiveParameters,
+          effectiveContext
         )(state.readBoxFromUtxoWithWalletFallback)
       sender() ! txTry
 
@@ -502,6 +510,27 @@ class ErgoWalletActor(settings: ErgoSettings,
 }
 
 object ErgoWalletActor extends ScorexLogging {
+
+  /**
+    * Build an `UpcomingStateContext` that forges `minerPk` in the preHeader while keeping
+    * the other fields aligned with what `simplifiedUpcoming` would compute from
+    * `base.lastHeaderOpt`. Used by sign / verify endpoints that accept an optional
+    * `minerPk` override.
+    */
+  def upcomingWithMinerPk(base: ErgoStateContext, minerPk: EcPointType): UpcomingStateContext = {
+    val last = base.lastHeaderOpt
+    val version = last.map(_.version).getOrElse(base.currentParameters.blockVersion)
+    val nBits = last.map(_.nBits).getOrElse(base.chainSettings.initialNBits)
+    val timestamp = last.map(_.timestamp + 1).getOrElse(System.currentTimeMillis())
+    base.upcoming(
+      minerPk = minerPk,
+      timestamp = timestamp,
+      nBits = nBits,
+      votes = Array.emptyByteArray,
+      proposedUpdate = ErgoValidationSettingsUpdate.empty,
+      version = version
+    )
+  }
 
   /** Start actor and register its proper closing into coordinated shutdown */
   def apply(settings: ErgoSettings,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -6,6 +6,7 @@ import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransact
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.wallet.models.CollectedBoxes
 import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, TransactionGenerationRequest}
+import sigma.crypto.EcPointType
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest}
 import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.wallet.Constants.ScanId
@@ -94,17 +95,21 @@ object ErgoWalletActorMessages {
   /**
    * A request to sign a transaction
    *
-   * @param utx          - unsigned transaction
-   * @param secrets      - additional secrets given to the prover
-   * @param hints        - hints used for transaction signing (commitments and partial proofs)
-   * @param boxesToSpend - boxes the transaction is spending
-   * @param dataBoxes    - read-only inputs of the transaction
+   * @param utx             - unsigned transaction
+   * @param secrets         - additional secrets given to the prover
+   * @param hints           - hints used for transaction signing (commitments and partial proofs)
+   * @param boxesToSpend    - boxes the transaction is spending
+   * @param dataBoxes       - read-only inputs of the transaction
+   * @param minerPkOverride - optional forged miner pk for the upcoming preHeader; when
+   *                          present, the prover signs against `stateContext.upcoming(pk, ...)`
+   *                          instead of the live node's `stateContext`
    */
   case class SignTransaction(utx: UnsignedErgoTransaction,
                              secrets: Seq[ExternalSecret],
                              hints: TransactionHintsBag,
                              boxesToSpend: Option[Seq[ErgoBox]],
-                             dataBoxes: Option[Seq[ErgoBox]])
+                             dataBoxes: Option[Seq[ErgoBox]],
+                             minerPkOverride: Option[EcPointType] = None)
 
   /**
    *

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -9,6 +9,7 @@ import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages._
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
 import org.ergoplatform.nodeView.wallet.persistence.WalletDigest
 import org.ergoplatform.nodeView.wallet.requests.{BoxesRequest, ExternalSecret, TransactionGenerationRequest}
+import sigma.crypto.EcPointType
 import org.ergoplatform.nodeView.wallet.scanning.ScanRequest
 import org.ergoplatform.sdk.SecretString
 import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey}
@@ -121,8 +122,9 @@ trait ErgoWalletReader extends NodeViewComponent {
                       secrets: Seq[ExternalSecret],
                       hints: TransactionHintsBag,
                       boxesToSpend: Option[Seq[ErgoBox]],
-                      dataBoxes: Option[Seq[ErgoBox]]): Future[Try[ErgoTransaction]] =
-    (walletActor ? SignTransaction(tx, secrets, hints, boxesToSpend, dataBoxes)).mapTo[Try[ErgoTransaction]]
+                      dataBoxes: Option[Seq[ErgoBox]],
+                      minerPkOverride: Option[EcPointType] = None): Future[Try[ErgoTransaction]] =
+    (walletActor ? SignTransaction(tx, secrets, hints, boxesToSpend, dataBoxes, minerPkOverride)).mapTo[Try[ErgoTransaction]]
 
   def extractHints(tx: ErgoTransaction,
                    real: Seq[SigmaBoolean],

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/TransactionSigningRequest.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/TransactionSigningRequest.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.nodeView.wallet.requests
 import org.ergoplatform.modifiers.mempool.UnsignedErgoTransaction
 import org.ergoplatform.sdk.wallet.secrets.{DhtSecretKey, DlogSecretKey}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
+import sigma.crypto.EcPointType
 
 /**
   * A request to sign a transaction
@@ -12,16 +13,21 @@ import org.ergoplatform.wallet.interpreter.TransactionHintsBag
   * @param externalSecrets - externally provided secrets
   * @param inputs     - hex-encoded input boxes bytes for the unsigned transaction (optional)
   * @param dataInputs - hex-encoded data-input boxes bytes for the unsigned transaction (optional)
+  * @param minerPk    - optional forged miner public key for the upcoming preHeader.
+  *                     When present, the prover signs against an upcoming state context that
+  *                     uses this pk instead of the placeholder one in `simplifiedUpcoming`.
+  *                     A tx signed under a forged minerPk only validates inside that same
+  *                     synthetic context and will not be accepted by the real network.
   */
 case class TransactionSigningRequest(unsignedTx: UnsignedErgoTransaction,
                                      hints: TransactionHintsBag,
                                      externalSecrets: Seq[ExternalSecret],
                                      inputs: Option[Seq[String]],
-                                     dataInputs: Option[Seq[String]]) {
+                                     dataInputs: Option[Seq[String]],
+                                     minerPk: Option[EcPointType] = None) {
 
   lazy val dlogs: Seq[DlogSecretKey] = externalSecrets.collect { case ExternalSecret(d: DlogSecretKey) => d }
 
   lazy val dhts: Seq[DhtSecretKey] = externalSecrets.collect { case ExternalSecret(d: DhtSecretKey) => d }
 
 }
-

--- a/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
@@ -126,6 +126,22 @@ class TransactionApiRouteSpec extends AnyFlatSpec
       }
   }
 
+  it should "check transaction with a forged minerPk query param" in {
+    import org.ergoplatform.utils.generators.ErgoCoreGenerators.genECPoint
+    import org.ergoplatform.mining.groupElemToBytes
+    val forgedPkHex = Base16.encode(groupElemToBytes(genECPoint.sample.get))
+    Post(prefix + s"/check?minerPk=$forgedPkHex", tx.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[String] shouldEqual tx.id
+    }
+  }
+
+  it should "reject /check with malformed minerPk" in {
+    Post(prefix + "/check?minerPk=not-hex", tx.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "get unconfirmed txs from mempool" in {
     Get(prefix + "/unconfirmed") ~> route ~> check {
       status shouldBe StatusCodes.OK

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Random, Try}
 import scala.concurrent.duration._
-import akka.http.scaladsl.server.MissingQueryParamRejection
+import akka.http.scaladsl.server.{MalformedRequestContentRejection, MissingQueryParamRejection}
 import org.ergoplatform.settings.Constants.FalseTree
 import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators
 
@@ -112,6 +112,25 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Post(prefix + "/transaction/sign", tsr.asJson) ~> r ~> check {
       status shouldBe StatusCodes.OK
       responseAs[ErgoTransaction].id shouldBe tsr.unsignedTx.id
+    }
+  }
+
+  it should "sign a transaction with a forged minerPk" in {
+    import org.ergoplatform.utils.generators.ErgoCoreGenerators.genECPoint
+    val baseTsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(includeInputs = true).sample.get
+    val forgedPk = genECPoint.sample.get
+    val tsr = baseTsr.copy(minerPk = Some(forgedPk))
+    Post(prefix + "/transaction/sign", tsr.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[ErgoTransaction].id shouldBe tsr.unsignedTx.id
+    }
+  }
+
+  it should "reject /transaction/sign with malformed minerPk" in {
+    val baseTsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(includeInputs = true).sample.get
+    val badJson = baseTsr.asJson.deepMerge(Json.obj("minerPk" -> "not-hex".asJson))
+    Post(prefix + "/transaction/sign", badJson) ~> route ~> check {
+      rejection shouldBe a[MalformedRequestContentRejection]
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -19,14 +19,16 @@ import scorex.util.ModifierId
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
 import sigma.ast.ErgoTree
+import sigma.crypto.EcPointType
 import sigma.data.{CAND, CTHRESHOLD}
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigmastate.eval.Extensions._
+import org.ergoplatform.mining.groupElemToBytes
 import org.ergoplatform.settings.Constants.TrueTree
 
 import scala.concurrent.duration._
 
-class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventually {
+class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with ErgoCompilerHelpers with Eventually {
   import org.ergoplatform.utils.ErgoCoreTestConstants._
   import org.ergoplatform.utils.ErgoNodeTestConstants._
   import org.ergoplatform.utils.generators.ErgoCoreGenerators._
@@ -1123,6 +1125,59 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
 
         val txSigned = await(wallet.signTransaction(utx, Seq(es1), hints, Some(Seq(in)), None)).get
         txSigned.statelessValidity().isSuccess shouldBe true
+      }
+    }
+  }
+
+  property("forged minerPk activates a context-dependent script for signing") {
+    withFixture { implicit w =>
+      val forgedSecret = DLogProverInput.random()
+      val forgedPk: EcPointType = forgedSecret.publicImage.value
+      val forgedPkHex = Base16.encode(groupElemToBytes(forgedPk))
+
+      // Script only validates when CONTEXT.preHeader.minerPk equals the forged pk.
+      val script: ErgoTree = compileSourceV5(
+        s"""{ CONTEXT.preHeader.minerPk == decodePoint(fromBase16("$forgedPkHex")) }""",
+        treeVersion = 0
+      )
+
+      val pubKey = getPublicKeys.head.pubkey
+      val genesisBlock = makeGenesisBlock(pubKey, randomNewAsset)
+      applyBlock(genesisBlock) shouldBe 'success
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
+      eventually {
+        val confirmedBalance = getConfirmedBalances.walletBalance
+
+        // Fund a box guarded by the script (leave room for fee + change).
+        val req = PaymentRequest(Pay2SAddress(script), confirmedBalance - MinBoxValue, Array.empty, Map.empty)
+        val fundingTx = await(wallet.generateTransaction(Seq(req))).get
+        val scriptBox = fundingTx.outputs.head
+
+        val out = new ErgoBoxCandidate(scriptBox.value, TrueTree, creationHeight = 0)
+        val utx = new UnsignedErgoTransaction(
+          IndexedSeq(new UnsignedInput(scriptBox.id)),
+          IndexedSeq.empty,
+          IndexedSeq(out)
+        )
+
+        // Without override: prover sees the live state context's minerPk (genesis header /
+        // PreHeader.fake), not forgedPk; the script reduces to false and signing fails.
+        val noOverride = await(wallet.signTransaction(
+          utx, Seq.empty, TransactionHintsBag.empty, Some(Seq(scriptBox)), None, None
+        ))
+        withClue(s"noOverride result was unexpectedly successful: $noOverride") {
+          noOverride.isFailure shouldBe true
+        }
+
+        // With override: prover sees forgedPk in preHeader, the script reduces to true,
+        // signing succeeds.
+        val withOverride = await(wallet.signTransaction(
+          utx, Seq.empty, TransactionHintsBag.empty, Some(Seq(scriptBox)), None, Some(forgedPk)
+        ))
+        withClue(s"withOverride result was unexpectedly a failure: $withOverride") {
+          withOverride.isSuccess shouldBe true
+        }
+        withOverride.get.id shouldBe utx.id
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
@@ -20,6 +20,7 @@ class JsonSerializationSpec extends ErgoCorePropertyTest
   with EitherValues {
   import org.ergoplatform.utils.generators.ErgoNodeWalletGenerators._
   import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+  import org.ergoplatform.utils.generators.ErgoCoreGenerators._
   import org.ergoplatform.utils.ErgoCoreTestConstants._
   import org.ergoplatform.utils.ErgoNodeTestConstants._
   import org.ergoplatform.utils.generators.ErgoNodeGenerators._
@@ -112,6 +113,15 @@ class JsonSerializationSpec extends ErgoCorePropertyTest
       val json = request.asJson
       val parsedRequest = json.as[TransactionSigningRequest].toOption.get
       parsedRequest shouldBe request
+    }
+  }
+
+  property("transactionSigningRequest with minerPk override roundtrip") {
+    forAll(transactionSigningRequestGen(includeInputs = false), genECPoint) { (req, pk) =>
+      val withOverride = req.copy(minerPk = Some(pk))
+      val parsed = withOverride.asJson.as[TransactionSigningRequest].toOption.get
+      parsed.minerPk shouldBe Some(pk)
+      parsed.unsignedTx shouldBe withOverride.unsignedTx
     }
   }
 

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -18,6 +18,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.{ProcessingOutcome, SortingOption}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{DigestState, ErgoStateContext, StateType}
+import org.ergoplatform.nodeView.wallet.ErgoWalletActor
 import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages._
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
 import org.ergoplatform.nodeView.wallet._
@@ -265,9 +266,16 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
         val tx = ErgoTransaction(IndexedSeq(input), IndexedSeq(ergoBoxCandidateGen.sample.value))
         sender() ! Success(tx)
 
-      case SignTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt) =>
-        val sc = ErgoStateContext.empty(settings.chainSettings, parameters)
-        sender() ! ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, parameters, sc) { boxId =>
+      case SignTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, minerPkOverride) =>
+        val baseSc = ErgoStateContext.empty(settings.chainSettings, parameters)
+        val (effectiveSc, effectiveParams) = minerPkOverride match {
+          case Some(pk) =>
+            val ctx = ErgoWalletActor.upcomingWithMinerPk(baseSc, pk)
+            (ctx, ctx.currentParameters)
+          case None =>
+            (baseSc, parameters)
+        }
+        sender() ! ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, effectiveParams, effectiveSc) { boxId =>
           utxoState.versionedBoxHolder.get(ByteArrayWrapper(boxId))
         }
     }


### PR DESCRIPTION
## Summary

Adds an optional `minerPk` override to `/wallet/transaction/sign` (body field) and `/transactions/check` (query parameter). When set, the prover/validator runs against an upcoming state context that forges this pubkey into the preHeader, so scripts that condition on `CONTEXT.preHeader.minerPk` (e.g. `(minerPk == alice && aliceLock) || aliceWithdraw`) can be signed and verified before the block is mined.

Backwards compatible: omitting `minerPk` keeps current behavior. A transaction signed under a forged pk only validates inside that same synthetic context and will not be accepted by the real network — this is intentional, and the OpenAPI description calls it out.

## Implementation note

- `ErgoWalletActor.upcomingWithMinerPk(base, pk)` builds the override context and is reused by the sign actor handler and by `ErgoBaseApiRoute.verifyTransaction`. The other four `simplifiedUpcoming` fields (`timestamp`, `nBits`, `votes`, `version`) keep their default-from-`lastHeaderOpt` derivation — not exposed on the wire (no concrete user has asked to forge them; off-node tooling like ergo-appkit covers that already).

Closes #1041 