### PR TITLE
Bound P2P message payload length

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageConstants.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageConstants.scala
@@ -11,4 +11,7 @@ object MessageConstants {
   val ChecksumLength: Int = 4
 
   val HeaderLength: Int = MagicLength + 5
+
+  // Largest currently accepted payload, allowing the modifier-message ADProof reserve.
+  val MaxPayloadLength: Int = 2048576 * 4
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/ModifiersSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/ModifiersSpec.scala
@@ -14,7 +14,7 @@ object ModifiersSpec extends MessageSpecV1[ModifiersData] with ScorexLogging {
 
   val maxMessageSize: Int = 2048576
 
-  private val maxMsgSizeWithReserve = maxMessageSize * 4 // due to big ADProofs
+  private val maxMsgSizeWithReserve = MessageConstants.MaxPayloadLength // due to big ADProofs
 
   override val messageCode: MessageCode = 33: Byte
   override val messageName: String = "Modifier"

--- a/src/main/scala/org/ergoplatform/network/message/MessageSerializer.scala
+++ b/src/main/scala/org/ergoplatform/network/message/MessageSerializer.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 
 class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
 
-  import MessageConstants.{ChecksumLength, HeaderLength, MagicLength}
+  import MessageConstants.{ChecksumLength, HeaderLength, MagicLength, MaxPayloadLength}
 
   import scala.language.existentials
 
@@ -49,7 +49,13 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
         throw MaliciousBehaviorException("Data length is negative!")
       }
 
-      if (length != 0 && byteString.length < length + HeaderLength + ChecksumLength) {
+      if (length > MaxPayloadLength) {
+        throw MaliciousBehaviorException(s"Data length $length exceeds limit $MaxPayloadLength")
+      }
+
+      val messageLength = HeaderLength.toLong + (if (length > 0) ChecksumLength.toLong + length.toLong else 0L)
+
+      if (length != 0 && byteString.length.toLong < messageLength) {
         None
       } else {
         //peer is from another network

--- a/src/test/scala/org/ergoplatform/network/MessageSerializerSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/MessageSerializerSpec.scala
@@ -1,0 +1,37 @@
+package org.ergoplatform.network
+
+import akka.util.ByteString
+import org.ergoplatform.network.message.{InvSpec, MessageConstants, MessageSerializer}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.network.MaliciousBehaviorException
+
+import java.nio.ByteOrder
+
+class MessageSerializerSpec extends AnyFlatSpec with Matchers {
+
+  private implicit val byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
+
+  private val magic = Array(1: Byte, 0: Byte, 2: Byte, 4: Byte)
+  private val serializer = new MessageSerializer(Seq(InvSpec), magic)
+
+  private def messageHeader(length: Int): ByteString =
+    ByteString.createBuilder
+      .putBytes(magic)
+      .putByte(InvSpec.messageCode)
+      .putInt(length)
+      .result()
+
+  it should "reject oversized payload lengths before buffering message data" in {
+    val result = serializer.deserialize(messageHeader(MessageConstants.MaxPayloadLength + 1), sourceOpt = None)
+
+    result.failed.get shouldBe a[MaliciousBehaviorException]
+  }
+
+  it should "reject overflowing payload lengths before computing total frame length" in {
+    val result = serializer.deserialize(messageHeader(Int.MaxValue), sourceOpt = None)
+
+    result.failed.get shouldBe a[MaliciousBehaviorException]
+  }
+
+}


### PR DESCRIPTION
## Covered by upstream

The oversized-length and frame-overflow invariant is already covered by merged [#2306](https://github.com/ergoplatform/ergo/pull/2306). At master `5528ef569a41ebccbc8658212e6ee3c97d990b96`, the shared payload cap rejects oversized lengths before frame arithmetic, payload reads or waiting for the body. Accepted lengths cannot overflow the total frame calculation.

The landed guard is [`1bfe1f0d`](https://github.com/ergoplatform/ergo/commit/1bfe1f0d70f2b44c4d156f7f15106cff38d5bfe6), with the shared cap in [`6c52b15c`](https://github.com/ergoplatform/ergo/commit/6c52b15c2c75048034226238e45ac636f1fbf3c6) and serializer regressions in [`ac09d82d`](https://github.com/ergoplatform/ergo/commit/ac09d82dcdc98a5c33e32aa0d9c9d3a013f25bdd). Source and independent review confirm coverage. Existing tests cover negative, maximum, above-maximum and incomplete-header lengths; this is not a new execution or a claim of identical test coverage.

Closing this PR as covered. Its smaller cap would be a separate policy restriction, so it is not carried forward as an additional bug fix.

## Original proposal

- Add a global P2P payload-length cap before message-specific parsing.
- Reject oversized or overflowing envelope lengths as malicious before waiting for message body bytes.
- Reuse the same cap for the modifier-message ADProof reserve.
- Add serializer regression coverage for oversized and `Int.MaxValue` payload lengths.
