### PR TITLE
inline the genesis empty-extension root branch at ExtensionCandidate.…

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionCandidate.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionCandidate.scala
@@ -21,12 +21,17 @@ import scala.collection.mutable
 class ExtensionCandidate(val fields: Seq[(Array[Byte], Array[Byte])]) {
   lazy val merkleTree: MerkleTree[Digest32] = Extension.merkleTree(fields)
 
-  lazy val digest: Digest32 = Algos.merkleTreeRoot(merkleTree)
+  // The genesis block is the only block whose extension can be empty (non-genesis
+  // extensions are validated non-empty by ExtensionValidator). Its on-chain
+  // `extensionRoot` was historically computed as `hash(empty)`, not as the empty
+  // tree's `rootHash` — preserve that value to keep genesis consensus intact.
+  lazy val digest: Digest32 =
+    if (fields.isEmpty) Algos.emptyMerkleTreeRoot else merkleTree.rootHash
 
   lazy val interlinksMerkleTree: MerkleTree[Digest32] =
     Extension.merkleTree(fields.filter(_._1.head.equals(InterlinksVectorPrefix)))
 
-  lazy val interlinksDigest: Digest32 = Algos.merkleTreeRoot(interlinksMerkleTree)
+  lazy val interlinksDigest: Digest32 = interlinksMerkleTree.rootHash
 
   def toExtension(headerId: ModifierId): Extension = Extension(headerId, fields)
 

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Algos.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Algos.scala
@@ -16,35 +16,23 @@ object Algos extends ErgoAlgos with utils.ScorexEncoding {
   //  we can fix this ugliness.
   override implicit val encoder: ScorexEncoder = utils.ScorexEncoder.default
 
+  /**
+    * Hash of an empty byte array. Locked in as the on-chain `extensionRoot` of the
+    * mainnet genesis block, whose extension is empty; preserved at the one call site
+    * (`ExtensionCandidate.digest`) so genesis consensus is not changed.
+    */
   lazy val emptyMerkleTreeRoot: Digest32 = Algos.hash(LeafData @@ Array[Byte]())
 
   @inline def encode(id: ModifierId): String = encoder.encode(id)
 
   /**
-    * A method to build a Merkle tree over binary objects (leafs of the tree)
-    * @param elements - Merkle tree leafs (byte arrays of arbitrary size)
-    * @return a Merkle tree built over the elements
+    * Build a Merkle tree over binary objects (leaves of the tree).
     */
   def merkleTree(elements: Seq[LeafData]): MerkleTree[Digest32] = MerkleTree(elements)(hash)
 
   /**
-    * A method which is building a Merkle tree over binary objects and returns a digest
-    * (256-bits long root hash) of the tree
-    *
-    * !!! If input sequence is empty, then the function returns a special value (hash of empty byte array), which is
-    *  equal to 0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8 and different from "rootHash" property
-    *  of a Merkle tree instance (merkleTree(elements).rootHash) which is equal to another special value
-    *  0000000000000000000000000000000000000000000000000000000000000000
-    *
-    *  See https://github.com/ergoplatform/ergo/issues/1077
-    *
-    * @param elements - tree leafs
-    * @return 256-bits (32-bytes) long digest of the tree
+    * Root hash of the Merkle tree built over the given leaves.
     */
-  def merkleTreeRoot(elements: Seq[LeafData]): Digest32 =
-    if (elements.isEmpty) emptyMerkleTreeRoot else merkleTree(elements).rootHash
-
-  def merkleTreeRoot(tree: MerkleTree[Digest32]): Digest32 =
-    if (tree.length == 0) emptyMerkleTreeRoot else tree.rootHash
+  def merkleTreeRoot(elements: Seq[LeafData]): Digest32 = merkleTree(elements).rootHash
 
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.modifiers.history
 
+import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.utils.ErgoCorePropertyTest
 
 class BlockTransactionsSpec extends ErgoCorePropertyTest {
@@ -13,6 +14,22 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
 
       // no proof should be generated for a transaction which is not there
       bt.proofFor(absentTx).isDefined shouldBe false
+    }
+  }
+
+  // The miner uses BlockTransactions.transactionsRoot (static) to fill header.transactionsRoot
+  // before a BlockTransactions instance exists; later the instance is constructed and its
+  // `digest` (= merkleTree.rootHash) must equal that value, otherwise blocks fail validation.
+  property("transactionsRoot (static) matches BlockTransactions.digest for v1 (no witnesses)") {
+    forAll(invalidBlockTransactionsGen) { bt =>
+      BlockTransactions.transactionsRoot(bt.txs, Header.InitialVersion) shouldBe bt.digest
+    }
+  }
+
+  property("transactionsRoot (static) matches BlockTransactions.digest for v2+ (with witnesses)") {
+    forAll(invalidBlockTransactionsGen) { bt =>
+      val withWitnesses = bt.copy(blockVersion = Header.HardeningVersion)
+      BlockTransactions.transactionsRoot(withWitnesses.txs, Header.HardeningVersion) shouldBe withWitnesses.digest
     }
   }
 

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/ExtensionCandidateTest.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/ExtensionCandidateTest.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.modifiers.history
 
 import org.ergoplatform.modifiers.history.extension.ExtensionCandidate
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
+import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalacheck.Gen
 
@@ -45,5 +46,25 @@ class ExtensionCandidateTest extends ErgoCorePropertyTest {
     val ext = ExtensionCandidate(fields)
     val proof = ext.batchProofFor(fields.map(_._1.clone).toArray: _*)
     proof shouldBe None
+  }
+
+  // Locks the on-chain `extensionRoot` of the (empty-extension) genesis block.
+  property("digest of an empty extension equals the legacy genesis extensionRoot") {
+    ExtensionCandidate(Seq.empty).digest shouldBe Algos.emptyMerkleTreeRoot
+  }
+
+  property("digest stays at the legacy genesis value when two empty extensions are combined") {
+    (ExtensionCandidate(Seq.empty) ++ ExtensionCandidate(Seq.empty)).digest shouldBe Algos.emptyMerkleTreeRoot
+  }
+
+  // A non-genesis extension always contains interlink fields (added by popow), but the
+  // interlinksMerkleTree is still computed by filtering for the InterlinksVectorPrefix.
+  // If no field has that prefix, the filtered tree is empty — and after #1077 its
+  // root hash is the MerkleTree library's empty value, not Algos.emptyMerkleTreeRoot.
+  property("interlinksDigest of an extension without interlink fields is the empty MerkleTree root") {
+    val nonInterlinkField: KV = (Array[Byte](0x01, 0x02), Array[Byte](0x03))
+    val ext = ExtensionCandidate(Seq(nonInterlinkField))
+    ext.interlinksDigest should not equal Algos.emptyMerkleTreeRoot
+    ext.interlinksDigest shouldBe ext.interlinksMerkleTree.rootHash
   }
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/settings/AlgosSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/settings/AlgosSpec.scala
@@ -1,0 +1,43 @@
+package org.ergoplatform.settings
+
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.generators.CoreObjectGenerators.nonEmptyBytesGen
+import org.scalacheck.Gen
+import scorex.crypto.authds.LeafData
+import scorex.crypto.authds.merkle.Leaf
+import scorex.crypto.hash.Digest32
+import scorex.util.encode.Base16
+
+class AlgosSpec extends ErgoCorePropertyTest {
+
+  property("merkleTreeRoot delegates to MerkleTree.rootHash for empty input") {
+    Algos.merkleTreeRoot(Seq.empty) shouldBe Algos.merkleTree(Seq.empty).rootHash
+  }
+
+  property("merkleTreeRoot agrees with MerkleTree.rootHash for non-empty input") {
+    forAll(Gen.nonEmptyListOf(nonEmptyBytesGen)) { bytes =>
+      val leaves = bytes.map(LeafData @@ _)
+      Algos.merkleTreeRoot(leaves) shouldBe Algos.merkleTree(leaves).rootHash
+    }
+  }
+
+  property("emptyMerkleTreeRoot equals hash of an empty byte array (genesis extensionRoot)") {
+    Base16.encode(Algos.emptyMerkleTreeRoot) shouldBe
+      "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+  }
+
+  // The tree↔proof contract is what consensus relies on: any leaf in the tree must
+  // produce a proof that validates against `merkleTreeRoot`. Catches future library
+  // drift that would silently invalidate proofs in production.
+  property("MerkleProof produced from a tree validates against merkleTreeRoot") {
+    forAll(Gen.nonEmptyListOf(nonEmptyBytesGen)) { bytes =>
+      val leaves = bytes.map(LeafData @@ _)
+      val tree = Algos.merkleTree(leaves)
+      val root = Algos.merkleTreeRoot(leaves)
+      leaves.forall { leaf =>
+        tree.proofByElement(Leaf[Digest32](leaf)(Algos.hash)).exists(_.valid(root))
+      } shouldBe true
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #1077 

`Algos.merkleTreeRoot` used to return `hash(empty)` (`0e5751c0…`) for empty input, diverging silently from `MerkleTree.rootHash` (`0000…`). The only place the empty branch actually fires in production is the genesis block's extension — every other caller has non-empty input by construction (`BlockTransactions` asserts ≥1 tx; non-genesis extensions are validated non-empty).

Simplified the helper to always delegate to `MerkleTree.rootHash`, and moved the genesis-only special case to an explicit `if (fields.isEmpty)` branch in `ExtensionCandidate.digest`. Mainnet genesis `extensionRoot` is unchanged. Also dropped the now-redundant `merkleTreeRoot(tree)` overload — its two callers switched to `.rootHash` directly.

Tests pin the new behavior, the legacy `0e5751c0…` constant for the genesis extension digest, and the static-vs-instance `transactionsRoot` invariant for both v1 and v2+ block versions.
