### PR TITLE
Add UTXO set statistics: collectStats, /utxo/stats endpoint, and UtxoSetStatsPrinter tool

### DIFF
--- a/avldb/src/main/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorage.scala
+++ b/avldb/src/main/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorage.scala
@@ -2,7 +2,7 @@ package scorex.crypto.authds.avltree.batch
 
 import com.google.common.primitives.Ints
 import scorex.crypto.authds.avltree.batch.Constants.{DigestType, HashFnType, hashFn}
-import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage.{topNodeHashKey, topNodeHeightKey}
+import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage.{InternalNodePrefix, LeafPrefix, noStoreSerializer, topNodeHashKey, topNodeHeightKey}
 import scorex.crypto.authds.avltree.batch.serialization.{BatchAVLProverManifest, BatchAVLProverSubtree, ProxyInternalNode}
 import scorex.crypto.authds.{ADDigest, ADKey}
 import scorex.util.encode.Base16
@@ -153,7 +153,121 @@ class VersionedLDBAVLStorage(store: LDBVersionedStore)
       rootNodeLabel
     }
   }
+
+  /**
+    * Collect statistics about the UTXO set and its backing store, see [[AvlStorageStats]].
+    *
+    * Does two passes over the database:
+    *   - a physical pass over every record in the main store ([[LDBVersionedStore.processAll]]), classifying each
+    *     record as a leaf (a box), an internal tree node, or other (metadata / index) record by its serialized
+    *     layout, and summing record and box-value sizes;
+    *   - a logical pass over the live AVL+ tree from its current root ([[LDBVersionedStore.processSnapshot]]),
+    *     yielding the exact current UTXO-set box count and total box-value size (without versioning overhead).
+    *
+    * The method reads potentially millions of records, so it is intended for occasional/diagnostic use.
+    */
+  def collectStats: Try[AvlStorageStats] = Try {
+    val keySize = StateTreeParameters.keySize
+    val labelSize = StateTreeParameters.labelSize
+    // serialized internal node: prefix + balance + key + left label + right label
+    val internalNodeSize = 1 + 1 + keySize + 2 * labelSize
+    // serialized leaf overhead (everything but the value): prefix + key + value length + nextLeafKey
+    val leafOverhead = 1 + keySize + 4 + labelSize
+    // offset of the 4-byte value length, stored right after the prefix and key
+    val valueLenOffset = 1 + keySize
+
+    var totalRecords, totalKeyBytes, totalValueBytes = 0L
+    var leafRecords, leafRecordBytes, leafValueBytes = 0L
+    var internalRecords, internalRecordBytes = 0L
+    var otherRecords, otherRecordBytes = 0L
+
+    // physical pass: classify every record in the main store
+    store.processAll { (k, v) =>
+      totalRecords += 1
+      totalKeyBytes += k.length
+      totalValueBytes += v.length
+      if (v.length == internalNodeSize && v(0) == InternalNodePrefix) {
+        internalRecords += 1
+        internalRecordBytes += v.length
+      } else if (v.length >= leafOverhead && v(0) == LeafPrefix &&
+        v.length == leafOverhead + Ints.fromBytes(
+          v(valueLenOffset), v(valueLenOffset + 1), v(valueLenOffset + 2), v(valueLenOffset + 3))) {
+        leafRecords += 1
+        leafRecordBytes += v.length
+        leafValueBytes += v.length - leafOverhead
+      } else {
+        otherRecords += 1
+        otherRecordBytes += v.length
+      }
+    }
+
+    // logical pass: traverse the live tree from its current root for the exact UTXO-set numbers
+    val (liveBoxes, liveBoxValueBytes, liveInternalNodes, treeHeight) = store.processSnapshot { dbReader =>
+      var boxes, boxValueBytes, internals = 0L
+      val height = Ints.fromByteArray(dbReader.get(topNodeHeightKey))
+
+      def loop(label: Array[Byte]): Unit = {
+        noStoreSerializer.parseBytes(dbReader.get(label)) match {
+          case in: ProxyInternalNode[DigestType] =>
+            internals += 1
+            loop(in.leftLabel)
+            loop(in.rightLabel)
+          case leaf: ProverLeaf[DigestType] =>
+            boxes += 1
+            boxValueBytes += leaf.value.length
+        }
+      }
+
+      loop(dbReader.get(topNodeHashKey))
+      (boxes, boxValueBytes, internals, height)
+    }.get
+
+    AvlStorageStats(
+      totalRecords, totalKeyBytes, totalValueBytes,
+      leafRecords, leafRecordBytes, leafValueBytes,
+      internalRecords, internalRecordBytes,
+      otherRecords, otherRecordBytes,
+      liveBoxes, liveBoxValueBytes, liveInternalNodes, treeHeight)
+  }
 }
