### PR TITLE
Advance wallet past unavailable blocks in pruned mode

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -248,8 +248,27 @@ class ErgoWalletActor(settings: ErgoSettings,
                 case Success(updatedState) =>
                   updatedState
               }
+            case None if settings.nodeSettings.isFullBlocksPruned =>
+              // The block data is unavailable - it was pruned before the wallet could scan it.
+              // Advance the wallet height past it (using the still-present header as version tag)
+              // so scanning does not get stuck; the block's wallet transactions, if any, are lost.
+              historyReader.bestHeaderIdAtHeight(blockHeight) match {
+                case Some(headerId) =>
+                  ergoWalletService.skipBlockUpdate(state, headerId, blockHeight) match {
+                    case Failure(ex) =>
+                      val errorMsg = s"Skipping unavailable block at height $blockHeight failed : ${ex.getMessage}"
+                      log.error(errorMsg, ex)
+                      state.copy(error = Some(errorMsg))
+                    case Success(updatedState) =>
+                      log.warn(s"Wallet skipped unavailable (pruned) block at height $blockHeight")
+                      updatedState
+                  }
+                case None =>
+                  log.warn(s"No header at height $blockHeight to skip, wallet left at ${state.getWalletHeight}")
+                  state
+              }
             case None =>
-              state // We may do not have a block if, for example, the blockchain is pruned. This is okay, just skip it.
+              state // We may do not have a block, e.g. it is not downloaded yet. This is okay, just skip it.
         }
         context.become(loadedWallet(newState))
         if (blockHeight < newState.fullHeight) {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -221,6 +221,16 @@ trait ErgoWalletService {
   def scanBlockUpdate(state: ErgoWalletState, block: ErgoFullBlock, dustLimit: Option[Long]): Try[ErgoWalletState]
 
   /**
+    * Advance the wallet's scanned height past a block whose data is unavailable (e.g. pruned
+    * before the wallet could scan it), so the wallet does not get stuck. Balances are unchanged.
+    *
+    * @param state       current wallet state
+    * @param blockId     - identifier of the header at `blockHeight` (still present after pruning)
+    * @param blockHeight - height to advance the wallet to
+    */
+  def skipBlockUpdate(state: ErgoWalletState, blockId: ModifierId, blockHeight: Int): Try[ErgoWalletState]
+
+  /**
     * Sign a transaction
     */
   def signTransaction(proverOpt: Option[ErgoProvingInterpreter],
@@ -595,6 +605,9 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
         ergoSettings.walletSettings.walletProfile).map { case (reg, offReg, updatedOutputsFilter) =>
         state.copy(registry = reg, offChainRegistry = offReg, outputsFilter = Some(updatedOutputsFilter))
       }
+
+  override def skipBlockUpdate(state: ErgoWalletState, blockId: ModifierId, blockHeight: Int): Try[ErgoWalletState] =
+    state.registry.skipBlock(blockId, blockHeight).map(_ => state)
 
   override def updateUtxoState(state: ErgoWalletState): ErgoWalletState = {
     (state.mempoolReaderOpt, state.stateReaderOpt) match {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -312,6 +312,22 @@ class WalletRegistry(private val store: LDBVersionedStore)(ws: WalletSettings) e
     }
   }
 
+  /**
+    * Advance the wallet's scanned height past a block whose data is unavailable (for example, it
+    * was pruned before the wallet could scan it). Balances are left untouched - only the digest
+    * height moves forward - and a new version is transacted so that rollback keeps working.
+    *
+    * @param blockId     - identifier of the (still-known) header at this height, used as version tag
+    * @param blockHeight - height to advance the wallet to
+    */
+  def skipBlock(blockId: ModifierId, blockHeight: Int): Try[Unit] =
+    updateDigest(KeyValuePairsBag.empty) { case WalletDigest(height, wBalance, wTokensSeq) =>
+      if (height + 1 != blockHeight) {
+        log.warn(s"Wallet skipping unscanned block(s), from $height until $blockHeight (data unavailable)")
+      }
+      Success(WalletDigest(blockHeight, wBalance, wTokensSeq))
+    }.flatMap(_.transact(store, idToBytes(blockId)))
+
   def rollback(version: VersionTag): Try[Unit] = {
     cache.clear()
     store.rollbackTo(org.ergoplatform.core.versionToBytes(version))

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -91,6 +91,26 @@ class ErgoWalletServiceSpec
     }
   }
 
+  property("skipBlockUpdate advances wallet height without scanning, recovering a stuck wallet") {
+    withVersionedStore(10) { versionedStore =>
+      withStore { store =>
+        val walletState = initialState(store, versionedStore)
+        val walletService = new ErgoWalletServiceImpl(settings)
+
+        // wallet has scanned the chain up to height 100
+        val blockId1 = modifierIdGen.sample.get
+        walletState.registry.updateOnBlock(ScanResults(Seq.empty, ArraySeq.empty, ArraySeq.empty), blockId1, 100).get
+        walletState.getWalletHeight shouldBe 100
+
+        // the next block is unavailable (pruned) - skipping it advances the wallet height
+        // so the scan loop does not get stuck on it
+        val blockId2 = modifierIdGen.sample.get
+        val updated = walletService.skipBlockUpdate(walletState, blockId2, 101).get
+        updated.getWalletHeight shouldBe 101
+      }
+    }
+  }
+
   property("it should prepare unsigned transaction") {
     val inputBoxes = {
       Seq(

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistrySpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistrySpec.scala
@@ -224,6 +224,31 @@ class WalletRegistrySpec
     }
   }
 
+  it should "skipBlock() advance height without changing balances and be rollback-able" in {
+    forAll(registrySummaryGen, modifierIdGen) { (index, blockId) =>
+      withVersionedStore(10) { store =>
+        val reg = new WalletRegistry(store)(ws)
+        val baseHeight = 100
+        val baseDigest = index.copy(height = baseHeight)
+        val checkpoint = scorex.utils.Random.randomBytes()
+
+        WalletRegistry.putDigest(emptyBag, baseDigest).transact(store, checkpoint).get
+        reg.fetchDigest() shouldBe baseDigest
+
+        // skipping the next (unavailable) block advances the height but keeps balances untouched
+        reg.skipBlock(blockId, baseHeight + 1).get
+        val skipped = reg.fetchDigest()
+        skipped.height shouldBe baseHeight + 1
+        skipped.walletBalance shouldBe baseDigest.walletBalance
+        skipped.walletAssetBalances shouldBe baseDigest.walletAssetBalances
+
+        // rolling back to the checkpoint restores the previous height
+        reg.rollback(VersionTag @@ Base16.encode(checkpoint)).isSuccess shouldBe true
+        reg.fetchDigest().height shouldBe baseHeight
+      }
+    }
+  }
+
   it should "update scans correctly" in {
     val appId1: ScanId = ScanId @@ 21.toShort
     val appId2: ScanId = ScanId @@ 22.toShort


### PR DESCRIPTION
In digest/pruning mode a node can prune block sections before the wallet has scanned them. When the wallet's catch-up loop (`ScanInThePast`) fetched such a block it received `None` and skipped it **without advancing the wallet's scanned height**. Because `expectedNextBlockHeight` then stayed put, the guard never matched again, the message was dropped, and the wallet dead-looped on that height forever — it stopped tracking balances. (Reported in issue 1187.)

This advances the wallet's scanned height past an unavailable block instead of getting stuck:

- `WalletRegistry.skipBlock` moves the digest height forward without touching balances, transacting a new version (keyed by the still-present header id) so rollback keeps working.
- `ErgoWalletService.skipBlockUpdate` exposes it on the service.
- `ErgoWalletActor.ScanInThePast` uses it for the `None` case in pruned mode; the existing recursion then proceeds and the loop self-heals. Non-pruned mode keeps its previous behaviour.

Transactions in a block that was already pruned are unrecoverable on a node that fell more than `blocksToKeep` behind, but the wallet no longer gets stuck. A follow-up PR keeps blocks from being pruned before the wallet scans them, avoiding that loss.
