### PR TITLE
Reduce malformed HTTP parser log detail

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -387,6 +387,8 @@ akka {
     }
     parsing {
       max-uri-length = 8192
+      # Malformed requests fail before routes are built; keep parser error logs concise.
+      error-logging-verbosity = simple
     }
   }
 }

--- a/src/test/scala/org/ergoplatform/http/HttpParsingSettingsSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/HttpParsingSettingsSpec.scala
@@ -1,0 +1,21 @@
+package org.ergoplatform.http
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HttpParsingSettingsSpec extends AnyFlatSpec with Matchers {
+
+  "Akka HTTP parser settings" should "log malformed requests as single-line summaries" in {
+    val config = ConfigFactory.defaultApplication()
+      .withFallback(ConfigFactory.defaultReference())
+      .resolve()
+
+    val effectiveServerParsing = config
+      .getConfig("akka.http.server.parsing")
+      .withFallback(config.getConfig("akka.http.parsing"))
+      .resolve()
+
+    effectiveServerParsing.getString("error-logging-verbosity") shouldBe "simple"
+  }
+}


### PR DESCRIPTION
This is a focused alternative for #1318 that keeps the change at the Akka HTTP parsing boundary.

Closes #1318

Summary:
- set Akka HTTP parser error logging to simple so malformed pre-route requests are logged as concise single-line summaries
- add a regression test that verifies the effective server parser settings inherit the condensed parser logging mode

Validation:
- sbt "testOnly org.ergoplatform.http.HttpParsingSettingsSpec"

Requests that fail before routing do not pass through the normal route exception handlers, so this keeps the behavior at the parser settings layer.