### PR TITLE
validate stateful tx rules when building unsigned transactions

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
@@ -67,8 +67,9 @@ trait BoxSelector extends ScorexLogging {
 
 object BoxSelector {
 
-  // from https://github.com/ergoplatform/ergo/blob/2ce78a0380977b8ca354518edca93a5269ac9f53/src/main/scala/org/ergoplatform/settings/Parameters.scala#L258-L258
-  private val MinValuePerByteDefault = 30 * 12
+  // Protocol default for the `minValuePerByte` storage-rent parameter, used by MinBoxValue below and as
+  // the fallback in TransactionBuilder's dust check when no network parameters are supplied.
+  val MinValuePerByteDefault = 30 * 12
   val MinBoxValue: Long = (MaxBoxSize.value / 2L) * MinValuePerByteDefault
 
   /**

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.wallet.transactions
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform._
 import org.ergoplatform.sdk.wallet.{AssetUtils, TokensMap}
-import org.ergoplatform.wallet.boxes.{BoxSelector, DefaultBoxSelector}
+import org.ergoplatform.wallet.boxes.{BoxSelector, DefaultBoxSelector, ErgoBoxAssetExtractor}
 import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, bytesToId}
@@ -11,6 +11,7 @@ import sigma.eval.Extensions.EvalIterableOps
 import sigmastate.utils.Extensions._
 import sigma.Coll
 import sigma.Extensions.{ArrayOps, CollBytesOps}
+import sigma.data.SigmaConstants.{MaxBoxSizeWithoutRefs, MaxPropositionBytes}
 
 import scala.collection.JavaConverters._
 import scala.util.Try
@@ -177,6 +178,81 @@ object TransactionBuilder {
     require(inputs.distinct.size == inputs.size, s"There should be no duplicate inputs")
   }
 
+  // Default value per byte used by the dust check. The wallet has no access to the network
+  // `minValuePerByte` parameter, so we use the protocol default (30 * 12), the same assumption
+  // BoxSelector.MinBoxValue (and the private BoxSelector.MinValuePerByteDefault) already makes.
+  private val MinValuePerByteDefault = 360
+
+  // Per-output checks from ErgoTransaction.validateStateful that depend only on a single output and the
+  // current height. Used both as an early fail-fast on user outputs and inside validateStatefulChecks.
+  private def validateStatefulOutputs(outputs: Seq[ErgoBoxCandidate], currentHeight: Int): Unit = {
+    require(outputs.forall(_.additionalTokens.forall(_._2 > 0)),
+      "all token amounts in outputs must be positive (txPositiveAssets)")
+    require(outputs.forall(_.creationHeight <= currentHeight),
+      s"output creationHeight must be <= currentHeight=$currentHeight (txFuture)")
+    require(outputs.forall(_.creationHeight >= 0),
+      "output creationHeight must be >= 0 (txNegHeight)")
+  }
+
+  /** Checks from `ErgoTransaction.validateStateful` that are feasible without an `ErgoStateContext`,
+    * network `Parameters` or a script interpreter. Run on the final transaction (inputs and outputs
+    * including miner's fee and change boxes), so it mirrors what a node validates.
+    *
+    * Not implemented here, as they require full node state: `txBoxesToSpend`/`txDataBoxes` (in the wallet
+    * inputs are the boxes and data inputs are not resolved), `txScriptValidation` (the tx is unsigned, so
+    * there are no proofs and no interpreter), `txReemission` (needs chain settings) and the block-cost
+    * rule (needs the cost model).
+    */
+  private def validateStatefulChecks(inputs: IndexedSeq[ErgoBox],
+                                     outputs: IndexedSeq[ErgoBoxCandidate],
+                                     currentHeight: Int): Unit = {
+    // txAssetsInOneBox: <= 255 tokens per box and per-token sums must not overflow. The per-box token
+    // count is already capped at construction (ErgoBoxCandidate stores it as an unsigned byte), so this
+    // mainly guards against a per-token sum overflowing across outputs. Checked first, as the node does.
+    require(ErgoBoxAssetExtractor.extractAssets(outputs).isSuccess,
+      s"each output must have <= ${ErgoBoxAssetExtractor.MaxAssetsPerBox} tokens and per-token sums must not overflow (txAssetsInOneBox)")
+
+    validateStatefulOutputs(outputs, currentHeight)
+
+    // txMonotonicHeight: enforced unconditionally (mainnet is past the v3 hardening that activated it).
+    val maxInputCreationHeight = inputs.map(_.creationHeight).max
+    require(outputs.forall(_.creationHeight >= maxInputCreationHeight),
+      s"output creationHeight must be >= max input creationHeight=$maxInputCreationHeight (txMonotonicHeight)")
+
+    // txDust: output value must cover its storage cost. Candidates lack the 34-byte tx reference, so we
+    // measure `bytesWithNoRef` against the default per-byte price (see MinValuePerByteDefault).
+    require(outputs.forall(out => out.value >= out.bytesWithNoRef.length.toLong * MinValuePerByteDefault),
+      s"output value is below the dust threshold of $MinValuePerByteDefault nanoErg per byte (txDust)")
+
+    // txBoxSize: candidates lack the tx reference, so compare against MaxBoxSizeWithoutRefs, not MaxBoxSize.
+    require(outputs.forall(_.bytesWithNoRef.length <= MaxBoxSizeWithoutRefs.value),
+      s"output box size must be <= ${MaxBoxSizeWithoutRefs.value} bytes (txBoxSize)")
+
+    // txBoxPropositionSize
+    require(outputs.forall(_.propositionBytes.length <= MaxPropositionBytes.value),
+      s"output proposition size must be <= ${MaxPropositionBytes.value} bytes (txBoxPropositionSize)")
+
+    // txInputsSum: input value sum must not overflow.
+    val inputSumTry = Try(inputs.map(_.value).reduce(java7.compat.Math.addExact(_, _)))
+    require(inputSumTry.isSuccess, s"sum of input values should not exceed ${Long.MaxValue} (txInputsSum)")
+
+    // txErgPreservation: no ERGs are created or destroyed.
+    val outputSumTry = Try(outputs.map(_.value).reduce(java7.compat.Math.addExact(_, _)))
+    require(inputSumTry.toOption == outputSumTry.toOption,
+      s"ERG not preserved: inputs sum ${inputSumTry.toOption}, outputs sum ${outputSumTry.toOption} (txErgPreservation)")
+
+    // txAssetsPreservation: each output token amount must not exceed the input amount, except for the
+    // single token minted by this tx (keyed by the first input's box id).
+    val firstInputBoxId = bytesToId(inputs.head.id)
+    val inTokens = collectOutputTokens(inputs)
+    val outTokens = collectOutputTokens(outputs)
+    require(
+      outTokens.forall { case (tokenId, outAmount) =>
+        inTokens.getOrElse(tokenId, 0L) >= outAmount || (tokenId == firstInputBoxId && outAmount > 0)
+      },
+      "output token amount exceeds input amount and is not the single minted token (txAssetsPreservation)")
+  }
+
   /** Creates unsigned transaction from given inputs and outputs adding outputs with miner's fee and change
     * Runs required checks ensuring that resulted transaction will be successfully validated by a node.
     *
@@ -206,7 +282,9 @@ object TransactionBuilder {
 
     validateStatelessChecks(inputs, dataInputs, outputCandidates)
 
-    // TODO: implement all appropriate checks from ErgoTransaction.validateStatefull
+    // fail fast on user outputs before doing box selection; the full set of stateful checks is run on
+    // the assembled transaction (incl. fee and change boxes) right before it is returned.
+    validateStatefulOutputs(outputCandidates, currentHeight)
 
     val feeAmount = createFeeOutput.getOrElse(0L)
     require(createFeeOutput.fold(true)(_ > 0), s"expected fee amount > 0, got $feeAmount")
@@ -266,6 +344,8 @@ object TransactionBuilder {
     }
 
     val finalOutputCandidates = outputCandidates ++ feeOutOpt ++ addedChangeOut
+
+    validateStatefulChecks(inputs, finalOutputCandidates.toIndexedSeq, currentHeight)
 
     new UnsignedErgoLikeTransaction(
       inputs.map(b => new UnsignedInput(b.id)),

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -2,16 +2,18 @@ package org.ergoplatform.wallet.transactions
 
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform._
+import org.ergoplatform.sdk.BlockchainParameters
 import org.ergoplatform.sdk.wallet.{AssetUtils, TokensMap}
 import org.ergoplatform.wallet.boxes.{BoxSelector, DefaultBoxSelector, ErgoBoxAssetExtractor}
 import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, bytesToId}
+import sigma.ast.ErgoTree
 import sigma.eval.Extensions.EvalIterableOps
 import sigmastate.utils.Extensions._
 import sigma.Coll
 import sigma.Extensions.{ArrayOps, CollBytesOps}
-import sigma.data.SigmaConstants.{MaxBoxSizeWithoutRefs, MaxPropositionBytes}
+import sigma.data.SigmaConstants.{MaxBoxSize, MaxPropositionBytes}
 
 import scala.collection.JavaConverters._
 import scala.util.Try
@@ -178,10 +180,19 @@ object TransactionBuilder {
     require(inputs.distinct.size == inputs.size, s"There should be no duplicate inputs")
   }
 
-  // Default value per byte used by the dust check. The wallet has no access to the network
-  // `minValuePerByte` parameter, so we use the protocol default (30 * 12), the same assumption
-  // BoxSelector.MinBoxValue (and the private BoxSelector.MinValuePerByteDefault) already makes.
-  private val MinValuePerByteDefault = 360
+  // Block version at which the monotonic-height rule (txMonotonicHeight) activates. Mirrors
+  // Header.HardeningVersion in the node, which lives in ergo-core and is not reachable from here.
+  private val HardeningBlockVersion: Byte = 2
+
+  // Block version assumed when no BlockchainParameters are supplied. Past the hardening version, so
+  // monotonic-height is enforced by default.
+  private val DefaultBlockVersion: Byte = 3
+
+  // Fixed-size, zero-filled stand-in for the (yet unknown) transaction id. Attaching it to an output
+  // candidate yields the same serialized length the node measures on the final box - including the
+  // 34-byte tx-id+index reference accounted for by BoxUtils.minimalErgoAmount and the box-size rule.
+  // The id value does not affect the length.
+  private val mockTxId: ModifierId = bytesToId(Array.fill(32)(0.toByte))
 
   // Per-output checks from ErgoTransaction.validateStateful that depend only on a single output and the
   // current height. Used both as an early fail-fast on user outputs and inside validateStatefulChecks.
@@ -200,12 +211,18 @@ object TransactionBuilder {
     *
     * Not implemented here, as they require full node state: `txBoxesToSpend`/`txDataBoxes` (in the wallet
     * inputs are the boxes and data inputs are not resolved), `txScriptValidation` (the tx is unsigned, so
-    * there are no proofs and no interpreter), `txReemission` (needs chain settings) and the block-cost
-    * rule (needs the cost model).
+    * there are no proofs and no interpreter), the EIP-27 `txReemission` rule (needs chain settings - note
+    * the pay-to-reemission *output* is still added by buildUnsignedTx) and the block-cost rule (needs the
+    * cost model).
+    *
+    * @param minValuePerByte - storage-rent price used by the dust rule (network parameter or default)
+    * @param blockVersion    - protocol block version, gating the monotonic-height rule
     */
   private def validateStatefulChecks(inputs: IndexedSeq[ErgoBox],
                                      outputs: IndexedSeq[ErgoBoxCandidate],
-                                     currentHeight: Int): Unit = {
+                                     currentHeight: Int,
+                                     minValuePerByte: Int,
+                                     blockVersion: Byte): Unit = {
     // txAssetsInOneBox: <= 255 tokens per box and per-token sums must not overflow. The per-box token
     // count is already capped at construction (ErgoBoxCandidate stores it as an unsigned byte), so this
     // mainly guards against a per-token sum overflowing across outputs. Checked first, as the node does.
@@ -214,29 +231,40 @@ object TransactionBuilder {
 
     validateStatefulOutputs(outputs, currentHeight)
 
-    // txMonotonicHeight: enforced unconditionally (mainnet is past the v3 hardening that activated it).
-    val maxInputCreationHeight = inputs.map(_.creationHeight).max
+    // txMonotonicHeight: activated past the hardening block version (mirrors the node). Before it, an
+    // output only needs a non-negative creation height, which validateStatefulOutputs already checks.
+    val maxInputCreationHeight = if (blockVersion <= HardeningBlockVersion) 0 else inputs.map(_.creationHeight).max
     require(outputs.forall(_.creationHeight >= maxInputCreationHeight),
       s"output creationHeight must be >= max input creationHeight=$maxInputCreationHeight (txMonotonicHeight)")
 
-    // txDust: output value must cover its storage cost. Candidates lack the 34-byte tx reference, so we
-    // measure `bytesWithNoRef` against the default per-byte price (see MinValuePerByteDefault).
-    require(outputs.forall(out => out.value >= out.bytesWithNoRef.length.toLong * MinValuePerByteDefault),
-      s"output value is below the dust threshold of $MinValuePerByteDefault nanoErg per byte (txDust)")
+    // Measure each output's full serialized size the way the node does, by attaching a fixed-size mock
+    // tx reference (candidates have none yet). Reused by both the dust and box-size rules.
+    val outputBoxSizes = outputs.zipWithIndex.map { case (out, idx) =>
+      out -> out.toBox(mockTxId, idx.toShort).bytes.length
+    }
 
-    // txBoxSize: candidates lack the tx reference, so compare against MaxBoxSizeWithoutRefs, not MaxBoxSize.
-    require(outputs.forall(_.bytesWithNoRef.length <= MaxBoxSizeWithoutRefs.value),
-      s"output box size must be <= ${MaxBoxSizeWithoutRefs.value} bytes (txBoxSize)")
+    // txDust: output value must cover its storage cost (full box size * minValuePerByte).
+    require(outputBoxSizes.forall { case (out, size) => out.value >= size.toLong * minValuePerByte },
+      s"output value is below the dust threshold of $minValuePerByte nanoErg per byte (txDust)")
 
-    // txBoxPropositionSize
+    // txBoxSize
+    require(outputBoxSizes.forall { case (_, size) => size <= MaxBoxSize.value },
+      s"output box size must be <= ${MaxBoxSize.value} bytes (txBoxSize)")
+
+    // txBoxPropositionSize. Not independently reachable through buildUnsignedTx: a proposition larger
+    // than MaxPropositionBytes also makes the whole box exceed MaxBoxSize, so txBoxSize fires first.
+    // Kept as a faithful guard mirroring the node's rule set.
     require(outputs.forall(_.propositionBytes.length <= MaxPropositionBytes.value),
       s"output proposition size must be <= ${MaxPropositionBytes.value} bytes (txBoxPropositionSize)")
 
-    // txInputsSum: input value sum must not overflow.
+    // txInputsSum: input value sum must not overflow. Defensive: the `changeAmt >= 0` check in
+    // buildUnsignedTx already rejects inputs that overflow before we get here.
     val inputSumTry = Try(inputs.map(_.value).reduce(java7.compat.Math.addExact(_, _)))
     require(inputSumTry.isSuccess, s"sum of input values should not exceed ${Long.MaxValue} (txInputsSum)")
 
-    // txErgPreservation: no ERGs are created or destroyed.
+    // txErgPreservation: no ERGs are created or destroyed. buildUnsignedTx balances inputs and outputs
+    // by construction, so this guards against a misbehaving box selector (e.g. wrong change or a dropped
+    // pay-to-reemission output).
     val outputSumTry = Try(outputs.map(_.value).reduce(java7.compat.Math.addExact(_, _)))
     require(inputSumTry.toOption == outputSumTry.toOption,
       s"ERG not preserved: inputs sum ${inputSumTry.toOption}, outputs sum ${outputSumTry.toOption} (txErgPreservation)")
@@ -265,6 +293,15 @@ object TransactionBuilder {
     * @param changeAddress    - address where to send change from the input boxes
     * @param minChangeValue   - minimum change value to send, otherwise add to miner's fee
     * @param minerRewardDelay - reward delay to encode in miner's fee box
+    * @param burnTokens       - tokens to burn (excluded from change outputs)
+    * @param boxSelector      - box selector to compute change boxes
+    * @param parameters       - optional network parameters; when given, the dust rule uses the network
+    *                           `minValuePerByte` and the monotonic-height rule follows its block version.
+    *                           When absent, the protocol default per-byte price and an enforced
+    *                           monotonic-height rule are assumed.
+    * @param payToReemissionScript - EIP-27 pay-to-reemission proposition. Required only when the box
+    *                           selector produces a pay-to-reemission output; the wallet cannot derive
+    *                           this contract itself (see ReemissionData) so it must be supplied.
     * @return unsigned transaction
     */
   def buildUnsignedTx(
@@ -277,7 +314,9 @@ object TransactionBuilder {
     minChangeValue: Long,
     minerRewardDelay: Int,
     burnTokens: TokensMap = Map.empty,
-    boxSelector: BoxSelector = new DefaultBoxSelector(None)
+    boxSelector: BoxSelector = new DefaultBoxSelector(None),
+    parameters: Option[BlockchainParameters] = None,
+    payToReemissionScript: Option[ErgoTree] = None
   ): Try[UnsignedErgoLikeTransaction] = Try {
 
     validateStatelessChecks(inputs, dataInputs, outputCandidates)
@@ -285,6 +324,9 @@ object TransactionBuilder {
     // fail fast on user outputs before doing box selection; the full set of stateful checks is run on
     // the assembled transaction (incl. fee and change boxes) right before it is returned.
     validateStatefulOutputs(outputCandidates, currentHeight)
+
+    val minValuePerByte = parameters.map(_.minValuePerByte).getOrElse(BoxSelector.MinValuePerByteDefault)
+    val blockVersion    = parameters.map(_.blockVersion).getOrElse(DefaultBlockVersion)
 
     val feeAmount = createFeeOutput.getOrElse(0L)
     require(createFeeOutput.fold(true)(_ > 0), s"expected fee amount > 0, got $feeAmount")
@@ -317,7 +359,18 @@ object TransactionBuilder {
     val changeBoxes = selection.changeBoxes
     val changeBoxesHaveTokens = changeBoxes.exists(_.tokens.nonEmpty)
 
-    val changeGoesToFee = changeAmt < minChangeValue && !changeBoxesHaveTokens
+    // EIP-27: if the selector carved out a pay-to-reemission output, send the reemitted ERGs to the
+    // (externally provided) reemission contract instead of dropping the output. The wallet cannot derive
+    // the contract itself (ReemissionData lacks it), so the script must be supplied by the caller.
+    val reemissionOutOpt = selection.payToReemissionBox.map { eip27Assets =>
+      val p2r = payToReemissionScript.getOrElse(throw new IllegalArgumentException(
+        "box selector produced an EIP-27 pay-to-reemission output but no payToReemissionScript was provided"))
+      new ErgoBoxCandidate(eip27Assets.value, p2r, currentHeight)
+    }
+
+    // small change is folded into the miner's fee, but never when a reemission output is present: the
+    // change bookkeeping below excludes the reemitted amount, so folding it would break ERG preservation.
+    val changeGoesToFee = changeAmt < minChangeValue && !changeBoxesHaveTokens && reemissionOutOpt.isEmpty
 
     require(!changeGoesToFee || (changeAmt == 0 || createFeeOutput.isDefined),
       s"""When change=$changeAmt < minChangeValue=$minChangeValue it is added to miner's fee,
@@ -343,9 +396,9 @@ object TransactionBuilder {
       Seq()
     }
 
-    val finalOutputCandidates = outputCandidates ++ feeOutOpt ++ addedChangeOut
+    val finalOutputCandidates = outputCandidates ++ feeOutOpt ++ reemissionOutOpt ++ addedChangeOut
 
-    validateStatefulChecks(inputs, finalOutputCandidates.toIndexedSeq, currentHeight)
+    validateStatefulChecks(inputs, finalOutputCandidates.toIndexedSeq, currentHeight, minValuePerByte, blockVersion)
 
     new UnsignedErgoLikeTransaction(
       inputs.map(b => new UnsignedInput(b.id)),

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
@@ -73,6 +73,24 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
     res
   }
 
+  // direct call variant allowing custom inputs/outputs and height (to exercise the stateful checks)
+  def buildTx(inputs: IndexedSeq[ErgoBox],
+              outputs: IndexedSeq[ErgoBoxCandidate],
+              height: Int = currentHeight,
+              fee: Option[Long] = Some(minBoxValue)): Try[UnsignedErgoLikeTransaction] = {
+    val changeAddress = P2PKAddress(rootSecret.privateInput.publicImage)
+    buildUnsignedTx(
+      inputs = inputs,
+      dataInputs = IndexedSeq(),
+      outputCandidates = outputs,
+      currentHeight = height,
+      createFeeOutput = fee,
+      changeAddress = changeAddress,
+      minChangeValue = minChangeValue,
+      minerRewardDelay = minerRewardDelay
+    )
+  }
+
   property("token minting") {
     val inputBox = box(minBoxValue * 2)
     val tokenId  = inputBox.id.toTokenId
@@ -125,6 +143,58 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
     assertExceptionThrown(
       res.getOrThrow,
       t => t.getMessage.contains("createFeeOutput should be defined"))
+  }
+
+  property("rejects output with creation height in the future (txFuture)") {
+    val inputBox = testBox(minBoxValue * 2, TrueTree, 5)
+    val outBox   = new ErgoBoxCandidate(minBoxValue, TrueTree, 15)
+    val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox), height = 5)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txFuture"))
+  }
+
+  property("rejects output with negative creation height (txNegHeight)") {
+    val inputBox = testBox(minBoxValue * 2, TrueTree, 0)
+    val outBox   = new ErgoBoxCandidate(minBoxValue, TrueTree, -1)
+    val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox), height = 0)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txNegHeight"))
+  }
+
+  property("rejects output below max input creation height (txMonotonicHeight)") {
+    val inputBox = testBox(minBoxValue * 2, TrueTree, 100)
+    val outBox   = new ErgoBoxCandidate(minBoxValue, TrueTree, 50)
+    val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox), height = 100)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txMonotonicHeight"))
+  }
+
+  property("accepts output at max input creation height (txMonotonicHeight)") {
+    val inputBox = testBox(minBoxValue * 2, TrueTree, 100)
+    val outBox   = new ErgoBoxCandidate(minBoxValue, TrueTree, 100)
+    val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox), height = 100)
+
+    res shouldBe a[Success[_]]
+  }
+
+  property("rejects non-positive token amount in output (txPositiveAssets)") {
+    val inputBox = testBox(minBoxValue * 2, TrueTree, currentHeight, Seq(tid1.toTokenId -> 100L))
+    val outBox   = boxCandidate(minBoxValue, Seq(tid1.toTokenId -> 0L))
+    val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox))
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txPositiveAssets"))
+  }
+
+  // Note: txAssetsInOneBox's per-box token-count limit (<= 255) is enforced by ErgoBoxCandidate
+  // construction itself (the count is an unsigned byte), so a violating output cannot be built to test
+  // here; the check in buildUnsignedTx remains as a faithful guard against cross-output sum overflow.
+
+  property("rejects dust output below the min value per byte (txDust)") {
+    val inputBox = box(1L)
+    val outBox   = boxCandidate(1L)
+    val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox), fee = None)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txDust"))
   }
 
 }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
@@ -2,15 +2,17 @@ package org.ergoplatform.wallet.transactions
 
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform._
-import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.{BlockchainParameters, SecretString}
 import org.ergoplatform.sdk.wallet.TokensMap
 import org.ergoplatform.sdk.wallet.secrets.ExtendedSecretKey
-import org.ergoplatform.wallet.boxes.BoxSelector
+import org.ergoplatform.wallet.boxes.BoxSelector.{BoxSelectionError, BoxSelectionResult}
+import org.ergoplatform.wallet.boxes.{BoxSelector, DefaultBoxSelector, ReemissionData}
 import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.ergoplatform.wallet.utils.WalletTestHelpers
 import org.scalatest.matchers.should.Matchers
-import sigma.ast.{ErgoTree, TrueLeaf}
+import sigma.ast.{ByteArrayConstant, ErgoTree, TrueLeaf}
 import sigma.ast.syntax.SigmaPropValue
+import sigma.data.SigmaConstants.MaxBoxSize
 import sigmastate.eval.Extensions._
 import sigmastate.helpers.TestingHelpers._
 import sigmastate.utils.Extensions._
@@ -77,18 +79,58 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
   def buildTx(inputs: IndexedSeq[ErgoBox],
               outputs: IndexedSeq[ErgoBoxCandidate],
               height: Int = currentHeight,
-              fee: Option[Long] = Some(minBoxValue)): Try[UnsignedErgoLikeTransaction] = {
-    val changeAddress = P2PKAddress(rootSecret.privateInput.publicImage)
+              fee: Option[Long] = Some(minBoxValue)): Try[UnsignedErgoLikeTransaction] =
+    buildTxWith(inputs, outputs, height = height, fee = fee)
+
+  // fuller variant also exposing the box selector, network parameters and reemission script
+  def buildTxWith(inputs: IndexedSeq[ErgoBox],
+                  outputs: IndexedSeq[ErgoBoxCandidate],
+                  height: Int = currentHeight,
+                  fee: Option[Long] = Some(minBoxValue),
+                  boxSelector: BoxSelector = new DefaultBoxSelector(None),
+                  parameters: Option[BlockchainParameters] = None,
+                  payToReemissionScript: Option[ErgoTree] = None): Try[UnsignedErgoLikeTransaction] =
     buildUnsignedTx(
       inputs = inputs,
       dataInputs = IndexedSeq(),
       outputCandidates = outputs,
       currentHeight = height,
       createFeeOutput = fee,
-      changeAddress = changeAddress,
+      changeAddress = P2PKAddress(rootSecret.privateInput.publicImage),
       minChangeValue = minChangeValue,
-      minerRewardDelay = minerRewardDelay
+      minerRewardDelay = minerRewardDelay,
+      boxSelector = boxSelector,
+      parameters = parameters,
+      payToReemissionScript = payToReemissionScript
     )
+
+  // minimal BlockchainParameters with overridable minValuePerByte / blockVersion
+  def params(minValuePerByteV: Int = BoxSelector.MinValuePerByteDefault,
+             blockVersionV: Byte = 3): BlockchainParameters =
+    new BlockchainParameters {
+      override def storageFeeFactor: Int = 1250000
+      override def minValuePerByte: Int = minValuePerByteV
+      override def maxBlockSize: Int = 524288
+      override def tokenAccessCost: Int = 100
+      override def inputCost: Int = 2000
+      override def dataInputCost: Int = 100
+      override def outputCost: Int = 100
+      override def maxBlockCost: Int = 1000000
+      override def softForkStartingHeight: Option[Int] = None
+      override def softForkVotesCollected: Option[Int] = None
+      override def blockVersion: Byte = blockVersionV
+    }
+
+  // box selector echoing back the given inputs with caller-supplied change / reemission outputs, used to
+  // exercise the defensive checks (txErgPreservation, txAssetsPreservation) and the EIP-27 output path
+  class StubBoxSelector(changeBoxes: Seq[ErgoBoxAssets],
+                        payToReemission: Option[ErgoBoxAssets] = None) extends BoxSelector {
+    override def reemissionDataOpt: Option[ReemissionData] = None
+    override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                            filterFn: T => Boolean,
+                                            targetBalance: Long,
+                                            targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+      Right(new BoxSelectionResult[T](inputBoxes.toIndexedSeq, changeBoxes, payToReemission))
   }
 
   property("token minting") {
@@ -195,6 +237,94 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
     val res      = buildTx(IndexedSeq(inputBox), IndexedSeq(outBox), fee = None)
 
     assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txDust"))
+  }
+
+  property("rejects oversized output box (txBoxSize)") {
+    // a register larger than MaxBoxSize pushes the whole box over the limit; the value is set high
+    // enough to clear the (now larger) dust threshold so the box-size rule is the one that fires
+    val oversized = Array.fill(MaxBoxSize.value.toInt)(1.toByte)
+    val bigValue  = MaxBoxSize.value.toLong * BoxSelector.MinValuePerByteDefault * 2
+    val bigBox = new ErgoBoxCandidate(
+      bigValue, TrueTree, currentHeight,
+      Array.empty[(TokenId, Long)].toColl,
+      Map(ErgoBox.R4 -> ByteArrayConstant(oversized)))
+    val inputBox = box(bigValue * 2)
+    val res      = buildTxWith(IndexedSeq(inputBox), IndexedSeq(bigBox), fee = None)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txBoxSize"))
+  }
+
+  // Note: txBoxPropositionSize cannot be triggered independently - a proposition over MaxPropositionBytes
+  // also makes the whole box exceed MaxBoxSize, so txBoxSize fires first. Likewise txInputsSum: inputs
+  // that overflow Long are already rejected by the `changeAmt >= 0` check before the stateful pass.
+
+  property("rejects transaction where ERGs are not preserved (txErgPreservation)") {
+    val inputBox = box(minBoxValue * 2)
+    val outBox   = boxCandidate(minBoxValue)
+    // selector returns an inflated change box, so outputs sum to more than inputs
+    val selector = new StubBoxSelector(changeBoxes = Seq(ErgoBoxAssetsHolder(minBoxValue * 5)))
+    val res      = buildTxWith(IndexedSeq(inputBox), IndexedSeq(outBox), fee = None, boxSelector = selector)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txErgPreservation"))
+  }
+
+  property("rejects transaction where tokens are not preserved (txAssetsPreservation)") {
+    val inputBox = box(minBoxValue * 2, Seq(tid1.toTokenId -> 100L))
+    val outBox   = boxCandidate(minBoxValue)
+    // selector returns a change box claiming more of tid1 than the inputs hold (ERGs stay balanced)
+    val selector = new StubBoxSelector(changeBoxes = Seq(ErgoBoxAssetsHolder(minBoxValue, Map(tid1 -> 500L))))
+    val res      = buildTxWith(IndexedSeq(inputBox), IndexedSeq(outBox), fee = None, boxSelector = selector)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txAssetsPreservation"))
+  }
+
+  property("adds the EIP-27 pay-to-reemission output supplied by the selector") {
+    val inputBox         = box(minBoxValue * 3)
+    val outBox           = boxCandidate(minBoxValue)
+    val reemissionScript = ErgoTreePredef.feeProposition(minerRewardDelay) // distinct from out/change scripts
+    // selector splits the remainder: one box to reemission, one to change (ERGs stay balanced)
+    val selector = new StubBoxSelector(
+      changeBoxes     = Seq(ErgoBoxAssetsHolder(minBoxValue)),
+      payToReemission = Some(ErgoBoxAssetsHolder(minBoxValue)))
+    val res = buildTxWith(
+      IndexedSeq(inputBox), IndexedSeq(outBox), fee = None,
+      boxSelector = selector, payToReemissionScript = Some(reemissionScript))
+
+    res shouldBe a[Success[_]]
+    res.get.outputCandidates.exists(o => o.ergoTree == reemissionScript && o.value == minBoxValue) shouldBe true
+  }
+
+  property("fails when a pay-to-reemission output is needed but no script is supplied") {
+    val inputBox = box(minBoxValue * 3)
+    val outBox   = boxCandidate(minBoxValue)
+    val selector = new StubBoxSelector(
+      changeBoxes     = Seq(ErgoBoxAssetsHolder(minBoxValue)),
+      payToReemission = Some(ErgoBoxAssetsHolder(minBoxValue)))
+    val res = buildTxWith(IndexedSeq(inputBox), IndexedSeq(outBox), fee = None, boxSelector = selector)
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("payToReemissionScript"))
+  }
+
+  property("uses minValuePerByte from supplied parameters (txDust)") {
+    // a box fine at the default per-byte price becomes dust under a much higher price
+    val inputBox = box(minBoxValue * 2)
+    val outBox   = boxCandidate(minBoxValue)
+    val res = buildTxWith(
+      IndexedSeq(inputBox), IndexedSeq(outBox), fee = None,
+      parameters = Some(params(minValuePerByteV = Int.MaxValue)))
+
+    assertExceptionThrown(res.getOrThrow, t => t.getMessage.contains("txDust"))
+  }
+
+  property("relaxes monotonic-height for a pre-hardening block version (txMonotonicHeight)") {
+    // same shape as the rejecting test above, but a pre-hardening block version disables the rule
+    val inputBox = testBox(minBoxValue * 2, TrueTree, 100)
+    val outBox   = new ErgoBoxCandidate(minBoxValue, TrueTree, 50)
+    val res = buildTxWith(
+      IndexedSeq(inputBox), IndexedSeq(outBox), height = 100, fee = None,
+      parameters = Some(params(blockVersionV = 1.toByte)))
+
+    res shouldBe a[Success[_]]
   }
 
 }


### PR DESCRIPTION
Closes #1078

## What's checked

The checks run on the **final** assembled transaction (inputs + user outputs + miner's fee + change + any pay-to-reemission box), mirroring what a node validates. Cheap per-output checks also run early on the user outputs, before box selection, for a precise fail-fast error.

- `txPositiveAssets` — output token amounts are positive
- `txFuture` / `txNegHeight` / `txMonotonicHeight` — output creation heights are valid and not below the max input creation height (monotonic-height activates past the hardening block version)
- `txDust` — output value covers its storage cost, measured on the **full** serialized box size like the node
- `txBoxSize` / `txBoxPropositionSize` — output box and proposition sizes are within limits
- `txAssetsInOneBox` — per-token sums don't overflow across outputs
- `txInputsSum` / `txErgPreservation` / `txAssetsPreservation` — no overflow, no ERGs created or destroyed, and tokens are preserved (with the single-mint exception)

An optional `BlockchainParameters` can be supplied: when present, `txDust` uses the network `minValuePerByte` and `txMonotonicHeight` follows its block version; otherwise the protocol default price is used (the same assumption `BoxSelector.MinBoxValue` makes) and monotonic-height is enforced.

## Out of scope

Checks that require full node state are intentionally not ported (documented in the helper): `txScriptValidation` (the tx is unsigned — no proofs/interpreter), the `txReemission` validation rule (needs chain settings), `txBoxesToSpend`/`txDataBoxes` (inputs are the boxes; data inputs aren't resolved), and the block-cost rule (needs the cost model).

## Notes

- Outputs are `ErgoBoxCandidate`, which has no tx reference yet; size and dust attach a fixed zero-id mock reference so they measure the full box and match the node's `MaxBoxSize` / `minimalErgoAmount` exactly.
- The EIP-27 pay-to-reemission **output** is now added when the box selector produces one. The wallet can't derive the contract (`ReemissionData` doesn't carry it), so it's supplied via the optional `payToReemissionScript`.
- `txAssetsInOneBox`'s ≤255-tokens-per-box limit is already enforced at `ErgoBoxCandidate` construction (the count is an unsigned byte), so the check remains only as a guard against cross-output sum overflow. Likewise `txBoxPropositionSize` and `txInputsSum` are kept as faithful guards but can't be triggered independently through `buildUnsignedTx` (an over-large proposition also trips `txBoxSize`; overflowing inputs are rejected by the change calculation first).