+
+/**
+  * Aggregate statistics about the UTXO set and the database backing its authenticating AVL+ tree.
+  *
+  * The first group of fields describes the physical state store (all records currently in the main database):
+  *
+  * @param totalRecords        - total number of records in the store
+  * @param totalKeyBytes       - total size of all record keys, in bytes
+  * @param totalValueBytes     - total size of all record values, in bytes
+  * @param leafRecords         - number of records that are AVL+ tree leaves (boxes)
+  * @param leafRecordBytes     - total serialized size of leaf records, in bytes
+  * @param leafValueBytes      - total size of box payloads stored in leaves (leaf values only), in bytes
+  * @param internalRecords     - number of records that are internal AVL+ tree nodes
+  * @param internalRecordBytes - total serialized size of internal-node records, in bytes
+  * @param otherRecords        - number of remaining records (metadata / index records)
+  * @param otherRecordBytes    - total serialized size of metadata / index records, in bytes
+  *
+  * The second group describes the live UTXO set (the AVL+ tree reachable from the current root):
+  *
+  * @param liveBoxes           - exact number of boxes in the current UTXO set
+  * @param liveBoxValueBytes   - total size of box payloads in the current UTXO set, in bytes
+  * @param liveInternalNodes   - number of internal nodes in the current tree
+  * @param treeHeight          - height of the current AVL+ tree
+  */
+case class AvlStorageStats(totalRecords: Long,
+                           totalKeyBytes: Long,
+                           totalValueBytes: Long,
+                           leafRecords: Long,
+                           leafRecordBytes: Long,
+                           leafValueBytes: Long,
+                           internalRecords: Long,
+                           internalRecordBytes: Long,
+                           otherRecords: Long,
+                           otherRecordBytes: Long,
+                           liveBoxes: Long,
+                           liveBoxValueBytes: Long,
+                           liveInternalNodes: Long,
+                           treeHeight: Int)
 
 
 object VersionedLDBAVLStorage {

--- a/avldb/src/test/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorageStatsSpec.scala
+++ b/avldb/src/test/scala/scorex/crypto/authds/avltree/batch/VersionedLDBAVLStorageStatsSpec.scala
@@ -1,0 +1,57 @@
+package scorex.crypto.authds.avltree.batch
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import scorex.crypto.authds.avltree.batch.benchmark.LDBVersionedStoreBenchmark.getRandomTempDir
+import scorex.crypto.authds.{ADKey, ADValue}
+import scorex.crypto.hash.{Blake2b256, Digest32}
+import scorex.db.LDBVersionedStore
+import scorex.utils.Random
+
+class VersionedLDBAVLStorageStatsSpec extends AnyPropSpec with Matchers {
+
+  type HF = Blake2b256.type
+  implicit val hf: HF = Blake2b256
+
+  private val ValueSize = 100
+  private val InsertCount = 200
+
+  property("collectStats counts boxes and store records correctly") {
+    val stateStore = new LDBVersionedStore(getRandomTempDir, initialKeepVersions = 10)
+    val storage = new VersionedLDBAVLStorage(stateStore)
+    val prover = PersistentBatchAVLProver.create(
+      new BatchAVLProver[Digest32, HF](keyLength = 32, valueLengthOpt = None), storage).get
+
+    (0 until InsertCount).foreach { i =>
+      prover.performOneOperation(
+        Insert(ADKey @@ Random.randomBytes(), ADValue @@ Array.fill(ValueSize)(i.toByte))
+      ).get
+    }
+    prover.generateProofAndUpdateStorage()
+
+    val stats = storage.collectStats.get
+
+    // every record is classified into exactly one bucket (nothing lost or double-counted)
+    stats.totalRecords shouldBe (stats.leafRecords + stats.internalRecords + stats.otherRecords)
+    stats.totalValueBytes shouldBe
+      (stats.leafRecordBytes + stats.internalRecordBytes + stats.otherRecordBytes)
+
+    // the live tree holds the inserted boxes plus the special (infinity) sentinel leaf
+    stats.liveBoxes shouldBe (InsertCount + 1)
+
+    // physical (single committed version) and live views agree on node counts and box bytes
+    stats.leafRecords shouldBe stats.liveBoxes
+    stats.internalRecords shouldBe stats.liveInternalNodes
+    stats.leafValueBytes shouldBe stats.liveBoxValueBytes
+
+    // box payload bytes account for all inserted values (the sentinel leaf may add a little)
+    stats.liveBoxValueBytes should be >= (InsertCount.toLong * ValueSize)
+
+    // metadata records (at least the two top-node index keys) are present and not miscounted as nodes
+    stats.otherRecords should be >= 2L
+
+    stats.treeHeight should be > 0
+
+    stateStore.close()
+  }
+}

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -107,6 +107,86 @@ components:
           items:
             type: object
 
+    UtxoSetStats:
+      type: object
+      description: >-
+        Statistics about the UTXO set and the database backing its authenticating AVL+ tree.
+        Fields prefixed with totals/leaf/internal/other describe the physical state store (all
+        records in the database); fields prefixed with live describe the current UTXO set (the tree
+        reachable from the current root, without versioning overhead).
+      required:
+        - totalRecords
+        - totalKeyBytes
+        - totalValueBytes
+        - leafRecords
+        - leafRecordBytes
+        - leafValueBytes
+        - internalRecords
+        - internalRecordBytes
+        - otherRecords
+        - otherRecordBytes
+        - liveBoxes
+        - liveBoxValueBytes
+        - liveInternalNodes
+        - treeHeight
+      properties:
+        totalRecords:
+          description: Total number of records in the state store
+          type: integer
+          format: int64
+        totalKeyBytes:
+          description: Total size of all record keys, in bytes
+          type: integer
+          format: int64
+        totalValueBytes:
+          description: Total size of all record values, in bytes
+          type: integer
+          format: int64
+        leafRecords:
+          description: Number of records that are AVL+ tree leaves (boxes)
+          type: integer
+          format: int64
+        leafRecordBytes:
+          description: Total serialized size of leaf records, in bytes
+          type: integer
+          format: int64
+        leafValueBytes:
+          description: Total size of box payloads stored in leaves (leaf values only), in bytes
+          type: integer
+          format: int64
+        internalRecords:
+          description: Number of records that are internal AVL+ tree nodes
+          type: integer
+          format: int64
+        internalRecordBytes:
+          description: Total serialized size of internal-node records, in bytes
+          type: integer
+          format: int64
+        otherRecords:
+          description: Number of remaining records (metadata / index records)
+          type: integer
+          format: int64
+        otherRecordBytes:
+          description: Total serialized size of metadata / index records, in bytes
+          type: integer
+          format: int64
+        liveBoxes:
+          description: Exact number of boxes in the current UTXO set
+          type: integer
+          format: int64
+        liveBoxValueBytes:
+          description: Total size of box payloads in the current UTXO set, in bytes
+          type: integer
+          format: int64
+        liveInternalNodes:
+          description: Number of internal nodes in the current tree
+          type: integer
+          format: int64
+        treeHeight:
+          description: Height of the current AVL+ tree
+          type: integer
+          format: int32
+
     ErgoTransactionOutput:
       type: object
       required:
@@ -5459,6 +5539,37 @@ paths:
                   $ref: '#/components/schemas/ErgoTransactionOutput'
         '404':
           description: Box with this id doesn't exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /utxo/stats:
+    get:
+      summary: Get statistics about the UTXO set and its backing store
+      description: >-
+        Returns record/box counts and sizes for the UTXO set and the database backing its
+        authenticating AVL+ tree. Available on UTXO-set nodes only; nodes running in digest
+        (stateless) mode return 404. Note: this scans the whole state database and is therefore an
+        expensive, diagnostic-grade call.
+      operationId: utxoSetStats
+      tags:
+        - utxo
+      responses:
+        '200':
+          description: UTXO set statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UtxoSetStats'
+        '404':
+          description: Statistics are not available (node is not in UTXO-set mode)
           content:
             application/json:
               schema:

--- a/src/main/scala/org/ergoplatform/http/api/ApiExtraCodecs.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ApiExtraCodecs.scala
@@ -9,6 +9,7 @@ import org.ergoplatform.nodeView.history.extra.{BalanceInfo, IndexedErgoBox, Ind
 import org.ergoplatform.nodeView.state.SnapshotsInfo
 import org.ergoplatform.nodeView.state.UtxoState.ManifestId
 import org.ergoplatform.nodeView.wallet.persistence.WalletDigest
+import scorex.crypto.authds.avltree.batch.AvlStorageStats
 
 /**
   * JSON codecs related to extra indices (available via /blockchain API methods), and also few codecs for wallet
@@ -112,6 +113,25 @@ trait ApiExtraCodecs extends JsonCodecs {
     for {
       availableManifests <- Decoder.decodeMap[Int, ManifestId].tryDecode(cursor.downField("availableManifests"))
     } yield new SnapshotsInfo(availableManifests)
+  }
+
+  implicit val avlStorageStatsEncoder: Encoder[AvlStorageStats] = { s =>
+    Json.obj(
+      "totalRecords" -> s.totalRecords.asJson,
+      "totalKeyBytes" -> s.totalKeyBytes.asJson,
+      "totalValueBytes" -> s.totalValueBytes.asJson,
+      "leafRecords" -> s.leafRecords.asJson,
+      "leafRecordBytes" -> s.leafRecordBytes.asJson,
+      "leafValueBytes" -> s.leafValueBytes.asJson,
+      "internalRecords" -> s.internalRecords.asJson,
+      "internalRecordBytes" -> s.internalRecordBytes.asJson,
+      "otherRecords" -> s.otherRecords.asJson,
+      "otherRecordBytes" -> s.otherRecordBytes.asJson,
+      "liveBoxes" -> s.liveBoxes.asJson,
+      "liveBoxValueBytes" -> s.liveBoxValueBytes.asJson,
+      "liveInternalNodes" -> s.liveInternalNodes.asJson,
+      "treeHeight" -> s.treeHeight.asJson
+    )
   }
 
   implicit val indexedBlockEncoder: Encoder[IndexedBlock] = { iBlock =>

--- a/src/main/scala/org/ergoplatform/http/api/UtxoApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/UtxoApiRoute.scala
@@ -27,7 +27,7 @@ case class UtxoApiRoute(readersHolder: ActorRef, override val settings: RESTApiS
     (readersHolder ? GetReaders).mapTo[Readers].map(rs => (rs.s, rs.m))
 
   override val route: Route = pathPrefix("utxo") {
-    byId ~ serializedById ~ genesis ~ withPoolById ~ withPoolByIds ~ withPoolSerializedById ~ getBoxesBinaryProof ~ getSnapshotsInfo
+    byId ~ serializedById ~ genesis ~ withPoolById ~ withPoolByIds ~ withPoolSerializedById ~ getBoxesBinaryProof ~ getSnapshotsInfo ~ stats
   }
 
   def withPoolById: Route = (get & path("withPool" / "byId" / Segment)) { id =>
@@ -105,6 +105,18 @@ case class UtxoApiRoute(readersHolder: ActorRef, override val settings: RESTApiS
     ApiResponse(getState.map {
       case usr: UtxoSetSnapshotPersistence =>
         Some(usr.getSnapshotInfo())
+      case _ => None
+    })
+  }
+
+  /**
+    * Handler for /utxo/stats API call, providing statistics about the UTXO set and its backing
+    * store (record/box counts and sizes). Available on UTXO-set nodes only; returns 404 in digest mode.
+    * Note: this scans the whole state database, so it is an expensive, diagnostic-grade call.
+    */
+  def stats: Route = (get & path("stats")) {
+    ApiResponse(getState.map {
+      case usr: UtxoStateReader => usr.utxoSetStats().toOption
       case _ => None
     })
   }

--- a/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/UtxoStateReader.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.settings.Algos.HF
 import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.validation.MalformedModifierError
-import scorex.crypto.authds.avltree.batch.{Lookup, PersistentBatchAVLProver, VersionedLDBAVLStorage}
+import scorex.crypto.authds.avltree.batch.{AvlStorageStats, Lookup, PersistentBatchAVLProver, VersionedLDBAVLStorage}
 import scorex.crypto.authds.{ADDigest, ADKey, SerializedAdProof}
 import scorex.crypto.hash.Digest32
 
@@ -39,6 +39,13 @@ trait UtxoStateReader extends ErgoStateReader with UtxoSetSnapshotPersistence {
     boxes.map { box => persistentProver.performOneOperation(Lookup(ADKey @@@ box)) }
     persistentProver.prover().generateProof()
   }
+
+  /**
+    * Collect statistics about the UTXO set and the database backing its authenticating AVL+ tree
+    * (record/box counts and sizes). This scans the whole state database, so it is intended for
+    * occasional/diagnostic use.
+    */
+  def utxoSetStats(): Try[AvlStorageStats] = storage.collectStats
 
   /**
     * Validate transaction against provided state context, if specified,

--- a/src/main/scala/org/ergoplatform/tools/UtxoSetStatsPrinter.scala
+++ b/src/main/scala/org/ergoplatform/tools/UtxoSetStatsPrinter.scala
@@ -1,0 +1,67 @@
+package org.ergoplatform.tools
+
+import java.io.File
+
+import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage
+import scorex.db.LDBVersionedStore
+
+import scala.util.{Failure, Success}
+
+/**
+  * Standalone utility printing statistics about a node's UTXO set and the database backing its
+  * authenticating AVL+ tree: record/box counts and sizes for both the physical state store and the
+  * current UTXO set. Useful for economic modelling and planning storage optimizations.
+  *
+  * Run with the node stopped (LevelDB locks the state directory):
+  * {{{
+  *   sbt "runMain org.ergoplatform.tools.UtxoSetStatsPrinter <path-to-state-dir>"
+  * }}}
+  * where `<path-to-state-dir>` is the node's `state` directory (the one containing the
+  * `ldb_main` / `ldb_undo` subdirectories).
+  */
+object UtxoSetStatsPrinter extends App {
+
+  if (args.isEmpty) {
+    println("Usage: UtxoSetStatsPrinter <path-to-state-dir>")
+    sys.exit(1)
+  }
+
+  val dir = new File(args(0))
+  if (!dir.isDirectory) {
+    println(s"State directory not found: ${dir.getAbsolutePath}")
+    sys.exit(1)
+  }
+
+  def mib(bytes: Long): String = f"${bytes.toDouble / (1024 * 1024)}%.2f MiB"
+
+  val store = new LDBVersionedStore(dir, initialKeepVersions = 0)
+  try {
+    new VersionedLDBAVLStorage(store).collectStats match {
+      case Success(s) =>
+        println(s"UTXO set statistics for ${dir.getAbsolutePath}")
+        println()
+        println("Physical state store (all records in the database):")
+        println(s"  total records:        ${s.totalRecords}")
+        println(s"  total key bytes:      ${s.totalKeyBytes} (${mib(s.totalKeyBytes)})")
+        println(s"  total value bytes:    ${s.totalValueBytes} (${mib(s.totalValueBytes)})")
+        println(s"  leaf records:         ${s.leafRecords}")
+        println(s"    box value bytes:    ${s.leafValueBytes} (${mib(s.leafValueBytes)})")
+        println(s"    leaf record bytes:  ${s.leafRecordBytes} (${mib(s.leafRecordBytes)})")
+        println(s"  internal records:     ${s.internalRecords}")
+        println(s"    record bytes:       ${s.internalRecordBytes} (${mib(s.internalRecordBytes)})")
+        println(s"  other records:        ${s.otherRecords}")
+        println(s"    record bytes:       ${s.otherRecordBytes} (${mib(s.otherRecordBytes)})")
+        println()
+        println("Live UTXO set (current AVL+ tree):")
+        println(s"  boxes:                ${s.liveBoxes}")
+        println(s"  box value bytes:      ${s.liveBoxValueBytes} (${mib(s.liveBoxValueBytes)})")
+        println(s"  internal nodes:       ${s.liveInternalNodes}")
+        println(s"  tree height:          ${s.treeHeight}")
+      case Failure(t) =>
+        println(s"Failed to collect UTXO set statistics: ${t.getMessage}")
+        t.printStackTrace()
+    }
+  } finally {
+    store.close()
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoSetStatsSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoSetStatsSpec.scala
@@ -1,0 +1,40 @@
+package org.ergoplatform.nodeView.state
+
+import org.ergoplatform.utils.ErgoCorePropertyTest
+
+class UtxoSetStatsSpec extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoCoreTestConstants._
+  import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+  import org.ergoplatform.utils.generators.ValidBlocksGenerators._
+
+  property("utxoSetStats reports correct box counts and conserves store bytes") {
+    val boxCount = 64
+    val bh = boxesHolderGenOfSize(boxCount).sample.get
+    val us = createUtxoState(bh, parameters)
+
+    val stats = us.utxoSetStats().get
+
+    // live UTXO set: inserted boxes plus the special (infinity) sentinel leaf
+    stats.liveBoxes shouldBe (bh.size + 1).toLong
+    stats.liveInternalNodes should be > 0L
+    stats.treeHeight should be > 0
+
+    // physical store agrees with the live tree (single committed version, no stale nodes)
+    stats.leafRecords shouldBe stats.liveBoxes
+    stats.internalRecords shouldBe stats.liveInternalNodes
+    stats.leafValueBytes shouldBe stats.liveBoxValueBytes
+
+    // box payloads account for every inserted box (sentinel leaf may add a little)
+    val insertedBytes = bh.sortedBoxes.toSeq.map(_.bytes.length.toLong).sum
+    stats.liveBoxValueBytes should be >= insertedBytes
+
+    // classification partitions every record and conserves both counts and bytes
+    stats.totalRecords shouldBe (stats.leafRecords + stats.internalRecords + stats.otherRecords)
+    stats.totalValueBytes shouldBe
+      (stats.leafRecordBytes + stats.internalRecordBytes + stats.otherRecordBytes)
+
+    // metadata / index records (top-node keys, block-id index, state context, ...) are present
+    // and not miscounted as tree nodes
+    stats.otherRecords should be >= 2L
+  }
+}


### PR DESCRIPTION
Closes #1094 

## Summary

Adds a utility to gather statistics about the UTXO set and the LevelDB store backing itsauthenticating AVL+ tree - useful for economic modelling and planning storage optimizations.

The statistics are computed once in `avldb` and exposed two ways:

- **HTTP API** — `GET /utxo/stats` (UTXO-set nodes only; `404` in digest/stateless mode).
- **Standalone tool** — `UtxoSetStatsPrinter`, run offline with the node stopped: `sbt "runMain org.ergoplatform.tools.UtxoSetStatsPrinter <path-to-state-dir>"`

## What it reports

A new `AvlStorageStats`, computed in `VersionedLDBAVLStorage.collectStats` via two passes over the state database:

- **Physical store** — one pass over every record (`processAll`), classifying each as a leaf (box), an internal tree node, or a metadata/index record by its serialized layout, with counts and byte totals per bucket plus the grand total. (Classification uses length + prefix checks so metadata is never miscounted as a node.)
- **Live UTXO set** — a traversal of the current AVL+ tree from its root (`processSnapshot`) for the exact box count, total box-value bytes, internal-node count, and tree height — excluding versioning overhead.

The gap between the two views is what surfaces per-record and versioning overhead.

## Notes

The endpoint scans the whole state database, so it is an expensive, diagnostic-grade call; the standalone tool is preferred for routine analysis.