### PR TITLE
Remove FullBlockProcessor.isLinkable

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -81,37 +81,45 @@ trait FullBlockProcessor extends HeadersProcessor {
   }
 
   private def processBetterChain: BlockProcessing = {
-    case ToProcess(fullBlock, newModRow, Some(newBestBlockHeader), _)
-      if bestFullBlockOpt.nonEmpty && isBetterChain(newBestBlockHeader.id) && isLinkable(fullBlock.header) =>
+    case params @ ToProcess(fullBlock, newModRow, Some(newBestBlockHeader), _)
+      if bestFullBlockOpt.nonEmpty && isBetterChain(newBestBlockHeader.id) =>
 
       val prevBest = bestFullBlockOpt.get
 
       //find chains starting from the forking point
       val (prevChain, newChain) = commonBlockThenSuffixes(prevBest.header, newBestBlockHeader)
-      val toRemove: Seq[ErgoFullBlock] = prevChain.tail.headers.flatMap(getFullBlock)
       val toApply: Seq[ErgoFullBlock] = newChain.tail.headers
         .flatMap(h => if (h == fullBlock.header) Some(fullBlock) else getFullBlock(h))
-        .ensuring(_.lengthCompare(newChain.length - 1) == 0)
 
-      // application of this block leads to full chain with higher score
-      logStatus(toRemove, toApply, fullBlock, Some(prevBest))
-      val branchPoint = toRemove.headOption.map(_ => prevChain.head.id)
+      if (toApply.lengthCompare(newChain.length - 1) != 0) {
+        // The header chain has a higher score, but its full chain is not complete yet: some
+        // full blocks between the fork point and the new tip are still missing (block sections
+        // may arrive out of order). Keep the block as non-best for now; a later `processFullBlock`
+        // that fills the gap will re-evaluate the fork and switch to it then.
+        nonBestBlock(params)
+      } else {
+        val toRemove: Seq[ErgoFullBlock] = prevChain.tail.headers.flatMap(getFullBlock)
 
-      // insert updated chains statuses
-      val additionalIndexes = toApply.map(b => chainStatusKey(b.id) -> FullBlockProcessor.BestChainMarker) ++
-        toRemove.map(b => chainStatusKey(b.id) -> FullBlockProcessor.NonBestChainMarker)
-      updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes).map { _ =>
-        // remove block ids which have no chance to be applied
-        val minForkRootHeight = toApply.last.height - nodeSettings.keepVersions
-        if (nonBestChainsCache.nonEmpty) nonBestChainsCache = nonBestChainsCache.dropUntil(minForkRootHeight)
+        // application of this block leads to full chain with higher score
+        logStatus(toRemove, toApply, fullBlock, Some(prevBest))
+        val branchPoint = toRemove.headOption.map(_ => prevChain.head.id)
 
-        if (nodeSettings.isFullBlocksPruned) {
-          val lastKept = updateBestFullBlock(fullBlock.header)
-          val bestHeight: Int = newBestBlockHeader.height
-          val diff = bestHeight - prevBest.header.height
-          pruneBlockDataAt(((lastKept - diff) until lastKept).filter(_ >= 0))
+        // insert updated chains statuses
+        val additionalIndexes = toApply.map(b => chainStatusKey(b.id) -> FullBlockProcessor.BestChainMarker) ++
+          toRemove.map(b => chainStatusKey(b.id) -> FullBlockProcessor.NonBestChainMarker)
+        updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes).map { _ =>
+          // remove block ids which have no chance to be applied
+          val minForkRootHeight = toApply.last.height - nodeSettings.keepVersions
+          if (nonBestChainsCache.nonEmpty) nonBestChainsCache = nonBestChainsCache.dropUntil(minForkRootHeight)
+
+          if (nodeSettings.isFullBlocksPruned) {
+            val lastKept = updateBestFullBlock(fullBlock.header)
+            val bestHeight: Int = newBestBlockHeader.height
+            val diff = bestHeight - prevBest.header.height
+            pruneBlockDataAt(((lastKept - diff) until lastKept).filter(_ >= 0))
+          }
+          ProgressInfo(branchPoint, toRemove, toApply, Seq.empty)
         }
-        ProgressInfo(branchPoint, toRemove, toApply, Seq.empty)
       }
   }
 
