### PR TITLE
Reject invalid secret proof hint hex

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
@@ -45,6 +45,14 @@ trait ApiCodecs extends JsonCodecs {
     fromTry(validationResult.toTry)
   }
 
+  private def fromTryAt[T](value: Try[T], cursor: ACursor): Decoder.Result[T] = value match {
+    case Success(result) => Right(result)
+    case Failure(e) => Left(DecodingFailure.fromThrowable(e, cursor.history))
+  }
+
+  private def decodeBase16(value: String, cursor: ACursor): Decoder.Result[Array[Byte]] =
+    fromTryAt(Base16.decode(value), cursor)
+
   implicit val leafDataEncoder: Encoder[LeafData] = Encoder.instance(xs => Base16.encode(xs).asJson)
 
   implicit val digestEncoder: Encoder[Digest] = Encoder.instance(x => Base16.encode(x).asJson)
@@ -338,11 +346,14 @@ trait ApiCodecs extends JsonCodecs {
           pubkey <- c.downField("pubkey").as[SigmaLeaf]
           proof <- c.downField("proof").as[String]
           position <- c.downField("position").as[NodePosition]
+          challengeBytes <- decodeBase16(challenge, c.downField("challenge"))
+          proofBytes <- decodeBase16(proof, c.downField("proof"))
+          proofTree <- fromTryAt(Try(SigSerializer.parseAndComputeChallenges(pubkey, proofBytes)(null)), c.downField("proof"))
         } yield
           RealSecretProof(
             pubkey,
-            Challenge @@ Base16.decode(challenge).get.toColl,
-            SigSerializer.parseAndComputeChallenges(pubkey, Base16.decode(proof).get)(null),
+            Challenge @@ challengeBytes.toColl,
+            proofTree,
             position
           )
       case h: String if h == "proofSimulated" =>
@@ -351,11 +362,14 @@ trait ApiCodecs extends JsonCodecs {
           pubkey <- c.downField("pubkey").as[SigmaLeaf]
           proof <- c.downField("proof").as[String]
           position <- c.downField("position").as[NodePosition]
+          challengeBytes <- decodeBase16(challenge, c.downField("challenge"))
+          proofBytes <- decodeBase16(proof, c.downField("proof"))
+          proofTree <- fromTryAt(Try(SigSerializer.parseAndComputeChallenges(pubkey, proofBytes)(null)), c.downField("proof"))
         } yield
           SimulatedSecretProof(
             pubkey,
-            Challenge @@ Base16.decode(challenge).get.toColl,
-            SigSerializer.parseAndComputeChallenges(pubkey, Base16.decode(proof).get)(null),
+            Challenge @@ challengeBytes.toColl,
+            proofTree,
             position
           )
       case _ =>

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.serialization
 
 import io.circe.syntax._
-import io.circe.ACursor
+import io.circe.{ACursor, Json}
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.ErgoBox.{AdditionalRegisters, NonMandatoryRegisterId}
 import org.ergoplatform.http.api.ApiCodecs
@@ -14,6 +14,9 @@ import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.TrackedBox
 import cats.syntax.either._
 import sigma.ast.{ErgoTree, EvaluatedValue, SType}
+import sigmastate.interpreter.SecretProven
+
+import scala.util.Try
 
 class JsonSerializationCoreSpec extends ErgoCorePropertyTest
   with ApiCodecs {
@@ -58,6 +61,26 @@ class JsonSerializationCoreSpec extends ErgoCorePropertyTest
       val json = wrappedSecret.asJson
       val parsedSecret = json.as[DhtSecretKey].toOption.get
       parsedSecret shouldBe wrappedSecret
+    }
+  }
+
+  property("secret proof decoder should reject invalid hex without throwing") {
+    val pubkey = proveDlogGen.sample.get
+    val pubkeyJson = Json.obj("op" -> pubkey.opCode.toByte.asJson, "h" -> pubkey.value.asJson)
+
+    Seq("zz" -> "00", "00" -> "zz").foreach { case (challenge, proof) =>
+      val json = Json.obj(
+        "hint" -> "proofReal".asJson,
+        "challenge" -> challenge.asJson,
+        "pubkey" -> pubkeyJson,
+        "proof" -> proof.asJson,
+        "position" -> "0".asJson
+      )
+
+      val decoded = Try(json.as[SecretProven])
+      decoded.isSuccess shouldBe true
+      decoded.get.isLeft shouldBe true
+      decoded.get.left.get.message.toLowerCase should include ("hex")
     }
   }
 


### PR DESCRIPTION
## Summary
- Decode secret proof `challenge` and `proof` hex through `Decoder.Result` instead of `.get`.
- Return a Circe decoding failure for invalid hint proof hex instead of throwing during JSON decoding.
- Apply the same handling to real and simulated secret proofs.

## Tests
- `sbt "ergoCore/testOnly org.ergoplatform.serialization.JsonSerializationCoreSpec"`
- `sbt ++2.11.12 "ergoCore/testOnly org.ergoplatform.serialization.JsonSerializationCoreSpec"`
- `sbt ++2.12.20 "testOnly org.ergoplatform.http.routes.WalletApiRouteSpec"`