### PR TITLE
Write miner version to block extensions

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.modifiers.history.extension
 
+import java.nio.charset.StandardCharsets
+
 import cats.syntax.either._
 import sigmastate.utils.Helpers._
 import com.google.common.primitives.Bytes
@@ -70,6 +72,19 @@ object Extension extends ApiCodecs {
     * against the genesis block are to be written into a single key space defined by the value below.
     */
   val ValidationRulesPrefix: Byte = 0x02
+
+  /**
+    * Node software version string written by a miner into locally produced blocks.
+    *
+    * This field is informational and not consensus-critical; it lets indexers collect network version statistics
+    * from block extensions without changing parameter, interlink, or validation-rule parsing.
+    */
+  val MinerVersionPrefix: Byte = 0x03
+
+  val MinerVersionKey: Array[Byte] = Array(MinerVersionPrefix, 0: Byte)
+
+  def minerVersionField(version: String): (Array[Byte], Array[Byte]) =
+    MinerVersionKey.clone() -> version.getBytes(StandardCharsets.UTF_8)
 
   /**
     * Id a type of network object encoding extension

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.mining.AutolykosPowScheme.derivedHeaderFields
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history._
-import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionCandidate}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderWithoutPow}
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
@@ -23,7 +23,7 @@ import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, StateType, 
 import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
 import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input, Version}
 import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging}
@@ -538,6 +538,8 @@ object CandidateGenerator extends ScorexLogging {
       // Obtain NiPoPoW interlinks vector to pack it into the extension section
       val updInterlinks       = popowAlgos.updateInterlinks(bestHeaderOpt, bestExtensionOpt)
       val interlinksExtension = popowAlgos.interlinksToExtension(updInterlinks)
+      val minerVersionExtension = ExtensionCandidate(Seq(Extension.minerVersionField(Version.VersionString)))
+      val baseExtension = interlinksExtension ++ minerVersionExtension
       val votingSettings      = ergoSettings.chainSettings.voting
       val (extensionCandidate, votes: Array[Byte], version: Byte) = bestHeaderOpt
         .map { header =>
@@ -556,7 +558,7 @@ object CandidateGenerator extends ScorexLogging {
             )
             val newValidationSettings = stateContext.validationSettings.updated(activatedUpdate)
             (
-              newParams.toExtensionCandidate ++ interlinksExtension ++ newValidationSettings.toExtensionCandidate,
+              newParams.toExtensionCandidate ++ baseExtension ++ newValidationSettings.toExtensionCandidate,
               newParams.suggestVotes(ergoSettings.votingTargets.targets, voteForSoftFork),
               newParams.blockVersion
             )
@@ -567,14 +569,14 @@ object CandidateGenerator extends ScorexLogging {
               voteForSoftFork
             )
             (
-              interlinksExtension,
+              baseExtension,
               votes,
               currentParams.blockVersion
             )
           }
         }
         .getOrElse(
-          (interlinksExtension, Array(0: Byte, 0: Byte, 0: Byte), Header.InitialVersion)
+          (baseExtension, Array(0: Byte, 0: Byte, 0: Byte), Header.InitialVersion)
         )
 
       val upcomingContext = state.stateContext.upcoming(

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -1,5 +1,8 @@
 package org.ergoplatform.mining
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
@@ -7,6 +10,7 @@ import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.FullBlockApplied
@@ -18,7 +22,7 @@ import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
 import org.ergoplatform.settings.NetworkType.DevNet60
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.ErgoTestHelpers
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input, Version}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import sigma.ast.ErgoTree
@@ -55,6 +59,35 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
+
+  it should "include miner version in generated block extension" in new TestKit(ActorSystem()) {
+    val testProbe = new TestProbe(system)
+    val isolatedSettings = defaultSettings.copy(
+      directory = Files.createTempDirectory("ergo-miner-version").toFile.getAbsolutePath
+    )
+
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(isolatedSettings)
+    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+
+    val candidateGenerator: ActorRef =
+      CandidateGenerator(
+        defaultMinerSecret.publicImage,
+        readersHolderRef,
+        viewHolderRef,
+        isolatedSettings
+      )
+
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+    testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        val versionFields = candidate.candidateBlock.extension.fields
+          .filter { case (key, _) => key sameElements Extension.MinerVersionKey }
+
+        versionFields should have size 1
+        versionFields.head._2.toSeq shouldBe Version.VersionString.getBytes(StandardCharsets.UTF_8).toSeq
+    }
+    system.terminate()
+  }
 
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
     ActorSystem()


### PR DESCRIPTION
## Summary

This addresses #962 with a focused miner-version extension field while keeping extension key definitions and value encoding centralized.

- reserve extension key-space `0x03` for the locally mined node software version
- add `Extension.MinerVersionKey` and `Extension.minerVersionField(...)` so the key and UTF-8 value encoding live beside the other extension key-space definitions
- append the miner version field to generated block candidates without changing parameter, interlink, or validation-rule parsing
- cover candidate generation with an isolated data directory and assert that exactly one miner version field is written

Closes #962

## Validation

- `git diff --check`
- `sbt "testOnly org.ergoplatform.mining.CandidateGeneratorSpec -- -z version"` - 1 test passed

Note: a full `CandidateGeneratorSpec` run was started first, but it exceeded the local timeout because that class runs several mining/actor scenarios. The new focused regression test was then run directly and passed.
