### PR TITLE
Collect recent rollbacks and expose them via /info/rollbacks

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2176,8 +2176,49 @@ components:
             type: string
             description: Blacklisted node address
 
+    RollbackInfo:
+      description: Information about a single chain rollback performed by the node
+        when switching to a better chain (a reorg).
+      type: object
+      required:
+        - branchPointId
+        - depth
+        - appliedBlocks
+        - timestamp
+      properties:
+        branchPointId:
+          description: Header id of the block which is last in the chain after the
+            rollback (the common branch point before applying the new chain suffix).
+          allOf:
+            - $ref: '#/components/schemas/ModifierId'
+        branchPointHeight:
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: true
+          description: Height of the branch point block. Can be 'null' if unknown.
+          example: 706158
+        depth:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Number of full blocks that were rolled back.
+          example: 2
+        appliedBlocks:
+          type: integer
+          format: int32
+          minimum: 0
+          description: Length of the new chain suffix applied after the rollback,
+            as intended at rollback time. In a rare partial-failure reorg it may
+            exceed the number of blocks actually committed.
+          example: 3
+        timestamp:
+          description: When the rollback happened.
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+
     NodeInfo:
-      description: Data container for /info API request output. 
+      description: Data container for /info API request output.
         Contains information about node's state and configuration.
         Contains data about best block, best header, state, etc.
         Best block is the block with the maximum height.
@@ -3183,6 +3224,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NodeInfo'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /info/rollbacks:
+    get:
+      summary: Get information about recent chain rollbacks (reorgs) performed by the node
+      operationId: getRecentRollbacks
+      tags:
+        - info
+      responses:
+        '200':
+          description: Most recent chain rollbacks performed by the node, newest first
+            (up to the last 20). Held in memory only, so the list is reset on node
+            restart and is empty if no rollback happened since launch.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RollbackInfo'
         default:
           description: Error
           content:

--- a/src/main/scala/org/ergoplatform/http/api/InfoApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/InfoApiRoute.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import io.circe.syntax._
 import io.circe.Json
-import org.ergoplatform.local.ErgoStatsCollector.{GetNodeInfo, NodeInfo}
+import org.ergoplatform.local.ErgoStatsCollector.{GetNodeInfo, GetRecentRollbacks, NodeInfo, RollbackInfo}
 import org.ergoplatform.settings.RESTApiSettings
 import scorex.core.api.http.ApiResponse
 
@@ -28,6 +28,9 @@ case class InfoApiRoute(statsCollector: ActorRef,
         "lastMemPoolUpdateTime" -> nodeInfo.lastMemPoolUpdateTime.asJson
       ))
     })
