### PR TITLE
Validate NiPoPoW proof parameters

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
@@ -129,9 +129,9 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
   def prove(chain: Seq[PoPowHeader])(params: PoPowParams): Try[NipopowProof] = Try {
     val k = params.k
     val m = params.m
+    val minChainLength = params.minChainLength
 
-    require(params.k >= 1, s"$k < 1")
-    require(chain.lengthCompare(k + m) >= 0, s"Can not prove chain of size < ${k + m}")
+    require(chain.lengthCompare(minChainLength) >= 0, s"Can not prove chain of size < $minChainLength")
     require(chain.head.header.isGenesis, "Can not prove non-anchored chain")
 
     @scala.annotation.tailrec

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
@@ -129,9 +129,8 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
   def prove(chain: Seq[PoPowHeader])(params: PoPowParams): Try[NipopowProof] = Try {
     val k = params.k
     val m = params.m
-    val minChainLength = params.minChainLength
 
-    require(chain.lengthCompare(minChainLength) >= 0, s"Can not prove chain of size < $minChainLength")
+    require(chain.lengthCompare(k + m) >= 0, s"Can not prove chain of size < ${k + m}")
     require(chain.head.header.isGenesis, "Can not prove non-anchored chain")
 
     @scala.annotation.tailrec

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/PoPowParams.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/PoPowParams.scala
@@ -12,5 +12,11 @@ package org.ergoplatform.modifiers.history.popow
   *                     to the block header)
   *
   */
-case class PoPowParams(m: Int, k: Int, continuous: Boolean)
+case class PoPowParams(m: Int, k: Int, continuous: Boolean) {
+  require(m >= 1, s"$m < 1")
+  require(k >= 1, s"$k < 1")
+  require(m <= Int.MaxValue - k, s"$m + $k exceeds Int.MaxValue")
+
+  val minChainLength: Int = m + k
+}
 

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/PoPowParams.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/PoPowParams.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.modifiers.history.popow
 
+import scala.util.Try
+
 /**
   * NiPoPoW proof params from the KMZ17 paper
   *
@@ -12,11 +14,13 @@ package org.ergoplatform.modifiers.history.popow
   *                     to the block header)
   *
   */
-case class PoPowParams(m: Int, k: Int, continuous: Boolean) {
-  require(m >= 1, s"$m < 1")
-  require(k >= 1, s"$k < 1")
-  require(m <= Int.MaxValue - k, s"$m + $k exceeds Int.MaxValue")
+final class PoPowParams private (val m: Int, val k: Int, val continuous: Boolean, val minChainLength: Int)
 
-  val minChainLength: Int = m + k
+object PoPowParams {
+  def apply(m: Int, k: Int, continuous: Boolean): Try[PoPowParams] = Try {
+    require(m >= 1, s"$m < 1")
+    require(k >= 1, s"$k < 1")
+    new PoPowParams(m, k, continuous, Math.addExact(m, k))
+  }
 }
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProverWithDbAlgs.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProverWithDbAlgs.scala
@@ -28,9 +28,9 @@ object NipopowProverWithDbAlgs {
 
       val k = params.k
       val m = params.m
+      val minChainLength = params.minChainLength
 
-      require(params.k >= 1, s"$k < 1")
-      require(histReader.headersHeight >= k + m, s"Can not prove chain of size < ${k + m}")
+      require(histReader.headersHeight >= minChainLength, s"Can not prove chain of size < $minChainLength")
 
       def linksWithIndexes(header: PoPowHeader): Seq[(ModifierId, Int)] = header.interlinks.tail.reverse.zipWithIndex
 

--- a/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProverWithDbAlgs.scala
+++ b/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProverWithDbAlgs.scala
@@ -28,9 +28,8 @@ object NipopowProverWithDbAlgs {
 
       val k = params.k
       val m = params.m
-      val minChainLength = params.minChainLength
 
-      require(histReader.headersHeight >= minChainLength, s"Can not prove chain of size < $minChainLength")
+      require(histReader.headersHeight >= k + m, s"Can not prove chain of size < ${k + m}")
 
       def linksWithIndexes(header: PoPowHeader): Seq[(ModifierId, Int)] = header.interlinks.tail.reverse.zipWithIndex
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/PopowProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/PopowProcessor.scala
@@ -107,8 +107,9 @@ trait PopowProcessor extends BasicReaders with ScorexLogging {
     * @return PoPow proof if success, Failure instance otherwise
     */
   def popowProof(m: Int, k: Int, headerIdOpt: Option[ModifierId]): Try[NipopowProof] = {
-    val proofParams = PoPowParams(m, k, continuous = true)
-    NipopowProverWithDbAlgs.prove(historyReader, headerIdOpt = headerIdOpt, chainSettings)(proofParams)
+    Try(PoPowParams(m, k, continuous = true)).flatMap { proofParams =>
+      NipopowProverWithDbAlgs.prove(historyReader, headerIdOpt = headerIdOpt, chainSettings)(proofParams)
+    }
   }
 
   /**

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/PopowProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/PopowProcessor.scala
@@ -107,7 +107,7 @@ trait PopowProcessor extends BasicReaders with ScorexLogging {
     * @return PoPow proof if success, Failure instance otherwise
     */
   def popowProof(m: Int, k: Int, headerIdOpt: Option[ModifierId]): Try[NipopowProof] = {
-    Try(PoPowParams(m, k, continuous = true)).flatMap { proofParams =>
+    PoPowParams(m, k, continuous = true).flatMap { proofParams =>
       NipopowProverWithDbAlgs.prove(historyReader, headerIdOpt = headerIdOpt, chainSettings)(proofParams)
     }
   }

--- a/src/test/scala/org/ergoplatform/http/routes/NipopowApiRoutesSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/NipopowApiRoutesSpec.scala
@@ -35,6 +35,12 @@ class NipopowApiRoutesSpec extends AnyFlatSpec
     }
   }
 
+  it should "reject proof request when minimum and suffix length overflow" in {
+    Get(s"/nipopow/proof/${Int.MaxValue}/1") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "proof request with missing headerId" in {
     Get("/nipopow/proof/1/1/05bf63aa1ecfc9f4e3fadc993f87b33edb4d58e151c1891816d734dd5a0e2e09") ~> route ~> check {
       status shouldBe StatusCodes.BadRequest

--- a/src/test/scala/org/ergoplatform/local/NipopowVerifierSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/NipopowVerifierSpec.scala
@@ -11,7 +11,7 @@ class NipopowVerifierSpec extends AnyPropSpec with Matchers {
   import org.ergoplatform.utils.generators.ChainGenerator._
 
 
-  private val poPowParams = PoPowParams(30, 30, continuous = false)
+  private val poPowParams = PoPowParams(30, 30, continuous = false).get
   val toPoPoWChain = (c: Seq[ErgoFullBlock]) => c.map(b => PoPowHeader.fromBlock(b).get)
 
   property("processes new proofs") {

--- a/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
@@ -12,17 +12,17 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
   import org.ergoplatform.utils.generators.CoreObjectGenerators._
   import org.ergoplatform.utils.ErgoCoreTestConstants._
 
-  private val poPowParams = PoPowParams(30, 30, continuous = false)
+  private val poPowParams = PoPowParams(30, 30, continuous = false).get
   private val ChainLength = 10
 
   private def toPoPoWChain = (c: Seq[ErgoFullBlock]) => c.map(b => PoPowHeader.fromBlock(b).get)
 
   property("PoPowParams rejects invalid minimum chain lengths") {
-    an[IllegalArgumentException] should be thrownBy PoPowParams(0, 1, continuous = false)
-    an[IllegalArgumentException] should be thrownBy PoPowParams(1, 0, continuous = false)
-    an[IllegalArgumentException] should be thrownBy PoPowParams(Int.MaxValue, 1, continuous = false)
+    PoPowParams(0, 1, continuous = false) shouldBe 'failure
+    PoPowParams(1, 0, continuous = false) shouldBe 'failure
+    PoPowParams(Int.MaxValue, 1, continuous = false) shouldBe 'failure
 
-    PoPowParams(1, 1, continuous = false).minChainLength shouldBe 2
+    PoPowParams(1, 1, continuous = false).get.minChainLength shouldBe 2
   }
 
   property("updateInterlinks") {
@@ -152,7 +152,7 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
   }
 
   property("isBetterThan - a disconnected prefix chain should not win") {
-    val smallPoPowParams = PoPowParams(50, 1, continuous = false)
+    val smallPoPowParams = PoPowParams(50, 1, continuous = false).get
     val size = 100
     val chain = toPoPoWChain(genChain(size))
     val proof = nipopowAlgos.prove(chain)(smallPoPowParams).get
@@ -166,7 +166,7 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
   }
 
   property("hasValidConnections - ensures a connected prefix chain") {
-    val smallPoPowParams = PoPowParams(5, 5, continuous = false)
+    val smallPoPowParams = PoPowParams(5, 5, continuous = false).get
     val sizes = Seq(100, 200)
     sizes.foreach { size =>
       val chain = toPoPoWChain(genChain(size))
@@ -180,7 +180,7 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
   }
 
   property("hasValidConnections - ensures a connected suffix chain") {
-    val smallPoPowParams = PoPowParams(5, 5, continuous = false)
+    val smallPoPowParams = PoPowParams(5, 5, continuous = false).get
     val sizes = Seq(100, 200)
 
     sizes.foreach { size =>

--- a/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
@@ -17,6 +17,14 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
 
   private def toPoPoWChain = (c: Seq[ErgoFullBlock]) => c.map(b => PoPowHeader.fromBlock(b).get)
 
+  property("PoPowParams rejects invalid minimum chain lengths") {
+    an[IllegalArgumentException] should be thrownBy PoPowParams(0, 1, continuous = false)
+    an[IllegalArgumentException] should be thrownBy PoPowParams(1, 0, continuous = false)
+    an[IllegalArgumentException] should be thrownBy PoPowParams(Int.MaxValue, 1, continuous = false)
+
+    PoPowParams(1, 1, continuous = false).minChainLength shouldBe 2
+  }
+
   property("updateInterlinks") {
     val chain = genChain(ChainLength)
     val genesis = chain.head

--- a/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosWithDBSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosWithDBSpec.scala
@@ -12,7 +12,7 @@ class PoPowAlgosWithDBSpec extends AnyPropSpec with Matchers {
   import org.ergoplatform.utils.generators.ChainGenerator._
 
   property("proof(chain) is equivalent to proof(histReader)") {
-    val poPowParams = PoPowParams(m = 5, k = 6, continuous = false)
+    val poPowParams = PoPowParams(m = 5, k = 6, continuous = false).get
     val blocksChain = genChain(3000)
     val pchain = blocksChain.map(b => PoPowHeader.fromBlock(b).get)
     val proof0 = nipopowAlgos.prove(pchain)(poPowParams).get
@@ -30,7 +30,7 @@ class PoPowAlgosWithDBSpec extends AnyPropSpec with Matchers {
   }
 
   property("proof(histReader) for a header in the past") {
-    val poPowParams = PoPowParams(5, 6, continuous = false)
+    val poPowParams = PoPowParams(5, 6, continuous = false).get
     val blocksChain = genChain(300)
 
     val at = 200

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeGenerators.scala
@@ -24,7 +24,7 @@ object ErgoNodeGenerators {
   } yield {
     val chain = genHeaderChain(m * mulM + k, diffBitsOpt = None, useRealTs = false)
     val popowChain = popowHeaderChain(chain)
-    val params = PoPowParams(m, k, continuous = false)
+    val params = PoPowParams(m, k, continuous = false).get
     nipopowAlgos.prove(popowChain)(params).get
   }
 }


### PR DESCRIPTION
## Summary
- Reject non-positive or overflowing NiPoPoW proof parameters before proof construction.
- Reuse the validated minimum chain length in both in-memory and database proof builders.
- Keep overflowing API requests as `BadRequest` instead of building a proof with overflowed `m + k`.

## Tests
- `sbt "testOnly org.ergoplatform.http.routes.NipopowApiRoutesSpec"`
- `sbt "testOnly org.ergoplatform.modifiers.history.PoPowAlgosSpec org.ergoplatform.modifiers.history.PoPowAlgosWithDBSpec org.ergoplatform.nodeView.history.PopowProcessorSpecification"`