### PR TITLE
Add node version to block extensions

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.modifiers.history.extension
 
+import java.nio.charset.StandardCharsets
+
 import cats.syntax.either._
 import sigmastate.utils.Helpers._
 import com.google.common.primitives.Bytes
@@ -70,6 +72,25 @@ object Extension extends ApiCodecs {
     * against the genesis block are to be written into a single key space defined by the value below.
     */
   val ValidationRulesPrefix: Byte = 0x02
+
+  /**
+    * Optional metadata emitted by block producers. Validators enforce generic extension field rules only.
+    */
+  val BlockMetadataPrefix: Byte = 0x03
+
+  /**
+    * Key for the node application version that produced the block.
+    */
+  val NodeVersionKey: Array[Byte] = Array(BlockMetadataPrefix, 0x00.toByte)
+
+  def nodeVersionField(version: String): (Array[Byte], Array[Byte]) = {
+    val versionBytes = version.getBytes(StandardCharsets.UTF_8)
+    require(
+      versionBytes.lengthCompare(FieldValueMaxSize) <= 0,
+      s"Node version extension field is ${versionBytes.length} bytes, max is $FieldValueMaxSize"
+    )
+    NodeVersionKey.clone() -> versionBytes
+  }
 
   /**
     * Id a type of network object encoding extension

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.mining.AutolykosPowScheme.derivedHeaderFields
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history._
-import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionCandidate}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderWithoutPow}
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
@@ -23,7 +23,7 @@ import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateType, 
 import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
 import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input, Version}
 import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging}
@@ -529,7 +529,7 @@ object CandidateGenerator extends ScorexLogging {
       val updInterlinks       = popowAlgos.updateInterlinks(bestHeaderOpt, bestExtensionOpt)
       val interlinksExtension = popowAlgos.interlinksToExtension(updInterlinks)
       val votingSettings      = ergoSettings.chainSettings.voting
-      val (extensionCandidate, votes: Array[Byte], version: Byte) = bestHeaderOpt
+      val (baseExtensionCandidate, votes: Array[Byte], version: Byte) = bestHeaderOpt
         .map { header =>
           val newHeight     = header.height + 1
           val currentParams = stateContext.currentParameters
@@ -566,6 +566,9 @@ object CandidateGenerator extends ScorexLogging {
         .getOrElse(
           (interlinksExtension, Array(0: Byte, 0: Byte, 0: Byte), Header.InitialVersion)
         )
+      val extensionCandidate = baseExtensionCandidate ++ ExtensionCandidate(
+        Seq(Extension.nodeVersionField(Version.VersionString))
+      )
 
       val upcomingContext = state.stateContext.upcoming(
         minerPk.value,

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -1,5 +1,8 @@
 package org.ergoplatform.mining
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
@@ -7,6 +10,7 @@ import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.FullBlockApplied
@@ -18,7 +22,7 @@ import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
 import org.ergoplatform.settings.NetworkType.DevNet60
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.ErgoTestHelpers
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input, Version}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import sigma.ast.ErgoTree
@@ -55,6 +59,35 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
+
+  it should "include node version in generated block extension" in new TestKit(ActorSystem()) {
+    val testProbe = new TestProbe(system)
+    val ergoSettings: ErgoSettings = defaultSettings.copy(
+      directory = Files.createTempDirectory("ergo-node-version").toFile.getAbsolutePath
+    )
+
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(ergoSettings)
+    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+
+    val candidateGenerator: ActorRef =
+      CandidateGenerator(
+        defaultMinerSecret.publicImage,
+        readersHolderRef,
+        viewHolderRef,
+        ergoSettings
+      )
+
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+    testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        val nodeVersionFields = candidate.candidateBlock.extension.fields
+          .filter { case (key, _) => key sameElements Extension.NodeVersionKey }
+
+        nodeVersionFields should have size 1
+        nodeVersionFields.head._2.toSeq shouldBe Version.VersionString.getBytes(StandardCharsets.UTF_8).toSeq
+    }
+    system.terminate()
+  }
 
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
     ActorSystem()

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -62,6 +62,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   it should "include node version in generated block extension" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
+    // ErgoNodeViewRef initializes local state, so keep this test isolated from the default data directory.
     val ergoSettings: ErgoSettings = defaultSettings.copy(
       directory = Files.createTempDirectory("ergo-node-version").toFile.getAbsolutePath
     )


### PR DESCRIPTION
## Summary
- reserve optional extension key `0x03/0x00` for the node application version
- append `Version.VersionString` to locally generated block candidates while leaving extension validation semantics unchanged
- cover candidate generation so the produced extension contains exactly one node-version field

## Notes
The new field is included in the extension root for blocks produced by upgraded miners, but validators still treat it as a generic extension field: parameter parsing continues to read prefix `0x00`, NiPoPoW interlinks continue to read prefix `0x01`, and validation settings continue to read prefix `0x02`. Existing extension validation only enforces field size, duplicate-key, non-empty, and interlink structure rules for unknown keys.

The candidate-generator test uses an isolated data directory because `ErgoNodeViewRef` initializes local node state during the test.

## Validation
- `git diff --check`
- `sbt "testOnly org.ergoplatform.mining.CandidateGeneratorSpec -- -z node"`

Closes #962
