### PR TITLE
Validate Transaction API box and token id lengths

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
@@ -14,7 +14,7 @@ import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.mempool.HistogramStats.getFeeHistogram
 import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
-import org.ergoplatform.settings.{Algos, ErgoSettings, RESTApiSettings}
+import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, RESTApiSettings}
 import scorex.core.api.http.ApiResponse
 import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
@@ -37,11 +37,11 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
   val boxId: Directive1[BoxId] = pathPrefix(Segment).flatMap(handleBoxId)
 
   private def handleBoxId(value: String): Directive1[BoxId] = {
-    ADKey @@ Base16.decode(value) match {
-      case Success(boxId) =>
-        provide(boxId)
+    Base16.decode(value) match {
+      case Success(boxId) if boxId.length == Constants.ModifierIdSize =>
+        provide(ADKey @@ boxId)
       case _ =>
-        reject(ValidationRejection(s"boxId $value is invalid, it should be hex string"))
+        reject(ValidationRejection(s"boxId $value is invalid, it should be 64 chars long hex string"))
     }
   }
 
@@ -49,7 +49,7 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
 
   private def handleTokenId(value: String): Directive1[TokenId] = {
     Algos.decode(value) match {
-      case Success(tokenId) =>
+      case Success(tokenId) if tokenId.length == Constants.ModifierIdSize =>
         provide(tokenId.toTokenId)
       case _ =>
         reject(ValidationRejection(s"tokenId $value is invalid, it should be 64 chars long hex string"))

--- a/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
@@ -240,6 +240,23 @@ class TransactionApiRouteSpec extends AnyFlatSpec
     }
   }
 
+  it should "reject box and token ids with invalid byte length" in {
+    val shortId = "00"
+    val sealedRoute = Route.seal(route)
+
+    Get(prefix + s"/unconfirmed/inputs/byBoxId/$shortId") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Get(prefix + s"/unconfirmed/outputs/byBoxId/$shortId") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Get(prefix + s"/unconfirmed/outputs/byTokenId/$shortId") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "return unconfirmed outputs by exact same registers" in {
     val searchedRegs =
       Map(


### PR DESCRIPTION
## Summary
- Reject Transaction API `boxId` and `tokenId` path values whose decoded byte length is not 32 bytes.
- Keep the existing route behavior for valid ids and non-hex input.
- Add regression coverage for short hex ids on mempool `byBoxId` and `byTokenId` routes.

## Tests
- `sbt "testOnly org.ergoplatform.http.routes.TransactionApiRouteSpec"`