### PR TITLE
Fix storage rent fee overflow for large boxes

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoInterpreter.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoInterpreter.scala
@@ -40,7 +40,7 @@ class ErgoInterpreter(params: BlockchainParameters)
     * @return whether the box is spent properly according to the storage fee rule
     */
   protected def checkExpiredBox(box: ErgoBox, output: ErgoBoxCandidate, currentHeight: Height): Boolean = {
-    val storageFee = params.storageFeeFactor * box.bytes.length
+    val storageFee = params.storageFeeFactor.toLong * box.bytes.length
 
     val storageFeeNotCovered = box.value - storageFee <= 0
     lazy val correctCreationHeight = output.creationHeight == currentHeight

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/interpreter/StorageRentOverflowSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/interpreter/StorageRentOverflowSpec.scala
@@ -1,0 +1,50 @@
+package org.ergoplatform.wallet.interpreter
+
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.util.ModifierId
+import scorex.util.encode.Base16
+import sigma.Colls
+import sigma.ast.{ByteArrayConstant, ErgoTree, EvaluatedValue, FalseLeaf, SType}
+import sigma.eval.Extensions._
+
+class StorageRentOverflowSpec
+  extends AnyFlatSpec
+    with Matchers
+    with InterpreterSpecCommon {
+
+  private class TestInterpreter extends ErgoInterpreter(parameters) {
+    def checkExpired(box: ErgoBox, output: ErgoBoxCandidate, currentHeight: Int): Boolean =
+      checkExpiredBox(box, output, currentHeight)
+  }
+
+  it should "accept covered storage-rent recreation when the byte fee is larger than Int.MaxValue" in {
+    val transactionId = ModifierId @@ Base16.encode(Array.fill(32)(5: Byte))
+    val registers: Map[ErgoBox.NonMandatoryRegisterId, EvaluatedValue[_ <: SType]] =
+      Map(ErgoBox.R4 -> ByteArrayConstant(Array.fill(2200)(1: Byte)))
+    val input = new ErgoBox(
+      value = 10000000000L,
+      ergoTree = ErgoTree.fromProposition(FalseLeaf.toSigmaProp),
+      additionalTokens = Colls.emptyColl[(ErgoBox.TokenId, Long)],
+      additionalRegisters = registers,
+      transactionId = transactionId,
+      index = 0,
+      creationHeight = 1
+    )
+
+    val storageFee = parameters.storageFeeFactor.toLong * input.bytes.length
+    storageFee should be > Int.MaxValue.toLong
+
+    val currentHeight = 2000000
+    val recreated = new ErgoBoxCandidate(
+      value = input.value - storageFee,
+      ergoTree = input.ergoTree,
+      creationHeight = currentHeight,
+      additionalTokens = input.additionalTokens,
+      additionalRegisters = input.additionalRegisters
+    )
+
+    new TestInterpreter().checkExpired(input, recreated, currentHeight) shouldBe true
+  }
+}

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ExpirationSpecification.scala
@@ -87,7 +87,7 @@ class ExpirationSpecification extends ErgoCorePropertyTest {
   property("successful spending w. max spending") {
     forAll(unspendableErgoBoxGen()) { from =>
       constructTest(from, 0, h => {
-        val fee = Math.min(parameters.storageFeeFactor * from.bytes.length, from.value)
+        val fee = Math.min(parameters.storageFeeFactor.toLong * from.bytes.length, from.value)
         val feeBoxCandidate = new ErgoBoxCandidate(fee, TrueTree, creationHeight = h)
         IndexedSeq(changeValue(from, -fee), Some(feeBoxCandidate)).flatten
       }, expectedValidity = true)
@@ -97,7 +97,7 @@ class ExpirationSpecification extends ErgoCorePropertyTest {
   property("unsuccessful spending due too big storage fee charged") {
     forAll(unspendableErgoBoxGen(parameters.storageFeeFactor * 100 + 1, Long.MaxValue)) { from =>
       constructTest(from, 0, h => {
-        val fee = Math.min(parameters.storageFeeFactor * from.bytes.length + 1, from.value)
+        val fee = Math.min(parameters.storageFeeFactor.toLong * from.bytes.length + 1, from.value)
         val feeBoxCandidate = new ErgoBoxCandidate(fee, TrueTree, creationHeight = h)
         IndexedSeq(changeValue(from, -fee), Some(feeBoxCandidate)).flatten
       }, expectedValidity = false)
@@ -107,7 +107,7 @@ class ExpirationSpecification extends ErgoCorePropertyTest {
   property("unsuccessful spending when more time passed than storage period and charged more than K*storagePeriod") {
     forAll(unspendableErgoBoxGen(parameters.storageFeeFactor * 100 + 1, Long.MaxValue)) { from =>
       constructTest(from, 1, h => {
-        val fee = Math.min(parameters.storageFeeFactor * from.bytes.length + 1, from.value)
+        val fee = Math.min(parameters.storageFeeFactor.toLong * from.bytes.length + 1, from.value)
         val feeBoxCandidate = new ErgoBoxCandidate(fee, TrueTree, creationHeight = h)
 
         IndexedSeq(changeValue(from, -fee), Some(feeBoxCandidate)).flatten
@@ -118,7 +118,7 @@ class ExpirationSpecification extends ErgoCorePropertyTest {
   property("too early spending") {
     forAll(unspendableErgoBoxGen()) { from =>
       constructTest(from, -1, h => {
-        val fee = Math.min(parameters.storageFeeFactor * from.bytes.length, from.value)
+        val fee = Math.min(parameters.storageFeeFactor.toLong * from.bytes.length, from.value)
         val feeBoxCandidate = new ErgoBoxCandidate(fee, TrueTree, creationHeight = h)
         IndexedSeq(changeValue(from, -fee), Some(feeBoxCandidate)).flatten
       }, expectedValidity = false)
@@ -155,7 +155,7 @@ class ExpirationSpecification extends ErgoCorePropertyTest {
     val minValue = out2.value + 1
 
     forAll(unspendableErgoBoxGen(minValue, Long.MaxValue)) { from =>
-      val outcome = from.value <= from.bytes.length * parameters.storageFeeFactor
+      val outcome = from.value <= from.bytes.length * parameters.storageFeeFactor.toLong
       val out1 = new ErgoBoxCandidate(from.value - minValue, TrueTree, creationHeight = from.creationHeight + 1)
       constructTest(from, 0, _ => IndexedSeq(out1, out2), expectedValidity = outcome)
     }


### PR DESCRIPTION
Superseded by [#2438](https://github.com/ergoplatform/ergo/pull/2438), which owns the storage-rent arithmetic correction and its legacy-compatibility boundary. The original branch and regression history remain available.

This proposal widened `storageFeeFactor * box.bytes.length` to `Long` unconditionally. That changes consensus-visible verdicts for large expired boxes under existing parameters. At head `08dccb480f7a6d6fb027bdc7e0798580ceb7be9e`, #2438 applies the same multiplication correction behind its proposed version gate and explicitly preserves the wrapped `Int` result below that gate. Its tests assert both legacy and repaired outcomes, including first- and second-wrap cases and ordinary-claim compatibility.

The arithmetic work and the release/activation decision should be reviewed in #2438. That PR remains a draft; this closure does not approve its broader proposal or select its activation. Related issue: [#2251](https://github.com/ergoplatform/ergo/issues/2251).

The original proposal added a large-box recreation regression and was locally checked with `StorageRentOverflowSpec`, `ExpirationSpecification` and the wallet suite. Those historical results do not resolve the compatibility decision.
