### PR TITLE
Validate REST modifier id byte length

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransacti
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
-import org.ergoplatform.settings.{Algos, ErgoSettings}
+import org.ergoplatform.settings.{Algos, Constants, ErgoSettings}
 import scorex.core.api.http.ApiRoute
 import scorex.util.{bytesToId, ModifierId}
 import akka.pattern.ask
@@ -34,10 +34,19 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   val modifierIdGet: Directive1[ModifierId] = parameters("id".as[String])
     .flatMap(handleModifierId)
 
+  private def parseModifierId(value: String): Try[ModifierId] =
+    Algos.decode(value).flatMap { bytes =>
+      if (bytes.length == Constants.ModifierIdSize) {
+        Success(bytesToId(bytes))
+      } else {
+        Failure(new IllegalArgumentException("Wrong modifierId length"))
+      }
+    }
+
   private def handleModifierId(value: String): Directive1[ModifierId] = {
-    Algos.decode(value) match {
-      case Success(bytes) => provide(bytesToId(bytes))
-      case _              => reject(ValidationRejection("Wrong modifierId format"))
+    parseModifierId(value) match {
+      case Success(id) => provide(id)
+      case _           => reject(ValidationRejection("Wrong modifierId format"))
     }
   }
 
@@ -45,9 +54,9 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
     val acc = collection.mutable.Buffer.empty[ModifierId]
     val err = collection.mutable.Buffer.empty[String]
     for (value <- values) {
-      Algos.decode(value) match {
-        case Success(bytes) => acc += bytesToId(bytes)
-        case Failure(e)     => err += e.getMessage
+      parseModifierId(value) match {
+        case Success(id) => acc += id
+        case Failure(e)  => err += e.getMessage
       }
     }
     if (err.nonEmpty) {

--- a/src/test/scala/org/ergoplatform/http/routes/ErgoBaseApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ErgoBaseApiRouteSpec.scala
@@ -1,0 +1,67 @@
+package org.ergoplatform.http.routes
+
+import akka.actor.ActorRefFactory
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import io.circe.syntax._
+import org.ergoplatform.http.api.ErgoBaseApiRoute
+import org.ergoplatform.settings.RESTApiSettings
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+
+class ErgoBaseApiRouteSpec extends AnyFlatSpec
+  with Matchers
+  with ScalatestRouteTest
+  with FailFastCirceSupport {
+
+  private val restApiSettings =
+    RESTApiSettings(new InetSocketAddress("localhost", 8080), None, None, 10.seconds, None)
+
+  private class TestRoute(implicit val context: ActorRefFactory) extends ErgoBaseApiRoute {
+    override val settings: RESTApiSettings = restApiSettings
+
+    override val route: Route = Route.seal {
+      pathPrefix("modifier") {
+        get {
+          modifierId { _ =>
+            complete(StatusCodes.OK)
+          }
+        }
+      } ~
+      path("modifiers") {
+        post {
+          modifierIds { _ =>
+            complete(StatusCodes.OK)
+          }
+        }
+      }
+    }
+  }
+
+  private val route = new TestRoute().route
+
+  it should "reject modifier ids with invalid byte length" in {
+    val validModifierId = "00" * 32
+
+    Get(s"/modifier/$validModifierId") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+    Get("/modifier/00") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Post("/modifiers", Seq(validModifierId).asJson) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+    Post("/modifiers", Seq("00").asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Reject modifier ids whose decoded byte length is not 32 bytes in the shared REST route helper.
- Apply the same validation to batch modifier-id request bodies.
- Add route-level regression coverage for valid 32-byte ids and short hex ids.

## Tests
- `sbt "testOnly org.ergoplatform.http.routes.ErgoBaseApiRouteSpec"`
- `sbt "testOnly org.ergoplatform.http.routes.ErgoBaseApiRouteSpec org.ergoplatform.http.routes.BlocksApiRouteSpec org.ergoplatform.http.routes.NipopowApiRoutesSpec org.ergoplatform.http.routes.TransactionApiRouteSpec org.ergoplatform.http.routes.WalletApiRouteSpec"`