### PR TITLE
Validate wallet external box bytes

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -190,6 +190,19 @@ case class WalletApiRoute(readersHolder: ActorRef,
     }
   }
 
+  private def decodeExternalBoxes(inputsRawOpt: Option[Seq[String]],
+                                  dataInputsRawOpt: Option[Seq[String]]): Try[(Option[Seq[ErgoBox]], Option[Seq[ErgoBox]])] = {
+    def decodeOpt(rawOpt: Option[Seq[String]]): Try[Option[Seq[ErgoBox]]] =
+      rawOpt.fold[Try[Option[Seq[ErgoBox]]]](Success(None)) { raw =>
+        ErgoWalletServiceUtils.stringsToBoxes(raw).map(Some(_))
+      }
+
+    for {
+      inputs <- decodeOpt(inputsRawOpt)
+      dataInputs <- decodeOpt(dataInputsRawOpt)
+    } yield inputs -> dataInputs
+  }
+
   private def sendTransaction(requests: Seq[TransactionGenerationRequest],
                               inputsRaw: Seq[String],
                               dataInputsRaw: Seq[String]): Route = {
@@ -219,12 +232,15 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
     val utx = gcr.unsignedTx
     val externalSecretsOpt = gcr.externalSecretsOpt
-    val extInputsOpt = gcr.inputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-    val extDataInputsOpt = gcr.dataInputs.map(ErgoWalletServiceUtils.stringsToBoxes)
 
-    withWalletOp(_.generateCommitmentsFor(utx, externalSecretsOpt, extInputsOpt, extDataInputsOpt).map(_.response)) {
-      case Failure(e) => BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
-      case Success(thb) => ApiResponse(thb)
+    decodeExternalBoxes(gcr.inputs, gcr.dataInputs) match {
+      case Failure(e) =>
+        BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
+      case Success((extInputsOpt, extDataInputsOpt)) =>
+        withWalletOp(_.generateCommitmentsFor(utx, externalSecretsOpt, extInputsOpt, extDataInputsOpt).map(_.response)) {
+          case Failure(e) => BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
+          case Success(thb) => ApiResponse(thb)
+        }
     }
   }
 
@@ -478,11 +494,13 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def extractHintsR: Route = (path("extractHints") & post & entity(as[HintExtractionRequest])) { her =>
-    withWallet { w =>
-      val extInputsOpt = her.inputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-      val extDataInputsOpt = her.dataInputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-
-      w.extractHints(her.tx, her.real, her.simulated, extInputsOpt, extDataInputsOpt).map(_.transactionHintsBag)
+    decodeExternalBoxes(her.inputs, her.dataInputs) match {
+      case Failure(e) =>
+        BadRequest(s"Bad request. ${Option(e.getMessage).getOrElse(e.toString)}")
+      case Success((extInputsOpt, extDataInputsOpt)) =>
+        withWallet { w =>
+          w.extractHints(her.tx, her.real, her.simulated, extInputsOpt, extDataInputsOpt).map(_.transactionHintsBag)
+        }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceUtils.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceUtils.scala
@@ -16,8 +16,14 @@ object ErgoWalletServiceUtils {
   case class DeriveNextKeyResult(result: Try[(DerivationPath, P2PKAddress, ExtendedSecretKey)])
 
   // A helper which is deserializing Base16-encoded boxes to ErgoBox instances
-  def stringsToBoxes(strings: Seq[String]): Seq[ErgoBox] =
-    strings.map(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry)).map(_.get)
+  def stringsToBoxes(strings: Seq[String]): Try[Seq[ErgoBox]] =
+    strings.foldLeft(Try(Seq.empty[ErgoBox])) { case (acc, encodedBox) =>
+      for {
+        boxes <- acc
+        boxBytes <- Base16.decode(encodedBox)
+        box <- ErgoBoxSerializer.parseBytesTry(boxBytes)
+      } yield boxes :+ box
+    }
 
 }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -280,74 +280,80 @@ trait ErgoWalletSupport extends ScorexLogging {
                                             boxSelector: BoxSelector,
                                             requests: Seq[TransactionGenerationRequest],
                                             inputsRaw: Seq[String],
-                                            dataInputsRaw: Seq[String]): Try[(UnsignedErgoTransaction, IndexedSeq[ErgoBox], IndexedSeq[ErgoBox])] = Try {
-    require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issuance requests")
+                                            dataInputsRaw: Seq[String]): Try[(UnsignedErgoTransaction, IndexedSeq[ErgoBox], IndexedSeq[ErgoBox])] = {
+    val decodedBoxes = for {
+      userInputs <- ErgoWalletServiceUtils.stringsToBoxes(inputsRaw)
+      dataInputs <- ErgoWalletServiceUtils.stringsToBoxes(dataInputsRaw)
+    } yield (userInputs, dataInputs.toIndexedSeq)
 
-    val userInputs = ErgoWalletServiceUtils.stringsToBoxes(inputsRaw)
+    decodedBoxes.flatMap { case (userInputs, dataInputs) =>
+      Try {
+        require(requests.count(_.isInstanceOf[AssetIssueRequest]) <= 1, "Too many asset issuance requests")
 
-    val inputBoxes = if (userInputs.nonEmpty) {
-      // make TrackedBox sequence out of boxes provided
-      val boxesToFakeTracked =
-        userInputs.map { box => // declare fake inclusion height in order to confirm the box is onchain
-          TrackedBox(box.transactionId, box.index, Some(1), None, None, box, Set(PaymentsScanId))
+        val inputBoxes = if (userInputs.nonEmpty) {
+          // make TrackedBox sequence out of boxes provided
+          val boxesToFakeTracked =
+            userInputs.map { box => // declare fake inclusion height in order to confirm the box is onchain
+              TrackedBox(box.transactionId, box.index, Some(1), None, None, box, Set(PaymentsScanId))
+            }
+          //inputs are provided externally, no need for filtering
+          boxesToFakeTracked
+        } else {
+          state.walletVars.proverOpt match {
+            case Some(_) =>
+              //inputs are to be filtered by the wallet filter, which is removing boxes spent offchain
+              state.getBoxesToSpend.filter(box => state.walletFilter(box))
+            case None =>
+              throw new Exception(s"Cannot generateUnsignedTransaction($requests, $inputsRaw): wallet is locked")
+          }
         }
-      //inputs are provided externally, no need for filtering
-      boxesToFakeTracked
-    } else {
-      state.walletVars.proverOpt match {
-        case Some(_) =>
-          //inputs are to be filtered by the wallet filter, which is removing boxes spent offchain
-          state.getBoxesToSpend.filter(box => state.walletFilter(box))
-        case None =>
-          throw new Exception(s"Cannot generateUnsignedTransaction($requests, $inputsRaw): wallet is locked")
-      }
+
+        require(inputBoxes.nonEmpty, "There must be at least one input box")
+
+        //filter burnTokens requests
+        val (requestsWithBurnTokens, requestsWithoutBurnTokens) = requests.partition(_.isInstanceOf[BurnTokensRequest])
+        val burnTokensRequestMap = TransactionBuilder.collTokensToMap(
+          requestsWithBurnTokens
+            .toArray
+            .map(_.asInstanceOf[BurnTokensRequest])
+            .flatMap(_.assetsToBurn)
+            .toColl
+        )
+        //filter out tokens on whitelist from wallet and merge the rest with burnTokens from requests
+        val burnTokensMap = mergeBurnWhitelistTokens(state, inputBoxes.toArray, burnTokensRequestMap)
+
+        //We're getting id of the first input, it will be used in case of asset issuance (asset id == first input id)
+        requestsToBoxCandidates(requestsWithoutBurnTokens, inputBoxes.head.box.id, state.fullHeight, state.parameters, state.walletVars.publicKeyAddresses)
+          .flatMap { outputs =>
+            require(outputs.forall(c => c.value >= BoxUtils.minimalErgoAmountSimulated(c, state.parameters)), "Minimal ERG value not met")
+            require(outputs.forall(_.additionalTokens.forall(_._2 > 0)), "Non-positive asset value")
+
+            val assetIssueBox = outputs
+              .zip(requests)
+              .filter(_._2.isInstanceOf[AssetIssueRequest])
+              .map(_._1)
+              .headOption
+
+            val targetBalance = outputs.map(_.value).sum
+            val targetAssets = TransactionBuilder.collectOutputTokens(outputs.filterNot(bx => assetIssueBox.contains(bx)))
+
+            //add burnTokens to target assets so that they are excluded from the change outputs
+            //thus total outputs assets will be reduced which is interpreted as _token burning_
+            val targetAssetsWithBurn = AssetUtils.mergeAssets(targetAssets, burnTokensMap)
+
+            val selectionOpt = boxSelector.select(inputBoxes.iterator, targetBalance, targetAssetsWithBurn)
+            selectionOpt.map { selectionResult =>
+              val changeAddressOpt: Option[ProveDlog] = state.getChangeAddress(addressEncoder).map(_.pubkey)
+              prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.inputBoxes
+            } match {
+              case Right((txTry, inputs)) => txTry.map(tx => (tx, inputs.map(_.box).toIndexedSeq, dataInputs))
+              case Left(e) => Failure(
+                new Exception(s"Failed to find boxes to assemble a transaction for $outputs, \nreason: $e")
+              )
+            }
+          }
+      }.flatten
     }
-
-    require(inputBoxes.nonEmpty, "There must be at least one input box")
-
-    //filter burnTokens requests
-    val (requestsWithBurnTokens, requestsWithoutBurnTokens) = requests.partition(_.isInstanceOf[BurnTokensRequest])
-    val burnTokensRequestMap = TransactionBuilder.collTokensToMap(
-      requestsWithBurnTokens
-        .toArray
-        .map(_.asInstanceOf[BurnTokensRequest])
-        .flatMap(_.assetsToBurn)
-        .toColl
-    )
-    //filter out tokens on whitelist from wallet and merge the rest with burnTokens from requests
-    val burnTokensMap = mergeBurnWhitelistTokens(state, inputBoxes.toArray, burnTokensRequestMap)
-
-    //We're getting id of the first input, it will be used in case of asset issuance (asset id == first input id)
-    requestsToBoxCandidates(requestsWithoutBurnTokens, inputBoxes.head.box.id, state.fullHeight, state.parameters, state.walletVars.publicKeyAddresses)
-      .flatMap { outputs =>
-        require(outputs.forall(c => c.value >= BoxUtils.minimalErgoAmountSimulated(c, state.parameters)), "Minimal ERG value not met")
-        require(outputs.forall(_.additionalTokens.forall(_._2 > 0)), "Non-positive asset value")
-
-        val assetIssueBox = outputs
-          .zip(requests)
-          .filter(_._2.isInstanceOf[AssetIssueRequest])
-          .map(_._1)
-          .headOption
-
-        val targetBalance = outputs.map(_.value).sum
-        val targetAssets = TransactionBuilder.collectOutputTokens(outputs.filterNot(bx => assetIssueBox.contains(bx)))
-
-        //add burnTokens to target assets so that they are excluded from the change outputs
-        //thus total outputs assets will be reduced which is interpreted as _token burning_
-        val targetAssetsWithBurn = AssetUtils.mergeAssets(targetAssets, burnTokensMap)
-
-        val selectionOpt = boxSelector.select(inputBoxes.iterator, targetBalance, targetAssetsWithBurn)
-        val dataInputs = ErgoWalletServiceUtils.stringsToBoxes(dataInputsRaw).toIndexedSeq
-        selectionOpt.map { selectionResult =>
-          val changeAddressOpt: Option[ProveDlog] = state.getChangeAddress(addressEncoder).map(_.pubkey)
-          prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.inputBoxes
-        } match {
-          case Right((txTry, inputs)) => txTry.map(tx => (tx, inputs.map(_.box).toIndexedSeq, dataInputs))
-          case Left(e) => Failure(
-            new Exception(s"Failed to find boxes to assemble a transaction for $outputs, \nreason: $e")
-          )
-        }
-      }
-  }.flatten
+  }
 
 }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -115,6 +115,19 @@ class WalletApiRouteSpec extends AnyFlatSpec
     }
   }
 
+  it should "reject invalid external box bytes in commitments request" in {
+    val tx = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get.unsignedTx
+    val request = Json.obj(
+      "tx" -> tx.asJson,
+      "secrets" -> Json.obj(),
+      "inputsRaw" -> Seq("zz").asJson
+    )
+
+    Post(prefix + "/generateCommitments", request) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "generate & send payment transaction" in {
     Post(prefix + "/payment/send", Seq(paymentRequest).asJson) ~> route ~> check {
       status shouldBe StatusCodes.OK


### PR DESCRIPTION
## Summary
- Decode wallet external input/data-input box bytes through `Try` instead of throwing from `.get`.
- Return `BadRequest` for invalid external box bytes in commitments and hint-extraction routes.
- Keep transaction generation behavior intact while propagating decode failures explicitly.

## Tests
- `sbt "testOnly org.ergoplatform.http.routes.WalletApiRouteSpec"`
- `sbt "testOnly org.ergoplatform.nodeView.wallet.ErgoWalletServiceSpec"`