### PR TITLE
Verify Matrix input block transaction bodies digest

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlocksProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlocksProcessor.scala
@@ -8,6 +8,8 @@ import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.state.ErgoState
 import org.ergoplatform.settings.Algos
 import org.ergoplatform.subblocks.InputBlockAnnouncement
+import scorex.crypto.authds.LeafData
+import scorex.crypto.hash.Digest32
 import scorex.util.{ModifierId, ScorexLogging}
 import spire.syntax.all.cfor
 
@@ -703,6 +705,17 @@ trait InputBlocksProcessor extends ScorexLogging {
   // extracts ordering block id from input block data provided
   private def extractOrderingId(ib: InputBlockAnnouncement) = ib.header.parentId
 
+  private def inputBlockTransactionsDigest(transactions: Seq[ErgoTransaction]): Digest32 = {
+    Algos.merkleTreeRoot(transactions.map(tx => LeafData @@ tx.serializedId))
+  }
+
+  private def transactionBodiesMatchAnnouncement(ib: InputBlockAnnouncement,
+                                                 transactions: Seq[ErgoTransaction]): Boolean = {
+    val proofCarriesInputBlockFields = ib.inputBlockFields.inputBlockFieldsProof.indices.nonEmpty
+    !proofCarriesInputBlockFields ||
+      inputBlockTransactionsDigest(transactions).sameElements(ib.inputBlockFields.transactionsDigest)
+  }
+
   /**
     * Gets the current best ordering block and best input block pair.
     *
@@ -907,6 +920,13 @@ trait InputBlocksProcessor extends ScorexLogging {
 
     try {
       log.info(s"Applying ${transactions.size} input block transactions for $sbId")
+      inputBlockRecords.get(sbId).foreach { ib =>
+        if (!transactionBodiesMatchAnnouncement(ib, transactions)) {
+          log.warn(s"Input block transactions digest does not match announcement for $sbId")
+          return Seq.empty -> Seq.empty
+        }
+      }
+
       val transactionIds = transactions.map(_.id)
       inputBlockTransactions.put(sbId, transactionIds)
 

--- a/src/test/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlockProcessorSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/modifierprocessors/InputBlockProcessorSpecification.scala
@@ -13,7 +13,7 @@ import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
 import org.ergoplatform.utils.HistoryTestHelpers.generateHistory
 import org.ergoplatform.utils.generators.ChainGenerator.{applyChain, genChain}
 import org.ergoplatform.utils.generators.ValidBlocksGenerators.validTransactionsFromBoxHolder
-import scorex.crypto.authds.ADDigest
+import scorex.crypto.authds.{ADDigest, LeafData}
 import scorex.crypto.authds.merkle.BatchMerkleProof
 import scorex.crypto.hash.Digest32
 import scorex.util.{bytesToId, idToBytes}
@@ -67,6 +67,13 @@ class InputBlockProcessorSpecification extends ErgoCorePropertyTest with ErgoCom
       Digest32 @@ Array.fill(32)(0.toByte),
       Digest32 @@ Array.fill(32)(0.toByte),
       BatchMerkleProof(Seq.empty, Seq.empty)(Algos.hash))
+  }
+
+  private def provedFieldsForTransactions(transactions: Seq[ErgoTransaction]): InputBlockFields = {
+    val digest = Algos.merkleTreeRoot(transactions.map(tx => LeafData @@ tx.serializedId))
+    val prevDigest = Digest32 @@ Array.fill(32)(0.toByte)
+    val extCandidate = InputBlockFields.toExtensionFields(None, digest, prevDigest)
+    new InputBlockFields(None, digest, prevDigest, extCandidate.proofForInputBlockData.get)
   }
 
   property("apply first input block after ordering block") {
@@ -393,6 +400,25 @@ class InputBlockProcessorSpecification extends ErgoCorePropertyTest with ErgoCom
     h.bestInputBlocksChain() shouldBe Seq()
     h.applyInputBlockTransactions(ib.id, Seq(tx), us) shouldBe (Seq.empty -> Seq.empty)
     h.bestInputBlocksChain() shouldBe Seq()
+  }
+
+  property("reject input block transactions that do not match the announced digest") {
+    val bh = BoxHolder(Seq(eb1))
+    val us = UtxoState.fromBoxHolder(bh, None, createTempDir, settings, parameters)
+    val tx1 = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(1)), 201)._1
+
+    val h = generateHistory(verifyTransactions = true, StateType.Utxo, PoPoWBootstrap = false, blocksToKeep = -1,
+      epochLength = 10000, useLastEpochs = 3, initialDiffOpt = None, None)
+    val c1 = genChain(2, h, stateOpt = Some(us))
+    applyChain(h, c1)
+
+    val c2 = genChain(2, h, stateOpt = Some(us)).tail
+    val ib = InputBlockAnnouncement(1, c2(0).header, provedFieldsForTransactions(Seq.empty), None)
+    h.applyInputBlock(ib) shouldBe None
+
+    h.applyInputBlockTransactions(ib.id, tx1, us) shouldBe (Seq.empty -> Seq.empty)
+    h.getInputBlockTransactionIds(ib.id) shouldBe None
+    h.getInputBlockTransactions(ib.id) shouldBe None
   }
 
   property("apply input block with parent ordering block not available") {


### PR DESCRIPTION
## Summary
- verify delivered input-block transaction bodies against the transaction digest announced in proven input-block fields
- reject mismatching bodies before caching or processing them
- add a regression test with a proven empty transaction digest and a non-empty delivered body set

## Validation
- `git diff --check`
- publication guard on staged diff and `origin/weak-blocks..HEAD`
- attempted `sbt "testOnly org.ergoplatform.nodeView.history.modifierprocessors.InputBlockProcessorSpecification -- -z announced digest"`, but the current Matrix base fails before compilation while resolving `org.scorexfoundation:sigma-state_2.12:6.0.2-30-59782d92-SNAPSHOT`