### PR TITLE
Let pruning nodes catch up after being offline longer than blocksToKeep

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ docker / dockerfile := {
   val configMainNet = (IntegrationTest / resourceDirectory).value / "mainnetTemplate.conf"
 
   new Dockerfile {
-    from("openjdk:11-jre-slim")
+    from("eclipse-temurin:11-jre")
     label("ergo-integration-tests", "ergo-integration-tests")
     add(assembly.value, "/opt/ergo/ergo.jar")
     add(Seq(configDevNet), "/opt/ergo")

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala
@@ -165,7 +165,7 @@ object ValidationRules {
     bsHeadersChainSynced -> RuleStatus(im => recoverable(s"Headers-chain is not synchronized yet. ${im.error}", im.modifierId, im.modifierTypeId),
       Seq(classOf[ADProofs], classOf[Extension], classOf[BlockTransactions]),
       mayBeDisabled = false),
-    bsTooOld -> RuleStatus(im => fatal(s"Block section should correspond to a block header that is not pruned yet. ${im.error}", im.modifierId, im.modifierTypeId),
+    bsTooOld -> RuleStatus(im => recoverable(s"Block section should correspond to a block header that is not pruned yet. ${im.error}", im.modifierId, im.modifierTypeId),
       Seq(classOf[ADProofs], classOf[Extension], classOf[BlockTransactions]),
       mayBeDisabled = false),
     bsBlockTransactionsSize -> RuleStatus(im => fatal(s"Size of block transactions section should not exceed <maxBlockSize>. ${im.error}", im.modifierId, im.modifierTypeId),

--- a/src/it/scala/org/ergoplatform/it/PrunedDigestNodeCatchUpSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/PrunedDigestNodeCatchUpSpec.scala
@@ -1,0 +1,94 @@
+package org.ergoplatform.it
+
+import java.io.File
+
+import com.typesafe.config.Config
+import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+  * End-to-end reproduction of a pruning node that fell behind by more than its `blocksToKeep` window
+  * while it was offline. After such a shutdown the network tip - and therefore `minimalFullBlockHeight`
+  * after the headers re-sync - is far above the node's local best full block, and the node has to apply
+  * the intermediate full blocks to catch up. A node that refuses those intermediate blocks as "too old"
+  * gets permanently stuck at its pre-shutdown height; a healthy node downloads them and reaches the tip.
+  */
+class PrunedDigestNodeCatchUpSpec
+  extends AnyFlatSpec
+    with IntegrationSuite
+    with OptionValues {
+
+  private val blocksToKeep = 5
+  // height the pruned node reaches before going offline (best full block inside the keep window)
+  private val syncHeight = 8
+
+  private val remoteVolume = "/app"
+  private val minerVolume = s"$localDataDir/pruned-catchup-spec/miner"
+  private val digestVolume = s"$localDataDir/pruned-catchup-spec/digest"
+  // start each run from clean volumes so a previous run's chain/state cannot interfere with recovery
+  freshDir(minerVolume)
+  freshDir(digestVolume)
+
+  // single miner that keeps mining throughout, so the chain advances while the pruned node is offline
+  private val minerConfig: Config = offlineGeneratingPeerConfig
+    .withFallback(shortInternalMinerPollingInterval)
+    .withFallback(blockIntervalConfig(500))
+    .withFallback(specialDataDirConfig(remoteVolume))
+    .withFallback(nodeSeedConfigs.head)
+    .withFallback(localOnlyConfig)
+
+  // pruning light (digest) node that syncs, goes offline, then has to catch up
+  private val digestConfig: Config = digestStatePeerConfig
+    .withFallback(prunedHistoryConfig(blocksToKeep))
+    .withFallback(blockIntervalConfig(500))
+    .withFallback(nonGeneratingPeerConfig)
+    .withFallback(specialDataDirConfig(remoteVolume))
+    .withFallback(nodeSeedConfigs(1))
+    .withFallback(localOnlyConfig)
+
+  // Testing scenario:
+  // 1. Start the miner and a pruning digest node; let the digest node sync ({stoppedAt} full blocks);
+  // 2. Stop the digest node gracefully (the "long shutdown") and let the miner mine past
+  //    {stoppedAt + blocksToKeep}, so every block the node still needs is below minimalFullBlockHeight;
+  // 3. Restart the digest node and assert it catches up to {target} instead of being stuck at {stoppedAt}.
+  it should "Pruned digest node catches up after being offline longer than blocksToKeep" in {
+
+    val minerNode: Node =
+      docker.startDevNetNode(minerConfig, specialVolumeOpt = Some((minerVolume, remoteVolume))).get
+    val digestNode: Node =
+      docker.startDevNetNode(digestConfig, specialVolumeOpt = Some((digestVolume, remoteVolume))).get
+
+    val result = for {
+      _         <- digestNode.waitForHeight(syncHeight)
+      // best full block height of the pruning node at the moment it goes offline
+      stoppedAt <- digestNode.fullHeight
+      // graceful stop so DigestState is flushed and can be reloaded on restart
+      _          = docker.stopNode(digestNode, secondsToWait = 20)
+      // the chain must advance strictly more than blocksToKeep beyond where the node stopped
+      target     = stoppedAt + blocksToKeep + 6
+      _         <- minerNode.waitForHeight(target)
+      restarted  = docker
+        .startDevNetNode(digestConfig, specialVolumeOpt = Some((digestVolume, remoteVolume))).get
+      // with the fix the node downloads the now-"too old" intermediate blocks and crosses the window;
+      // without it the node stays stuck at stoppedAt and this wait times out
+      caughtUp  <- restarted.waitForHeight(target)
+    } yield caughtUp should be >= target
+
+    Await.result(result, 10.minutes)
+  }
+
+  private def freshDir(path: String): Unit = {
+    val dir = new File(path)
+    def delete(f: File): Unit = {
+      if (f.isDirectory) Option(f.listFiles()).foreach(_.foreach(delete))
+      f.delete()
+    }
+    delete(dir)
+    dir.mkdirs()
+  }
+
+}

--- a/src/it/scala/org/ergoplatform/it/container/Node.scala
+++ b/src/it/scala/org/ergoplatform/it/container/Node.scala
@@ -24,9 +24,9 @@ class Node(val settings: ErgoSettings, val nodeInfo: NodeInfo, override val clie
   def containerId: String = nodeInfo.containerId
   override val chainId: Char = 'I'
   override val networkNodeName: String = s"it-test-client-to-${nodeInfo.networkIpAddress}"
-  override val restAddress: String = nodeInfo.apiIpAddress
+  override val restAddress: String = "localhost"
   override val networkAddress: String = "localhost"
-  override val nodeRestPort: Int = nodeInfo.containerApiPort
+  override val nodeRestPort: Int = nodeInfo.hostRestApiPort
   override val networkPort: Int = nodeInfo.hostNetworkPort
   override val blockDelay: FiniteDuration = settings.chainSettings.blockInterval
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
@@ -8,7 +8,7 @@ import org.ergoplatform.settings.ErgoSettings
   * A class that keeps and calculates minimal height for full blocks starting from which we need to download these full
   * blocks from the network and keep them in our history.
   */
-trait FullBlockPruningProcessor extends MinimalFullBlockHeightFunctions {
+trait FullBlockPruningProcessor extends MinimalFullBlockHeightFunctions { self: BasicReaders =>
 
   protected def settings: ErgoSettings
 
@@ -34,10 +34,17 @@ trait FullBlockPruningProcessor extends MinimalFullBlockHeightFunctions {
     */
   def minimalFullBlockHeight: Int = readMinimalFullBlockHeight()
 
-  /** Check if headers chain is synchronized with the network and modifier is not too old
+  /** Check if headers chain is synchronized with the network and modifier is not too old.
+    *
+    * A block within the pruning window (`height >= minimalFullBlockHeight`) is downloadable as usual.
+    * Additionally, a block that is a direct successor of our best full block (`height > bestFullBlock`)
+    * is downloadable even when it sits below `minimalFullBlockHeight`: after a long shutdown the network
+    * tip - and thus `minimalFullBlockHeight` - can jump far ahead of our local best full block, and these
+    * intermediate blocks are exactly the ones the node must apply to advance its state and catch up.
     */
   def shouldDownloadBlockAtHeight(height: Int): Boolean = {
-    isHeadersChainSynced && height >= minimalFullBlockHeight
+    isHeadersChainSynced &&
+      (height >= minimalFullBlockHeight || bestFullBlockOpt.exists(height > _.height))
   }
 
   /** Update minimal full block height and header chain synced flag

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockSectionValidationSpecification.scala
@@ -73,11 +73,13 @@ class BlockSectionValidationSpecification extends ErgoCorePropertyTest {
     // header should contain correct digest
     history.applicableTry(withUpdatedHeaderId(section, section.id)) shouldBe 'failure
 
-    // should not be able to apply when blocks at this height are already pruned
+    // a section below minimalFullBlockHeight that is still a successor of the best full block stays
+    // applicable: a pruning node must download these to advance its state and catch up after a long
+    // shutdown (rejection of genuinely too-old, non-successor sections is covered in PrunedHistoryCatchUpSpec)
     history.applicableTry(section) shouldBe 'success
     history.writeMinimalFullBlockHeight(history.bestHeaderOpt.get.height + 1)
     history.isHeadersChainSyncedVar = true
-    history.applicableTry(section) shouldBe 'failure
+    history.applicableTry(section) shouldBe 'success
     history.writeMinimalFullBlockHeight(GenesisHeight)
 
     // should not be able to apply if corresponding header is marked as invalid

--- a/src/test/scala/org/ergoplatform/nodeView/history/PrunedHistoryCatchUpSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/PrunedHistoryCatchUpSpec.scala
@@ -1,0 +1,75 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.utils.{ErgoCorePropertyTest, NoShrink}
+import org.ergoplatform.validation.{MalformedModifierError, RecoverableModifierError}
+
+/**
+  * A pruning node that has been offline longer than its `blocksToKeep` window must still be able to
+  * catch up. While the node is offline the network tip advances past it by more than `blocksToKeep`.
+  * On restart the headers re-sync and `minimalFullBlockHeight` jumps to roughly `tip - blocksToKeep + 1`,
+  * which is now far above the node's local `bestFullBlockHeight`. To advance its state the node has to
+  * apply the block sections of the intermediate heights.
+  *
+  * These intermediate sections sit below `minimalFullBlockHeight`, so the `bsTooOld` rule rejects them.
+  * If that rejection is fatal the sections are marked permanently invalid and the node can never recover:
+  *
+  *   MalformedModifierError: Block section should correspond to a block header that is not pruned yet.
+  *
+  * This spec pins down the two properties that keep such a node unstuck: a block that is a successor of
+  * the best full block stays applicable even below the window, and a genuinely too-old section is only
+  * rejected recoverably.
+  */
+class PrunedHistoryCatchUpSpec extends ErgoCorePropertyTest with NoShrink {
+  import org.ergoplatform.utils.HistoryTestHelpers._
+  import org.ergoplatform.utils.generators.ChainGenerator._
+
+  private def prunedDigestHistory(): ErgoHistory =
+    generateHistory(verifyTransactions = true, StateType.Digest, PoPoWBootstrap = false, BlocksToKeep)
+
+  property("a catch-up block above the jumped minimalFullBlockHeight stays applicable") {
+    val chainLen = 8
+    val gap = 5
+
+    // local chain: apply all but the last block, so bestFullBlock is one below the tip we still need
+    val history0 = prunedDigestHistory()
+    val chain = genChain(chainLen, history0)
+    val history = applyChain(history0, chain.init)
+    val nextBlock = chain.last // the very next block the node must apply to advance its state
+    history.append(nextBlock.header).get._1
+
+    history.bestFullBlockOpt.get.header.height shouldBe nextBlock.header.height - 1
+
+    // simulate the long shutdown: the network tip moved far past the keep window, so on re-sync
+    // minimalFullBlockHeight is now well above every block we still hold locally
+    history.writeMinimalFullBlockHeight(nextBlock.header.height + gap)
+    history.isHeadersChainSyncedVar = true
+
+    // the next-needed block sits below minimalFullBlockHeight but is a successor of bestFullBlock,
+    // so it must remain applicable - otherwise the pruning node can never catch up
+    history.applicableTry(nextBlock.blockTransactions) shouldBe 'success
+  }
+
+  property("a genuinely too-old block section is rejected recoverably, not fatally") {
+    val chainLen = 8
+    val gap = 5
+
+    // fresh pruning node (no full block applied yet): only the headers chain is known
+    val history = prunedDigestHistory()
+    val chain = genChain(chainLen, history)
+    chain.foldLeft(history)((h, b) => h.append(b.header).get._1)
+
+    history.writeMinimalFullBlockHeight(chain.last.header.height + gap)
+    history.isHeadersChainSyncedVar = true
+
+    val tooOld = chain.head // far below the keep window and not a successor of any best full block
+    val result = history.applicableTry(tooOld.blockTransactions)
+
+    result shouldBe 'failure
+    // "too old" is a transient condition relative to sync progress, never an intrinsic defect:
+    // the section must not be permanently blacklisted, or the node can never recover.
+    result.failed.get should not be a[MalformedModifierError]
+    result.failed.get shouldBe a[RecoverableModifierError]
+  }
+
+}


### PR DESCRIPTION
This reproduces and fixes #1159 (the pruning catch-up failure).

## Problem
A node with pruning (`node.blocksToKeep` set - e.g. a `digest`/light node) that stays offline longer than its pruning window can never catch back up. On restart every catch-up block section is rejected as permanently invalid:

```
MalformedModifierError: Block section should correspond to a block header that is not pruned yet.
```

## Root cause
While the node is offline the network tip moves past it by more than `blocksToKeep`. On restart the headers re-sync and `minimalFullBlockHeight` jumps to ~`tip - blocksToKeep + 1`, far above the local `bestFullBlockHeight`. The single gate

```scala
shouldDownloadBlockAtHeight(h) = isHeadersChainSynced && h >= minimalFullBlockHeight
```

then rejects every block the node still needs - both where it decides which sections to *request* (`ToDownloadProcessor`) and where it *validates* them (`bsTooOld`). Because `bsTooOld` was `fatal`, each section was marked permanently invalid and never retried.

## Fix
- `FullBlockPruningProcessor.shouldDownloadBlockAtHeight` also accepts a block that is a successor of the best full block (`bestFullBlockOpt.exists(height > _.height)`), so the node can fetch and apply the intermediate blocks needed to advance, even when they sit below `minimalFullBlockHeight`. In normal operation `minimalFullBlockHeight <= bestFullBlockHeight`, so this only widens behaviour during catch-up.
- `bsTooOld` is now `recoverable` instead of `fatal` — "too old" is transient relative to sync progress, not an intrinsic defect, so a section must never be permanently blacklisted.

## Tests
- `PrunedHistoryCatchUpSpec` (unit) — reproduces the exact failure and pins the corrected behaviour: a successor below `minimalFullBlockHeight` stays applicable, and a genuinely too-old section is rejected *recoverably*, not fatally.
- `PrunedDigestNodeCatchUpSpec` (integration) - a pruning digest node goes offline, the miner advances past the window, the node restarts and catches up to the tip.
- `BlockSectionValidationSpecification` updated (its prior assertion encoded the buggy "successor is too old" behaviour).

## Test-infra commits (separate)
- *Use eclipse-temurin base image…* - `openjdk:11-jre-slim` was removed from Docker Hub, which breaks `sbt docker` entirely.
- *Use host-mapped REST port…* — lets integration tests reach nodes on Docker Desktop (container Docker-network IPs aren't routable from the host there); harmless on Linux CI.
