### PR TITLE
Validate fixed-size byte JSON codecs

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.http.api
 
+import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
 import org.bouncycastle.util.BigIntegers

--- a/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
@@ -13,14 +13,14 @@ import org.ergoplatform.mining.{groupElemFromBytes, groupElemToBytes}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Difficulty
 import org.ergoplatform.sdk.wallet.secrets.{DhtSecretKey, DlogSecretKey}
-import org.ergoplatform.settings.{Algos, ErgoAlgos}
+import org.ergoplatform.settings.{Algos, Constants, ErgoAlgos}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.TrackedBox
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.validation.ValidationResult
 import scorex.crypto.authds.merkle.MerkleProof
-import scorex.crypto.authds.{LeafData, Side}
-import scorex.crypto.hash.Digest
+import scorex.crypto.authds.{ADDigest, ADKey, LeafData, Side}
+import scorex.crypto.hash.{Digest, Digest32}
 import scorex.util.encode.Base16
 import sigmastate._
 import sigmastate.crypto.DLogProtocol.{DLogProverInput, FirstDLogProverMessage}
@@ -39,6 +39,29 @@ import scala.util.{Failure, Success, Try}
 
 
 trait ApiCodecs extends JsonCodecs {
+
+  private def fixedSizeBytesDecoder[T](typeName: String, expectedSize: Int)(wrap: Array[Byte] => T): Decoder[T] =
+    Decoder.instance { cursor =>
+      cursor.as[String].flatMap { str =>
+        Algos.decode(str) match {
+          case Success(bytes) if bytes.length == expectedSize =>
+            Right(wrap(bytes))
+          case Success(_) =>
+            Left(DecodingFailure(s"$typeName should be $expectedSize bytes", cursor.history))
+          case Failure(e) =>
+            Left(DecodingFailure.fromThrowable(e, cursor.history))
+        }
+      }
+    }
+
+  override implicit val adKeyDecoder: Decoder[ADKey] =
+    fixedSizeBytesDecoder("ADKey", Constants.ModifierIdSize)(ADKey @@ _)
+
+  override implicit val adDigestDecoder: Decoder[ADDigest] =
+    fixedSizeBytesDecoder("ADDigest", Constants.ModifierIdSize + 1)(ADDigest @@ _)
+
+  override implicit val digest32Decoder: Decoder[Digest32] =
+    fixedSizeBytesDecoder("Digest32", Constants.ModifierIdSize)(Digest32 @@ _)
 
   def fromValidation[T](validationResult: ValidationResult[T])
                        (implicit cursor: ACursor): Either[DecodingFailure, T] = {
@@ -81,7 +104,8 @@ trait ApiCodecs extends JsonCodecs {
     for {
       str <- cursor.as[String]
       bytes <- fromTry(Algos.decode(str))
-    } yield groupElemFromBytes(bytes)
+      point <- fromTry(Try(groupElemFromBytes(bytes)))
+    } yield point
   }
 
   implicit val ecPointEncoder: Encoder[EcPointType] = Encoder.instance({ point: EcPointType =>

--- a/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
@@ -1,8 +1,5 @@
 package org.ergoplatform.http.api
 
-import cats.syntax.either._
-import sigmastate.utils.Helpers._
-
 import io.circe._
 import io.circe.syntax._
 import org.bouncycastle.util.BigIntegers
@@ -13,14 +10,14 @@ import org.ergoplatform.mining.{groupElemFromBytes, groupElemToBytes}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Difficulty
 import org.ergoplatform.sdk.wallet.secrets.{DhtSecretKey, DlogSecretKey}
-import org.ergoplatform.settings.{Algos, ErgoAlgos}
+import org.ergoplatform.settings.{Algos, Constants, ErgoAlgos}
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.TrackedBox
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.validation.ValidationResult
 import scorex.crypto.authds.merkle.MerkleProof
-import scorex.crypto.authds.{LeafData, Side}
-import scorex.crypto.hash.Digest
+import scorex.crypto.authds.{ADDigest, ADKey, LeafData, Side}
+import scorex.crypto.hash.{Digest, Digest32}
 import scorex.util.encode.Base16
 import sigmastate._
 import sigmastate.crypto.DLogProtocol.{DLogProverInput, FirstDLogProverMessage}
@@ -39,6 +36,29 @@ import scala.util.{Failure, Success, Try}
 
 
 trait ApiCodecs extends JsonCodecs {
+
+  private def fixedSizeBytesDecoder[T](typeName: String, expectedSize: Int)(wrap: Array[Byte] => T): Decoder[T] =
+    Decoder.instance { cursor =>
+      cursor.as[String].flatMap { str =>
+        Algos.decode(str) match {
+          case Success(bytes) if bytes.lengthCompare(expectedSize) == 0 =>
+            Right(wrap(bytes))
+          case Success(_) =>
+            Left(DecodingFailure(s"$typeName should be $expectedSize bytes", cursor.history))
+          case Failure(e) =>
+            Left(DecodingFailure.fromThrowable(e, cursor.history))
+        }
+      }
+    }
+
+  override implicit val adKeyDecoder: Decoder[ADKey] =
+    fixedSizeBytesDecoder("ADKey", Constants.ModifierIdSize)(ADKey @@ _)
+
+  override implicit val adDigestDecoder: Decoder[ADDigest] =
+    fixedSizeBytesDecoder("ADDigest", Constants.ModifierIdSize + 1)(ADDigest @@ _)
+
+  override implicit val digest32Decoder: Decoder[Digest32] =
+    fixedSizeBytesDecoder("Digest32", Constants.ModifierIdSize)(Digest32 @@ _)
 
   def fromValidation[T](validationResult: ValidationResult[T])
                        (implicit cursor: ACursor): Either[DecodingFailure, T] = {

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
@@ -13,6 +13,8 @@ import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.TrackedBox
 import cats.syntax.either._
+import scorex.crypto.authds.{ADDigest, ADKey}
+import scorex.crypto.hash.Digest32
 import sigma.ast.{ErgoTree, EvaluatedValue, SType}
 import sigmastate.interpreter.SecretProven
 
@@ -82,6 +84,48 @@ class JsonSerializationCoreSpec extends ErgoCorePropertyTest
       decoded.get.isLeft shouldBe true
       decoded.get.left.get.message.toLowerCase should include ("hex")
     }
+  }
+
+  property("fixed-size byte JSON decoders should reject non-canonical lengths and invalid hex") {
+    Seq(31, 33).foreach { size =>
+      val json = ("00" * size).asJson
+      json.as[ADKey].isLeft shouldBe true
+      json.as[Digest32].isLeft shouldBe true
+    }
+
+    Seq(32, 34).foreach { size =>
+      ("00" * size).asJson.as[ADDigest].isLeft shouldBe true
+    }
+
+    Seq("zz", "0").foreach { value =>
+      val json = value.asJson
+      json.as[ADKey].isLeft shouldBe true
+      json.as[ADDigest].isLeft shouldBe true
+      json.as[Digest32].isLeft shouldBe true
+    }
+  }
+
+  property("fixed-size byte JSON decoders should accept canonical lengths") {
+    val digest = ("00" * 32).asJson
+    val stateDigest = ("00" * 33).asJson
+
+    digest.as[ADKey].isRight shouldBe true
+    stateDigest.as[ADDigest].isRight shouldBe true
+    digest.as[Digest32].isRight shouldBe true
+  }
+
+  property("invalid dht secret group element bytes should fail decoding without throwing") {
+    val json = Json.obj(
+      "secret" -> "01".asJson,
+      "g" -> "00".asJson,
+      "h" -> "00".asJson,
+      "u" -> "00".asJson,
+      "v" -> "00".asJson
+    )
+
+    val decoded = Try(json.as[DhtSecretKey])
+    decoded.isSuccess shouldBe true
+    decoded.get.isLeft shouldBe true
   }
 
   private def checkTrackedBox(c: ACursor, b: TrackedBox)(implicit opts: Detalization) = {

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
@@ -12,7 +12,8 @@ import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.TrackedBox
-import cats.syntax.either._
+import scorex.crypto.authds.{ADDigest, ADKey}
+import scorex.crypto.hash.Digest32
 import sigma.ast.{ErgoTree, EvaluatedValue, SType}
 
 class JsonSerializationCoreSpec extends ErgoCorePropertyTest
@@ -59,6 +60,23 @@ class JsonSerializationCoreSpec extends ErgoCorePropertyTest
       val parsedSecret = json.as[DhtSecretKey].toOption.get
       parsedSecret shouldBe wrappedSecret
     }
+  }
+
+  property("fixed-size byte JSON decoders should reject non-canonical lengths") {
+    val short = "00".asJson
+
+    short.as[ADKey].isLeft shouldBe true
+    short.as[ADDigest].isLeft shouldBe true
+    short.as[Digest32].isLeft shouldBe true
+  }
+
+  property("fixed-size byte JSON decoders should accept canonical lengths") {
+    val digest = ("00" * 32).asJson
+    val stateDigest = ("00" * 33).asJson
+
+    digest.as[ADKey].isRight shouldBe true
+    stateDigest.as[ADDigest].isRight shouldBe true
+    digest.as[Digest32].isRight shouldBe true
   }
 
   private def checkTrackedBox(c: ACursor, b: TrackedBox)(implicit opts: Detalization) = {

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.serialization
 
+import cats.syntax.either._
 import io.circe.syntax._
 import io.circe.ACursor
 import org.ergoplatform.ErgoBox

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -892,74 +892,68 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val viewHolderProbe = new TestProbe(system)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsForExplicitForcing: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            // Keep automatic refresh outside this test of explicit forcing.
+            .copy(blockCandidateGenerationInterval = 1.hour),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
-    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+    // Keep readers fixed: a later ChangedMempool event may legitimately regenerate the cache.
+    val (initialState, boxes) = createUtxoState(settingsForExplicitForcing)
+    val block = validFullBlock(None, initialState, boxes)
+    val state = initialState.applyModifier(block, None)(_ => ()).get
+    // Initialization computes mining-time averages from pairs of headers.
+    val history = historyWithBestFullBlock(Seq(block))
+    val readers = Readers(history, state, ErgoMemPool.empty(settingsForExplicitForcing), walletStub)
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
 
     val candidateGenerator: ActorRef =
       CandidateGenerator(
         defaultMinerSecret.publicImage,
         readersHolderRef,
-        viewHolderRef,
-        settingsWithShortRegeneration
+        viewHolderProbe.ref,
+        settingsForExplicitForcing
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    try {
+      // Get first candidate from the coherent, already applied block snapshot.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate1.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
 
-    // First mine a block to establish chain (needed for avg mining time calculation)
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val initCandidate = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+      // Request with forced = false should return cached candidate immediately.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate2 = testProbe.expectMsgPF(100.millis) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate2 should be theSameInstanceAs candidate1
+      candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
+
+      // Request with forced = true should bypass cache and regenerate.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+      val candidate3 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+
+      // Identity proves regeneration even when the clock has not advanced.
+      candidate3 should not be theSameInstanceAs(candidate1)
+      candidate3.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
+      candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    } finally {
+      TestKit.shutdownActorSystem(system)
+      history.closeStorage()
+      state.closeStorage()
     }
-    val initBlock = powScheme
-      .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
-      .get
-    candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
-      case _ => false
-    }
-
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // Request with forced = false should return cached candidate immediately
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate2 = testProbe.expectMsgPF(100.millis) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-    // Should be the exact same cached candidate
-    candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
-
-    // Request with forced = true should bypass cache and regenerate
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-    val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
-      case StatusReply.Success(_: Candidate) => true
-      case _: FullBlockApplied => false
-    } match {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // candidate3 should have timestamp >= candidate1 (regenerated, possibly same or newer)
-    candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-
-    system.terminate()
   }
 
   it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -64,8 +64,13 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val (us, bh) = createUtxoState(settings)
     val genesis = validFullBlock(None, us, bh)
     val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-    val inputBox = wus.takeBoxes(1).head
-    val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+    val inputBox = wus.takeBoxes(100).find(_.ergoTree == TrueTree).get
+    val feeOut = new ErgoBoxCandidate(
+      inputBox.value,
+      feeProp,
+      creationHeight = 0,
+      additionalTokens = inputBox.additionalTokens
+    )
     val tx = ErgoTransaction(
       IndexedSeq(new Input(inputBox.id, ProverResult.empty)),
       IndexedSeq(feeOut)
@@ -79,8 +84,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerByte,
       ))
 
-    var poolSize = ErgoMemPool.empty(sortBySizeSettings)
-    poolSize = poolSize.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolSize, sizeOutcome) =
+      ErgoMemPool.empty(sortBySizeSettings).process(UnconfirmedTransaction(tx, None), wus)
+    sizeOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val size = tx.size
     poolSize.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, size).weight
 
