### PR TITLE
Decode Autolykos PoW solution public keys lazily to speed up header reads

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosSolution.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosSolution.scala
@@ -17,17 +17,58 @@ import sigma.crypto.{CryptoConstants, EcPointType}
   *
   * In Autolykos v.1 all the four fields are used, in Autolykos v.2 only pk and n fields are used.
   *
+  * The miner public key `pk` and one-time public key `w` are exposed as elliptic-curve points but
+  * backed internally by their canonical compressed bytes, decoded lazily on first access. This lets
+  * the trusted local-database read path (see `HistoryStorage.modifierById`) rehydrate headers for
+  * chain traversal, id computation or re-serialization without paying for EC point decompression,
+  * which the profiler flagged as a hotspot. Untrusted (network) input is still decoded eagerly by
+  * `AutolykosSolutionSerializer.parse`, which also re-canonicalizes the encoding, so malformed keys
+  * are rejected and ids stay consistent with other nodes, exactly as before.
+  *
+  * Implementation note: this is a regular class rather than a `case class` so the points can be decoded
+  * lazily from hidden byte fields. The point-based public surface (`apply`, `copy`, `unapply`, `equals`,
+  * `hashCode`) is kept for source compatibility, but this is a binary/ABI-breaking change for code
+  * compiled against the previous case-class form. Do not reintroduce the case class.
+  *
   * @param pk - miner public key. Should be used to collect block rewards
   * @param w  - one-time public key. Prevents revealing of miners secret
   * @param n  - nonce (8 bytes)
   * @param d  - distance between pseudo-random number, corresponding to nonce `n` and a secret,
   *           corresponding to `pk`. The lower `d` is, the harder it was to find this solution.
   */
