### PR TITLE
Add Inv -> RequestModifier test to ErgoNodeViewSynchronizerSpecificat…

### DIFF
--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -16,7 +16,7 @@ import org.ergoplatform.wallet.utils.FileUtils
 import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
-import scorex.core.network.ModifiersStatus.{Received, Unknown}
+import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.message._
 import org.ergoplatform.network.peer.PeerInfo
@@ -221,6 +221,37 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
             msg.data.get.asInstanceOf[InvData].ids.head == chain.head.id
           case _ => false
         }
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: Message: InvSpec - header next to the best one is requested via RequestModifier") {
+    withFixture { ctx =>
+      import ctx._
+      deliveryTracker.reset()
+
+      // header immediately following the best header the node has
+      // (history applied to the synchronizer contains the first 1000 headers of `chain`)
+      val nextHeader = chain.take(1001).last
+      deliveryTracker.status(nextHeader.id, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+
+      // a peer announces the header via an Inv message
+      val invData = InvData(Header.modifierTypeId, Seq(nextHeader.id))
+      synchronizer ! Message(InvSpec, Left(InvSpec.toBytes(invData)), Some(peer))
+
+      // the synchronizer should reply to the peer with a RequestModifier message asking for the header
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val data = stn.message.data.get.asInstanceOf[InvData]
+            data.typeId == Header.modifierTypeId && data.ids == Seq(nextHeader.id)
+          case _ => false
+        }
+      }
+
+      // and the header should be tracked as Requested
+      eventually {
+        deliveryTracker.status(nextHeader.id, Header.modifierTypeId, Seq.empty) shouldBe Requested
       }
     }
   }


### PR DESCRIPTION
# Add Inv → RequestModifier test to ErgoNodeViewSynchronizerSpecification

Closes #2184

## Summary

Adds the test requested in #2184 to `ErgoNodeViewSynchronizerSpecification`:

> Make a test following existing ones, where INV message of a header after the best one the receiver has is sent, and check that it replies with RequestModifier message.

## What the test does

Using the existing `SynchronizerFixture` (synchronizer wired to a history containing the first 1000 headers of `chain`):

1. takes `chain.take(1001).last` — the header immediately following the node's best header — and asserts its `DeliveryTracker` status is `Unknown`;
2. sends to the synchronizer an `InvSpec` message announcing that header id from a connected peer (serialized with `InvSpec.toBytes`, as in the other message-handling tests);
3. uses `ncProbe.fishForMessage` to assert that the synchronizer replies with a `SendToNetwork` carrying a `RequestModifierSpec` message whose `InvData` contains exactly the announced header id (`processInv → requestBlockSection` path);
4. additionally asserts (via `eventually`) that the header is tracked as `Requested` in the `DeliveryTracker` afterwards.

## Notes

- The test mirrors the structure and helpers of the neighbouring properties in the same spec (`withFixture`, `fishForMessage`, `eventually`), no production code is touched.
- Only one import line is extended (`ModifiersStatus.Requested`).
- The whole suite (9 properties) passes locally with `sbt "testOnly org.ergoplatform.network.ErgoNodeViewSynchronizerSpecification"`.