### PR TITLE
Add /wallet/secret endpoint for importing custom DLog secret

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
@@ -89,6 +89,20 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
   }
 
   /**
+    * Produces updated instance of ErgoProvingInterpreter with a new primitive (non-hierarchical) secret included.
+    *
+    * cachedHdPubKeysOpt is preserved unchanged: a primitive secret is not an ExtendedSecretKey, so it is not
+    * collected into hdKeys and the cached public keys still correspond one-to-one to the hierarchical secrets.
+    *
+    * @param secret - new primitive secret to add
+    * @return modified prover
+    */
+  def withNewSecret(secret: SecretKey): ErgoProvingInterpreter = {
+    val sks = secretKeys :+ secret
+    new ErgoProvingInterpreter(sks, params, cachedHdPubKeysOpt)
+  }
+
+  /**
     * Produces updated instance of ErgoProvingInterpreter with updated parameters
     * @param newParams - updated parameters
     * @return modified prover

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -564,6 +564,15 @@ components:
       type: string
       example: '433080ff80d0d52d7f8bfffff47f00807f44f680000949b800007f7f7ff1017f'
 
+    AddSecretRequest:
+      description: A request to add a custom DLog secret to the wallet
+      type: object
+      required:
+        - secret
+      properties:
+        secret:
+          $ref: '#/components/schemas/DlogSecret'
+
     DhtSecret:
       description: Hex-encoded big-endian 256-bits secret exponent "w" along with generators "g", "h", and group
         elements "u", "v", such as g^w = u, h^w = v
@@ -5084,6 +5093,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /wallet/secret:
+    post:
+      security:
+        - ApiKeyAuth: [api_key]
+      summary: Add a custom DLog secret to the wallet so it can sign for the corresponding address
+      description: |
+        Adds an externally provided DLog secret (a big-endian 256-bit secret exponent) to the wallet so that
+        subsequent signing operations (e.g. /wallet/transaction/sign) can sign for the corresponding address
+        without re-supplying the secret. The wallet must be unlocked. The secret is kept in memory only and is
+        lost when the wallet is locked or the node restarts. The address is not tracked for balances.
+        This endpoint is disabled unless ergo.wallet.allowCustomSecrets is set to true in the node config.
+      operationId: walletAddSecret
+      tags:
+        - wallet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddSecretRequest'
+      responses:
+        '200':
+          description: Address corresponding to the added secret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeriveKeyResult'
         default:
           description: Error
           content:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -331,6 +331,12 @@ ergo {
     # e.g. doing transfers correctly in the presence of re-emission tokens
     checkEIP27 = false
 
+    # Allow adding arbitrary custom DLog secrets to the wallet via POST /wallet/secret.
+    # Security-sensitive: anyone with API access could make the node sign for keys they control.
+    # The added secrets are kept in memory only and are lost on wallet lock or node restart.
+    # Disabled by default.
+    allowCustomSecrets = false
+
     # Wallet profile allows to say wallet what kind of load it should expect,
     # and so spend memory on caches and Bloom filters accordingly.
     # There are three options: user, exchange, appServer

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -24,6 +24,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import akka.http.scaladsl.server.MissingQueryParamRejection
 import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.wallet.secrets.DlogSecretKey
 
 case class WalletApiRoute(readersHolder: ActorRef,
                           nodeViewActorRef: ActorRef,
@@ -67,7 +68,8 @@ case class WalletApiRoute(readersHolder: ActorRef,
         checkSeedR ~
         rescanWalletR ~
         extractHintsR ~
-        getPrivateKeyR
+        getPrivateKeyR ~
+        addSecretR
     }
   }
 
@@ -78,6 +80,11 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   private val derivationPath: Directive1[String] = entity(as[Json]).flatMap { p =>
     p.hcursor.downField("derivationPath").as[String]
+      .fold(_ => reject, s => provide(s))
+  }
+
+  private val dlogSecret: Directive1[DlogSecretKey] = entity(as[Json]).flatMap { p =>
+    p.hcursor.downField("secret").as[DlogSecretKey]
       .fold(_ => reject, s => provide(s))
   }
 
@@ -496,6 +503,17 @@ case class WalletApiRoute(readersHolder: ActorRef,
           }
         case None => NotExists("Address not found in wallet database.")
       }
+    }
+  }
+
+  def addSecretR: Route = (path("secret") & post & dlogSecret) { secret =>
+    if (ergoSettings.walletSettings.allowCustomSecrets) {
+      withWalletOp(_.addSecret(secret)) {
+        case Success(address) => ApiResponse(Json.obj("address" -> address.toString.asJson))
+        case Failure(e) => BadRequest(e.getMessage)
+      }
+    } else {
+      BadRequest("Adding custom secrets is disabled. Set ergo.wallet.allowCustomSecrets = true to enable.")
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -407,6 +407,15 @@ class ErgoWalletActor(settings: ErgoSettings,
           sender() ! DeriveNextKeyResult(Failure(t))
       }
 
+    case AddSecret(secret) =>
+      ergoWalletService.addSecret(state, secret) match {
+        case Success((p2pkAddress, newState)) =>
+          context.become(loadedWallet(newState))
+          sender() ! Success(p2pkAddress)
+        case f@Failure(_) =>
+          sender() ! f
+      }
+
     case UpdateChangeAddress(address) =>
       state.storage.updateChangeAddress(address) match {
         case Success(_) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.wallet.models.CollectedBoxes
 import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, TransactionGenerationRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest}
-import org.ergoplatform.sdk.wallet.secrets.DerivationPath
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DlogSecretKey}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.ChainStatus
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
@@ -165,6 +165,14 @@ object ErgoWalletActorMessages {
    * @param path
    */
   final case class DeriveKey(path: String)
