### PR TITLE
Reject invalid ErgoTree route input

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -69,7 +69,10 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   private def handleErgoTree(value: String): Directive1[ErgoTree] = {
     Base16.decode(fromJsonOrPlain(value)) match {
       case Success(bytes) =>
-        provide(ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes))
+        Try(ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes)) match {
+          case Success(tree) => provide(tree)
+          case Failure(_)    => reject(ValidationRejection("Invalid ErgoTree data"))
+        }
       case _ => reject(ValidationRejection("Invalid hex data"))
     }
 

--- a/src/main/scala/org/ergoplatform/http/api/ErgoUtilsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoUtilsApiRoute.scala
@@ -15,7 +15,7 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 
 import java.security.SecureRandom
-import scala.util.Failure
+import scala.util.{Failure, Try}
 import sigma.serialization.{ErgoTreeSerializer, GroupElementSerializer, SigmaSerializer}
 
 class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
@@ -94,10 +94,11 @@ class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
     Base16
       .decode(ergoTreeHex)
       .flatMap { etBytes =>
-        ergoAddressEncoder.fromProposition(treeSerializer.deserializeErgoTree(etBytes))
+        Try(treeSerializer.deserializeErgoTree(etBytes))
+          .flatMap(ergoAddressEncoder.fromProposition)
       }
       .fold(
-        e => BadRequest(e.getMessage),
+        _ => BadRequest("Invalid ErgoTree data"),
         address => ApiResponse(Map("address" -> address.toString.asJson).asJson)
       )
   }

--- a/src/test/scala/org/ergoplatform/http/routes/ErgoBaseApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ErgoBaseApiRouteSpec.scala
@@ -1,0 +1,50 @@
+package org.ergoplatform.http.routes
+
+import akka.actor.ActorRefFactory
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.ergoplatform.http.api.ErgoBaseApiRoute
+import org.ergoplatform.settings.RESTApiSettings
+import org.ergoplatform.settings.Constants.TrueTree
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+
+class ErgoBaseApiRouteSpec extends AnyFlatSpec
+  with Matchers
+  with ScalatestRouteTest {
+
+  private val restApiSettings =
+    RESTApiSettings(new InetSocketAddress("localhost", 8080), None, None, 10.seconds, None)
+
+  private class TestRoute(implicit val context: ActorRefFactory) extends ErgoBaseApiRoute {
+    override val settings: RESTApiSettings = restApiSettings
+
+    override val route: Route = Route.seal {
+      path("tree") {
+        post {
+          ergoTree { _ =>
+            complete(StatusCodes.OK)
+          }
+        }
+      }
+    }
+  }
+
+  private val route = new TestRoute().route
+
+  it should "parse valid ErgoTree bodies" in {
+    Post("/tree", TrueTree.bytesHex) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  it should "reject hex bodies that are not valid ErgoTrees" in {
+    Post("/tree", "00") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/http/routes/UtilsApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/UtilsApiRouteSpec.scala
@@ -29,6 +29,7 @@ class UtilsApiRouteSpec extends AnyFlatSpec
 
   val restApiSettings = RESTApiSettings(new InetSocketAddress("localhost", 8080), None, None, 10.seconds, None)
   val route: Route = ErgoUtilsApiRoute(settings).route
+  val sealedRoute: Route = Route.seal(route)
   val p2pkaddress = P2PKAddress(defaultMinerPk)(settings.addressEncoder)
   val p2shaddress = Pay2SHAddress(feeProp)(settings.addressEncoder)
   val p2saddress = Pay2SAddress(feeProp)(settings.addressEncoder)
@@ -40,6 +41,16 @@ class UtilsApiRouteSpec extends AnyFlatSpec
     Get(s"$prefix/ergoTreeToAddress/$et") ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(p2saddress.toString())
+    }
+  }
+
+  it should "reject invalid ErgoTree data when deriving addresses" in {
+    Get(s"$prefix/ergoTreeToAddress/00") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Post(s"$prefix/ergoTreeToAddress", "\"00\"") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 


### PR DESCRIPTION
## Summary
- Catch ErgoTree deserialization failures in the shared REST route parser and reject invalid-but-hex bodies as bad input instead of letting them reach the default 500 handler.
- Apply the same parsing guard to `/utils/ergoTreeToAddress` GET/POST.
- Add route-level regression coverage for valid ErgoTree bodies and invalid hex bodies that are not ErgoTrees.

## Tests
- `sbt "testOnly org.ergoplatform.http.routes.ErgoBaseApiRouteSpec org.ergoplatform.http.routes.UtilsApiRouteSpec"`