-case class AutolykosSolution(pk: EcPointType,
-                             w: EcPointType,
-                             n: Array[Byte],
-                             d: BigInt) {
-  val encodedPk: Array[Byte] = groupElemToBytes(pk)
+class AutolykosSolution private (private[mining] val pkBytes: Array[Byte],
+                                 private[mining] val wBytes: Array[Byte],
+                                 val n: Array[Byte],
+                                 val d: BigInt) {
+
+  lazy val pk: EcPointType = groupElemFromBytes(pkBytes)
+
+  lazy val w: EcPointType = groupElemFromBytes(wBytes)
+
+  def copy(pk: EcPointType = this.pk,
+           w: EcPointType = this.w,
+           n: Array[Byte] = this.n,
+           d: BigInt = this.d): AutolykosSolution = AutolykosSolution(pk, w, n, d)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: AutolykosSolution =>
+      java.util.Arrays.equals(pkBytes, other.pkBytes) &&
+        java.util.Arrays.equals(wBytes, other.wBytes) &&
+        java.util.Arrays.equals(n, other.n) &&
+        d == other.d
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = java.util.Arrays.hashCode(pkBytes)
+    result = 31 * result + java.util.Arrays.hashCode(wBytes)
+    result = 31 * result + java.util.Arrays.hashCode(n)
+    result = 31 * result + d.hashCode()
+    result
+  }
+
+  override def toString: String =
+    s"AutolykosSolution(${Algos.encode(pkBytes)},${Algos.encode(wBytes)},${Algos.encode(n)},$d)"
 }
 
 object AutolykosSolution extends ApiCodecs {
@@ -35,6 +76,35 @@ object AutolykosSolution extends ApiCodecs {
   val pkForV2: EcPointType = CryptoConstants.dlogGroup.identity
   val wForV2: EcPointType = CryptoConstants.dlogGroup.generator
   val dForV2: BigInt = 0
+
+  // compressed bytes of `wForV2`, kept private and cloned per solution so the shared constant
+  // cannot be mutated through a parsed solution
+  private val wBytesForV2: Array[Byte] = groupElemToBytes(wForV2)
+
+  private[mining] def wBytesForV2Copy: Array[Byte] = wBytesForV2.clone()
+
+  /**
+    * Build a solution from decoded EC points. The points are compressed to their canonical byte form
+    * once, here, so serialization and id computation never have to compress them again.
+    */
+  def apply(pk: EcPointType,
+            w: EcPointType,
+            n: Array[Byte],
+            d: BigInt): AutolykosSolution =
+    new AutolykosSolution(groupElemToBytes(pk), groupElemToBytes(w), n, d)
+
+  /**
+    * Build a solution directly from compressed point bytes, deferring EC point decompression until
+    * `pk`/`w` are accessed. Intended for trusted, already-validated data (the storage read path).
+    */
+  private[mining] def fromBytes(pkBytes: Array[Byte],
+                                wBytes: Array[Byte],
+                                n: Array[Byte],
+                                d: BigInt): AutolykosSolution =
+    new AutolykosSolution(pkBytes, wBytes, n, d)
+
+  def unapply(s: AutolykosSolution): Option[(EcPointType, EcPointType, Array[Byte], BigInt)] =
+    Some((s.pk, s.w, s.n, s.d))
 
   implicit val jsonEncoder: Encoder[AutolykosSolution] = Encoder.instance { s: AutolykosSolution =>
     Map(
@@ -67,21 +137,31 @@ class AutolykosV1SolutionSerializer extends ErgoSerializer[AutolykosSolution] {
 
   override def serialize(obj: AutolykosSolution, w: Writer): Unit = {
     val dBytes = BigIntegers.asUnsignedByteArray(obj.d.bigInteger)
-    w.putBytes(groupElemToBytes(obj.pk))
-    w.putBytes(groupElemToBytes(obj.w))
+    w.putBytes(obj.pkBytes)
+    w.putBytes(obj.wBytes)
     require(obj.n.length == 8) // non-consensus check on prover side
     w.putBytes(obj.n)
     w.putUByte(dBytes.length)
     w.putBytes(dBytes)
   }
 
+  // eager, validating parse: decode the points (rejecting malformed group elements) and rebuild from
+  // them, so the serialized form is canonical - matching the original parser, which round-tripped
+  // points through groupElemToBytes (e.g. a non-canonical infinity encoding normalizes to 33 zeroes,
+  // which keeps `Header.serializedId` consistent with other nodes)
   override def parse(r: Reader): AutolykosSolution = {
-    val pk = groupElemFromBytes(r.getBytes(PublicKeyLength))
-    val w = groupElemFromBytes(r.getBytes(PublicKeyLength))
+    val raw = parseLazy(r)
+    AutolykosSolution(raw.pk, raw.w, raw.n, raw.d)
+  }
+
+  // lazy read for the trusted storage path only - defers EC point decompression, no validation
+  private[mining] def parseLazy(r: Reader): AutolykosSolution = {
+    val pkBytes = r.getBytes(PublicKeyLength)
+    val wBytes = r.getBytes(PublicKeyLength)
     val nonce = r.getBytes(8)
     val dBytesLength = r.getUByte()
     val d = BigInt(BigIntegers.fromUnsignedByteArray(r.getBytes(dBytesLength)))
-    AutolykosSolution(pk, w, nonce, d)
+    AutolykosSolution.fromBytes(pkBytes, wBytes, nonce, d)
   }
 
 }
@@ -91,18 +171,26 @@ class AutolykosV1SolutionSerializer extends ErgoSerializer[AutolykosSolution] {
   */
 class AutolykosV2SolutionSerializer extends ErgoSerializer[AutolykosSolution] {
 
-  import AutolykosSolution.{dForV2, wForV2}
+  import AutolykosSolution.{dForV2, wBytesForV2Copy}
 
   override def serialize(obj: AutolykosSolution, w: Writer): Unit = {
-    w.putBytes(groupElemToBytes(obj.pk))
+    w.putBytes(obj.pkBytes)
     require(obj.n.length == 8) // non-consensus check on prover side
     w.putBytes(obj.n)
   }
 
+  // eager, validating parse: decode pk (rejecting malformed group elements) and rebuild from the
+  // points so the serialized form is canonical, matching the original parser (see v1 serializer)
   override def parse(r: Reader): AutolykosSolution = {
-    val pk = groupElemFromBytes(r.getBytes(PublicKeyLength))
+    val raw = parseLazy(r)
+    AutolykosSolution(raw.pk, raw.w, raw.n, raw.d)
+  }
+
+  // lazy read for the trusted storage path only - defers EC point decompression, no validation
+  private[mining] def parseLazy(r: Reader): AutolykosSolution = {
+    val pkBytes = r.getBytes(PublicKeyLength)
     val nonce = r.getBytes(8)
-    AutolykosSolution(pk, wForV2, nonce, dForV2)
+    AutolykosSolution.fromBytes(pkBytes, wBytesForV2Copy, nonce, dForV2)
   }
 
 }
@@ -127,8 +215,20 @@ object AutolykosSolutionSerializer {
     serializer(blockVersion).serialize(solution, w)
   }
 
+  /**
+    * Default, validating parse used for all untrusted (e.g. network) input. The group element(s) are
+    * decoded immediately so malformed keys are rejected here, exactly as the original parser did.
+    */
   def parse(r: Reader, blockVersion: Version): AutolykosSolution = {
     serializer(blockVersion).parse(r)
+  }
+
+  /**
+    * Lazy parse for trusted, already-validated input only (the storage read path). EC point
+    * decompression is deferred until `pk`/`w` are accessed. Must not be used for untrusted input.
+    */
+  private[ergoplatform] def parseLazy(r: Reader, blockVersion: Version): AutolykosSolution = {
+    if (blockVersion == 1) v1Serializer.parseLazy(r) else v2Serializer.parseLazy(r)
   }
 
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/HistoryModifierSerializer.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/HistoryModifierSerializer.scala
@@ -4,7 +4,10 @@ import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSerializer}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.serialization.ErgoSerializer
-import scorex.util.serialization.{Reader, Writer}
+import scorex.util.serialization.{Reader, VLQByteBufferReader, Writer}
+
+import java.nio.ByteBuffer
+import scala.util.Try
 
 object HistoryModifierSerializer extends ErgoSerializer[BlockSection] {
 
@@ -41,4 +44,30 @@ object HistoryModifierSerializer extends ErgoSerializer[BlockSection] {
         throw new Error(s"Deserialization for unknown type byte: $m")
     }
   }
+
+  /**
+    * Like [[parse]], but parses headers lazily (deferring PoW solution EC point decompression).
+    * Only for trusted, already-validated data read back from local storage. Non-header sections are
+    * parsed exactly as in [[parse]].
+    */
+  private def parseLazy(r: Reader): BlockSection = {
+    r.getByte() match {
+      case Header.`modifierTypeId` =>
+        HeaderSerializer.parseLazy(r)
+      case ADProofs.`modifierTypeId` =>
+        ADProofsSerializer.parse(r)
+      case BlockTransactions.`modifierTypeId` =>
+        BlockTransactionsSerializer.parse(r)
+      case Extension.`modifierTypeId` =>
+        ExtensionSerializer.parse(r)
+      case m =>
+        throw new Error(s"Deserialization for unknown type byte: $m")
+    }
+  }
+
+  /**
+    * Deserialize trusted storage bytes, parsing headers lazily (see [[parseLazy]]).
+    */
+  private[ergoplatform] def parseBytesTryLazy(bytes: Array[Byte]): Try[BlockSection] =
+    Try(parseLazy(new VLQByteBufferReader(ByteBuffer.wrap(bytes))))
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/header/HeaderSerializer.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/header/HeaderSerializer.scala
@@ -80,4 +80,15 @@ object HeaderSerializer extends ErgoSerializer[Header] {
     headerWithoutPow.toHeader(powSolution, Some(r.consumed))
   }
 
+  /**
+    * Parse a header from trusted, already-validated bytes (the storage read path), deferring EC point
+    * decompression of the PoW solution. Must NOT be used for untrusted (network) input - use [[parse]],
+    * which decodes the solution eagerly and thereby validates it.
+    */
+  private[history] def parseLazy(r: Reader): Header = {
+    val headerWithoutPow = parseWithoutPow(r)
+    val powSolution = AutolykosSolutionSerializer.parseLazy(r, headerWithoutPow.version)
+    headerWithoutPow.toHeader(powSolution, Some(r.consumed))
+  }
+
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.mining
 
 import com.google.common.primitives.Ints
 import org.ergoplatform.mining.difficulty.DifficultySerializer
+import org.ergoplatform.modifiers.history.HistoryModifierSerializer
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalacheck.Gen
@@ -114,6 +115,50 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
     Base16.encode(header.powSolution.n) shouldBe "0000000000003105"
 
     pow.validate(header) shouldBe 'success
+  }
+
+  property("malformed v2 miner pk: default parse rejects, lazy storage parse defers until pk is read") {
+    forAll(invalidHeaderGen) { inHeader =>
+      val h = inHeader.copy(version = Header.HardeningVersion) // Autolykos v2
+      val s = h.powSolution
+      // 33 bytes that do not decode to a curve point. v2 PoW ignores pk, so such a header could carry
+      // valid PoW and must still be rejected by the (validating) default parser, not silently accepted.
+      val badPk = Array.fill[Byte](PublicKeyLength)(0x05.toByte)
+      val tampered = h.copy(powSolution = AutolykosSolution.fromBytes(badPk, s.wBytes, s.n, s.d))
+      val modifierBytes = HistoryModifierSerializer.toBytes(tampered)
+
+      // default (untrusted/network) deserialization decodes the key eagerly and rejects it
+      HistoryModifierSerializer.parseBytesTry(modifierBytes).isSuccess shouldBe false
+
+      // the trusted storage path (used by HistoryStorage.modifierById) defers the decode: it
+      // deserializes successfully, and the bad key only surfaces when the miner pk is accessed
+      val recovered = HistoryModifierSerializer.parseBytesTryLazy(modifierBytes)
+      recovered.isSuccess shouldBe true
+      assertThrows[Exception](recovered.get.asInstanceOf[Header].powSolution.pk)
+    }
+  }
+
+  property("eager parse canonicalizes a non-canonical PoW solution encoding") {
+    forAll(invalidHeaderGen) { inHeader =>
+      val h = inHeader.copy(version = Header.HardeningVersion) // Autolykos v2
+      val s = h.powSolution
+      // GroupElementSerializer decodes any 33 bytes starting with 0 as the infinity point, whose
+      // canonical encoding is 33 zero bytes - so this is a non-canonical encoding of a valid point.
+      val nonCanonicalPk = Array(0.toByte) ++ Array.fill(PublicKeyLength - 1)(0xff.toByte)
+      val canonicalPk = groupElemToBytes(groupElemFromBytes(nonCanonicalPk))
+      Base16.encode(canonicalPk) shouldNot equal(Base16.encode(nonCanonicalPk)) // input is non-canonical
+
+      val nonCanon = h.copy(powSolution = AutolykosSolution.fromBytes(nonCanonicalPk, s.wBytes, s.n, s.d))
+      val canon = h.copy(powSolution = AutolykosSolution.fromBytes(canonicalPk, s.wBytes, s.n, s.d))
+
+      // the raw serialized forms differ, but the eager (untrusted) parser normalizes both, so they
+      // yield the same canonical header bytes and id - keeping serializedId consistent across nodes
+      Base16.encode(nonCanon.bytes) shouldNot equal(Base16.encode(canon.bytes))
+      val parsedNonCanon = HeaderSerializer.parseBytes(nonCanon.bytes)
+      val parsedCanon = HeaderSerializer.parseBytes(canon.bytes)
+      parsedNonCanon.id shouldBe parsedCanon.id
+      Base16.encode(parsedNonCanon.bytes) shouldBe Base16.encode(parsedCanon.bytes)
+    }
   }
 
   // testing an invalid header got from a mining pool

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
@@ -78,7 +78,9 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
 
   def modifierById(id: ModifierId): Option[BlockSection] =
     lookupModifier(id) orElse objectsStore.get(idToBytes(id)).flatMap { bytes =>
-      HistoryModifierSerializer.parseBytesTry(bytes) match {
+      // objects in this store were validated before insertion, so headers can be parsed lazily,
+      // deferring PoW solution EC point decompression that is not needed for chain traversal
+      HistoryModifierSerializer.parseBytesTryLazy(bytes) match {
         case Success(pm) =>
           log.trace(s"Cache miss for existing modifier $id")
           cacheModifier(pm)


### PR DESCRIPTION
`HistoryStorage.modifierById` was a profiler hotspot during header sync, dominated by EC point decompression (`decodePoint`) while parsing Autolykos solutions. Headers rehydrated from local storage for chain traversal (scoring, difficulty look-back, best-chain checks) need only height/parentId/etc., never the miner public key — yet every parse decompressed it.

`AutolykosSolution` now stores the miner public key and one-time key as their compressed bytes and decodes them to EC points lazily via `pk`/`w`. A dedicated, internal lazy parse path (`HistoryStorage.modifierById` → `HistoryModifierSerializer.parseBytesTryLazy` → `HeaderSerializer.parseLazy` → `AutolykosSolutionSerializer.parseLazy`) defers decompression for trusted, already-validated storage bytes. The dead `encodedPk` field (an EC point compression performed on every construction but never read) is removed.

Untrusted/network deserialization is unchanged: `AutolykosSolutionSerializer.parse` still decodes the points eagerly — rejecting malformed keys at parse — and rebuilds from them so the serialized form is canonical and `Header.serializedId` stays consistent across nodes. Wire serialization, header ids, and PoW validation are byte-for-byte unchanged.

**Breaking (binary, ergo-core):** `AutolykosSolution` is no longer a `case class`. Its point-based public surface (`apply(pk, w, n, d)`, `copy`, `unapply`, `equals`, `hashCode`) is preserved at source level, so source-compatible code keeps compiling — but this is binary-incompatible: downstream code compiled against the previous case class (its `Product`/synthetic methods, or the old constructor) must be recompiled. Equality is value-based over the canonical bytes. ergo-core ships cross-compiled (2.11/2.12/2.13) with no MiMa gate, so this is documented here rather than caught automatically.
