### PR TITLE
Validate wallet request token ids

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/BoxesRequest.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/BoxesRequest.scala
@@ -3,8 +3,6 @@ package org.ergoplatform.nodeView.wallet.requests
 import io.circe.generic.decoding.DerivedDecoder.deriveDecoder
 import io.circe.{Decoder, KeyDecoder}
 import org.ergoplatform.ErgoBox
-import scorex.util.encode.Base16
-import sigmastate.eval.Extensions.ArrayByteOps
 
 /**
   * A request for boxes with given balance and assets
@@ -14,7 +12,7 @@ case class BoxesRequest(targetBalance: Long, targetAssets: Map[ErgoBox.TokenId, 
 object BoxesRequest {
 
   implicit val keyDecoder: KeyDecoder[ErgoBox.TokenId] =
-    KeyDecoder.instance(s => Base16.decode(s).toOption.map(_.toTokenId))
+    WalletRequestCodecs.tokenIdKeyDecoder
 
   implicit val decoder: Decoder[BoxesRequest] =
     cursor =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/BurnTokensRequest.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/BurnTokensRequest.scala
@@ -26,8 +26,8 @@ class BurnTokensRequestEncoder extends Encoder[BurnTokensRequest] {
 class BurnTokensRequestDecoder extends Decoder[BurnTokensRequest] {
   def apply(cursor: HCursor): Decoder.Result[BurnTokensRequest] = {
     for {
-      assetsToBurn <- cursor.downField("assetsToBurn").as[Option[Seq[(ErgoBox.TokenId, Long)]]]
-    } yield BurnTokensRequest(assetsToBurn.toArray.flatten)
+      assetsToBurn <- WalletRequestCodecs.decodeTokenAmounts(cursor, "assetsToBurn")
+    } yield BurnTokensRequest(assetsToBurn)
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/PaymentRequest.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/PaymentRequest.scala
@@ -43,9 +43,9 @@ class PaymentRequestDecoder(ergoSettings: ErgoSettings) extends Decoder[PaymentR
     for {
       address <- cursor.downField("address").as[ErgoAddress]
       value <- cursor.downField("value").as[Long]
-      assets <- cursor.downField("assets").as[Option[Seq[(ErgoBox.TokenId, Long)]]]
+      assets <- WalletRequestCodecs.decodeTokenAmounts(cursor, "assets")
       registers <- cursor.downField("registers").as[Option[Map[NonMandatoryRegisterId, EvaluatedValue[SType]]]]
-    } yield PaymentRequest(address, value, assets.toArray.flatten, registers.getOrElse(Map.empty))
+    } yield PaymentRequest(address, value, assets, registers.getOrElse(Map.empty))
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/TransactionGenerationRequest.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/TransactionGenerationRequest.scala
@@ -28,18 +28,15 @@ class TransactionRequestDecoder(settings: ErgoSettings) extends Decoder[Transact
   val burnTokensRequestDecoder: BurnTokensRequestDecoder = new BurnTokensRequestDecoder()
 
   def apply(cursor: HCursor): Decoder.Result[TransactionGenerationRequest] = {
-    val paymentRequestDecoderResult = paymentRequestDecoder.apply(cursor)
-    val assetIssueRequestDecoderResult = assetIssueRequestDecoder.apply(cursor)
-    val burnTokensRequestDecoderResult = burnTokensRequestDecoder.apply(cursor)
-    if (paymentRequestDecoderResult.isLeft &&
-        assetIssueRequestDecoderResult.isLeft &&
-        burnTokensRequestDecoderResult.isLeft
-    ) {
-      paymentRequestDecoderResult
+    val keys = cursor.keys.map(_.toSet).getOrElse(Set.empty[String])
+    if (keys.contains("value") || keys.contains("assets")) {
+      paymentRequestDecoder(cursor)
+    } else if (Seq("amount", "name", "description", "decimals", "ergValue").exists(keys.contains)) {
+      assetIssueRequestDecoder(cursor)
+    } else if (keys.contains("assetsToBurn")) {
+      burnTokensRequestDecoder(cursor)
     } else {
-      Seq(paymentRequestDecoderResult, assetIssueRequestDecoderResult, burnTokensRequestDecoderResult)
-        .find(_.isRight)
-        .get
+      Left(DecodingFailure("Missing transaction request discriminator", cursor.history))
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/WalletRequestCodecs.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/WalletRequestCodecs.scala
@@ -1,0 +1,51 @@
+package org.ergoplatform.nodeView.wallet.requests
+
+import io.circe.{CursorOp, Decoder, DecodingFailure, HCursor, Json, KeyDecoder}
+import org.ergoplatform.ErgoBox
+import org.ergoplatform.settings.Constants
+import scorex.util.encode.Base16
+import sigmastate.eval.Extensions.ArrayByteOps
+
+import scala.util.{Failure, Success}
+
+private[requests] object WalletRequestCodecs {
+
+  private val TokenIdSize = Constants.ModifierIdSize
+
+  implicit val tokenIdKeyDecoder: KeyDecoder[ErgoBox.TokenId] =
+    KeyDecoder.instance { value =>
+      Base16.decode(value).toOption
+        .filter(_.lengthCompare(TokenIdSize) == 0)
+        .map(_.toTokenId)
+    }
+
+  def decodeTokenAmounts(cursor: HCursor, field: String): Decoder.Result[Array[(ErgoBox.TokenId, Long)]] = {
+    val fieldCursor = cursor.downField(field)
+
+    fieldCursor.as[Option[Seq[Json]]].flatMap { valuesOpt =>
+      valuesOpt.getOrElse(Seq.empty)
+        .foldLeft(Right(Vector.empty): Decoder.Result[Vector[(ErgoBox.TokenId, Long)]]) {
+          case (acc, tokenJson) =>
+            val tokenCursor = tokenJson.hcursor
+            for {
+              values <- acc
+              tokenId <- tokenCursor.downField("tokenId").as[String]
+              amount <- tokenCursor.downField("amount").as[Long]
+              decodedTokenId <- decodeTokenId(tokenId, tokenCursor.downField("tokenId").history)
+            } yield values :+ (decodedTokenId -> amount)
+        }
+        .map(_.toArray)
+      }
+  }
+
+  private def decodeTokenId(value: String, history: List[CursorOp]): Decoder.Result[ErgoBox.TokenId] = {
+    Base16.decode(value) match {
+      case Success(bytes) if bytes.lengthCompare(TokenIdSize) == 0 =>
+        Right(bytes.toTokenId)
+      case Success(_) =>
+        Left(DecodingFailure(s"Token id should be $TokenIdSize bytes", history))
+      case Failure(e) =>
+        Left(DecodingFailure.fromThrowable(e, history))
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/requests/WalletRequestCodecs.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/requests/WalletRequestCodecs.scala
@@ -1,0 +1,52 @@
+package org.ergoplatform.nodeView.wallet.requests
+
+import io.circe.{CursorOp, Decoder, DecodingFailure, HCursor, Json, KeyDecoder}
+import org.ergoplatform.ErgoBox
+import org.ergoplatform.settings.Constants
+import scorex.util.encode.Base16
+import sigma.Extensions.ArrayOps
+import sigma.data.Digest32Coll
+
+import scala.util.{Failure, Success}
+
+private[requests] object WalletRequestCodecs {
+
+  private val TokenIdSize = Constants.ModifierIdSize
+
+  val tokenIdKeyDecoder: KeyDecoder[ErgoBox.TokenId] =
+    KeyDecoder.instance { value =>
+      Base16.decode(value).toOption
+        .filter(_.length == TokenIdSize)
+        .map(bytes => Digest32Coll @@ bytes.toColl)
+    }
+
+  def decodeTokenAmounts(cursor: HCursor, field: String): Decoder.Result[Array[(ErgoBox.TokenId, Long)]] = {
+    val fieldCursor = cursor.downField(field)
+
+    fieldCursor.as[Option[Seq[Json]]].flatMap { valuesOpt =>
+      valuesOpt.getOrElse(Seq.empty)
+        .foldLeft(Right(Vector.empty): Decoder.Result[Vector[(ErgoBox.TokenId, Long)]]) {
+          case (acc, tokenJson) =>
+            val tokenCursor = tokenJson.hcursor
+            for {
+              values <- acc
+              tokenId <- tokenCursor.downField("tokenId").as[String]
+              amount <- tokenCursor.downField("amount").as[Long]
+              decodedTokenId <- decodeTokenId(tokenId, tokenCursor.downField("tokenId").history)
+            } yield values :+ (decodedTokenId -> amount)
+        }
+        .map(_.toArray)
+    }
+  }
+
+  private def decodeTokenId(value: String, history: List[CursorOp]): Decoder.Result[ErgoBox.TokenId] = {
+    Base16.decode(value) match {
+      case Success(bytes) if bytes.length == TokenIdSize =>
+        Right(Digest32Coll @@ bytes.toColl)
+      case Success(_) =>
+        Left(DecodingFailure(s"Token id should be $TokenIdSize bytes", history))
+      case Failure(e) =>
+        Left(DecodingFailure.fromThrowable(e, history))
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.serialization
 
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 import org.ergoplatform.Pay2SAddress
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs}
 import org.ergoplatform.modifiers.ErgoFullBlock
@@ -154,6 +154,195 @@ class JsonSerializationSpec extends ErgoCorePropertyTest
       val json = request.asJson
       val parsedRequest = json.as[TransactionSigningRequest].toOption.get
       parsedRequest shouldBe request
+    }
+  }
+
+  property("TransactionRequestDecoder should roundtrip every request subtype") {
+    val ergoSettings = ErgoSettingsReader.read()
+    val encoder = new TransactionRequestEncoder(ergoSettings)
+    val decoder = new TransactionRequestDecoder(ergoSettings)
+    forAll(paymentRequestGen, assetIssueRequestGen, burnTokensRequestGen) { (payment, issuance, burn) =>
+      Seq(payment, issuance, burn).foreach { request =>
+        val restored = decoder.decodeJson(encoder(request)).value
+        restored.getClass shouldEqual request.getClass
+        encoder(restored) shouldEqual encoder(request)
+      }
+    }
+  }
+
+  property("TransactionRequestDecoder should preserve optional payment assets and burn arrays") {
+    val ergoSettings = ErgoSettingsReader.read()
+    val decoder = new TransactionRequestDecoder(ergoSettings)
+    val address = Pay2SAddress(FalseTree)(ergoSettings.addressEncoder)
+    val payment = PaymentRequest(address, 1000000L, Array.empty, Map.empty)
+    val paymentJson = new PaymentRequestEncoder(ergoSettings)(payment)
+    val paymentForms = Seq(
+      paymentJson.mapObject(_.remove("assets")),
+      paymentJson.mapObject(_.add("assets", Json.Null)),
+      paymentJson
+    )
+    paymentForms.foreach { json =>
+      val restored = decoder.decodeJson(json).value.asInstanceOf[PaymentRequest]
+      restored.address shouldEqual payment.address
+      restored.value shouldEqual payment.value
+      restored.assets shouldBe empty
+      restored.registers shouldBe empty
+    }
+    Seq(Json.Null, Json.arr()).foreach { assets =>
+      val restored = decoder.decodeJson(Json.obj("assetsToBurn" -> assets)).value.asInstanceOf[BurnTokensRequest]
+      restored.assetsToBurn shouldBe empty
+    }
+  }
+
+  property("TransactionRequestDecoder should preserve optional issuance fields") {
+    val ergoSettings = ErgoSettingsReader.read()
+    val decoder = new TransactionRequestDecoder(ergoSettings)
+    val encoder = new AssetIssueRequestEncoder(ergoSettings)
+    val issuance = AssetIssueRequest(None, None, 100L, "Example", "Example asset", 2, None)
+    val encoded = encoder(issuance)
+    val omitted = encoded.mapObject(_.remove("address").remove("ergValue").remove("registers"))
+    Seq(encoded, omitted).foreach { json =>
+      decoder.decodeJson(json).value shouldEqual issuance
+    }
+    val populated = issuance.copy(
+      addressOpt = Some(Pay2SAddress(FalseTree)(ergoSettings.addressEncoder)),
+      valueOpt = Some(1000000L),
+      registers = Some(Map.empty)
+    )
+    decoder.decodeJson(encoder(populated)).value shouldEqual populated
+  }
+
+  property("TransactionRequestDecoder should retain mixed RequestsHolder content and order") {
+    val ergoSettings = ErgoSettingsReader.read()
+    val encoder = new RequestsHolderEncoder(ergoSettings)
+    val decoder = new RequestsHolderDecoder(ergoSettings)
+    forAll(paymentRequestGen, assetIssueRequestGen, burnTokensRequestGen) { (payment, issuance, burn) =>
+      val holder = RequestsHolder(
+        Seq(issuance, burn, payment, issuance), Some(1000000L), Seq("input"), Seq("data-input"),
+        ergoSettings.chainSettings.monetary.minerRewardDelay
+      )(ergoSettings.addressEncoder)
+      val restored = decoder.decodeJson(encoder(holder)).value
+      restored.requests.map(_.getClass) shouldEqual holder.requests.map(_.getClass)
+      encoder(restored) shouldEqual encoder(holder)
+      restored.minerRewardDelay shouldEqual holder.minerRewardDelay
+    }
+  }
+
+  property("TransactionRequestDecoder should select by key presence and priority") {
+    val ergoSettings = ErgoSettingsReader.read()
+    val address = Pay2SAddress(FalseTree)(ergoSettings.addressEncoder)
+    val payment = PaymentRequest(address, 1000000L, Array.empty, Map.empty)
+    val issuance = AssetIssueRequest(None, None, 100L, "Example", "Example asset", 2, None)
+    val burn = BurnTokensRequest(Array.empty)
+    var calls = Vector.empty[String]
+    val decoder = new TransactionRequestDecoder(ergoSettings) {
+      override val paymentRequestDecoder: PaymentRequestDecoder = new PaymentRequestDecoder(ergoSettings) {
+        override def apply(cursor: HCursor): Decoder.Result[PaymentRequest] = {
+          calls :+= "payment"
+          Right(payment)
+        }
+      }
+      override val assetIssueRequestDecoder: AssetIssueRequestDecoder = new AssetIssueRequestDecoder(ergoSettings) {
+        override def apply(cursor: HCursor): Decoder.Result[AssetIssueRequest] = {
+          calls :+= "issuance"
+          Right(issuance)
+        }
+      }
+      override val burnTokensRequestDecoder: BurnTokensRequestDecoder = new BurnTokensRequestDecoder {
+        override def apply(cursor: HCursor): Decoder.Result[BurnTokensRequest] = {
+          calls :+= "burn"
+          Right(burn)
+        }
+      }
+    }
+    val encoder = new TransactionRequestEncoder(ergoSettings)
+    val burnJson = encoder(burn)
+    val issuanceJson = encoder(issuance)
+    val markers = Seq(
+      ("value", 1000000L.asJson, payment),
+      ("assets", Json.arr(), payment),
+      ("amount", 100L.asJson, issuance),
+      ("name", "Example".asJson, issuance),
+      ("description", "Example asset".asJson, issuance),
+      ("decimals", 2.asJson, issuance),
+      ("ergValue", 1000000L.asJson, issuance),
+      ("assetsToBurn", Json.arr(), burn)
+    )
+    def check(json: Json, expected: TransactionGenerationRequest, selected: String): Unit = {
+      calls = Vector.empty
+      decoder.decodeJson(json) shouldEqual Right(expected)
+      calls shouldEqual Vector(selected)
+    }
+    markers.foreach { case (key, value, expected) =>
+      val selected = if (expected == payment) "payment" else if (expected == issuance) "issuance" else "burn"
+      Seq(value, Json.Null).foreach { markerValue =>
+        check(burnJson.mapObject(_.add(key, markerValue)), expected, selected)
+      }
+    }
+    Seq("value" -> 1000000L.asJson, "assets" -> Json.arr()).foreach { case (key, value) =>
+      Seq(value, Json.Null).foreach { markerValue =>
+        check(issuanceJson.mapObject(_.add("assetsToBurn", Json.arr()).add(key, markerValue)), payment, "payment")
+      }
+    }
+    Seq(
+      Json.obj("address" -> address.toString.asJson, "registers" -> Json.obj()),
+      Json.obj("address" -> Json.Null, "registers" -> Json.Null)
+    ).foreach { sharedFields =>
+      check(burnJson.deepMerge(sharedFields), burn, "burn")
+    }
+    Seq(Json.obj(), Json.obj("address" -> address.toString.asJson, "registers" -> Json.obj())).foreach { json =>
+      calls = Vector.empty
+      decoder.decodeJson(json).isLeft shouldBe true
+      calls shouldBe empty
+    }
+  }
+
+  Seq("payment", "issuance", "burn").foreach { selected =>
+    property(s"TransactionRequestDecoder should propagate the selected $selected failure through RequestsHolder") {
+      val ergoSettings = ErgoSettingsReader.read()
+      val address = Pay2SAddress(FalseTree)(ergoSettings.addressEncoder)
+      val fixtures: Map[String, TransactionGenerationRequest] = Map(
+        "payment" -> PaymentRequest(address, 1000000L, Array.empty, Map.empty),
+        "issuance" -> AssetIssueRequest(None, None, 100L, "Example", "Example asset", 2, None),
+        "burn" -> BurnTokensRequest(Array.empty)
+      )
+      val encoder = new TransactionRequestEncoder(ergoSettings)
+      val json = encoder(fixtures(selected))
+      var calls = Vector.empty[String]
+      def failure(cursor: HCursor): DecodingFailure =
+        DecodingFailure(s"Synthetic $selected decoder failure", cursor.downField("synthetic").history)
+
+      val decoder = new TransactionRequestDecoder(ergoSettings) {
+        override val paymentRequestDecoder: PaymentRequestDecoder = new PaymentRequestDecoder(ergoSettings) {
+          override def apply(cursor: HCursor): Decoder.Result[PaymentRequest] = {
+            calls :+= "payment"
+            if (selected == "payment") Left(failure(cursor)) else super.apply(cursor)
+          }
+        }
+        override val assetIssueRequestDecoder: AssetIssueRequestDecoder = new AssetIssueRequestDecoder(ergoSettings) {
+          override def apply(cursor: HCursor): Decoder.Result[AssetIssueRequest] = {
+            calls :+= "issuance"
+            if (selected == "issuance") Left(failure(cursor)) else super.apply(cursor)
+          }
+        }
+        override val burnTokensRequestDecoder: BurnTokensRequestDecoder = new BurnTokensRequestDecoder {
+          override def apply(cursor: HCursor): Decoder.Result[BurnTokensRequest] = {
+            calls :+= "burn"
+            if (selected == "burn") Left(failure(cursor)) else super.apply(cursor)
+          }
+        }
+      }
+
+      decoder.decodeJson(json) shouldEqual Left(failure(json.hcursor))
+      calls shouldEqual Vector(selected)
+
+      val preceding = encoder(fixtures(if (selected == "payment") "issuance" else "payment"))
+      val holderJson = Json.obj("requests" -> Json.arr(preceding, json))
+      val holderDecoder = new RequestsHolderDecoder(ergoSettings) {
+        override implicit val transactionRequestDecoder: TransactionRequestDecoder = decoder
+      }
+      val itemCursor = holderJson.hcursor.downField("requests").downArray.right.success.get
+      holderDecoder.decodeJson(holderJson) shouldEqual Left(failure(itemCursor))
     }
   }
 

--- a/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
@@ -2,14 +2,17 @@ package org.ergoplatform.serialization
 
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
+import org.ergoplatform.Pay2SAddress
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.popow.NipopowProof
 import org.ergoplatform.modifiers.mempool.UnsignedErgoTransaction
 import org.ergoplatform.nodeView.wallet.requests._
-import org.ergoplatform.settings.ErgoSettingsReader
+import org.ergoplatform.settings.Constants.FalseTree
+import org.ergoplatform.settings.{Constants, ErgoSettingsReader}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalatest.{EitherValues, Inspectors}
+import scorex.util.encode.Base16
 
 import scala.util.Random
 
@@ -88,6 +91,45 @@ class JsonSerializationSpec extends ErgoCorePropertyTest
           restoredValue shouldEqual requestValue
       }
     }
+  }
+
+  property("wallet request token ids should enforce the canonical length") {
+    val ergoSettings = ErgoSettingsReader.read()
+    implicit val paymentRequestDecoder: Decoder[PaymentRequest] = new PaymentRequestDecoder(ergoSettings)
+    implicit val burnTokensRequestDecoder: Decoder[BurnTokensRequest] = new BurnTokensRequestDecoder()
+    val address = Pay2SAddress(FalseTree)(ergoSettings.addressEncoder).toString
+
+    def boxesRequest(tokenId: String): Decoder.Result[BoxesRequest] =
+      Json.obj(
+        "targetBalance" -> 1L.asJson,
+        "targetAssets" -> Json.obj(tokenId -> 1L.asJson)
+      ).as[BoxesRequest]
+
+    def paymentRequest(tokenId: String): Decoder.Result[PaymentRequest] =
+      Json.obj(
+        "address" -> address.asJson,
+        "value" -> 1L.asJson,
+        "assets" -> Json.arr(Json.obj("tokenId" -> tokenId.asJson, "amount" -> 1L.asJson))
+      ).as[PaymentRequest]
+
+    def burnRequest(tokenId: String): Decoder.Result[BurnTokensRequest] =
+      Json.obj(
+        "assetsToBurn" -> Json.arr(Json.obj("tokenId" -> tokenId.asJson, "amount" -> 1L.asJson))
+      ).as[BurnTokensRequest]
+
+    val invalidTokenIds = Seq(1, 31, 33)
+      .map(length => Base16.encode(Array.fill(length)(length.toByte))) :+ "not-hex"
+
+    invalidTokenIds.foreach { tokenId =>
+      boxesRequest(tokenId).isLeft shouldBe true
+      paymentRequest(tokenId).isLeft shouldBe true
+      burnRequest(tokenId).isLeft shouldBe true
+    }
+
+    val validTokenId = Base16.encode(Array.fill(Constants.ModifierIdSize)(1.toByte))
+    boxesRequest(validTokenId).isRight shouldBe true
+    paymentRequest(validTokenId).isRight shouldBe true
+    burnRequest(validTokenId).isRight shouldBe true
   }
 
   property("AssetIssueRequest should be serialized to json") {

--- a/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
@@ -2,11 +2,13 @@ package org.ergoplatform.serialization
 
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
+import org.ergoplatform.Pay2SAddress
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.popow.NipopowProof
 import org.ergoplatform.modifiers.mempool.UnsignedErgoTransaction
 import org.ergoplatform.nodeView.wallet.requests._
+import org.ergoplatform.settings.Constants.FalseTree
 import org.ergoplatform.settings.ErgoSettingsReader
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalatest.{EitherValues, Inspectors}
@@ -88,6 +90,31 @@ class JsonSerializationSpec extends ErgoCorePropertyTest
           restoredValue shouldEqual requestValue
       }
     }
+  }
+
+  property("wallet request token ids should reject non-canonical lengths") {
+    val ergoSettings = ErgoSettingsReader.read()
+    implicit val paymentRequestDecoder: Decoder[PaymentRequest] = new PaymentRequestDecoder(ergoSettings)
+    implicit val burnTokensRequestDecoder: Decoder[BurnTokensRequest] = new BurnTokensRequestDecoder()
+
+    val shortTokenId = "00"
+    val invalidAssets = Json.arr(Json.obj("tokenId" -> shortTokenId.asJson, "amount" -> 1L.asJson))
+    val address = Pay2SAddress(FalseTree)(ergoSettings.addressEncoder).toString
+
+    Json.obj(
+      "targetBalance" -> 1L.asJson,
+      "targetAssets" -> Json.obj(shortTokenId -> 1L.asJson)
+    ).as[BoxesRequest].isLeft shouldBe true
+
+    Json.obj(
+      "address" -> address.asJson,
+      "value" -> 1L.asJson,
+      "assets" -> invalidAssets
+    ).as[PaymentRequest].isLeft shouldBe true
+
+    Json.obj(
+      "assetsToBurn" -> invalidAssets
+    ).as[BurnTokensRequest].isLeft shouldBe true
   }
 
   property("AssetIssueRequest should be serialized to json") {


### PR DESCRIPTION
## Summary

- Reject wallet request token IDs unless the hexadecimal value decodes to exactly 32 bytes.
- Apply the check to `BoxesRequest.targetAssets`, `PaymentRequest.assets`, and `BurnTokensRequest.assetsToBurn`.
- Select a transaction request subtype by its fields before decoding, and propagate that decoder's error without falling back to another subtype.
- Keep generic API and scanning codecs unchanged.

## Compatibility

Normal payment, asset-issuance, and burn encodings retain their content and order. Optional payment assets, explicit null/empty burn arrays, and optional issuance fields remain supported.

Subtype selection uses field presence, including null, with payment before issuance before explicit burn. Objects without a recognized subtype field are rejected; partially mixed subtype objects can now be rejected instead of being reinterpreted after a decoding error.

## Validation

- Eight focused dispatcher/holder properties cover subtype roundtrips, optional fields, every selection key, precedence, and exact propagation of synthetic child-decoder failures.
- RED with the previous dispatcher: 4 passed, 4 failed. GREEN with this change: 8/8.
- Full `JsonSerializationSpec`: 16/16.
- Affected consumer suites: 91/91 across wallet JSON, wallet routes, wallet service, wallet behavior, and scanning JSON codecs (Scala 2.12.20 / Java 17).
- Independent source review of the exact six-file candidate: no blocking findings.