### PR TITLE
Harden blocks API bounds

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -141,7 +141,7 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
   def getChainSliceR: Route = (pathPrefix("chainSlice") & chainPagination) { (fromHeight, toHeight) =>
     if (toHeight < fromHeight) {
       BadRequest("toHeight < fromHeight")
-    } else if (fromHeight - toHeight > MaxHeaders) {
+    } else if (toHeight.toLong - fromHeight.toLong > MaxHeaders) {
       BadRequest(s"No more than $MaxHeaders headers can be requested")
     } else {
       ApiResponse(getChainSlice(fromHeight, toHeight))
@@ -181,7 +181,11 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
   }
 
   def getFullBlockByHeaderIdsR: Route = (post & path("headerIds") & modifierIds) { ids =>
-    ApiResponse(getFullBlockByHeaderIds(ids))
+    if (ids.length > MaxHeaders) {
+      BadRequest(s"No more than $MaxHeaders blocks can be requested")
+    } else {
+      ApiResponse(getFullBlockByHeaderIds(ids))
+    }
   }
 
 }

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -84,6 +84,12 @@ class BlocksApiRouteSpec
     }
   }
 
+  it should "reject chain slices above the maximum header count" in {
+    Get(prefix + "/chainSlice?fromHeight=0&toHeight=16385") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "get block by header id" in {
     Get(prefix + "/" + headerIdString) ~> route ~> check {
       status shouldBe StatusCodes.OK
@@ -111,6 +117,14 @@ class BlocksApiRouteSpec
         )
 
       responseAs[Seq[ErgoFullBlock]] shouldEqual expected
+    }
+  }
+
+  it should "reject too many header ids" in {
+    val headerIdsString = Seq.fill(16385)(Algos.encode(headerIdBytes))
+
+    Post(prefix + "/headerIds", headerIdsString.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 


### PR DESCRIPTION
Summary:
- Reject `/blocks/chainSlice` requests above the maximum header count by fixing the range-size check.
- Add the same maximum-count guard to bulk `/blocks/headerIds` requests.
- Add route-level regression coverage for both cases.

Tests:
- `sbt "testOnly org.ergoplatform.http.routes.BlocksApiRouteSpec"`