### PR TITLE
Harden wallet amount validation

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -17,6 +17,9 @@ import scala.util.Try
 
 object TransactionBuilder {
 
+  def sumLongExact(values: Iterable[Long]): Long =
+    values.foldLeft(0L)(java7.compat.Math.addExact(_, _))
+
   /**
     * @param recipientAddress - payment recipient address
     * @param transferAmt - amount of ERGs to transfer
@@ -172,7 +175,7 @@ object TransactionBuilder {
     require(outputCandidates.size <= Short.MaxValue,
       s"too many outputCandidates - ${outputCandidates.size} (max ${Short.MaxValue})")
     require(outputCandidates.forall(_.value >= 0), s"outputCandidate.value must be >= 0")
-    val outputSumTry = Try(outputCandidates.map(_.value).reduce(java7.compat.Math.addExact(_, _)))
+    val outputSumTry = Try(sumLongExact(outputCandidates.map(_.value)))
     require(outputSumTry.isSuccess, s"Sum of transaction output values should not exceed ${Long.MaxValue}")
     require(inputs.distinct.size == inputs.size, s"There should be no duplicate inputs")
   }
@@ -210,10 +213,10 @@ object TransactionBuilder {
 
     val feeAmount = createFeeOutput.getOrElse(0L)
     require(createFeeOutput.fold(true)(_ > 0), s"expected fee amount > 0, got $feeAmount")
-    val inputTotal  = inputs.map(_.value).sum
-    val outputSum   = outputCandidates.map(_.value).sum
-    val outputTotal = outputSum + feeAmount
-    val changeAmt   = inputTotal - outputTotal
+    val inputTotal  = sumLongExact(inputs.map(_.value))
+    val outputSum   = sumLongExact(outputCandidates.map(_.value))
+    val outputTotal = java7.compat.Math.addExact(outputSum, feeAmount)
+    val changeAmt   = java7.compat.Math.subtractExact(inputTotal, outputTotal)
     require(changeAmt >= 0, s"total inputs $inputTotal is less then total outputs $outputTotal")
 
     val firstInputBoxId = bytesToId(inputs(0).id)

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -17,6 +17,9 @@ import scala.util.Try
 
 object TransactionBuilder {
 
+  private[ergoplatform] def sumLongExact(values: Iterable[Long]): Long =
+    values.foldLeft(0L)(java7.compat.Math.addExact(_, _))
+
   /**
     * @param recipientAddress - payment recipient address
     * @param transferAmt - amount of ERGs to transfer
@@ -170,7 +173,7 @@ object TransactionBuilder {
     require(outputCandidates.size <= Short.MaxValue,
       s"too many outputCandidates - ${outputCandidates.size} (max ${Short.MaxValue})")
     require(outputCandidates.forall(_.value >= 0), s"outputCandidate.value must be >= 0")
-    val outputSumTry = Try(outputCandidates.map(_.value).reduce(java7.compat.Math.addExact(_, _)))
+    val outputSumTry = Try(sumLongExact(outputCandidates.map(_.value)))
     require(outputSumTry.isSuccess, s"Sum of transaction output values should not exceed ${Long.MaxValue}")
     require(inputs.distinct.size == inputs.size, s"There should be no duplicate inputs")
   }
@@ -208,10 +211,10 @@ object TransactionBuilder {
 
     val feeAmount = createFeeOutput.getOrElse(0L)
     require(createFeeOutput.fold(true)(_ > 0), s"expected fee amount > 0, got $feeAmount")
-    val inputTotal  = inputs.map(_.value).sum
-    val outputSum   = outputCandidates.map(_.value).sum
-    val outputTotal = outputSum + feeAmount
-    val changeAmt   = inputTotal - outputTotal
+    val inputTotal  = sumLongExact(inputs.map(_.value))
+    val outputSum   = sumLongExact(outputCandidates.map(_.value))
+    val outputTotal = java7.compat.Math.addExact(outputSum, feeAmount)
+    val changeAmt   = java7.compat.Math.subtractExact(inputTotal, outputTotal)
     require(changeAmt >= 0, s"total inputs $inputTotal is less then total outputs $outputTotal")
 
     val firstInputBoxId = bytesToId(inputs(0).id)

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
@@ -116,6 +116,14 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
     tx.outputCandidates(0) shouldEqual outBox
   }
 
+  property("reject output and fee total overflow") {
+    val inputBox = box(Long.MaxValue)
+    val outBox = boxCandidate(Long.MaxValue)
+    val res = transaction(inputBox, outBox, fee = Some(1L))
+
+    res.isFailure shouldBe true
+  }
+
   property("change goes to fee, but no outFee box") {
     val inputBox = box(minBoxValue + minBoxValue / 2)
     val tokenId  = inputBox.id.toTokenId

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
@@ -116,6 +116,37 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
     tx.outputCandidates(0) shouldEqual outBox
   }
 
+  property("reject output and fee total overflow") {
+    val inputBox = box(Long.MaxValue)
+    val outBox = boxCandidate(Long.MaxValue)
+    val res = transaction(inputBox, outBox, fee = Some(1L))
+
+    res.isFailure shouldBe true
+    res.failed.get shouldBe a[ArithmeticException]
+  }
+
+  property("reject input total overflow") {
+    val inputBoxes = IndexedSeq(
+      testBox(Long.MaxValue, TrueTree, currentHeight, boxIndex = 0),
+      testBox(1L, TrueTree, currentHeight, boxIndex = 1)
+    )
+    val outBox = boxCandidate(minBoxValue)
+    val changeAddress = P2PKAddress(rootSecret.privateInput.publicImage)
+    val res = buildUnsignedTx(
+      inputs = inputBoxes,
+      dataInputs = IndexedSeq.empty,
+      outputCandidates = IndexedSeq(outBox),
+      currentHeight = currentHeight,
+      createFeeOutput = Some(minBoxValue),
+      changeAddress = changeAddress,
+      minChangeValue = minChangeValue,
+      minerRewardDelay = minerRewardDelay
+    )
+
+    res.isFailure shouldBe true
+    res.failed.get shouldBe a[ArithmeticException]
+  }
+
   property("change goes to fee, but no outFee box") {
     val inputBox = box(minBoxValue + minBoxValue / 2)
     val tokenId  = inputBox.id.toTokenId

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -454,16 +454,22 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       boxSelector: BoxSelector,
       targetBalance: Long,
       targetAssets: Map[ErgoBox.TokenId, Long]): Try[CollectedBoxes] = {
-    val assetsMap = targetAssets.map(t => t._1.toModifierId -> t._2)
-    val inputBoxes = state.getBoxesToSpend
-    boxSelector
-      .select(inputBoxes.iterator, state.walletFilter, targetBalance, assetsMap)
-      .leftMap(m => new Exception(m.message))
-      .map { res =>
-        val ergoBoxes = res.inputBoxes.map(_.box)
-        val changeBoxes = res.changeBoxes.map(b => ChangeBox(b.value, b.tokens))
-        CollectedBoxes(ergoBoxes, changeBoxes)
-      }.toTry
+    if (targetBalance < 0) {
+      Failure(new IllegalArgumentException(s"targetBalance must be >= 0, got $targetBalance"))
+    } else if (!targetAssets.values.forall(_ > 0)) {
+      Failure(new IllegalArgumentException(s"targetAssets values must be > 0, got $targetAssets"))
+    } else {
+      val assetsMap = targetAssets.map(t => t._1.toModifierId -> t._2)
+      val inputBoxes = state.getBoxesToSpend
+      boxSelector
+        .select(inputBoxes.iterator, state.walletFilter, targetBalance, assetsMap)
+        .leftMap(m => new Exception(m.message))
+        .map { res =>
+          val ergoBoxes = res.inputBoxes.map(_.box)
+          val changeBoxes = res.changeBoxes.map(b => ChangeBox(b.value, b.tokens))
+          CollectedBoxes(ergoBoxes, changeBoxes)
+        }.toTry
+    }
   }
 
   override def generateTransaction(state: ErgoWalletState,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -329,7 +329,7 @@ trait ErgoWalletSupport extends ScorexLogging {
           .map(_._1)
           .headOption
 
-        val targetBalance = outputs.map(_.value).sum
+        val targetBalance = TransactionBuilder.sumLongExact(outputs.map(_.value))
         val targetAssets = TransactionBuilder.collectOutputTokens(outputs.filterNot(bx => assetIssueBox.contains(bx)))
 
         //add burnTokens to target assets so that they are excluded from the change outputs

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -304,6 +304,8 @@ trait ErgoWalletSupport extends ScorexLogging {
     }
 
     require(inputBoxes.nonEmpty, "There must be at least one input box")
+    val inputBalance = TransactionBuilder.sumLongExact(inputBoxes.map(_.box.value))
+    require(inputBalance >= 0, s"Input balance must be non-negative, got $inputBalance")
 
     //filter burnTokens requests
     val (requestsWithBurnTokens, requestsWithoutBurnTokens) = requests.partition(_.isInstanceOf[BurnTokensRequest])
@@ -329,7 +331,7 @@ trait ErgoWalletSupport extends ScorexLogging {
           .map(_._1)
           .headOption
 
-        val targetBalance = outputs.map(_.value).sum
+        val targetBalance = TransactionBuilder.sumLongExact(outputs.map(_.value))
         val targetAssets = TransactionBuilder.collectOutputTokens(outputs.filterNot(bx => assetIssueBox.contains(bx)))
 
         //add burnTokens to target assets so that they are excluded from the change outputs

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -274,6 +274,40 @@ class ErgoWalletServiceSpec
     }
   }
 
+  property("it should reject unsigned transaction requests whose total ERG value overflows") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+
+        val encodedBoxes =
+          boxesAvailable(makeGenesisBlock(pks.head.pubkey, randomNewAsset), pks.head.pubkey)
+            .map { box =>
+              Base16.encode(ErgoBoxSerializer.toBytes(box))
+            }
+        val requests = Seq(
+          PaymentRequest(pks.head, Long.MaxValue, Array.empty, Map.empty),
+          PaymentRequest(pks.head, Long.MaxValue, Array.empty, Map.empty)
+        )
+        val boxSelector = new ReplaceCompactCollectBoxSelector(settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None)
+
+        generateUnsignedTransaction(wState, boxSelector, requests, inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty).isFailure shouldBe true
+      }
+    }
+  }
+
+  property("it should reject invalid collect boxes targets") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val boxSelector = new ReplaceCompactCollectBoxSelector(settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None)
+
+        walletService.collectBoxes(wState, boxSelector, targetBalance = -1L, targetAssets = Map.empty).isFailure shouldBe true
+        walletService.collectBoxes(wState, boxSelector, targetBalance = 0L, targetAssets = Map(randomNewAsset.head._1 -> -1L)).isFailure shouldBe true
+      }
+    }
+  }
+
   property("it should process unlock using preEip3Derivation") {
     withVersionedStore(2) { versionedStore =>
       withStore { store =>

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -370,6 +370,71 @@ class ErgoWalletServiceSpec
     }
   }
 
+  property("it should reject unsigned transaction requests whose total ERG value overflows") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+
+        val encodedBoxes =
+          boxesAvailable(makeGenesisBlock(pks.head.pubkey, randomNewAsset), pks.head.pubkey)
+            .map { box =>
+              Base16.encode(ErgoBoxSerializer.toBytes(box))
+            }
+        val requests = Seq(
+          PaymentRequest(pks.head, Long.MaxValue, Array.empty, Map.empty),
+          PaymentRequest(pks.head, Long.MaxValue, Array.empty, Map.empty)
+        )
+        val boxSelector = new ReplaceCompactCollectBoxSelector(settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None)
+
+        val result = generateUnsignedTransaction(wState, boxSelector, requests, inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty)
+
+        result.isFailure shouldBe true
+        result.failed.get shouldBe a[ArithmeticException]
+      }
+    }
+  }
+
+  property("it should reject provided input boxes whose total ERG value overflows") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+        val encodedBoxes = Seq(
+          testBox(Long.MaxValue - 5L, TrueTree, 0, boxIndex = 0),
+          testBox(10L, TrueTree, 0, boxIndex = 1)
+        ).map(box => Base16.encode(ErgoBoxSerializer.toBytes(box)))
+        val requests = Seq(PaymentRequest(pks.head, Long.MaxValue, Array.empty, Map.empty))
+        val boxSelector = new ReplaceCompactCollectBoxSelector(settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None)
+
+        val result = generateUnsignedTransaction(wState, boxSelector, requests, inputsRaw = encodedBoxes, dataInputsRaw = Seq.empty)
+
+        result.isFailure shouldBe true
+        result.failed.get shouldBe a[ArithmeticException]
+      }
+    }
+  }
+
+  property("it should reject invalid collect boxes targets") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val boxSelector = new ReplaceCompactCollectBoxSelector(settings.walletSettings.maxInputs, settings.walletSettings.optimalInputs, None)
+
+        val invalidTargets = Seq(
+          walletService.collectBoxes(wState, boxSelector, targetBalance = -1L, targetAssets = Map.empty),
+          walletService.collectBoxes(wState, boxSelector, targetBalance = 0L, targetAssets = Map(randomNewAsset.head._1 -> -1L)),
+          walletService.collectBoxes(wState, boxSelector, targetBalance = 0L, targetAssets = Map(randomNewAsset.head._1 -> 0L))
+        )
+
+        invalidTargets.foreach { result =>
+          result.isFailure shouldBe true
+          result.failed.get shouldBe a[IllegalArgumentException]
+        }
+        walletService.collectBoxes(wState, boxSelector, targetBalance = 0L, targetAssets = Map.empty).isSuccess shouldBe true
+      }
+    }
+  }
+
   property("it should process unlock using preEip3Derivation") {
     withVersionedStore(2) { versionedStore =>
       withStore { store =>


### PR DESCRIPTION
## Summary
- Fail closed when wallet input, output, fee, or request ERG totals overflow `Long`.
- Reject negative `collectBoxes` ERG targets and non-positive token targets before selection.
- Preserve valid zero-ERG/empty-token collection and current input-ID plus issue/burn ordering behavior.
- Add isolated regressions for request totals, provided-input totals, builder input/output/fee totals, and invalid collection targets.

## Validation
- New overflow and invalid-target regressions were observed failing before the production guards.
- `ErgoWalletServiceSpec`: 17/17 passed.
- `TransactionBuilderSpec`: 8/8 passed on Scala 2.11.12, 2.12.20, and 2.13.18.
- Full `ergoWallet/test`: 59/59 passed on Scala 2.12.20.
- Independent review completed with no findings on the exact pushed files.