### PR TITLE
Bound Matrix input-block transaction message counts

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockMessageLimits.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockMessageLimits.scala
@@ -1,0 +1,14 @@
+package org.ergoplatform.network.message.inputblocks
+
+object InputBlockMessageLimits {
+
+  /**
+    * Maximum allowed count for array and sequence allocations during input-block message parsing.
+    */
+  val MaxArraySize: Long = 32768L
+
+  def requireArraySize(count: Long, label: String): Unit = {
+    require(count <= MaxArraySize, s"$label count too large: $count")
+  }
+
+}

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionIdsMessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionIdsMessageSpec.scala
@@ -28,7 +28,9 @@ object InputBlockTransactionIdsMessageSpec extends MessageSpecInputBlocks[InputB
 
   override def parse(r: Reader): InputBlockTransactionIdsData = {
     val subBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize))
-    val txsCount = r.getUInt().toIntExact
+    val txsCountLong = r.getUInt()
+    InputBlockMessageLimits.requireArraySize(txsCountLong, "Input-block transaction IDs")
+    val txsCount = txsCountLong.toIntExact
     val transactionIds = (1 to txsCount).map { _ =>
       r.getBytes(ErgoTransaction.WeakIdLength)
     }

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsMessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsMessageSpec.scala
@@ -29,7 +29,9 @@ object InputBlockTransactionsMessageSpec extends MessageSpecInputBlocks[InputBlo
 
   override def parse(r: Reader): InputBlockTransactionsData = {
     val subBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize))
-    val txsCount = r.getUInt().toIntExact
+    val txsCountLong = r.getUInt()
+    InputBlockMessageLimits.requireArraySize(txsCountLong, "Input-block transactions")
+    val txsCount = txsCountLong.toIntExact
 
     val txs = new Array[ErgoTransaction](txsCount)
     cfor(0)(_ < txsCount, _ + 1) { i =>

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsRequestMessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsRequestMessageSpec.scala
@@ -31,7 +31,9 @@ object InputBlockTransactionsRequestMessageSpec
 
   override def parse(r: Reader): InputBlockTransactionsRequest = {
     val inputBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize))
-    val cnt          = r.getUInt().toIntExact
+    val cntLong      = r.getUInt()
+    InputBlockMessageLimits.requireArraySize(cntLong, "Input-block transaction request IDs")
+    val cnt          = cntLong.toIntExact
     val txIds        = (1 to cnt).map(_ => r.getBytes(ErgoTransaction.WeakIdLength))
     InputBlockTransactionsRequest(inputBlockId, txIds)
   }

--- a/ergo-core/src/test/scala/org/ergoplatform/network/InputBlockMessageSpecsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/network/InputBlockMessageSpecsSpec.scala
@@ -4,6 +4,7 @@ import org.ergoplatform.mining.InputBlockFields
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.network.message.inputblocks.{
   InputBlockMessageSpec,
+  InputBlockMessageLimits,
   InputBlockTransactionIdsData,
   InputBlockTransactionIdsMessageSpec,
   InputBlockTransactionsData,
@@ -17,6 +18,10 @@ import org.ergoplatform.utils.{ErgoCorePropertyTest, SerializationTests}
 import org.scalacheck.Gen
 import scorex.crypto.authds.merkle.BatchMerkleProof
 import scorex.crypto.hash.Blake2b256
+import scorex.util.ModifierId
+import scorex.util.serialization.{VLQByteBufferReader, VLQByteBufferWriter}
+
+import java.nio.ByteBuffer
 
 class InputBlockMessageSpecsSpec extends ErgoCorePropertyTest with SerializationTests {
   import org.ergoplatform.utils.generators.CoreObjectGenerators._
@@ -27,6 +32,13 @@ class InputBlockMessageSpecsSpec extends ErgoCorePropertyTest with Serialization
   private val inputBlockTransactionIdsMessageSpec = InputBlockTransactionIdsMessageSpec
   private val inputBlockTransactionsMessageSpec = InputBlockTransactionsMessageSpec
   private val inputBlockTransactionsRequestMessageSpec = InputBlockTransactionsRequestMessageSpec
+
+  private def bytesWithInputBlockIdAndCount(inputBlockId: ModifierId, count: Long): Array[Byte] = {
+    val writer = new VLQByteBufferWriter(new scorex.util.ByteArrayBuilder())
+    writer.putBytes(scorex.util.idToBytes(inputBlockId))
+    writer.putUInt(count)
+    writer.toBytes
+  }
 
   private def inputBlockInfoGen: Gen[InputBlockAnnouncement] = for {
     header <- defaultHeaderGen
@@ -129,6 +141,33 @@ class InputBlockMessageSpecsSpec extends ErgoCorePropertyTest with Serialization
       recovered.inputBlockId shouldEqual emptyRequest.inputBlockId
       recovered.txIds shouldEqual emptyRequest.txIds
     }
+  }
+
+  property("InputBlockTransactionIdsData rejects excessive transaction id count") {
+    val inputBlockId = modifierIdGen.sample.get
+    val bytes = bytesWithInputBlockIdAndCount(inputBlockId, InputBlockMessageLimits.MaxArraySize + 1)
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+
+    val ex = the[Exception] thrownBy inputBlockTransactionIdsMessageSpec.parse(reader)
+    ex.getMessage should include ("Input-block transaction IDs count too large")
+  }
+
+  property("InputBlockTransactionsData rejects excessive transaction count") {
+    val inputBlockId = modifierIdGen.sample.get
+    val bytes = bytesWithInputBlockIdAndCount(inputBlockId, InputBlockMessageLimits.MaxArraySize + 1)
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+
+    val ex = the[Exception] thrownBy inputBlockTransactionsMessageSpec.parse(reader)
+    ex.getMessage should include ("Input-block transactions count too large")
+  }
+
+  property("InputBlockTransactionsRequest rejects excessive transaction id count") {
+    val inputBlockId = modifierIdGen.sample.get
+    val bytes = bytesWithInputBlockIdAndCount(inputBlockId, InputBlockMessageLimits.MaxArraySize + 1)
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+
+    val ex = the[Exception] thrownBy inputBlockTransactionsRequestMessageSpec.parse(reader)
+    ex.getMessage should include ("Input-block transaction request IDs count too large")
   }
 
   property("InputBlock hardcoded test vectors") {


### PR DESCRIPTION
Closed as covered by the current `weak-blocks` target at `c216c5b6e3310911d5f3822b40c5e57eee6fc45a`. Upstream commit [b7e522b1](https://github.com/ergoplatform/ergo/commit/b7e522b1b7b4957e9762192e852962a76ad50bb7) already checks all three input-block message counts against the available payload before allocation or iteration, with boundary and round-trip tests.

This PR's original oversized-count rejection cases are covered by those checks. Its fixed 32,768-item ceiling would impose an additional policy limit on payloads that contain enough bytes, so it is not carried forward as part of the already integrated correction. The original branch and regression history remain available.

This closure records source coverage on the target; it does not claim that the old branch's CI passed. The contribution inventory is maintained in [#2533](https://github.com/ergoplatform/ergo/issues/2533).
