### PR TITLE
Validate wallet scan id route parameters

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScanApiRoute.scala
@@ -13,7 +13,6 @@ import scala.util.{Failure, Success}
 import ScanEntities._
 import org.ergoplatform.ErgoBox.R1
 import org.ergoplatform.http.api.ApiError.BadRequest
-import org.ergoplatform.wallet.Constants.ScanId
 import sigma.ast.ByteArrayConstant
 import sigma.serialization.ErgoTreeSerializer
 
@@ -66,21 +65,23 @@ case class ScanApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
 
   def unspentR: Route = (path("unspentBoxes" / IntNumber) & get & boxParams) {
     (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
-      val scanId = ScanId @@ scanIdInt.toShort
-      val considerUnconfirmed = minConfNum == -1
-      withWallet(_.scanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight).map {
-        _.filter(boxConfirmationFilter(_, minConfNum, maxConfNum))
-        .slice(offset, offset + limit)
-      })
+      withScanId(scanIdInt) { scanId =>
+        val considerUnconfirmed = minConfNum == -1
+        withWallet(_.scanUnspentBoxes(scanId, considerUnconfirmed, minHeight, maxHeight).map {
+          _.filter(boxConfirmationFilter(_, minConfNum, maxConfNum))
+          .slice(offset, offset + limit)
+        })
+      }
   }
 
   def spentR: Route = (path("spentBoxes" / IntNumber) & get & boxParams) {
     (scanIdInt, minConfNum, maxConfNum, minHeight, maxHeight, limit, offset) =>
-      val scanId = ScanId @@ scanIdInt.toShort
-      withWallet(_.scanSpentBoxes(scanId).map {
-        _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
-        .slice(offset, offset + limit)
-      })
+      withScanId(scanIdInt) { scanId =>
+        withWallet(_.scanSpentBoxes(scanId).map {
+          _.filter(boxConfirmationHeightFilter(_, minConfNum, maxConfNum, minHeight, maxHeight))
+          .slice(offset, offset + limit)
+        })
+      }
   }
 
   def stopTrackingR: Route = (path("stopTracking") & post & entity(as[ScanIdBoxId])) { scanIdBoxId =>

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiOperations.scala
@@ -4,11 +4,14 @@ import akka.actor.ActorRef
 import akka.http.scaladsl.server.{Directive, Route, ValidationRejection}
 import akka.pattern.ask
 import io.circe.Encoder
+import org.ergoplatform.http.api.ApiError.BadRequest
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.wallet.{ErgoWalletReader, WalletBox}
+import org.ergoplatform.wallet.Constants.ScanId
 import scorex.core.api.http.ApiResponse
 
 import scala.concurrent.Future
+import scala.util.Try
 
 trait WalletApiOperations extends ErgoBaseApiRoute {
 
@@ -73,6 +76,21 @@ trait WalletApiOperations extends ErgoBaseApiRoute {
 
   protected def withWallet[T: Encoder](op: ErgoWalletReader => Future[T]): Route = {
     withWalletOp(op)(ApiResponse.apply[T])
+  }
+
+  protected def withScanId(scanId: Int)(route: ScanId => Route): Route = {
+    if (scanId < Short.MinValue || scanId > Short.MaxValue) {
+      BadRequest(s"scanId $scanId is outside Short range")
+    } else {
+      route(ScanId @@ scanId.toShort)
+    }
+  }
+
+  protected def withScanId(scanId: String)(route: ScanId => Route): Route = {
+    Try(scanId.toShort).toOption match {
+      case Some(id) => route(ScanId @@ id)
+      case None => BadRequest(s"scanId $scanId is invalid")
+    }
   }
 
 }

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -13,7 +13,6 @@ import org.ergoplatform.nodeView.wallet._
 import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
 import org.ergoplatform.wallet.Constants
-import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
 import org.ergoplatform.http.api.ApiError.{BadRequest, NotExists}
 import scorex.core.api.http.ApiResponse
@@ -367,23 +366,25 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
   def getTransactionsByScanIdR: Route = (path("transactionsByScanId" / Segment) & get & txsByScanIdParams) {
     case (id, minHeight, maxHeight, minConfNum, maxConfNum, includeUnconfirmed) =>
-      if ((minHeight > 0 || maxHeight < Int.MaxValue) && (minConfNum > 0 || maxConfNum < Int.MaxValue))
-        BadRequest("Bad request: both heights and confirmations set")
-      else if (minHeight == 0 && maxHeight == Int.MaxValue && minConfNum == 0 && maxConfNum == Int.MaxValue) {
-        withWalletOp(_.transactionsByScanId(ScanId @@ id.toShort, includeUnconfirmed)) {
-          resp => ApiResponse(resp.result.asJson)
+      withScanId(id) { scanId =>
+        if ((minHeight > 0 || maxHeight < Int.MaxValue) && (minConfNum > 0 || maxConfNum < Int.MaxValue))
+          BadRequest("Bad request: both heights and confirmations set")
+        else if (minHeight == 0 && maxHeight == Int.MaxValue && minConfNum == 0 && maxConfNum == Int.MaxValue) {
+          withWalletOp(_.transactionsByScanId(scanId, includeUnconfirmed)) {
+            resp => ApiResponse(resp.result.asJson)
+          }
         }
-      }
-      else {
-        withWalletOp(_.filteredScanTransactions(
-          List(ScanId @@ id.toShort),
-          minHeight,
-          maxHeight,
-          minConfNum,
-          maxConfNum,
-          includeUnconfirmed)
-        ) {
-          resp => ApiResponse(resp.asJson)
+        else {
+          withWalletOp(_.filteredScanTransactions(
+            List(scanId),
+            minHeight,
+            maxHeight,
+            minConfNum,
+            maxConfNum,
+            includeUnconfirmed)
+          ) {
+            resp => ApiResponse(resp.asJson)
+          }
         }
       }
   }

--- a/src/test/scala/org/ergoplatform/http/routes/ScanApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ScanApiRouteSpec.scala
@@ -39,6 +39,7 @@ class ScanApiRouteSpec extends AnyFlatSpec
   val ergoSettings: ErgoSettings = ErgoSettingsReader.read(
     Args(userConfigPathOpt = Some("src/test/resources/application.conf"), networkTypeOpt = None))
   val route: Route = ScanApiRoute(utxoReadersRef, ergoSettings).route
+  val sealedRoute: Route = Route.seal(route)
 
   private val predicate0 = ContainsScanningPredicate(ErgoBox.R4, ByteArrayConstant(Array(0: Byte, 1: Byte)))
   private val predicate1 = ContainsScanningPredicate(ErgoBox.R4, ByteArrayConstant(Array(1: Byte, 1: Byte)))
@@ -98,6 +99,16 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
       apps.map(_.scanName).contains(appRequest.scanName) shouldBe true
       apps.map(_.scanName).contains(appRequest2.scanName) shouldBe true
+    }
+  }
+
+  it should "reject scan ids outside Short range" in {
+    Get(prefix + "/unspentBoxes/70000") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Get(prefix + "/spentBoxes/70000") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -41,6 +41,7 @@ class WalletApiRouteSpec extends AnyFlatSpec
   val ergoSettings: ErgoSettings = ErgoSettingsReader.read(
     Args(userConfigPathOpt = Some("src/test/resources/application.conf"), networkTypeOpt = None))
   val route: Route = WalletApiRoute(digestReadersRef, nodeViewRef, settings).route
+  val sealedRoute: Route = Route.seal(route)
   val failingNodeViewRef = system.actorOf(NodeViewStub.failingProps())
   val failingRoute: Route = WalletApiRoute(digestReadersRef, failingNodeViewRef, settings).route
 
@@ -304,6 +305,16 @@ class WalletApiRouteSpec extends AnyFlatSpec
       }
       walletTxs.size shouldBe response.size
       walletTxs.forall(_.numConfirmations == 0) shouldBe true
+    }
+  }
+
+  it should "reject invalid transactionsByScanId values" in {
+    Get(prefix + "/transactionsByScanId/not-a-number") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Get(prefix + "/transactionsByScanId/32768") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 


### PR DESCRIPTION
﻿Summary:
- Reject wallet and scan route ids that cannot be represented as wallet ScanId values.
- Avoid Int-to-Short wrapping in scan box routes.
- Avoid NumberFormatException/500 responses from wallet transactionsByScanId on invalid path values.
- Add route-level regressions for out-of-range and non-numeric scan ids.

Tests:
- sbt "testOnly org.ergoplatform.http.routes.ScanApiRouteSpec org.ergoplatform.http.routes.WalletApiRouteSpec"