@@ -89,8 +95,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerCycle,
       ))
 
-    var poolCost = ErgoMemPool.empty(sortByCostSettings)
-    poolCost = poolCost.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolCost, costOutcome) =
+      ErgoMemPool.empty(sortByCostSettings).process(UnconfirmedTransaction(tx, None), wus)
+    costOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val validationContext = wus.stateContext.simplifiedUpcoming()
     val cost = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
     poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,9 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    val box = wusAfterGenesis.takeBoxes(wusAfterGenesis.size)
+      .find(_.ergoTree == TrueTree)
+      .getOrElse(fail("Expected an unspent TrueTree box after genesis"))
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
## Summary

- Enforce canonical JSON byte lengths for `ADKey` (32), `ADDigest` (33), and `Digest32` (32).
- Return a normal JSON decoding failure for invalid EC point bytes instead of letting an exception escape.
- Preserve the proof JSON decoding behavior from [#2391](https://github.com/ergoplatform/ergo/pull/2391).
- Supersede [#2394](https://github.com/ergoplatform/ergo/pull/2394) by consolidating its EC-point validation here.

## Validation and shared fixtures

The codec correction passed 9/9 direct tests on Scala 2.11.12, 2.12.20 and 2.13.18, with independent replay on each version. The previous implementation failed the invalid-length and malformed-point cases. Those two codec source/test files remain unchanged in the current head.

The prior node CI failed in a transaction-script fixture that could select a post-genesis box not spendable by its prover. The shared correction explicitly selects an unspent TrueTree box before constructing the valid transaction. This preserves the later transaction-failure assertions.

Current head `ad6de0515fe33c113f9e4071cfc3e7c46cac2fd8` merges exact historical shared-support commit [`7c753910`](https://github.com/a-shannon/ergo/commit/7c753910bf28b7c69f69228e120e101de2d83bb7), owned by [#2535](https://github.com/ergoplatform/ergo/pull/2535). Its eight test/support paths are reused unchanged. The [two-file codec review increment](https://github.com/a-shannon/ergo/compare/7c753910bf28b7c69f69228e120e101de2d83bb7...ad6de0515fe33c113f9e4071cfc3e7c46cac2fd8) isolates this PR's correction; the upstream diff remains cumulative until the shared support lands on master. The current release-targeted #2535 uses a separate port, so this historical commit is not claimed to be its current ancestor.

On this composition, all 83 targeted fixture/consumer tests passed, including the four transaction-failure holder cases, and normal test/integration compilation passed. [Current exact-head CI](https://github.com/ergoplatform/ergo/actions/runs/34730074714) is running. [The tracker](https://github.com/ergoplatform/ergo/issues/2533) records current heads and review order.