+
+  /**
+   * Add an externally provided primitive (DLog) secret to the running prover. The secret is held in
+   * memory only and is lost when the wallet is locked or the node restarts.
+   *
+   * @param secret - the DLog secret to add
+   */
+  final case class AddSecret(secret: DlogSecretKey)
 
   /**
    * Get boxes related to P2PK payments

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.nodeView.wallet.persistence.WalletDigest
 import org.ergoplatform.nodeView.wallet.requests.{BoxesRequest, ExternalSecret, TransactionGenerationRequest}
 import org.ergoplatform.nodeView.wallet.scanning.ScanRequest
 import org.ergoplatform.sdk.SecretString
-import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey}
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DlogSecretKey, ExtendedPublicKey}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.ChainStatus
 import org.ergoplatform.wallet.boxes.ChainStatus.{OffChain, OnChain}
@@ -62,6 +62,9 @@ trait ErgoWalletReader extends NodeViewComponent {
 
   def deriveNextKey: Future[DeriveNextKeyResult] =
     (walletActor ? DeriveNextKey).mapTo[DeriveNextKeyResult]
+
+  def addSecret(secret: DlogSecretKey): Future[Try[P2PKAddress]] =
+    (walletActor ? AddSecret(secret)).mapTo[Try[P2PKAddress]]
 
   def balances(chainStatus: ChainStatus): Future[WalletDigest] =
     (walletActor ? ReadBalances(chainStatus)).mapTo[WalletDigest]

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -12,7 +12,7 @@ import org.ergoplatform.nodeView.wallet.persistence.{WalletRegistry, WalletStora
 import org.ergoplatform.nodeView.wallet.requests.{ExternalSecret, TransactionGenerationRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest}
 import org.ergoplatform.sdk.SecretString
-import org.ergoplatform.sdk.wallet.secrets.DerivationPath
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DlogSecretKey}
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.{BoxSelector, TrackedBox}
@@ -178,6 +178,15 @@ trait ErgoWalletService {
     * @return Try of the derived key and new wallet state
     */
   def deriveNextKey(state: ErgoWalletState, usePreEip3Derivation: Boolean): Try[(DeriveNextKeyResult, ErgoWalletState)]