@@ -138,36 +146,6 @@ trait FullBlockProcessor extends HeadersProcessor {
       historyStorage.insert(Array.empty[(ByteArrayWrapper, Array[Byte])], Array(params.newModRow)).map { _ =>
         ProgressInfo(None, Seq.empty, Seq.empty, Seq.empty)
       }
-  }
-
-  /**
-    * @return `true` if a given `header` is linkable to some existing full chain or
-    *         contains original genesis block, `false` otherwise
-    */
-  private def isLinkable(header: Header): Boolean = {
-    // todo check loop for possible inefficient chains (e.g. limit the loop depth)
-    @tailrec
-    def loop(id: ModifierId, height: Int, acc: Seq[ModifierId]): Seq[ModifierId] = {
-      nonBestChainsCache.getParentId(id, height).orElse { // lookup block in the cache
-        typedModifierById[Header](id) // lookup block in storage in case its not presented in the cache.
-          .flatMap(h => if (!isInBestFullChain(id)) getFullBlock(h) else None)
-          .map(_.parentId)
-      } match {
-        case Some(parentId) => loop(parentId, height - 1, parentId +: acc)
-        case None => acc
-      }
-    }
-
-    if (bestFullBlockIdOpt.contains(header.parentId)) {
-      true
-    } else {
-      // follow links back until main chain or absent section is reached
-      val headOpt = loop(header.parentId, header.height - 1, Seq.empty).headOption
-      headOpt.contains(Header.GenesisParentId) ||
-        headOpt.orElse(Some(header.parentId))
-          .flatMap(id => typedModifierById[Header](id).flatMap(getFullBlock)) // check whether first block actually exists
-          .isDefined
-    }
   }
 
   /**

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -5,6 +5,7 @@ import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.HeaderChain
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
+import org.ergoplatform.nodeView.history.storage.modifierprocessors.FullBlockProcessor
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.nodeView.ErgoModifiersCache
 import org.ergoplatform.nodeView.state.StateType
@@ -194,6 +195,40 @@ class VerifyADHistorySpecification extends ErgoCorePropertyTest with NoShrink {
     history = applyBlock(history, block3)
 
     history.bestFullBlockOpt shouldBe Some(block3)
+  }
+
+  property("better fork with a missing full block is parked, then applied once the gap is filled") {
+    var history = genHistory()._1
+
+    // main full chain: genesis, m1, m2
+    val mainChain = genChain(3)
+    history = applyChain(history, mainChain)
+    val m1 = mainChain(1)
+    val m2 = mainChain(2)
+    history.bestFullBlockOpt.value.header shouldBe m2.header
+
+    // a longer fork branching off m1; apply its headers only for now
+    val fork = genChain(3, m1).tail // fa (height 3), fb (height 4), fc (height 5)
+    val fa = fork.head
+    val fb = fork(1)
+    val fc = fork(2)
+    applyHeaderChain(history, HeaderChain(fork.map(_.header)))
+    history.bestHeaderOpt.value shouldBe fc.header
+
+    // complete every fork block but the first one (fa): a backward gap remains
+    history = applyChain(history, Seq(fb, fc))
+
+    // the fork has a higher header score, but it is not fully downloaded yet, so the node must
+    // keep its current best block rather than reorg onto (or crash on) the incomplete chain
+    history.bestFullBlockOpt.value.header shouldBe m2.header
+    history.asInstanceOf[FullBlockProcessor].isInBestFullChain(fc.id) shouldBe false
+
+    // filling the gap lets the deeper fork win and rolls the previous best chain back
+    history = applyChain(history, Seq(fa))
+    history.bestFullBlockOpt.value.header shouldBe fc.header
+    val fbp = history.asInstanceOf[FullBlockProcessor]
+    fbp.isInBestFullChain(fc.id) shouldBe true
+    fbp.isInBestFullChain(m2.id) shouldBe false
   }
 
   property("bootstrap from headers and last full blocks") {


### PR DESCRIPTION
## Summary

`FullBlockProcessor.isLinkable` was a convoluted standalone method that walked a block's parent links backward through the cache and storage to decide whether a higher-scoring fork was fully backed by full blocks before committing to a reorg. It guarded `processBetterChain` and, separately, the reorg body asserted the same property via `.ensuring(toApply.length == newChain.length - 1)` — so the same condition was computed twice, once in an opaque helper and once as an assertion.

This removes the helper and consolidates the check into a single inline comparison in `processBetterChain`: build `toApply`, and if it doesn't cover the whole `newChain.tail`, fall through to `nonBestBlock` (park the block in `nonBestChainsCache` until the missing sections arrive and a later `processFullBlock` re-evaluates the fork). This is the structure that existed before the 2019 "Deeper modifiers application optimization" commit that introduced `isLinkable`.

## Why the check itself must stay

A fork can outscore the current best chain by *header* score while the full blocks between the fork point and the arriving block are still missing — block sections are applied as soon as a block's own sections are present, with no requirement that the parent full block exists, so out-of-order completion across a fork is normal (this is exactly why `nonBestChainsCache` / `continuationChains` exist). `calculateBestChain` only verifies full-block availability *forward* of the arriving block, not the segment *backward* to the fork point, so that gap has to be checked before reorging.

This was verified empirically: simulating a pure deletion (drop the guard, keep the `ensuring`) makes the new gap test throw `AssertionError` on block append. The consolidated length check routes that case to `nonBestBlock` instead.

Trade-off: `commonBlockThenSuffixes` is now computed even for a not-yet-complete better fork (the 2019 micro-optimization is given up). This only happens for a genuinely heavier fork with an out-of-order gap, and the work is bounded by fork depth.

Closes #1125 