### PR TITLE
mempool: explicit tx graph and box-map cleanups

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -117,11 +117,11 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     }
 
     val poolWithoutTx = removeTx(this, tx)
-    val doubleSpentTransactionIds = tx.inputs.flatMap(i =>
+    val doubleSpentTransactionIds: Set[ModifierId] = tx.inputs.flatMap(i =>
       poolWithoutTx.pool.inputs.get(i.boxId)
     ).toSet
     val doubleSpentTransactions = doubleSpentTransactionIds.flatMap { txId =>
-      poolWithoutTx.pool.orderedTransactions.get(txId)
+      poolWithoutTx.pool.transactionsRegistry.get(txId).flatMap(poolWithoutTx.pool.orderedTransactions.get)
     }
     doubleSpentTransactions.foldLeft(poolWithoutTx) { case (pool, tx) =>
       removeTx(pool, tx.transaction)
@@ -192,22 +192,28 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
                                     validationStartTime: Long): (ErgoMemPool, ProcessingOutcome) = {
     val tx = unconfirmedTransaction.transaction
 
-    val doubleSpendingWtxs = tx.inputs.flatMap { inp =>
+    val doubleSpendingTxIds: Set[ModifierId] = tx.inputs.flatMap { inp =>
       pool.inputs.get(inp.boxId)
     }.toSet
 
     val feeF = feeFactor(unconfirmedTransaction)
 
-    if (doubleSpendingWtxs.nonEmpty) {
+    if (doubleSpendingTxIds.nonEmpty) {
       val ownWtx = weighted(tx, feeF)
+      val doubleSpendingWtxs: Set[WeightedTxId] =
+        doubleSpendingTxIds.flatMap(id => pool.transactionsRegistry.get(id))
       val doubleSpendingTotalWeight = doubleSpendingWtxs.map(_.weight).sum / doubleSpendingWtxs.size
       if (ownWtx.weight > doubleSpendingTotalWeight) {
-        val doubleSpendingTxs = doubleSpendingWtxs.map(wtx => pool.orderedTransactions(wtx)).toSeq
-        val p = pool.put(unconfirmedTransaction, feeF).remove(doubleSpendingTxs)
+        val doubleSpendingTxs = doubleSpendingWtxs.flatMap(wtx => pool.orderedTransactions.get(wtx)).toSeq
+        // Remove the losers FIRST so the shared `inputs`/`outputs` map entries are gone before the
+        // winning tx writes its own. With put-then-remove, the loser's `tx.inputs.map(_.boxId)` would
+        // delete the winner's just-written entry for the shared box, leaving the winner orphaned
+        // in the index and breaking subsequent double-spend detection.
+        val p = pool.remove(doubleSpendingTxs).put(unconfirmedTransaction, feeF)
         val updPool = new ErgoMemPool(p, stats, sortingOption)
         updPool -> new ProcessingOutcome.Accepted(unconfirmedTransaction, validationStartTime)
       } else {
-        this -> new ProcessingOutcome.DoubleSpendingLoser(doubleSpendingWtxs.map(_.id), validationStartTime)
+        this -> new ProcessingOutcome.DoubleSpendingLoser(doubleSpendingTxIds, validationStartTime)
       }
     } else {
       val poolSizeLimit = nodeSettings.mempoolCapacity

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -14,14 +14,16 @@ import scala.collection.immutable.TreeMap
   * @param orderedTransactions  - collection containing transactions ordered by `tx.weight`
   * @param transactionsRegistry - mapping `tx.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting transaction by its `id`
   * @param invalidatedTxIds     - invalidated transaction ids in bloom filters
-  * @param outputs              - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its output box
-  * @param inputs               - mapping `box.id` -> `WeightedTxId(tx.id,tx.weight)` required for getting a transaction by its input box id
+  * @param outputs              - mapping `box.id` -> producing `tx.id`; current weight is resolved via `transactionsRegistry`
+  * @param inputs               - mapping `box.id` -> spending `tx.id`; current weight is resolved via `transactionsRegistry`
+  * @param family               - explicit parent/child dependency graph between mempool transactions, used by `updateFamily`
   */
 class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTransaction],
                     val transactionsRegistry: TreeMap[ModifierId, WeightedTxId],
                     val invalidatedTxIds: ApproximateCacheLike[String],
-                    val outputs: TreeMap[BoxId, WeightedTxId],
-                    val inputs: TreeMap[BoxId, WeightedTxId])
+                    val outputs: TreeMap[BoxId, ModifierId],
+                    val inputs: TreeMap[BoxId, ModifierId],
+                    val family: TxFamilyGraph)
                    (implicit settings: ErgoSettings) extends ScorexLogging {
 
   import OrderedTxPool.weighted
@@ -74,17 +76,20 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
           transactionsRegistry,
           invalidatedTxIds,
           outputs,
-          inputs
+          inputs,
+          family
         )
       case None =>
         val wtx = weighted(tx, feeFactor)
+        val parentIds = tx.inputs.flatMap(in => outputs.get(in.boxId)).toSet
         new OrderedTxPool(
           orderedTransactions.updated(wtx, unconfirmedTx),
           transactionsRegistry.updated(wtx.id, wtx),
           invalidatedTxIds,
-          outputs ++ tx.outputs.map(_.id -> wtx),
-          inputs ++ tx.inputs.map(_.boxId -> wtx)
-        ).updateFamily(tx, wtx.weight, System.currentTimeMillis(), 0)
+          outputs ++ tx.outputs.map(_.id -> tx.id),
+          inputs ++ tx.inputs.map(_.boxId -> tx.id),
+          family.addTx(tx.id, parentIds)
+        ).updateFamily(tx, parentIds, wtx.weight, System.currentTimeMillis(), 0)
     }
     if (newPool.orderedTransactions.size > mempoolCapacity) {
       val victim = newPool.orderedTransactions.last._2
@@ -106,13 +111,16 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
   def remove(tx: ErgoTransaction): OrderedTxPool = {
     transactionsRegistry.get(tx.id) match {
       case Some(wtx) =>
+        // Snapshot parents from the live graph before removeTx, so updateFamily can still walk them.
+        val parentIds = family.parentsOf(tx.id)
         new OrderedTxPool(
           orderedTransactions - wtx,
           transactionsRegistry - tx.id,
           invalidatedTxIds,
           outputs -- tx.outputs.map(_.id),
-          inputs -- tx.inputs.map(_.boxId)
-        ).updateFamily(tx, -wtx.weight, System.currentTimeMillis(), depth = 0)
+          inputs -- tx.inputs.map(_.boxId),
+          family.removeTx(tx.id)
+        ).updateFamily(tx, parentIds, -wtx.weight, System.currentTimeMillis(), depth = 0)
       case None => this
     }
   }
@@ -126,25 +134,21 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
     val tx = unconfirmedTx.transaction
     transactionsRegistry.get(tx.id) match {
       case Some(wtx) =>
+        // Snapshot parents from the live graph before removeTx, so updateFamily can still walk them.
+        val parentIds = family.parentsOf(tx.id)
         new OrderedTxPool(
           orderedTransactions - wtx,
           transactionsRegistry - tx.id,
           invalidatedTxIds.put(tx.id),
           outputs -- tx.outputs.map(_.id),
-          inputs -- tx.inputs.map(_.boxId)
-        ).updateFamily(tx, -wtx.weight, System.currentTimeMillis(), depth = 0)
+          inputs -- tx.inputs.map(_.boxId),
+          family.removeTx(tx.id)
+        ).updateFamily(tx, parentIds, -wtx.weight, System.currentTimeMillis(), depth = 0)
       case None =>
-        if (orderedTransactions.valuesIterator.exists(utx => utx.id == tx.id)) {
-          new OrderedTxPool(
-            orderedTransactions.filter(_._2.id != tx.id),
-            transactionsRegistry - tx.id,
-            invalidatedTxIds.put(tx.id),
-            outputs -- tx.outputs.map(_.id),
-            inputs -- tx.inputs.map(_.boxId)
-          )
-        } else {
-          new OrderedTxPool(orderedTransactions, transactionsRegistry, invalidatedTxIds.put(tx.id), outputs, inputs)
-        }
+        // After Phase 3's RBF order fix, no natural code path desyncs `transactionsRegistry`
+        // from `orderedTransactions`. The previous fallback that scanned `orderedTransactions`
+        // for a stale entry is therefore unreachable; we just record the tx as invalidated.
+        new OrderedTxPool(orderedTransactions, transactionsRegistry, invalidatedTxIds.put(tx.id), outputs, inputs, family)
     }
   }
 
@@ -183,6 +187,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
     * @return
     */
   private def updateFamily(tx: ErgoTransaction,
+                           parentIds: Set[ModifierId],
                            weight: Long,
                            startTime: Long,
                            depth: Int): OrderedTxPool = {
@@ -193,20 +198,24 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
       this
     } else {
 
-      val uniqueTxIds: Set[WeightedTxId] = tx.inputs.flatMap(input => this.outputs.get(input.boxId)).toSet
-      val parentTxs = uniqueTxIds.flatMap(wtx => this.orderedTransactions.get(wtx).map(ut => wtx -> ut))
+      val parentWtxs: Set[WeightedTxId] =
+        parentIds.flatMap(pid => this.transactionsRegistry.get(pid))
+      val parentTxs = parentWtxs.flatMap(wtx => this.orderedTransactions.get(wtx).map(ut => wtx -> ut))
 
       parentTxs.foldLeft(this) { case (pool, (wtx, ut)) =>
         val parent = ut.transaction
         val newWtx = WeightedTxId(wtx.id, wtx.weight + weight, wtx.feePerFactor, wtx.created)
+        // Weight propagation does not add or remove graph nodes/edges, nor change which tx produced/spent a box,
+        // so `family`, `outputs` and `inputs` are threaded through unchanged. Only the weight-bearing maps rebuild.
         val newPool = new OrderedTxPool(
           pool.orderedTransactions - wtx + (newWtx -> ut),
           pool.transactionsRegistry.updated(parent.id, newWtx),
           invalidatedTxIds,
-          parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)),
-          parent.inputs.foldLeft(pool.inputs)((newInputs, inp) => newInputs.updated(inp.boxId, newWtx))
+          pool.outputs,
+          pool.inputs,
+          pool.family
         )
-        newPool.updateFamily(parent, weight, startTime, depth + 1)
+        newPool.updateFamily(parent, pool.family.parentsOf(parent.id), weight, startTime, depth + 1)
       }
     }
   }
@@ -243,8 +252,10 @@ object OrderedTxPool {
       TreeMap.empty[WeightedTxId, UnconfirmedTransaction],
       TreeMap.empty[ModifierId, WeightedTxId],
       ExpiringApproximateCache.empty(frontCacheSize, frontCacheExpiration),
-      TreeMap.empty[BoxId, WeightedTxId],
-      TreeMap.empty[BoxId, WeightedTxId])(settings)
+      TreeMap.empty[BoxId, ModifierId],
+      TreeMap.empty[BoxId, ModifierId],
+      TxFamilyGraph.empty
+    )(settings)
   }
 
   def weighted(unconfirmedTx: UnconfirmedTransaction, feeFactor: Int)(implicit ms: MonetarySettings): WeightedTxId = {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/TxFamilyGraph.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/TxFamilyGraph.scala
@@ -1,0 +1,97 @@
+package org.ergoplatform.nodeView.mempool
+
+import scorex.util.ModifierId
+
+import scala.annotation.tailrec
+
+/**
+  * Explicit parent/child dependency graph over mempool transactions.
+  *
+  * Nodes are identified by `ModifierId`. An edge `parent -> child` exists when
+  * `child` spends an output produced by `parent`. Adjacency is stored eagerly
+  * in both directions so parent lookups (used by weight propagation in
+  * [[OrderedTxPool.updateFamily]]) and child / descendant lookups (used by
+  * removal and future algorithms over the pool) are constant-time.
+  *
+  * The graph lives alongside the BoxId-keyed `outputs`/`inputs` maps in
+  * [[OrderedTxPool]]: the box maps stay authoritative for double-spend
+  * detection; this graph stays authoritative for tx-to-tx traversal.
+  *
+  * Empty adjacency sets are pruned so map keys do not accumulate on
+  * long-running nodes.
+  */
+final case class TxFamilyGraph(parents: Map[ModifierId, Set[ModifierId]],
+                               children: Map[ModifierId, Set[ModifierId]]) {
+
+  /**
+    * Register `txId` with the given direct `parentIds`. Idempotent: a repeat
+    * call overwrites prior parents and reconciles the matching `children`
+    * back-edges (former parents that are no longer parents lose the back-edge).
+    */
+  def addTx(txId: ModifierId, parentIds: Set[ModifierId]): TxFamilyGraph = {
+    val previousParents = parents.getOrElse(txId, Set.empty)
+    val stale           = previousParents -- parentIds
+    val fresh           = parentIds -- previousParents
+
+    val childrenAfterStale = stale.foldLeft(children) { (acc, p) =>
+      val updated = acc.getOrElse(p, Set.empty) - txId
+      if (updated.isEmpty) acc - p else acc.updated(p, updated)
+    }
+    val childrenAfterFresh = fresh.foldLeft(childrenAfterStale) { (acc, p) =>
+      acc.updated(p, acc.getOrElse(p, Set.empty) + txId)
+    }
+    val newParents =
+      if (parentIds.isEmpty) parents - txId
+      else parents.updated(txId, parentIds)
+
+    TxFamilyGraph(newParents, childrenAfterFresh)
+  }
+
+  /**
+    * Remove `txId` from the graph, cleaning both directions: drop the
+    * `parents(txId)` and `children(txId)` entries, and remove `txId` from the
+    * adjacency set of every former parent and former child. Empty sets are
+    * pruned. No-op if `txId` is not in the graph.
+    */
+  def removeTx(txId: ModifierId): TxFamilyGraph = {
+    val myParents  = parents.getOrElse(txId, Set.empty)
+    val myChildren = children.getOrElse(txId, Set.empty)
+
+    val parentsAfter = myChildren.foldLeft(parents - txId) { (acc, c) =>
+      val updated = acc.getOrElse(c, Set.empty) - txId
+      if (updated.isEmpty) acc - c else acc.updated(c, updated)
+    }
+    val childrenAfter = myParents.foldLeft(children - txId) { (acc, p) =>
+      val updated = acc.getOrElse(p, Set.empty) - txId
+      if (updated.isEmpty) acc - p else acc.updated(p, updated)
+    }
+    TxFamilyGraph(parentsAfter, childrenAfter)
+  }
+
+  def parentsOf(txId: ModifierId): Set[ModifierId]  = parents.getOrElse(txId, Set.empty)
+  def childrenOf(txId: ModifierId): Set[ModifierId] = children.getOrElse(txId, Set.empty)
+
+  /** Transitive ancestors of `txId` via BFS over `parents`. */
+  def ancestorsOf(txId: ModifierId): Set[ModifierId] =
+    bfs(parentsOf(txId), Set.empty, parentsOf)
+
+  /** Transitive descendants of `txId` via BFS over `children`. */
+  def descendantsOf(txId: ModifierId): Set[ModifierId] =
+    bfs(childrenOf(txId), Set.empty, childrenOf)
+
+  @tailrec
+  private def bfs(frontier: Set[ModifierId],
+                  visited: Set[ModifierId],
+                  step: ModifierId => Set[ModifierId]): Set[ModifierId] = {
+    if (frontier.isEmpty) visited
+    else {
+      val visitedNext = visited ++ frontier
+      val next        = frontier.flatMap(step) -- visitedNext
+      bfs(next, visitedNext, step)
+    }
+  }
+}
+
+object TxFamilyGraph {
+  val empty: TxFamilyGraph = TxFamilyGraph(Map.empty, Map.empty)
+}

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -526,4 +526,111 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     outcome2.isInstanceOf[ProcessingOutcome.Invalidated] shouldBe true
   }
 
+  it should "maintain TxFamilyGraph consistent with outputs map across put/invalidate" in {
+    val feeProposition = settings.chainSettings.monetary.feeProposition
+
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+    var txs = validTransactionsFromUtxoState(wus).map(tx => UnconfirmedTransaction(tx, None))
+    val family_depth = 5
+    val limitedPoolSettings = settings.copy(
+      nodeSettings = settings.nodeSettings.copy(mempoolCapacity = (family_depth + 1) * txs.size))
+    var pool = ErgoMemPool.empty(limitedPoolSettings)
+
+    def checkInvariant(): Unit = {
+      val p = pool.pool
+      val expectedParents = p.orderedTransactions.values.flatMap { utx =>
+        val pids = utx.transaction.inputs.flatMap(in => p.outputs.get(in.boxId)).toSet
+        if (pids.isEmpty) None else Some(utx.transaction.id -> pids)
+      }.toMap
+      val expectedChildren = expectedParents.toSeq
+        .flatMap { case (child, parents) => parents.map(_ -> child) }
+        .groupBy(_._1)
+        .map { case (parent, edges) => parent -> edges.map(_._2).toSet }
+      p.family.parents shouldBe expectedParents
+      p.family.children shouldBe expectedChildren
+    }
+
+    txs.foreach { tx =>
+      pool = pool.put(tx)
+      checkInvariant()
+    }
+
+    for (_ <- 1 to family_depth) {
+      txs = txs.map { tx =>
+        val spendingBox = tx.transaction.outputs.head
+        val sc = spendingBox.toCandidate
+        val out0 = new ErgoBoxCandidate(sc.value - 55000, sc.ergoTree, sc.creationHeight)
+        val out1 = new ErgoBoxCandidate(55000, feeProposition, sc.creationHeight)
+        val newTx = UnconfirmedTransaction(tx.transaction.copy(
+          inputs = IndexedSeq(new Input(spendingBox.id, emptyProverResult)),
+          outputCandidates = IndexedSeq(out0, out1)), None)
+        val (newPool, outcome) = pool.process(newTx, us)
+        outcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+        pool = newPool
+        checkInvariant()
+        newTx
+      }
+    }
+
+    while (pool.size > 0) {
+      val victim = pool.getAll.head
+      pool = pool.invalidate(victim)
+      checkInvariant()
+    }
+
+    pool.pool.family.parents shouldBe empty
+    pool.pool.family.children shouldBe empty
+  }
+
+  it should "preserve the inputs index after replace-by-fee" in {
+    // With put-then-remove ordering, the new tx's inputs entry overwrites the loser's,
+    // and the subsequent loser-remove deletes the shared box id from `inputs`,
+    // leaving the new (winning) tx with NO inputs index entry for the shared box.
+    // Downstream double-spend detection would then miss further conflicts.
+    forAll(smallPositiveInt, smallPositiveInt) { case (n1, n2) =>
+      whenever(n1 != n2 && n1 < n2) {
+        val (us, bh) = createUtxoState(settings)
+        val genesis = validFullBlock(None, us, bh)
+        val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+
+        val feeProp = settings.chainSettings.monetary.feeProposition
+        val inputBox = wus.takeBoxes(100).collectFirst {
+          case box if box.ergoTree == TrueTree => box
+        }.get
+        val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+
+        def ctx(n: Int): ContextExtension =
+          ContextExtension(Map((1: Byte) -> ByteArrayConstant(Array.fill(1 + n)(0: Byte))))
+
+        // tx2 is smaller (n1 < n2 means tx1's context is shorter, so tx2... wait,
+        // the existing test treats larger context as bigger size, so larger n => larger tx).
+        // Pick n2 > n1 so tx_small has n=n1 (smaller tx, higher fee/byte after replacement).
+        val txLargeLike = ErgoTransaction(
+          IndexedSeq(new Input(inputBox.id, new ProverResult(Array.emptyByteArray, ctx(n2)))),
+          IndexedSeq(feeOut))
+        val txSmallLike = ErgoTransaction(
+          IndexedSeq(new Input(inputBox.id, new ProverResult(Array.emptyByteArray, ctx(n1)))),
+          IndexedSeq(feeOut))
+
+        val txLarge = UnconfirmedTransaction(ErgoTransaction(txLargeLike.inputs, txLargeLike.outputCandidates), None)
+        val txSmall = UnconfirmedTransaction(ErgoTransaction(txSmallLike.inputs, txSmallLike.outputCandidates), None)
+
+        val pool0 = ErgoMemPool.empty(settings)
+        val (poolWithLarge, oLarge) = pool0.process(txLarge, us)
+        oLarge.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+
+        val (poolWithSmall, oSmall) = poolWithLarge.process(txSmall, us)
+        oSmall.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+        poolWithSmall.size shouldBe 1
+        poolWithSmall.take(1).head.transaction.id shouldBe txSmall.transaction.id
+
+        // The crux: inputs index must point to the winner (txSmall) for the shared input box.
+        // With the buggy put-then-remove order this is `None`.
+        poolWithSmall.pool.inputs.get(inputBox.id) shouldBe Some(txSmall.transaction.id)
+      }
+    }
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/TxFamilyGraphSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/TxFamilyGraphSpec.scala
@@ -1,0 +1,140 @@
+package org.ergoplatform.nodeView.mempool
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.util.ModifierId
+
+class TxFamilyGraphSpec extends AnyFlatSpec with Matchers {
+
+  private def id(s: String): ModifierId = ModifierId @@ s
+
+  private val tA = id("a")
+  private val tB = id("b")
+  private val tC = id("c")
+  private val tD = id("d")
+
+  "TxFamilyGraph.empty" should "have no parents or children" in {
+    TxFamilyGraph.empty.parents shouldBe empty
+    TxFamilyGraph.empty.children shouldBe empty
+    TxFamilyGraph.empty.parentsOf(tA) shouldBe empty
+    TxFamilyGraph.empty.childrenOf(tA) shouldBe empty
+  }
+
+  "addTx" should "register a root tx with no parents without populating either map" in {
+    val g = TxFamilyGraph.empty.addTx(tA, Set.empty)
+    g.parents shouldBe empty
+    g.children shouldBe empty
+    g.parentsOf(tA) shouldBe empty
+  }
+
+  it should "wire parent and back-edge for a single parent" in {
+    val g = TxFamilyGraph.empty.addTx(tB, Set(tA))
+    g.parentsOf(tB) shouldBe Set(tA)
+    g.childrenOf(tA) shouldBe Set(tB)
+  }
+
+  it should "wire all parents and back-edges for multiple parents (diamond)" in {
+    // tA, tB are roots; tC spends both; tD spends tC
+    val g = TxFamilyGraph.empty
+      .addTx(tC, Set(tA, tB))
+      .addTx(tD, Set(tC))
+    g.parentsOf(tC) shouldBe Set(tA, tB)
+    g.childrenOf(tA) shouldBe Set(tC)
+    g.childrenOf(tB) shouldBe Set(tC)
+    g.parentsOf(tD) shouldBe Set(tC)
+    g.childrenOf(tC) shouldBe Set(tD)
+  }
+
+  it should "be idempotent when called twice with the same parents" in {
+    val g1 = TxFamilyGraph.empty.addTx(tB, Set(tA))
+    val g2 = g1.addTx(tB, Set(tA))
+    g2 shouldBe g1
+  }
+
+  it should "reconcile back-edges when called again with a different parent set" in {
+    val g1 = TxFamilyGraph.empty.addTx(tC, Set(tA, tB))
+    val g2 = g1.addTx(tC, Set(tB)) // tA is no longer a parent of tC
+    g2.parentsOf(tC) shouldBe Set(tB)
+    g2.childrenOf(tA) shouldBe empty
+    g2.childrenOf(tB) shouldBe Set(tC)
+    g2.children.keySet should not contain tA // pruned
+  }
+
+  "removeTx" should "be a no-op for an unknown id" in {
+    val g = TxFamilyGraph.empty.addTx(tB, Set(tA))
+    g.removeTx(tD) shouldBe g
+  }
+
+  it should "remove a leaf and clean the parent's back-edge" in {
+    val g = TxFamilyGraph.empty.addTx(tB, Set(tA))
+    val g2 = g.removeTx(tB)
+    g2.parentsOf(tB) shouldBe empty
+    g2.childrenOf(tA) shouldBe empty
+    g2.parents.keySet should not contain tB
+    g2.children.keySet should not contain tA // pruned
+  }
+
+  it should "remove a middle node, dropping its parents' back-edges and trimming children's parents" in {
+    // chain tA -> tB -> tC
+    val g = TxFamilyGraph.empty
+      .addTx(tB, Set(tA))
+      .addTx(tC, Set(tB))
+    val g2 = g.removeTx(tB)
+    g2.parents.keySet should not contain tB
+    g2.children.keySet should not contain tB
+    g2.childrenOf(tA) shouldBe empty // tA -> tB edge gone
+    g2.parentsOf(tC) shouldBe empty // tB -> tC edge gone
+  }
+
+  it should "remove a root and trim parents of its direct children" in {
+    val g = TxFamilyGraph.empty
+      .addTx(tB, Set(tA))
+      .addTx(tC, Set(tA))
+    val g2 = g.removeTx(tA)
+    g2.parentsOf(tB) shouldBe empty
+    g2.parentsOf(tC) shouldBe empty
+    g2.children.keySet should not contain tA
+  }
+
+  "ancestorsOf" should "return transitive parents and skip the start id itself" in {
+    // chain tA -> tB -> tC -> tD
+    val g = TxFamilyGraph.empty
+      .addTx(tB, Set(tA))
+      .addTx(tC, Set(tB))
+      .addTx(tD, Set(tC))
+    g.ancestorsOf(tD) shouldBe Set(tA, tB, tC)
+    g.ancestorsOf(tA) shouldBe empty
+  }
+
+  it should "handle a diamond without duplicating shared ancestors" in {
+    // tA -> tB, tA -> tC, tB -> tD, tC -> tD
+    val g = TxFamilyGraph.empty
+      .addTx(tB, Set(tA))
+      .addTx(tC, Set(tA))
+      .addTx(tD, Set(tB, tC))
+    g.ancestorsOf(tD) shouldBe Set(tA, tB, tC)
+  }
+
+  "descendantsOf" should "return transitive children and skip the start id itself" in {
+    val g = TxFamilyGraph.empty
+      .addTx(tB, Set(tA))
+      .addTx(tC, Set(tB))
+      .addTx(tD, Set(tC))
+    g.descendantsOf(tA) shouldBe Set(tB, tC, tD)
+    g.descendantsOf(tD) shouldBe empty
+  }
+
+  it should "handle a diamond without duplicating shared descendants" in {
+    val g = TxFamilyGraph.empty
+      .addTx(tB, Set(tA))
+      .addTx(tC, Set(tA))
+      .addTx(tD, Set(tB, tC))
+    g.descendantsOf(tA) shouldBe Set(tB, tC, tD)
+  }
+
+  "the graph" should "stay empty after add followed by remove of the same tx" in {
+    val g = TxFamilyGraph.empty.addTx(tB, Set(tA)).removeTx(tB)
+    g.parents shouldBe empty
+    g.children shouldBe empty
+  }
+}


### PR DESCRIPTION
Closes #1051 

## Summary

Three-stage refactor of the mempool's transaction-relationship handling.

**1. Explicit `TxFamilyGraph`.** The parent/child dependency graph between mempool transactions used to be implicit — `updateFamily` rediscovered parents on every call by chasing `tx.inputs` through the `outputs: BoxId → WeightedTxId` index. It is now a first-class `Map[ModifierId, Set[ModifierId]]` (parents + children) maintained alongside `OrderedTxPool`. Weight propagation walks `family.parentsOf(tx.id)` directly; child enumeration is now O(1) instead of an O(n) scan through `inputs`.

**2. Box maps stop carrying weight.** `outputs` and `inputs` switched from `TreeMap[BoxId, WeightedTxId]` to `TreeMap[BoxId, ModifierId]`. `updateFamily` no longer rebuilds both maps for every parent at every recursion level — they're threaded through unchanged on weight propagation. For long chains that's a quadratic saving on map node allocation. The two `ErgoMemPool` consumers (`acceptIfNoDoubleSpend`, `removeTxAndDoubleSpends`) resolve the current weight via `transactionsRegistry` when needed.

**3. RBF order fix.** `acceptIfNoDoubleSpend` did `pool.put(winner).remove(losers)` — but when winner and loser shared an input box, `put` wrote `inputs[X] := winner.id` and then `remove` deleted `inputs[X]` because the loser had `X` as an input. The winner ended up in `orderedTransactions` with no entry in the `inputs` index, so any later double-spender against `X` passed the conflict check and was wrongly accepted. Swapped to `remove(losers).put(winner)`. Regression test added.

## Notes

- `TxFamilyGraph` is internal to the mempool package; not exposed on `ErgoMemPoolReader`.
- Cascading-eviction-of-descendants on RBF/overflow is out of scope — preserved master's lazy-invalidation behaviour via `CleanupWorker`.
- Removed the now-unreachable fallback scan in `OrderedTxPool.invalidate`. A similar dead scan in `ErgoMemPool.invalidate(ModifierId)` was left as a future tidy.