+
+  /**
+    * Add an externally provided primitive (DLog) secret to the in-memory prover so the wallet can sign for it.
+    * The secret is not persisted and is lost when the wallet is locked or the node restarts.
+    * @param state current wallet state
+    * @param secret the DLog secret to add
+    * @return Try of the pay-to-public-key address of the secret and new wallet state
+    */
+  def addSecret(state: ErgoWalletState, secret: DlogSecretKey): Try[(P2PKAddress, ErgoWalletState)]
 
   /**
     * Get unconfirmed transactions from mempool that are associated with given scan id
@@ -582,6 +591,17 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
         Failure(new Exception("Unable to derive key, wallet is locked"))
       case None =>
         Failure(new Exception("Unable to derive key, wallet is not initialized"))
+    }
+
+  override def addSecret(state: ErgoWalletState, secret: DlogSecretKey): Try[(P2PKAddress, ErgoWalletState)] =
+    state.walletVars.proverOpt match {
+      case Some(_) =>
+        state.walletVars.withSecret(secret).map { newWalletVars =>
+          val address = P2PKAddress(secret.privateInput.publicImage)(ergoSettings.addressEncoder)
+          address -> state.copy(walletVars = newWalletVars)
+        }
+      case None =>
+        Failure(new Exception("Unable to add secret, wallet is locked"))
     }
 
   override def scanBlockUpdate(state: ErgoWalletState, block: ErgoFullBlock, dustLimit: Option[Long]): Try[ErgoWalletState] =

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.nodeView.wallet
 import com.google.common.hash.BloomFilter
 import org.ergoplatform.nodeView.wallet.persistence.WalletStorage
 import org.ergoplatform.nodeView.wallet.scanning.Scan
-import org.ergoplatform.sdk.wallet.secrets.{ExtendedPublicKey, ExtendedSecretKey}
+import org.ergoplatform.sdk.wallet.secrets.{ExtendedPublicKey, ExtendedSecretKey, SecretKey}
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
@@ -77,6 +77,27 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
       case Some(prover) =>
         val newProver = prover.withNewExtendedSecret(secret)
         this.copy(proverOpt = Some(newProver))
+      case None =>
+        log.warn(s"Trying to add new secret, but prover is not initialized")
+        this
+    }
+  }
+
+  /**
+    * Add a new primitive (non-hierarchical) secret to the prover. The secret is held in memory only and
+    * is lost when the wallet is locked or the node restarts. Adding a secret already known to the prover
+    * is a no-op.
+    *
+    * @param secret - secret to add to existing ones
+    * @return updated WalletVars instance
+    */
+  def withSecret(secret: SecretKey): Try[WalletVars] = Try {
+    proverOpt match {
+      case Some(prover) if prover.secretKeys.exists(_.privateInput == secret.privateInput) =>
+        log.warn(s"Trying to add a secret already known to the prover, ignoring")
+        this
+      case Some(prover) =>
+        this.copy(proverOpt = Some(prover.withNewSecret(secret)))
       case None =>
         log.warn(s"Trying to add new secret, but prover is not initialized")
         this

--- a/src/main/scala/org/ergoplatform/settings/WalletSettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/WalletSettings.scala
@@ -17,6 +17,7 @@ case class WalletSettings(secretStorage: SecretStorageSettings,
                           // Some(Seq(x)) burns all except x, Some(Seq.empty) burns all, None ignores that feature
                           tokensWhitelist: Option[Seq[String]] = None,
                           checkEIP27: Boolean = false,
+                          allowCustomSecrets: Boolean = false,
                           profile: String = WalletProfile.User.label) {
 
   val walletProfile: WalletProfile = WalletProfile.fromLabel(profile)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -186,6 +186,9 @@ ergo {
 
     # Number of keys to be generated for tests
     testKeysQty = 5
+
+    # Allow adding custom DLog secrets to the wallet via POST /wallet/secret (enabled for tests)
+    allowCustomSecrets = true
   }
 
 }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -46,6 +46,11 @@ class WalletApiRouteSpec extends AnyFlatSpec
 
   val utxoRoute: Route = WalletApiRoute(utxoReadersRef, nodeViewRef, settings).route
 
+  private val customSecretsDisabledSettings =
+    settings.copy(walletSettings = settings.walletSettings.copy(allowCustomSecrets = false))
+  val customSecretsDisabledRoute: Route =
+    WalletApiRoute(digestReadersRef, nodeViewRef, customSecretsDisabledSettings).route
+
   implicit val paymentRequestEncoder: PaymentRequestEncoder = new PaymentRequestEncoder(ergoSettings)
   implicit val assetIssueRequestEncoder: AssetIssueRequestEncoder = new AssetIssueRequestEncoder(ergoSettings)
   implicit val requestsHolderEncoder: RequestsHolderEncoder = new RequestsHolderEncoder(ergoSettings)
@@ -200,6 +205,34 @@ class WalletApiRouteSpec extends AnyFlatSpec
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("derivationPath").as[String] shouldEqual Right(WalletActorStub.path.encoded)
       responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(WalletActorStub.address.toString)
+    }
+  }
+
+  it should "add a custom secret" in {
+    val secretHex = "433080ff80d0d52d7f8bfffff47f00807f44f680000949b800007f7f7ff1017f"
+    Post(prefix + "/secret", Json.obj("secret" -> secretHex.asJson)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(WalletActorStub.address.toString)
+    }
+  }
+
+  it should "reject adding a custom secret when allowCustomSecrets is disabled" in {
+    val secretHex = "433080ff80d0d52d7f8bfffff47f00807f44f680000949b800007f7f7ff1017f"
+    Post(prefix + "/secret", Json.obj("secret" -> secretHex.asJson)) ~> customSecretsDisabledRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[Json].hcursor.downField("detail").as[String].toOption.getOrElse("") should include("disabled")
+    }
+  }
+
+  it should "not add a custom secret with a missing secret field" in {
+    Post(prefix + "/secret", Json.obj("notSecret" -> "deadbeef".asJson)) ~> route ~> check {
+      handled shouldBe false
+    }
+  }
+
+  it should "not add a custom secret with a malformed secret value" in {
+    Post(prefix + "/secret", Json.obj("secret" -> "not-a-hex-secret".asJson)) ~> route ~> check {
+      handled shouldBe false
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -10,7 +10,7 @@ import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletReg
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, PaymentRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{EqualsScanningPredicate, ScanRequest, ScanWalletInteraction}
 import org.ergoplatform.sdk.SecretString
-import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedSecretKey}
+import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DlogSecretKey, ExtendedSecretKey}
 import org.ergoplatform.settings.Constants.TrueTree
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.utils.fixtures.WalletFixture
@@ -28,6 +28,7 @@ import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
 import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, SType}