+    } ~
+    (path("info" / "rollbacks") & get) {
+      ApiResponse((statsCollector ? GetRecentRollbacks).mapTo[Seq[RollbackInfo]])
     } ~
     (path(".well-known" / "ai-plugin.json") & get) {
       getFromResource(".well-known/ai-plugin.json", ContentTypes.`application/json`)

--- a/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
+++ b/src/main/scala/org/ergoplatform/local/ErgoStatsCollector.scala
@@ -5,7 +5,7 @@ import io.circe.Encoder
 import io.circe.syntax._
 import org.ergoplatform.Version
 import org.ergoplatform.http.api.ApiCodecs
-import org.ergoplatform.local.ErgoStatsCollector.{GetNodeInfo, NodeInfo}
+import org.ergoplatform.local.ErgoStatsCollector.{GetNodeInfo, GetRecentRollbacks, NodeInfo, RollbackInfo}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
@@ -41,6 +41,7 @@ class ErgoStatsCollector(readersHolder: ActorRef,
     context.system.eventStream.subscribe(self, classOf[ChangedState])
     context.system.eventStream.subscribe(self, classOf[ChangedMempool])
     context.system.eventStream.subscribe(self, classOf[FullBlockApplied])
+    context.system.eventStream.subscribe(self, classOf[Rollback])
     context.system.scheduler.scheduleAtFixedRate(10.seconds, 20.seconds, networkController, GetConnectedPeers)(ec, self)
     context.system.scheduler.scheduleAtFixedRate(45.seconds, 30.seconds, networkController, GetPeersStatus)(ec, self)
   }
@@ -69,14 +70,20 @@ class ErgoStatsCollector(readersHolder: ActorRef,
     settings.scorexSettings.restApi.publicUrl,
     settings.nodeSettings.extraIndex)
 
+  // most recent chain rollbacks observed by the node, newest first, kept in memory only
+  private val MaxRecentRollbacks = 20
+  private var recentRollbacks: Seq[RollbackInfo] = Seq.empty
+
   override def receive: Receive =
     onConnectedPeers orElse
       onPeersStatus orElse
       getInfo orElse
+      getRollbacks orElse
       onMempoolChanged orElse
       onStateChanged orElse
       onHistoryChanged orElse
       onSemanticallySuccessfulModification orElse
+      onRollback orElse
       init orElse {
         case a: Any => log.warn(s"Stats collector got strange input: $a")
       }
@@ -97,6 +104,10 @@ class ErgoStatsCollector(readersHolder: ActorRef,
 
   private def getInfo: Receive = {
     case GetNodeInfo => sender() ! nodeInfo
+  }
+
+  private def getRollbacks: Receive = {
+    case GetRecentRollbacks => sender() ! recentRollbacks
   }
 
   private def onMempoolChanged: Receive = {
@@ -148,11 +159,50 @@ class ErgoStatsCollector(readersHolder: ActorRef,
         stateVersion = Some(header.encodedId))
   }
 
+  private def onRollback: Receive = {
+    case Rollback(branchPoint, branchPointHeight, depth, appliedBlocks, timestamp) =>
+      val record =
+        RollbackInfo(branchPoint, branchPointHeight, depth, appliedBlocks, timestamp)
+      recentRollbacks = (record +: recentRollbacks).take(MaxRecentRollbacks)
+      log.info(s"Recorded rollback to $branchPoint " +
+        s"(height ${branchPointHeight.getOrElse("?")}, depth $depth)")
+  }
+
 }
 
 object ErgoStatsCollector {
 
   case object GetNodeInfo
+
+  case object GetRecentRollbacks
+
+  /**
+    * Information about a single chain rollback performed by the node when switching to a better chain.
+    *
+    * @param branchPointId - header id of the block which is last in the chain after the rollback
+    *                        (the common branch point before applying the new chain suffix)
+    * @param branchPointHeight - height of the branch point block, if known
+    * @param depth - number of full blocks rolled back
+    * @param appliedBlocks - length of the new chain suffix applied after rollback
+    *                        (intended applies captured at rollback time)
+    * @param timestamp - when the rollback happened (in Java time, basically, UNIX time * 1000)
+    */
+  case class RollbackInfo(branchPointId: String,
+                          branchPointHeight: Option[Int],
+                          depth: Int,
+                          appliedBlocks: Int,
+                          timestamp: Long)
+
+  object RollbackInfo {
+    implicit val jsonEncoder: Encoder[RollbackInfo] = (ri: RollbackInfo) =>
+      Map(
+        "branchPointId" -> ri.branchPointId.asJson,
+        "branchPointHeight" -> ri.branchPointHeight.asJson,
+        "depth" -> ri.depth.asJson,
+        "appliedBlocks" -> ri.appliedBlocks.asJson,
+        "timestamp" -> ri.timestamp.asJson
+      ).asJson
+  }
 
   /**
     * Data container for /info API request output

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -52,9 +52,18 @@ object ErgoNodeViewSynchronizerMessages {
     /**
      * Event which is published when rollback happened (on finding a better chain)
      *
-     * @param branchPoint - block id which is last in the chain after rollback (before applying blocks from a fork)
+     * @param branchPoint       - block id which is last in the chain after rollback (before applying blocks from a fork)
+     * @param branchPointHeight - height of the branch point block, if known
+     * @param depth             - number of full blocks rolled back
+     * @param appliedBlocks     - length of the new chain suffix applied after rollback
+     *                            (intended applies captured at rollback time)
+     * @param timestamp         - when the rollback happened (in Java time, basically, UNIX time * 1000)
      */
-    case class Rollback(branchPoint: ModifierId) extends NodeViewHolderEvent
+    case class Rollback(branchPoint: ModifierId,
+                        branchPointHeight: Option[Int],
+                        depth: Int,
+                        appliedBlocks: Int,
+                        timestamp: Long) extends NodeViewHolderEvent
 
     case object RollbackFailed extends NodeViewHolderEvent
 

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -526,7 +526,16 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                     Some(ChainProgress(pmod, headersHeight, fullBlockHeight, System.currentTimeMillis()))
 
                   if (progressInfo.chainSwitchingNeeded) {
-                    context.system.eventStream.publish(Rollback(progressInfo.branchPoint.get))
+                    val branchPoint = progressInfo.branchPoint.get
+                    context.system.eventStream.publish(
+                      Rollback(
+                        branchPoint,
+                        history().heightOf(branchPoint),
+                        progressInfo.toRemove.length,
+                        progressInfo.toApply.length,
+                        System.currentTimeMillis()
+                      )
+                    )
                   }
                 case Failure(e) =>
                   log.warn(s"Can`t apply persistent modifier (id: ${pmod.encodedId}, contents: $pmod) to minimal state", e)

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -494,7 +494,7 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
       } else // applied block has already been indexed, skipping duplicate
         log.warn(s"Skipping block ${header.id} applied at height ${header.height}, indexed height is ${state.indexedHeight}")
 
-    case Rollback(branchPoint: ModifierId) =>
+    case Rollback(branchPoint, _, _, _, _) =>
       if (state.rollbackInProgress) {
         log.warn(s"Rollback already in progress")
         stash()

--- a/src/test/scala/org/ergoplatform/http/routes/InfoApiRoutesSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/InfoApiRoutesSpec.scala
@@ -16,11 +16,12 @@ import org.ergoplatform.local.ErgoStatsCollector.{GetNodeInfo, NodeInfo}
 import org.ergoplatform.local.ErgoStatsCollectorRef
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.history.header.Header
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.ChangedHistory
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedHistory, Rollback}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Difficulty
 import org.ergoplatform.utils.Stubs
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scorex.util.ModifierId
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -73,6 +74,36 @@ class InfoApiRoutesSpec extends AnyFlatSpec
   "difficulty" should "be encoded with non-exponential form " in {
     val res = difficultyEncoder(requiredDifficulty)
     res.toString shouldEqual requiredDifficulty.toString
+  }
+
+  it should "expose a recent rollback via /info/rollbacks" in {
+    val branchPoint =
+      ModifierId @@ "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    statsCollector ! Rollback(branchPoint, Some(706158), 2, 3, System.currentTimeMillis())
+    Get("/info/rollbacks") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val arr = responseAs[Json].asArray.get
+      arr should not be empty
+      val first = arr.head.hcursor
+      first.downField("branchPointId").as[String] shouldEqual Right(branchPoint: String)
+      first.downField("branchPointHeight").as[Int] shouldEqual Right(706158)
+      first.downField("depth").as[Int] shouldEqual Right(2)
+      first.downField("appliedBlocks").as[Int] shouldEqual Right(3)
+    }
+  }
+
+  it should "cap recent rollbacks at 20 and order them newest first" in {
+    (1 to 22).foreach { i =>
+      val id = ModifierId @@ "%064d".format(i)
+      statsCollector ! Rollback(id, Some(i), i, i, System.currentTimeMillis())
+    }
+    Get("/info/rollbacks") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val arr = responseAs[Json].asArray.get
+      arr.size shouldBe 20
+      arr.head.hcursor.downField("branchPointHeight").as[Int] shouldEqual Right(22)
+      arr.last.hcursor.downField("branchPointHeight").as[Int] shouldEqual Right(3)
+    }
   }
 
   private def initDifficulty(difficulty: Difficulty): Future[Option[Difficulty]] = {

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -166,7 +166,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
       val (addresses, templates, indexedTokens, txsIndexed, boxesIndexed) = manualIndex(n)
 
       // perform rollback
-      indexer ! Rollback(history.bestHeaderIdAtHeight(n).get)
+      indexer ! Rollback(history.bestHeaderIdAtHeight(n).get, Some(n), 0, 0, System.currentTimeMillis())
       lock.lock()
       done.await()
       state = IndexerState.fromHistory(_history)
@@ -335,7 +335,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     indexer ! Index()
     lock.lock()
     done.await()
-    indexer ! Rollback(history.bestHeaderIdAtHeight(HEIGHT).get)
+    indexer ! Rollback(history.bestHeaderIdAtHeight(HEIGHT).get, Some(HEIGHT), 0, 0, System.currentTimeMillis())
     lock.lock()
     done.await()
     val (_, _, indexedTokens, _, _) = manualIndex(HEIGHT)


### PR DESCRIPTION
Closes #1111 

## Summary

When the node resolves a fork it first rolls back state to the common branch point, then applies the better chain suffix. Until now this happened silently - operators had no way to see that a reorg occurred, how deep it was, or when.

This records each rollback and exposes the most recent ones over a new HTTP endpoint, `GET /info/rollbacks`.

## Notes

- `appliedBlocks` is the intended suffix length captured at rollback time; on a rare partial-failure reorg it may exceed the number of blocks actually committed. Documented as such in the API.
- Added `InfoApiRoutesSpec` cases (single rollback round-trips; buffer caps at 20, newest-first) and updated the `Rollback` construction sites in `ExtraIndexerSpecification`.
