### PR TITLE
Optimize mempool transaction collection

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -589,13 +589,21 @@ object CandidateGenerator extends ScorexLogging {
         500000
       }
 
+      val transactionsToCollect = {
+        val builder = Vector.newBuilder[ErgoTransaction]
+        builder ++= emissionTxs
+        builder ++= prioritizedTransactions
+        builder ++= poolTxs.iterator.map(_.transaction)
+        builder.result()
+      }
+
       val (txs, toEliminate) = collectTxs(
         minerPk,
         state.stateContext.currentParameters.maxBlockCost - safeGap,
         state.stateContext.currentParameters.maxBlockSize,
         state,
         upcomingContext,
-        emissionTxs ++ prioritizedTransactions ++ poolTxs.map(_.transaction)
+        transactionsToCollect
       )
 
       val eliminateTransactions = EliminateTransactions(toEliminate)
@@ -860,13 +868,13 @@ object CandidateGenerator extends ScorexLogging {
     @tailrec
     def loop(
               mempoolTxs: Iterable[ErgoTransaction],
-              acc: Seq[CostedTransaction],
+              acc: Vector[CostedTransaction],
               lastFeeTx: Option[CostedTransaction],
-              invalidTxs: Seq[ModifierId]
+              invalidTxs: Vector[ModifierId]
             ): (Seq[ErgoTransaction], Seq[ModifierId]) = {
       // transactions from mempool and fee txs from the previous step
-      val currentCosted = acc ++ lastFeeTx
-      def current: Seq[ErgoTransaction] = currentCosted.map(_._1)
+      val currentCosted = lastFeeTx.fold(acc)(acc :+ _)
+      def current: Vector[ErgoTransaction] = currentCosted.map(_._1)
 
       val stateWithTxs = us.withTransactions(current)
 
@@ -913,7 +921,7 @@ object CandidateGenerator extends ScorexLogging {
                     }
                   case None =>
                     log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
-                    val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
+                    val blockTxs: Vector[CostedTransaction] = lastFeeTx.fold(newTxs)(newTxs :+ _)
                     if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
                       loop(mempoolTxs.tail, blockTxs, lastFeeTx, invalidTxs)
                     } else {
@@ -930,7 +938,7 @@ object CandidateGenerator extends ScorexLogging {
       }
     }
 
-    val res = loop(transactions, Seq.empty, None, Seq.empty)
+    val res = loop(transactions, Vector.empty, None, Vector.empty)
     log.debug(
       s"Collected ${res._1.length} transactions for block #$currentHeight, " +
         s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -591,9 +591,10 @@ object CandidateGenerator extends ScorexLogging {
 
       val transactionsToCollect = {
         val builder = Vector.newBuilder[ErgoTransaction]
-        builder ++= emissionTxs
-        builder ++= prioritizedTransactions
-        builder ++= poolTxs.iterator.map(_.transaction)
+        builder.sizeHint(emissionTxs.size + prioritizedTransactions.size + poolTxs.size)
+        emissionTxs.foreach(tx => builder += tx)
+        prioritizedTransactions.foreach(tx => builder += tx)
+        poolTxs.foreach(tx => builder += tx.transaction)
         builder.result()
       }
 

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -77,14 +77,14 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     result.result()
   }
 
-  override def getAll: Seq[UnconfirmedTransaction] = pool.orderedTransactions.values.toSeq
+  override def getAll: Seq[UnconfirmedTransaction] = pool.orderedTransactions.valuesIterator.toVector
 
   override def getAll(ids: Seq[ModifierId]): Seq[UnconfirmedTransaction] = ids.flatMap(pool.get)
 
   /**
     * Returns all transactions resided in pool sorted by weight in descending order
     */
-  override def getAllPrioritized: Seq[UnconfirmedTransaction] = pool.orderedTransactions.values.toSeq
+  override def getAllPrioritized: Seq[UnconfirmedTransaction] = pool.orderedTransactions.valuesIterator.toVector
 
   /**
     * Method to put a transaction into the memory pool. Validation of the transactions against
@@ -299,7 +299,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     }
   }
 
-  def weightedTransactionIds(limit: Int): Seq[WeightedTxId] = pool.orderedTransactions.keysIterator.take(limit).toSeq
+  def weightedTransactionIds(limit: Int): Seq[WeightedTxId] = pool.orderedTransactions.keysIterator.take(limit).toVector
 
   private def extractFee(tx: ErgoTransaction): Long = {
     tx.outputs

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -373,6 +373,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     pool.take(11).toSeq.map(_.transaction.id) shouldBe ids
     pool.getAll.map(_.transaction.id) shouldBe ids
     pool.getAllPrioritized.map(_.transaction.id) shouldBe ids
+    pool.getAll shouldBe a [Vector[_]]
+    pool.getAllPrioritized shouldBe a [Vector[_]]
+    pool.weightedTransactionIds(11) shouldBe a [Vector[_]]
 
     val conformingTxs = pool.take(3).toSeq
     val stateWithTxs = wus.withUnconfirmedTransactions(conformingTxs)


### PR DESCRIPTION
## Summary

- Materialize ordered mempool transaction snapshots with `valuesIterator.toVector` instead of `TreeMap.values.toSeq`, avoiding lazy `Stream` results on Scala 2.12.
- Build the candidate transaction list with a `Vector` builder before block assembly.
- Use `Vector` accumulators in `collectTxs` to avoid repeated generic `Seq` appends while preserving transaction order.
- Extend the mempool ordering test to assert the public prioritized transaction snapshots are strict `Vector`s.

Closes #1551

## Validation

- `git diff --check`
- `sbt "testOnly org.ergoplatform.nodeView.mempool.ErgoMemPoolSpec"` - 19 tests passed
- `sbt "testOnly org.ergoplatform.mining.CandidateGeneratorPropSpec"` - 8 tests passed