+import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigmastate.helpers.TestingHelpers.testBox
 
 import scala.collection.compat.immutable.ArraySeq
@@ -87,6 +88,77 @@ class ErgoWalletServiceSpec
           walletPass = SecretString.create("y"),
           usePre1627KeyDerivation = false
         ).failed.get.getMessage shouldBe "Unable to restore wallet when pruning is enabled"
+      }
+    }
+  }
+
+  property("addSecret adds a primitive secret to the prover and returns its address") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletState = initialState(store, versionedStore)
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val secret = DlogSecretKey(DLogProverInput.random())
+
+        val before = walletState.walletVars.proverOpt.get
+        val (address, newState) = walletService.addSecret(walletState, secret).get
+        val after = newState.walletVars.proverOpt.get
+
+        address shouldBe P2PKAddress(secret.privateInput.publicImage)(settings.addressEncoder)
+        after.secretKeys.length shouldBe before.secretKeys.length + 1
+        after.secretKeys.contains(secret) shouldBe true
+        // adding a primitive secret must not affect the hierarchical keys / tracking machinery
+        after.hdKeys.length shouldBe before.hdKeys.length
+
+        // adding the same secret again is a no-op
+        val (_, sameState) = walletService.addSecret(newState, secret).get
+        sameState.walletVars.proverOpt.get.secretKeys.length shouldBe after.secretKeys.length
+      }
+    }
+  }
+
+  property("addSecret fails when the wallet is locked") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val lockedState = initialState(store, versionedStore).copy(
+          walletVars = WalletVars(None, Seq.empty, None)
+        )
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val secret = DlogSecretKey(DLogProverInput.random())
+        val result = walletService.addSecret(lockedState, secret)
+        result.isFailure shouldBe true
+        result.failed.get.getMessage shouldBe "Unable to add secret, wallet is locked"
+      }
+    }
+  }
+
+  property("a custom secret added to the wallet is cleared on lock") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletState = initialState(store, versionedStore)
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val secret = DlogSecretKey(DLogProverInput.random())
+
+        val (_, withSecret) = walletService.addSecret(walletState, secret).get
+        withSecret.walletVars.proverOpt.get.secretKeys.contains(secret) shouldBe true
+
+        val locked = walletService.lockWallet(withSecret)
+        locked.walletVars.proverOpt shouldBe None
+      }
+    }
+  }
+
+  property("addSecret deduplicates a secret matching an existing hierarchical key") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletState = initialState(store, versionedStore)
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val before = walletState.walletVars.proverOpt.get
+
+        // wrap an existing HD key's secret exponent as a primitive DLog secret
+        val existing = DlogSecretKey(before.secretKeys.head.privateInput.asInstanceOf[DLogProverInput])
+        val (_, newState) = walletService.addSecret(walletState, existing).get
+
+        newState.walletVars.proverOpt.get.secretKeys.length shouldBe before.secretKeys.length
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -6,7 +6,7 @@ import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
 import org.ergoplatform.nodeView.wallet.IdUtils._
 import org.ergoplatform.nodeView.wallet.persistence.{WalletDigest, WalletDigestSerializer}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, BurnTokensRequest, ExternalSecret, PaymentRequest}
