### PR TITLE
Improve mempool transaction collection

### DIFF
--- a/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
+++ b/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
@@ -67,10 +67,10 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
     val now = System.currentTimeMillis()
 
     // Check transactions sorted by priority. Parent transaction comes before its children.
-    val allPoolTxs = mempool.getAllPrioritized
-    val txsToValidate = allPoolTxs.filter { utx =>
+    val allPoolTxs = mempool.getAllPrioritized.toVector
+    val txsToValidate = allPoolTxs.iterator.filter { utx =>
       (now - utx.lastCheckedTime) > TimeLimit
-    }.toList
+    }
 
 
     // Take into account other transactions from the pool.
@@ -79,25 +79,25 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
 
     //internal loop function validating transactions, returns validated and invalidated transaction ids
     @tailrec
-    def validationLoop(txs: Seq[UnconfirmedTransaction],
+    def validationLoop(txs: Iterator[UnconfirmedTransaction],
                        validated: mutable.ArrayBuilder[UnconfirmedTransaction],
                        invalidated: mutable.ArrayBuilder[ModifierId],
-                       costAcc: Long
+                      costAcc: Long
                       ): (mutable.ArrayBuilder[UnconfirmedTransaction], mutable.ArrayBuilder[ModifierId]) = {
-      txs match {
-        case head :: tail if costAcc < CostLimit =>
-          val validationContext = state.stateContext.simplifiedUpcoming()
-          state.validateWithCost(head.transaction, validationContext, nodeSettings.maxTransactionCost, None) match {
-            case Success(txCost) =>
-              val updTx = head.withCost(txCost)
-              validationLoop(tail, validated += updTx, invalidated, txCost + costAcc)
-            case Failure(e) =>
-              val txId = head.id
-              log.info(s"Transaction $txId invalidated: ${e.getMessage}")
-              validationLoop(tail, validated, invalidated += txId, head.lastCost.getOrElse(0) + costAcc) //add old cost
-          }
-        case _ =>
-          validated -> invalidated
+      if (costAcc < CostLimit && txs.hasNext) {
+        val head = txs.next()
+        val validationContext = state.stateContext.simplifiedUpcoming()
+        state.validateWithCost(head.transaction, validationContext, nodeSettings.maxTransactionCost, None) match {
+          case Success(txCost) =>
+            val updTx = head.withCost(txCost)
+            validationLoop(txs, validated += updTx, invalidated, txCost + costAcc)
+          case Failure(e) =>
+            val txId = head.id
+            log.info(s"Transaction $txId invalidated: ${e.getMessage}")
+            validationLoop(txs, validated, invalidated += txId, head.lastCost.getOrElse(0) + costAcc) //add old cost
+        }
+      } else {
+        validated -> invalidated
       }
     }
 

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -589,13 +589,22 @@ object CandidateGenerator extends ScorexLogging {
         500000
       }
 
+      val transactionsToCollect = {
+        val builder = Vector.newBuilder[ErgoTransaction]
+        builder.sizeHint(emissionTxs.size + prioritizedTransactions.size + poolTxs.size)
+        emissionTxs.foreach(tx => builder += tx)
+        prioritizedTransactions.foreach(tx => builder += tx)
+        poolTxs.foreach(tx => builder += tx.transaction)
+        builder.result()
+      }
+
       val (txs, toEliminate) = collectTxs(
         minerPk,
         state.stateContext.currentParameters.maxBlockCost - safeGap,
         state.stateContext.currentParameters.maxBlockSize,
         state,
         upcomingContext,
-        emissionTxs ++ prioritizedTransactions ++ poolTxs.map(_.transaction)
+        transactionsToCollect
       )
 
       val eliminateTransactions = EliminateTransactions(toEliminate)
@@ -859,24 +868,24 @@ object CandidateGenerator extends ScorexLogging {
 
     @tailrec
     def loop(
-              mempoolTxs: Iterable[ErgoTransaction],
-              acc: Seq[CostedTransaction],
+              mempoolTxs: Iterator[ErgoTransaction],
+              acc: Vector[CostedTransaction],
               lastFeeTx: Option[CostedTransaction],
-              invalidTxs: Seq[ModifierId]
+              invalidTxs: Vector[ModifierId]
             ): (Seq[ErgoTransaction], Seq[ModifierId]) = {
       // transactions from mempool and fee txs from the previous step
-      val currentCosted = acc ++ lastFeeTx
-      def current: Seq[ErgoTransaction] = currentCosted.map(_._1)
+      val currentCosted = lastFeeTx.fold(acc)(acc :+ _)
+      def current: Vector[ErgoTransaction] = currentCosted.map(_._1)
 
       val stateWithTxs = us.withTransactions(current)
 
-      mempoolTxs.headOption match {
-        case Some(tx) =>
+      if (mempoolTxs.hasNext) {
+        val tx = mempoolTxs.next()
           if (!inputsNotSpent(tx, stateWithTxs) || doublespend(current, tx)) {
             //mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
             //do these checks before validating the scripts to save time
             log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
-            loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
+            loop(mempoolTxs, acc, lastFeeTx, invalidTxs :+ tx.id)
           } else {
             // check validity and calculate transaction cost
             stateWithTxs.validateWithCost(
@@ -887,7 +896,7 @@ object CandidateGenerator extends ScorexLogging {
             ) match {
               case Success(costConsumed) =>
                 val newTxs = acc :+ (tx -> costConsumed)
-                val newBoxes = newTxs.flatMap(_._1.outputs)
+                val newBoxes = newTxs.iterator.flatMap(_._1.outputs).toVector
 
                 collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
                   case Some(feeTx) =>
@@ -898,7 +907,7 @@ object CandidateGenerator extends ScorexLogging {
                       case Success(cost) =>
                         val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
                         if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                          loop(mempoolTxs.tail, newTxs, Some(feeTx -> cost), invalidTxs)
+                          loop(mempoolTxs, newTxs, Some(feeTx -> cost), invalidTxs)
                         } else {
                           log.debug(s"Finishing block assembly on limits overflow, " +
                                     s"cost is ${currentCosted.map(_._2).sum}, cost limit: $maxBlockCost")
@@ -915,22 +924,22 @@ object CandidateGenerator extends ScorexLogging {
                     log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
                     val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
                     if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                      loop(mempoolTxs.tail, blockTxs, lastFeeTx, invalidTxs)
+                      loop(mempoolTxs, newTxs, lastFeeTx, invalidTxs)
                     } else {
                       current -> invalidTxs
                     }
                 }
               case Failure(e) =>
                 log.info(s"Not included transaction ${tx.id} due to ${e.getMessage}: ", e)
-                loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
+                loop(mempoolTxs, acc, lastFeeTx, invalidTxs :+ tx.id)
             }
           }
-        case None => // mempool is empty
-          current -> invalidTxs
+      } else { // mempool is empty
+        current -> invalidTxs
       }
     }
 
-    val res = loop(transactions, Seq.empty, None, Seq.empty)
+    val res = loop(transactions.iterator, Vector.empty, None, Vector.empty)
     log.debug(
       s"Collected ${res._1.length} transactions for block #$currentHeight, " +
         s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -57,9 +57,12 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     pool.orderedTransactions.values.take(limit)
   }
 
+  private def orderedTransactionsSnapshot: Vector[UnconfirmedTransaction] =
+    pool.orderedTransactions.valuesIterator.toVector
+
   def random(limit: Int): Iterable[UnconfirmedTransaction] = {
     val result = mutable.WrappedArray.newBuilder[UnconfirmedTransaction]
-    val txSeq = pool.orderedTransactions.values.to[Vector]
+    val txSeq = orderedTransactionsSnapshot
     val total = txSeq.size
     val start = if (total <= limit) {
       0
@@ -77,14 +80,14 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     result.result()
   }
 
-  override def getAll: Seq[UnconfirmedTransaction] = pool.orderedTransactions.values.toSeq
+  override def getAll: Seq[UnconfirmedTransaction] = orderedTransactionsSnapshot
 
   override def getAll(ids: Seq[ModifierId]): Seq[UnconfirmedTransaction] = ids.flatMap(pool.get)
 
   /**
     * Returns all transactions resided in pool sorted by weight in descending order
     */
-  override def getAllPrioritized: Seq[UnconfirmedTransaction] = pool.orderedTransactions.values.toSeq
+  override def getAllPrioritized: Seq[UnconfirmedTransaction] = orderedTransactionsSnapshot
 
   /**
     * Method to put a transaction into the memory pool. Validation of the transactions against
@@ -299,7 +302,7 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
     }
   }
 
-  def weightedTransactionIds(limit: Int): Seq[WeightedTxId] = pool.orderedTransactions.keysIterator.take(limit).toSeq
+  def weightedTransactionIds(limit: Int): Seq[WeightedTxId] = pool.orderedTransactions.keysIterator.take(limit).toVector
 
   private def extractFee(tx: ErgoTransaction): Long = {
     tx.outputs

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -180,6 +180,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
       }
 
       fromBigMempool.length should be > 2
+      fromBigMempool.map(_.encodedId).distinct.length shouldBe fromBigMempool.length
       fromBigMempool.map(_.size).sum should be < maxSize
       costs.sum should be < maxCost
       if (!withTokens) fromBigMempool.size should be < txsWithFees.size

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -373,6 +373,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     pool.take(11).toSeq.map(_.transaction.id) shouldBe ids
     pool.getAll.map(_.transaction.id) shouldBe ids
     pool.getAllPrioritized.map(_.transaction.id) shouldBe ids
+    pool.getAll shouldBe a [Vector[_]]
+    pool.getAllPrioritized shouldBe a [Vector[_]]
+    pool.weightedTransactionIds(11) shouldBe a [Vector[_]]
 
     val conformingTxs = pool.take(3).toSeq
     val stateWithTxs = wus.withUnconfirmedTransactions(conformingTxs)


### PR DESCRIPTION
## Summary

This addresses #1551 with a current `master` implementation focused on reducing avoidable mempool collection overhead while preserving transaction priority order.

- materialize ordered mempool snapshots with `valuesIterator.toVector` so Scala 2.12 does not expose lazy `Stream` results through `getAll` / `getAllPrioritized`
- build candidate transaction input with a size-hinted `Vector` builder instead of chained `++` and mapped intermediate collections
- make `collectTxs` consume an iterator while preserving transaction priority order and avoiding repeated `headOption` / `tail` traversal
- apply the same strict snapshot approach to `CleanupWorker` before filtering transactions for re-validation
- cover strict mempool snapshot return types and guard against duplicate transaction ids in collected block transactions

Closes #1551

## Validation

- `git diff --check`
- `sbt "testOnly org.ergoplatform.nodeView.mempool.ErgoMemPoolSpec org.ergoplatform.mining.CandidateGeneratorPropSpec org.ergoplatform.local.MempoolAuditorSpec"` - 29 tests passed
