### PR TITLE
Keep full blocks until the wallet has scanned them (pruned mode)

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -50,6 +50,15 @@ object ErgoNodeViewSynchronizerMessages {
     case class ChangedState(reader: ErgoStateReader) extends NodeViewChange
 
     /**
+     * Event published by the wallet after it has scanned (or skipped) a block, reporting the
+     * height up to which it has processed the chain. Used by the node view holder to keep the
+     * history from pruning block data the wallet has not scanned yet.
+     *
+     * @param height - height of the last block the wallet has scanned
+     */
+    case class WalletScannedHeight(height: Int) extends NodeViewHolderEvent
+
+    /**
      * Event which is published when rollback happened (on finding a better chain)
      *
      * @param branchPoint - block id which is last in the chain after rollback (before applying blocks from a fork)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -87,6 +87,12 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         Escalate
     }
 
+  override def preStart(): Unit = {
+    // Track the wallet's scanned height so history pruning does not delete full block data the
+    // wallet has not processed yet, which would otherwise leave the wallet stuck.
+    context.system.eventStream.subscribe(self, classOf[WalletScannedHeight])
+  }
+
   override def postStop(): Unit = {
     log.warn("Stopping ErgoNodeViewHolder")
     history().closeStorage()
@@ -689,6 +695,11 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       sender() ! healthCheckReply
   }
 
+  private def handleWalletScannedHeight: Receive = {
+    case WalletScannedHeight(height) =>
+      history().updateWalletScannedHeight(height)
+  }
+
   override def receive: Receive =
     processRemoteModifiers orElse
       processLocallyGeneratedModifiers orElse
@@ -696,7 +707,8 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       getCurrentInfo orElse
       getNodeViewChanges orElse
       processStateSnapshot orElse
-      handleHealthCheck orElse {
+      handleHealthCheck orElse
+      handleWalletScannedHeight orElse {
         case a: Any => log.error("Strange input: " + a)
       }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -106,10 +106,20 @@ trait FullBlockProcessor extends HeadersProcessor {
         if (nonBestChainsCache.nonEmpty) nonBestChainsCache = nonBestChainsCache.dropUntil(minForkRootHeight)
 
         if (nodeSettings.isFullBlocksPruned) {
-          val lastKept = updateBestFullBlock(fullBlock.header)
-          val bestHeight: Int = newBestBlockHeader.height
-          val diff = bestHeight - prevBest.header.height
-          pruneBlockDataAt(((lastKept - diff) until lastKept).filter(_ >= 0))
+          // Marker of what we have pruned so far; read before the floor is advanced below. For
+          // nodes upgraded from the previous sliding-window logic it defaults to the old floor.
+          val prunedFrom = readPrunedHeight()
+          val lastKept = updateBestFullBlock(fullBlock.header) // new minimal full block height
+          // Do not prune block data the wallet has not scanned yet, so it can always catch up.
+          // `None` means the wallet imposes no constraint (mining-only / not-yet-initialized).
+          val pruneUntil = walletScannedHeight match {
+            case Some(walletHeight) => Math.min(lastKept, walletHeight + 1)
+            case None               => lastKept
+          }
+          if (pruneUntil > prunedFrom) {
+            pruneBlockDataAt((prunedFrom until pruneUntil).filter(_ >= 0))
+            writePrunedHeight(pruneUntil)
+          }
         }
         ProgressInfo(branchPoint, toRemove, toApply, Seq.empty)
       }

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockPruningProcessor.scala
@@ -19,6 +19,19 @@ trait FullBlockPruningProcessor extends MinimalFullBlockHeightFunctions {
 
   @volatile private[history] var isHeadersChainSyncedVar: Boolean = false
 
+  // Height up to which the wallet has reported scanning, if known. Used to avoid pruning full
+  // block data the wallet has not processed yet. `None` means no constraint (e.g. mining-only or
+  // not-yet-initialized wallet), in which case pruning behaves as before.
+  @volatile private var walletScannedHeightOpt: Option[Int] = None
+
+  /** Report the height up to which the wallet has scanned the chain. */
+  def updateWalletScannedHeight(height: Int): Unit = {
+    if (height > GenesisHeight) walletScannedHeightOpt = Some(height)
+  }
+
+  /** Wallet's last scanned height if known, used to bound full block pruning. */
+  def walletScannedHeight: Option[Int] = walletScannedHeightOpt
+
   private def extensionWithParametersHeight(height: Int): Int = {
     require(height >= VotingEpochLength)
     height - (height % VotingEpochLength)

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/HeadersProcessor.scala
@@ -47,6 +47,12 @@ trait HeadersProcessor extends ToDownloadProcessor with PopowProcessor with Scor
     ByteArrayWrapper(Base16.decode("4987eb6a8fecbed88a6f733f456cdf4e334b944f4436be4cab50cacb442e15e6").get)
   }
 
+  /**
+    * Key for database record storing the height up to which full block data has been pruned
+    */
+  protected val PrunedHeightKey: ByteArrayWrapper =
+    ByteArrayWrapper(Algos.hash("pruned_height".getBytes(CharsetName)))
+
 
   protected val historyStorage: HistoryStorage
 
@@ -79,6 +85,16 @@ trait HeadersProcessor extends ToDownloadProcessor with PopowProcessor with Scor
 
   override def readMinimalFullBlockHeight(): Height = {
     historyStorage.getIndex(MinFullBlockHeightKey).map(Ints.fromByteArray).getOrElse(GenesisHeight)
+  }
+
+  override def writePrunedHeight(height: Height): Unit = {
+    historyStorage.insert(
+      indexesToInsert = Array(PrunedHeightKey -> Ints.toByteArray(height)),
+      objectsToInsert = BlockSection.emptyArray)
+  }
+
+  override def readPrunedHeight(): Height = {
+    historyStorage.getIndex(PrunedHeightKey).map(Ints.fromByteArray).getOrElse(readMinimalFullBlockHeight())
   }
 
   def bestHeaderIdOpt: Option[ModifierId] = historyStorage.getIndex(BestHeaderKey).map(bytesToId)

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/MinimalFullBlockHeightFunctions.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/MinimalFullBlockHeightFunctions.scala
@@ -21,4 +21,17 @@ trait MinimalFullBlockHeightFunctions {
     */
   def writeMinimalFullBlockHeight(height: Height): Unit
 
+  /**
+    * @return height (exclusive) up to which full block data has already been pruned. Used to drive
+    * backlog-aware pruning: pruning may be deferred (e.g. to keep blocks the wallet has not scanned
+    * yet) and resumed later from this marker. Defaults to the current minimal full block height for
+    * nodes upgraded from a version that pruned everything below that height.
+    */
+  def readPrunedHeight(): Height
+
+  /**
+    * Update the pruned-up-to height marker, see `readPrunedHeight`
+    */
+  def writePrunedHeight(height: Height): Unit
+
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -4,7 +4,7 @@ import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor._
 import akka.pattern.StatusReply
 import org.ergoplatform.ErgoBox._
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState, WalletScannedHeight}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.ErgoStateReader
@@ -31,6 +31,14 @@ class ErgoWalletActor(settings: ErgoSettings,
   extends Actor with Stash with ScorexLogging with ScorexEncoding {
 
   private val ergoAddressEncoder: ErgoAddressEncoder = settings.addressEncoder
+
+  /** Report the height up to which the wallet has scanned, so the node view holder can keep
+    * history from pruning blocks the wallet has not processed yet. Height 0 (fresh or
+    * uninitialized wallet) is not reported, leaving pruning unconstrained in that case. */
+  private def reportScannedHeight(state: ErgoWalletState): Unit = {
+    val h = state.getWalletHeight
+    if (h > 0) context.system.eventStream.publish(WalletScannedHeight(h))
+  }
 
   override val supervisorStrategy: OneForOneStrategy =
     OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
@@ -77,6 +85,7 @@ class ErgoWalletActor(settings: ErgoSettings,
       // Try to read wallet from json file or test mnemonic provided in a config file
       val newState = ergoWalletService.readWallet(state, ws.testMnemonic.map(SecretString.create(_)), ws.testKeysQty, ws.secretStorage)
       context.become(loadedWallet(newState))
+      reportScannedHeight(newState) // report persisted height early (e.g. after a restart)
       unstashAll()
     case _ => // stashing all messages until wallet is setup
       stash()
@@ -271,6 +280,7 @@ class ErgoWalletActor(settings: ErgoSettings,
               state // We may do not have a block, e.g. it is not downloaded yet. This is okay, just skip it.
         }
         context.become(loadedWallet(newState))
+        reportScannedHeight(newState)
         if (blockHeight < newState.fullHeight) {
           self ! ScanInThePast(blockHeight + 1, rescan)
         } else if (rescan) {
@@ -295,6 +305,7 @@ class ErgoWalletActor(settings: ErgoSettings,
                 updatedState
             }
           context.become(loadedWallet(newState))
+          reportScannedHeight(newState)
         } else if (nextBlockHeight < newBlock.height) {
           log.warn(s"Wallet: skipped blocks found starting from $nextBlockHeight, going back to scan them")
           self ! ScanInThePast(nextBlockHeight, false)

--- a/src/test/scala/org/ergoplatform/nodeView/history/UtxoSetSnapshotProcessorSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/UtxoSetSnapshotProcessorSpecification.scala
@@ -34,6 +34,11 @@ class UtxoSetSnapshotProcessorSpecification extends ErgoCorePropertyTest {
     override def writeMinimalFullBlockHeight(height: Int): Unit = {
       minimalFullBlockHeightVar = height
     }
+    var prunedHeightVar = GenesisHeight
+    override def readPrunedHeight() = prunedHeightVar
+    override def writePrunedHeight(height: Int): Unit = {
+      prunedHeightVar = height
+    }
   }
 
   var history = generateHistory(

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyADHistorySpecification.scala
@@ -380,6 +380,37 @@ class VerifyADHistorySpecification extends ErgoCorePropertyTest with NoShrink {
     }
   }
 
+  property("does not prune full blocks the wallet has not scanned, then sweeps the backlog") {
+    val blocksToPrune = 20
+    val walletHeight = 10 // wallet has scanned the chain only up to this height
+
+    // constrain pruning to the wallet height before applying the chain
+    val (emptyHist, _) = genHistory()
+    emptyHist.updateWalletScannedHeight(walletHeight)
+    val chain = genChain(BlocksToKeep + blocksToPrune + 1, emptyHist)
+    var history = applyChain(emptyHist, chain)
+
+    // blocks above the wallet height (but below the normal keep window) are kept, not pruned
+    chain.slice(walletHeight, blocksToPrune).foreach { b =>
+      history.modifierById(b.header.transactionsId).isDefined shouldBe true
+      history.modifierById(b.header.ADProofsId).isDefined shouldBe true
+    }
+    // blocks the wallet has already scanned (above genesis) are pruned as usual
+    chain.slice(1, walletHeight).foreach { b =>
+      history.modifierById(b.header.transactionsId) shouldBe None
+      history.modifierById(b.header.ADProofsId) shouldBe None
+    }
+
+    // once the wallet reports catching up, the deferred backlog gets pruned
+    history.updateWalletScannedHeight(chain.last.header.height)
+    val extra = genChain(1, history.bestFullBlockOpt.value).tail
+    history = applyChain(history, extra)
+    chain.slice(walletHeight, blocksToPrune).foreach { b =>
+      history.modifierById(b.header.transactionsId) shouldBe None
+      history.modifierById(b.header.ADProofsId) shouldBe None
+    }
+  }
+
   property("process fork from genesis") {
     var (history, c) = genHistory(1)
     val genesis = c.head


### PR DESCRIPTION
Builds on #2361. That PR stops the wallet from getting stuck when it needs an already-pruned block, but the block's wallet transactions are then lost. This PR prevents the situation from arising: full-block pruning no longer deletes a height the wallet hasn't scanned yet, so the wallet can always catch up. (Context: issue 1187.)

- The wallet reports how far it has scanned via a new `WalletScannedHeight` event after each scan/skip (and once on load, so the hint is set right after a restart). Height 0 — a fresh or uninitialized wallet — is not reported, leaving pruning unconstrained.
- `ErgoNodeViewHolder` subscribes and feeds the height into a volatile hint on `FullBlockPruningProcessor` (the same long-lived `ErgoHistory` instance).
- `FullBlockProcessor` pruning is now bounded by that hint. Since pruning is a sliding window, a deferred prune would otherwise be lost, so a persisted `prunedHeight` marker tracks how far we've pruned and sweeps the backlog forward once the wallet catches up. The marker defaults to the current minimal full-block height, so nodes upgraded from the old sliding-window logic don't re-sweep from genesis.

A wallet that reports nothing (mining-only or uninitialized) leaves pruning exactly as before, so non-wallet nodes are unaffected. The trade-off: a permanently stalled wallet halts pruning above its height — #2361 still guarantees the node never deadlocks, only that storage grows in that degenerate case.

Tests: `VerifyADHistorySpecification` — blocks above the wallet height are kept while blocks it has scanned are pruned, and the deferred backlog is pruned once the wallet catches up; `UtxoSetSnapshotProcessorSpecification` stub updated for the new marker methods.