-import org.ergoplatform.sdk.wallet.secrets.PrimitiveSecretKey
+import org.ergoplatform.sdk.wallet.secrets.{DlogSecretKey, PrimitiveSecretKey}
 import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils._
 import org.ergoplatform.utils.fixtures.WalletFixture
@@ -1122,6 +1122,37 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         val hints = hintsExtracted.addHintsForInput(0, cmts1.allHintsForInput(0))
 
         val txSigned = await(wallet.signTransaction(utx, Seq(es1), hints, Some(Seq(in)), None)).get
+        txSigned.statelessValidity().isSuccess shouldBe true
+      }
+    }
+  }
+
+  property("add custom secret, then sign for it without re-supplying the secret") {
+    withFixture { implicit w =>
+      val secret = DLogProverInput.random()
+
+      val pubKey = getPublicKeys.head.pubkey
+      val genesisBlock = makeGenesisBlock(pubKey, randomNewAsset)
+      applyBlock(genesisBlock) shouldBe 'success
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
+      eventually {
+        val confirmedBalance = getConfirmedBalances.walletBalance
+
+        val assetToSpend = assetsByTokenId(boxesAvailable(genesisBlock, pubKey)).toArray
+        assetToSpend should not be empty
+
+        // add the custom secret; the returned address is where we send the wallet balance
+        val customAddress = await(wallet.addSecret(DlogSecretKey(secret))).get
+        customAddress.pubkey shouldBe secret.publicImage
+
+        val req = PaymentRequest(customAddress, confirmedBalance, assetToSpend, Map.empty)
+        val tx = await(wallet.generateTransaction(Seq(req))).get
+        val in = tx.outputs.head
+
+        val utx = new UnsignedErgoTransaction(IndexedSeq(new UnsignedInput(in.id)), IndexedSeq.empty, IndexedSeq(in.toCandidate))
+
+        // sign with NO external secrets: only succeeds because the wallet now holds the added secret
+        val txSigned = await(wallet.signTransaction(utx, Seq.empty, TransactionHintsBag.empty, Some(Seq(in)), None)).get
         txSigned.statelessValidity().isSuccess shouldBe true
       }
     }

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -215,6 +215,8 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
 
       case DeriveKey(_) => sender() ! Success(WalletActorStub.address)
 
+      case AddSecret(_) => sender() ! Success(WalletActorStub.address)
+
       case DeriveNextKey => sender() !
         DeriveNextKeyResult(Success((WalletActorStub.path, WalletActorStub.address, WalletActorStub.secretKey)))
 


### PR DESCRIPTION
Closes #1153

## Summary

Adds `POST /wallet/secret`, letting an unlocked wallet import an arbitrary DLog (Schnorr) secret — a big-endian 256-bit secret exponent — so the node can sign for the corresponding P2PK address without supplying the secret on every signing call.

The two adjacent capabilities already existed — exporting a key via `/wallet/getPrivateKey`, and one-shot signing with a supplied secret via `/wallet/transaction/sign` — so this fills the remaining gap: holding the secret in the running wallet. Implements the feature requested in #1153.

## Behavior

- **In-memory only** — the secret is added to the running prover and cleared on wallet lock or node restart.
- **Sign-only** — the address is not tracked for balances or auto box-selection; provide inputs explicitly via `inputsRaw`, or rely on the node's UTXO set.
- **Off by default** — gated behind a new `ergo.wallet.allowCustomSecrets` flag; returns `400` when disabled.
- Requires the wallet to be unlocked (`400` otherwise). Returns the derived P2PK address. A duplicate secret (including one matching an existing HD key) is a no-op.

## Request / response

```
POST /wallet/secret
{ "secret": "433080ff80d0d52d7f8bfffff47f00807f44f680000949b800007f7f7ff1017f" }

200 OK
{ "address": "9f4QF8AD1nQ3nJahQVkMj8hFSVVzVom77b52JU7EW71Zexg6N8v" }
```

## Out of scope (deferred)

- **Persistence across restart** — would require an SDK `EncryptedSecret` format change and the wallet password at add-time, and breaks the "seed reproduces all keys" invariant.
- **Main-balance tracking** of the imported address — would need `WalletCache` changes that risk HD-derivation/mining regressions; auto-registering an external Scan is the lower-risk path if it's wanted later.
