### PR TITLE
Collect Matrix input block transactions by ordering id

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlocksProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlocksProcessor.scala
@@ -1165,9 +1165,8 @@ trait InputBlocksProcessor extends ScorexLogging {
     * @return Some(sequence of transactions from the best input block chain) if the ordering block exists, None otherwise
     */
   def getCollectedInputBlocksTransactions(id: ModifierId): Option[Seq[ErgoTransaction]] = {
-    bestOrderingBlock()
-      .map(_.id)
-      .flatMap(inputBlockTrees.get)
+    inputBlockTrees
+      .get(id)
       .map(_.bestChainTransactions)
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlockProcessorSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlockProcessorSpecification.scala
@@ -1374,6 +1374,8 @@ class InputBlockProcessorSpecification extends ErgoCorePropertyTest with ErgoCom
 
     // Test transaction retrieval
     h.getInputBlockTransactions(ib1.id) shouldBe Some(tx1)
+    h.getCollectedInputBlocksTransactions(h.bestFullBlockOpt.get.id) shouldBe Some(tx1)
+    h.getCollectedInputBlocksTransactions(bytesToId(Algos.hash("other-ordering-block"))) shouldBe None
 
     // Test weak ID retrieval
     h.getInputBlockTransactionWeakIds(ib1.id) shouldBe Some(tx1.map(_.weakId))


### PR DESCRIPTION
## Summary
- use the requested ordering block id when collecting transactions from its best input-block chain
- avoid returning the current best ordering block's input transactions for unrelated ids
- add a regression assertion for an unrelated ordering id lookup

## Validation
- `git diff --check`
- publication guard on staged diff and `origin/weak-blocks..HEAD`
- attempted `sbt "testOnly org.ergoplatform.nodeView.history.modifierprocessors.InputBlockProcessorSpecification -- -z transaction retrieval methods"`, but the current Matrix base fails before compilation while resolving `org.scorexfoundation:sigma-state_2.12:6.0.2-30-59782d92-SNAPSHOT`