### PR TITLE
Validate wallet external box bindings

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreter.scala
@@ -102,11 +102,10 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
                  dataBoxes: IndexedSeq[ErgoBox],
                  stateContext: VersionedBlockchainStateContext,
                  txHints: TransactionHintsBag): Try[(IndexedSeq[Input], Long)] = {
-    if (unsignedTx.inputs.length != boxesToSpend.length) {
-      Failure(new Exception("Not enough boxes to spend"))
-    } else if (unsignedTx.dataInputs.length != dataBoxes.length) {
-      Failure(new Exception("Not enough data boxes"))
-    } else {
+    (for {
+      _ <- ErgoProvingInterpreter.validateBoxIds("Input", unsignedTx.inputs.map(_.boxId), boxesToSpend)
+      _ <- ErgoProvingInterpreter.validateBoxIds("Data input", unsignedTx.dataInputs.map(_.boxId), dataBoxes)
+    } yield ()).flatMap { _ =>
       ErgoBoxAssetExtractor.extractTotalAssetsAccessCost(boxesToSpend, unsignedTx.outputCandidates, params.tokenAccessCost)
         .flatMap { totalAssetsAccessCost =>
 
@@ -124,7 +123,6 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
             .zipWithIndex
             .foldLeft(Try(IndexedSeq[Input]() -> initialCost)) { case (inputsCostTry, (inputBox, boxIdx)) =>
               val unsignedInput = unsignedTx.inputs(boxIdx)
-              require(util.Arrays.equals(unsignedInput.boxId, inputBox.id))
 
               inputsCostTry.flatMap { case (ins, totalCost) =>
                 val context = new ErgoLikeContext(
@@ -190,8 +188,10 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
   def generateCommitmentsFor(unsignedTx: UnsignedErgoLikeTransaction,
                              boxesToSpend: IndexedSeq[ErgoBox],
                              dataBoxes: IndexedSeq[ErgoBox],
-                             stateContext: BlockchainStateContext): Try[TransactionHintsBag] = Try {
-    val inputCmts = unsignedTx.inputs.zipWithIndex.map { case (unsignedInput, inpIndex) =>
+                             stateContext: BlockchainStateContext): Try[TransactionHintsBag] = for {
+    _ <- ErgoProvingInterpreter.validateBoxIds("Input", unsignedTx.inputs.map(_.boxId), boxesToSpend)
+    _ <- ErgoProvingInterpreter.validateBoxIds("Data input", unsignedTx.dataInputs.map(_.boxId), dataBoxes)
+    inputCmts <- Try(unsignedTx.inputs.zipWithIndex.map { case (unsignedInput, inpIndex) =>
 
       val inputBox = boxesToSpend(inpIndex)
 
@@ -211,10 +211,8 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
       )
       val scriptToReduce = inputBox.ergoTree
       inpIndex -> generateCommitments(scriptToReduce, context)
-    }
-
-    TransactionHintsBag(inputCmts.toMap)
-  }
+    })
+  } yield TransactionHintsBag(inputCmts.toMap)
 
   /**
     * Extract hints from (supposedly, partially) signed transaction. Useful for distributed signing.
@@ -233,8 +231,9 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
                         stateContext: BlockchainStateContext,
                         realSecretsToExtract: Seq[SigmaBoolean],
                         simulatedSecretsToExtract: Seq[SigmaBoolean]): TransactionHintsBag = {
+    ErgoProvingInterpreter.validateBoxIds("Input", tx.inputs.map(_.boxId), boxesToSpend).get
+    ErgoProvingInterpreter.validateBoxIds("Data input", tx.dataInputs.map(_.boxId), dataBoxes).get
     val augmentedInputs = tx.inputs.zipWithIndex.zip(boxesToSpend)
-    require(augmentedInputs.forall { case ((input, _), box) => input.boxId.sameElements(box.id) }, "Wrong boxes")
 
     augmentedInputs.foldLeft(TransactionHintsBag.empty) { case (bag, ((input, idx), box)) =>
       val exp = box.ergoTree
@@ -260,6 +259,18 @@ class ErgoProvingInterpreter(val secretKeys: IndexedSeq[SecretKey],
 }
 
 object ErgoProvingInterpreter {
+
+  private[ergoplatform] def validateBoxIds(kind: String,
+                                           expectedIds: Seq[ErgoBox.BoxId],
+                                           boxes: Seq[ErgoBox]): Try[Unit] = Try {
+    require(
+      expectedIds.length == boxes.length,
+      s"$kind box count ${boxes.length} does not match transaction count ${expectedIds.length}"
+    )
+    expectedIds.zip(boxes).zipWithIndex.foreach { case ((expectedId, box), index) =>
+      require(util.Arrays.equals(expectedId, box.id), s"$kind box at index $index does not match transaction")
+    }
+  }
 
   def apply(secrets: IndexedSeq[SecretKey],
             params: BlockchainParameters): ErgoProvingInterpreter =

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreterSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/interpreter/ErgoProvingInterpreterSpec.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.wallet.interpreter
 
 import org.ergoplatform.sdk.wallet.secrets.{DlogSecretKey, ExtendedSecretKey}
 import org.ergoplatform.wallet.crypto.ErgoSignature
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, UnsignedErgoLikeTransaction, UnsignedInput}
+import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, ErgoLikeTransaction, UnsignedErgoLikeTransaction, UnsignedInput}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -25,6 +25,37 @@ class ErgoProvingInterpreterSpec
 
 
   private def obtainSecretKey() = ExtendedSecretKey.deriveMasterKey(Random.randomBytes(32), usePre1627KeyDerivation = false)
+
+  private case class TransactionBoxes(prover: ErgoProvingInterpreter,
+                                      unsignedTx: UnsignedErgoLikeTransaction,
+                                      signedTx: ErgoLikeTransaction,
+                                      inputBox: ErgoBox,
+                                      otherInputBox: ErgoBox,
+                                      dataBox: ErgoBox,
+                                      otherDataBox: ErgoBox)
+
+  private def transactionBoxes(): TransactionBoxes = {
+    val prover = ErgoProvingInterpreter(obtainSecretKey(), parameters)
+    val boxCandidate = new ErgoBoxCandidate(
+      100000000L,
+      ErgoTree.fromSigmaBoolean(prover.hdPubKeys.head.key),
+      10000
+    )
+    val firstTxId = ModifierId @@ Base16.encode(Array.fill(32)(5: Byte))
+    val secondTxId = ModifierId @@ Base16.encode(Array.fill(32)(6: Byte))
+    val inputBox = boxCandidate.toBox(firstTxId, 0.toShort)
+    val otherInputBox = boxCandidate.toBox(secondTxId, 0.toShort)
+    val dataBox = boxCandidate.toBox(firstTxId, 1.toShort)
+    val otherDataBox = boxCandidate.toBox(secondTxId, 1.toShort)
+    val unsignedTx = new UnsignedErgoLikeTransaction(
+      IndexedSeq(new UnsignedInput(inputBox.id, ContextExtension.empty)),
+      IndexedSeq(DataInput(dataBox.id)),
+      IndexedSeq(boxCandidate)
+    )
+    val signedTx = prover.sign(unsignedTx, IndexedSeq(inputBox), IndexedSeq(dataBox), stateContext).get
+
+    TransactionBoxes(prover, unsignedTx, signedTx, inputBox, otherInputBox, dataBox, otherDataBox)
+  }
 
   it should "produce proofs with primitive secrets" in {
     val extendedSecretKey = obtainSecretKey()
@@ -142,6 +173,104 @@ class ErgoProvingInterpreterSpec
     thb.secretHints(0).hints.size shouldBe 1
 
     thb.publicHints(0).hints.size shouldBe 1
+  }
+
+  it should "reject commitments for a different input box" in {
+    val fixture = transactionBoxes()
+
+    fixture.prover.generateCommitmentsFor(
+      fixture.unsignedTx,
+      IndexedSeq(fixture.otherInputBox),
+      IndexedSeq(fixture.dataBox),
+      stateContext
+    ).isFailure shouldBe true
+  }
+
+  it should "reject commitments when input boxes are reordered" in {
+    val fixture = transactionBoxes()
+    val unsignedTx = new UnsignedErgoLikeTransaction(
+      IndexedSeq(
+        new UnsignedInput(fixture.inputBox.id, ContextExtension.empty),
+        new UnsignedInput(fixture.otherInputBox.id, ContextExtension.empty)
+      ),
+      IndexedSeq(DataInput(fixture.dataBox.id)),
+      IndexedSeq(fixture.inputBox.toCandidate, fixture.otherInputBox.toCandidate)
+    )
+
+    fixture.prover.generateCommitmentsFor(
+      unsignedTx,
+      IndexedSeq(fixture.otherInputBox, fixture.inputBox),
+      IndexedSeq(fixture.dataBox),
+      stateContext
+    ).isFailure shouldBe true
+  }
+
+  it should "reject commitments with extra data boxes" in {
+    val fixture = transactionBoxes()
+
+    fixture.prover.generateCommitmentsFor(
+      fixture.unsignedTx,
+      IndexedSeq(fixture.inputBox),
+      IndexedSeq(fixture.dataBox, fixture.otherDataBox),
+      stateContext
+    ).isFailure shouldBe true
+  }
+
+  it should "reject signing with a different data-input box" in {
+    val fixture = transactionBoxes()
+
+    fixture.prover.sign(
+      fixture.unsignedTx,
+      IndexedSeq(fixture.inputBox),
+      IndexedSeq(fixture.otherDataBox),
+      stateContext
+    ).isFailure shouldBe true
+  }
+
+  it should "reject hint extraction with missing input boxes" in {
+    val fixture = transactionBoxes()
+
+    an[IllegalArgumentException] should be thrownBy fixture.prover.bagForTransaction(
+      fixture.signedTx,
+      IndexedSeq.empty,
+      IndexedSeq(fixture.dataBox),
+      stateContext,
+      Seq.empty,
+      Seq.empty
+    )
+  }
+
+  it should "reject hint extraction with a different data-input box" in {
+    val fixture = transactionBoxes()
+
+    an[IllegalArgumentException] should be thrownBy fixture.prover.bagForTransaction(
+      fixture.signedTx,
+      IndexedSeq(fixture.inputBox),
+      IndexedSeq(fixture.otherDataBox),
+      stateContext,
+      Seq.empty,
+      Seq.empty
+    )
+  }
+
+  it should "accept matching input and data-input boxes for distributed signing" in {
+    val fixture = transactionBoxes()
+
+    fixture.prover.generateCommitmentsFor(
+      fixture.unsignedTx,
+      IndexedSeq(fixture.inputBox),
+      IndexedSeq(fixture.dataBox),
+      stateContext
+    ).isSuccess shouldBe true
+
+    noException should be thrownBy fixture.prover.bagForTransaction(
+      fixture.signedTx,
+      IndexedSeq(fixture.inputBox),
+      IndexedSeq(fixture.dataBox),
+      stateContext,
+      Seq.empty,
+      Seq.empty
+    )
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
@@ -1,0 +1,57 @@
+package org.ergoplatform.it
+
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ForkResolutionDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  import ForkResolutionDiagnostics._
+
+  "Fork observations" should "retain independently accepted results while later selections change" in {
+    val first = latch(Vector.fill[Option[String]](4)(None), Vector(Some("a"), None, Some("a"), None))
+    val later = latch(first, Vector(None, Some("a"), None, Some("a")))
+    later shouldBe Vector.fill(4)(Some("a"))
+    latch(later, Vector.fill(4)(Some("b"))) shouldBe later
+  }
+
+  it should "retain missing results until their own predicate succeeds" in {
+    latch(Vector(Some("a"), None), Vector(None, None)) shouldBe Vector(Some("a"), None)
+  }
+
+  it should "report the fixed target separately from the current selected header" in {
+    val target = "ab" * 32
+    val current = "cd" * 32
+    val snapshot = Snapshot(Right(NodeInfo(None, None, Some(25), Some(20), None, Some(false))),
+      Right(3), Right(Seq(current, target)), Right(20), reachable = true)
+    val text = describe("match-anchor", 2, Some(10), Some(target), snapshot)
+    text should include(s"fixed=Some($target)")
+    text should include(s"selected=$current")
+    text should include("headerHeight=Some(25) fullHeight=Some(20) mining=Some(false)")
+    text should include("peerCount=3")
+  }
+
+  it should "exclude response text, addresses and paths from observed fields" in {
+    val payload = "http://example.invalid/private/location"
+    val snapshot = Snapshot(Right(NodeInfo(Some(payload), Some(payload), Some(1), Some(1), Some(payload), None)),
+      Left(payload), Right(Seq(payload)), Right(1), reachable = true)
+    val text = describe("match-anchor", 0, Some(1), Some(payload), snapshot)
+    text should not include payload
+    text should include("peerErrorClass=ObservationError")
+    text should include("selected=invalid-header-id")
+    text should include("fixed=Some(invalid-header-id)")
+    describe("initial-height", 0, None, None,
+      Snapshot(Left("TimeoutException"), Left("IOException"), Left("ParsingFailure"),
+        Left("TimeoutException"), reachable = false)) should
+      include("statusErrorClass=TimeoutException peerErrorClass=IOException headerErrorClass=ParsingFailure")
+  }
+
+  it should "keep supplementary failures out of the startup and height acceptance gates" in {
+    val snapshot = Snapshot(Left("ParsingFailure"), Left("TimeoutException"), Left("IOException"),
+      Right(20), reachable = true)
+    startupReached(snapshot) shouldBe Some(())
+    heightReached(20)(snapshot) shouldBe Some(20)
+    heightReached(21)(snapshot) shouldBe None
+    heightReached(20)(snapshot.copy(fullHeight = Left("ParsingFailure"))) shouldBe None
+    startupReached(snapshot.copy(reachable = false)) shouldBe None
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
@@ -1,20 +1,24 @@
 package org.ergoplatform.it
 
 import java.io.File
-import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
 import com.typesafe.config.Config
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.NodeInfo
 import org.ergoplatform.it.container.Docker.{ExtraConfig, noExtraConfig}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.scalatest.concurrent.Eventually
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.async.Async
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Try
+import scala.util.control.NonFatal
 
-class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite with Eventually {
+class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite {
+
+  import ForkResolutionDiagnostics._
 
   val nodesQty: Int = 4
 
@@ -43,24 +47,107 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
 
   def localVolume(n: Int): String = s"$localDataDir/fork-resolution-spec/node-$n/data"
 
+  private var phase = "initial-start"
+  private var recent = Vector.empty[String]
+  private val active = new AtomicBoolean(true)
+
+  private def enter(next: String): Unit = synchronized {
+    requireActive()
+    phase = next
+    log.info(s"Fork resolution phase=$phase")
+  }
+
+  private def remember(entry: String): Unit = synchronized {
+    recent = (recent :+ entry).takeRight(nodesQty * 3)
+  }
+
+  private def evidence: String = synchronized { s"phase=$phase; ${recent.mkString("; ")}" }
+
   def clearPeerDatabases(): Unit = {
-    volumesMapping.foreach { case (localVolume, remoteVolume) =>
+    volumesMapping.zipWithIndex.foreach { case ((localVolume, remoteVolume), index) =>
+      requireActive()
+      remember(s"phase=$phase node=$index operation=clear-peers")
       docker.removeFromMountedVolume(localVolume, remoteVolume, "peers")
     }
   }
 
-  def startNodesWithBinds(nodeConfigs: List[Config],
+  private def startNodesWithBinds(nodeConfigs: List[Config], observations: ConvergenceObservations,
+                          deadline: Option[Deadline] = None,
                           configEnrich: ExtraConfig = noExtraConfig): List[Node] = {
-    log.trace(s"Starting ${nodeConfigs.size} containers")
-    val nodes: Try[List[Node]] = nodeConfigs
+    val nodes = nodeConfigs
       .map(_.withFallback(specialDataDirConfig(remoteVolume)))
       .zip(volumesMapping)
-      .map { case (cfg, vol) => docker.startDevNetNode(cfg, configEnrich, Some(vol)) }
-      .sequence
-    implicit val patienceConfig: PatienceConfig = PatienceConfig((nodeConfigs.size * 2).seconds, 3.second)
-    eventually {
-      Await.result(Future.traverse(nodes.get)(_.waitForStartup), 180.seconds)
+      .zipWithIndex.map { case ((cfg, vol), index) =>
+        requireActive()
+        deadline.foreach(d => requireTime(d))
+        remember(s"phase=$phase node=$index operation=start")
+        docker.startDevNetNode(cfg, configEnrich, Some(vol)).get
+      }
+    val startupDeadline = deadline.map(d => d.timeLeft.min(180.seconds).fromNow).getOrElse(180.seconds.fromNow)
+    waitFor(nodes, observations, startupDeadline, None, None)(startupReached)
+    nodes
+  }
+
+  private def requireTime(deadline: Deadline): Unit = {
+    requireActive()
+    if (deadline.isOverdue()) throw new java.util.concurrent.TimeoutException("Fork resolution deadline")
+  }
+
+  private def requireActive(): Unit = {
+    if (!active.get()) throw new java.util.concurrent.CancellationException("Fork resolution finished")
+  }
+
+  private def waitFor[A](nodes: List[Node], observations: ConvergenceObservations, deadline: Deadline,
+                         headerHeight: Option[Int], fixedSample: Option[String])
+                        (accept: Snapshot => Option[A]): Vector[A] = {
+    val currentPhase = phase
+    val probes = nodes.map { node =>
+      def json(path: String): Future[Json] = {
+        requireTime(deadline)
+        node.singleGet(path, _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[Json](response.getResponseBody)
+        }
+      }
+      val status = observations.probe {
+        requireTime(deadline)
+        node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          val parsed = Try(node.ergoJsonAnswerAs[Json](response.getResponseBody))
+          val info = parsed.flatMap(j => Try(j.as[NodeInfo].fold(throw _, identity)))
+            .toEither.left.map(_.getClass.getSimpleName)
+          // Height gates retain NodeApi.fullHeight's exact field/default semantics.
+          val height = parsed.flatMap(j => Try(j.hcursor.downField("fullHeight").as[Option[Int]]
+            .fold(throw _, identity).getOrElse(0))).toEither.left.map(_.getClass.getSimpleName)
+          (info, height)
+        }
+      }
+      val peers = observations.probe(json("/peers/connected").map(_.asArray.get.size))
+      val headers = headerHeight.map { height =>
+        observations.probe(json(s"/blocks/at/$height").map(_.as[Seq[String]].fold(throw _, identity)))
+      }
+      (status, peers, headers)
     }
+    var accepted = Vector.fill[Option[A]](nodes.size)(None)
+    val result = observations.until(deadline, 100.millis, 5.seconds) { budget =>
+      requireTime(deadline)
+      Future.traverse(probes.zipWithIndex) { case ((status, peers, headers), index) =>
+        val infoResult = status.sample(budget)
+        val peerResult = peers.sample(budget)
+        val headerResult = headers.map(_.sample(budget)).getOrElse(Future.successful(Right(Seq.empty[String])))
+        infoResult.zip(peerResult).zip(headerResult).map { case ((status, peerCount), ids) =>
+          val snapshot = Snapshot(status.flatMap(_._1), peerCount, ids,
+            status.flatMap(_._2), status.isRight)
+          remember(describe(currentPhase, index, headerHeight, fixedSample, snapshot) +
+            s" sampledAt=${System.currentTimeMillis()}")
+          accept(snapshot)
+        }
+      }.map { observed =>
+        accepted = latch(accepted, observed.toVector)
+        accepted
+      }
+    }(_.forall(_.isDefined))(s"Fork resolution did not complete; $evidence")
+    Await.result(result, deadline.timeLeft.max(Duration.Zero)).map(_.get)
   }
 
   // Testing scenario:
@@ -71,38 +158,84 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
   // 5. Check that nodes reached consensus on created forks;
   it should "Fork resolution after isolated mining" in {
 
-    log.info(minerConfig.toString)
-    onlineSyncNodesConfig.foreach(x => log.info(x.toString))
-
-    val nodes: List[Node] = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig)
-
-    val result = Async.async {
-      val initMaxHeight = Async.await(Future.traverse(nodes)(_.fullHeight).map(_.max))
-      Async.await(Future.traverse(nodes)(_.waitForHeight(initMaxHeight + commonChainLength, 100.millis)))
-      val isolatedNodes = Async.await {
-        nodes.foreach(node => docker.stopNode(node.containerId))
+    val observations = new ConvergenceObservations
+    try {
+      enter("initial-start")
+      val nodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations)
+      // Match the original budget: initial startup precedes the 15-minute scenario deadline.
+      val deadline = 15.minutes.fromNow
+      val result = Future {
+        enter("initial-height")
+        val initMaxHeight = waitFor(nodes, observations, deadline, None, None)(_.fullHeight.toOption).max
+        val forkHeight = initMaxHeight + commonChainLength + forkLength
+        enter(s"common-height target=${initMaxHeight + commonChainLength}")
+        waitFor(nodes, observations, deadline, Some(initMaxHeight + commonChainLength), None)(
+          heightReached(initMaxHeight + commonChainLength))
+        def stop(current: List[Node]): Unit = current.zipWithIndex.foreach { case (node, index) =>
+          requireTime(deadline)
+          remember(s"phase=$phase node=$index operation=stop")
+          docker.stopNode(node.containerId)
+        }
+        enter("isolate-stop")
+        stop(nodes)
+        enter("isolate-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: offlineMiningNodesConfig, isolatedPeersConfig))
-      }
-      val forkHeight = initMaxHeight + commonChainLength + forkLength
-      Async.await(Future.traverse(isolatedNodes)(_.waitForHeight(forkHeight, 100.millis)))
-      val regularNodes = Async.await {
-        isolatedNodes.foreach(node => docker.stopNode(node.containerId))
+        enter("isolate-start")
+        val isolatedNodes = startNodesWithBinds(minerConfig +: offlineMiningNodesConfig,
+          observations, Some(deadline), isolatedPeersConfig)
+        enter(s"isolated-height target=$forkHeight")
+        waitFor(isolatedNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight))
+        enter("reconnect-stop")
+        stop(isolatedNodes)
+        enter("reconnect-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: onlineSyncNodesConfig))
+        enter("reconnect-start")
+        val regularNodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations, Some(deadline))
+        enter(s"reconnected-height target=${forkHeight + syncLength}")
+        waitFor(regularNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight + syncLength))
+        enter("select-anchor")
+        val sample = waitFor(regularNodes.take(1), observations, deadline, Some(forkHeight), None)(
+          _.headers.toOption).head.headOption.value
+        enter("match-anchor")
+        val headers = waitFor(regularNodes, observations, deadline, Some(forkHeight), Some(sample))(
+          _.headers.toOption.filter(_.headOption.contains(sample)))
+        val headerIdsAtSameHeight = headers.map(_.headOption.value)
+        headerIdsAtSameHeight should contain only sample
+        log.info(s"Fork resolution completed; $evidence")
       }
-      Async.await(Future.traverse(regularNodes)(_.waitForHeight(forkHeight + syncLength, 100.millis)))
-      val sample = Async.await(regularNodes.head.headerIdsByHeight(forkHeight)).headOption.value
-      val headers = Async.await(Future.traverse(regularNodes) { node =>
-        node.waitFor[Seq[String]](_.headerIdsByHeight(forkHeight), _.headOption.contains(sample), 100.millis)
-      })
-
-      log.debug(s"Headers at height $forkHeight: ${headers.mkString(",")}")
-      val headerIdsAtSameHeight = headers.map(_.headOption.value)
-      headerIdsAtSameHeight should contain only sample
+      Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    } catch {
+      case NonFatal(error) =>
+        log.error(s"Fork resolution failed errorClass=${error.getClass.getSimpleName}; $evidence")
+        throw error
+    } finally {
+      active.set(false)
+      observations.close()
     }
-
-    Await.result(result, 15.minutes)
   }
 
+}
+
+private[it] object ForkResolutionDiagnostics {
+  final case class Snapshot(info: Either[String, NodeInfo], peers: Either[String, Int],
+                            headers: Either[String, Seq[String]], fullHeight: Either[String, Int],
+                            reachable: Boolean)
+
+  def startupReached(snapshot: Snapshot): Option[Unit] = if (snapshot.reachable) Some(()) else None
+
+  def heightReached(target: Int)(snapshot: Snapshot): Option[Int] =
+    snapshot.fullHeight.toOption.filter(_ >= target)
+
+  def latch[A](previous: Vector[Option[A]], observed: Vector[Option[A]]): Vector[Option[A]] =
+    previous.zip(observed).map { case (accepted, current) => accepted.orElse(current) }
+
+  def describe(phase: String, index: Int, height: Option[Int], fixedSample: Option[String], snapshot: Snapshot): String = {
+    def error(value: String): String = if (value.matches("[A-Za-z0-9_$]+")) value else "ObservationError"
+    val info = snapshot.info.fold(e => s"statusErrorClass=${error(e)}", value =>
+      s"headerHeight=${value.bestHeaderHeightOpt} fullHeight=${value.bestBlockHeightOpt} mining=${value.isMining}")
+    val peers = snapshot.peers.fold(e => s"peerErrorClass=${error(e)}", count => s"peerCount=$count")
+    val selected = snapshot.headers.fold(e => s"headerErrorClass=${error(e)}", ids =>
+      s"selected=${ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing")}")
+    s"phase=$phase node=$index height=$height fixed=${fixedSample.map(ConvergenceObservations.headerId)} $info $peers $selected"
+  }
 }

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  /** Both nodes report mining disabled and share a completely applied selected header tip. */
+  def sameFullyAppliedNonMiningBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean =
+    infoA.isMining.contains(false) && infoB.isMining.contains(false) &&
+      sameBestBlock(infoA, infoB, minHeight) &&
+      infoA.bestBlockIdOpt.exists(_.nonEmpty) &&
+      infoA.bestHeaderHeightOpt == infoA.bestBlockHeightOpt &&
+      infoB.bestHeaderHeightOpt == infoB.bestBlockHeightOpt &&
+      infoA.bestHeaderIdOpt == infoA.bestBlockIdOpt &&
+      infoB.bestHeaderIdOpt == infoB.bestBlockIdOpt
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,145 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  "Fully applied block agreement" should "accept a complete shared tip at the minimum height" in {
+    val info = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 12) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 13) shouldBe false
+  }
+
+  it should "reject a shared 21-header 12-full-block seed despite full-block agreement" in {
+    val lagging = NodeInfo(Some("header21"), Some("block12"), Some(21), Some(12), None, Some(false))
+    ConvergenceObservations.sameBestBlock(lagging, lagging, 1) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(lagging, lagging, 1) shouldBe false
+  }
+
+  private val completeSeed = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+
+  Seq[(String, NodeInfo => NodeInfo)](
+    "missing header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = None)),
+    "missing full-block height" -> ((info: NodeInfo) => info.copy(bestBlockHeightOpt = None)),
+    "missing header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = None)),
+    "missing full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = None)),
+    "different header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = Some("other"))),
+    "different full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = Some("other"))),
+    "different header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = Some(21))),
+    "unknown mining status" -> ((info: NodeInfo) => info.copy(isMining = None)),
+    "active mining" -> ((info: NodeInfo) => info.copy(isMining = Some(true)))
+  ).foreach { case (fault, change) =>
+    Seq("A", "B").foreach { side =>
+      it should s"reject $fault on node $side independently" in {
+        val (a, b) = if (side == "A") (change(completeSeed), completeSeed)
+                     else (completeSeed, change(completeSeed))
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, 1) shouldBe false
+      }
+    }
+  }
+
+  it should "reject two empty tip identifiers" in {
+    val empty = completeSeed.copy(bestHeaderIdOpt = Some(""), bestBlockIdOpt = Some(""))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(empty, empty, 1) shouldBe false
+  }
+
+  it should "reject different complete tips at the same height" in {
+    val other = completeSeed.copy(bestHeaderIdOpt = Some("other"), bestBlockIdOpt = Some("other"))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  it should "reject different complete heights independently of matching IDs" in {
+    val other = completeSeed.copy(bestHeaderHeightOpt = Some(13), bestBlockHeightOpt = Some(13))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  "Full block agreement" should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/main/scala/org/ergoplatform/http/api/ApiRequestsCodecs.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ApiRequestsCodecs.scala
@@ -88,10 +88,10 @@ trait ApiRequestsCodecs extends ApiCodecs {
       "tx" -> gcr.unsignedTx.asJson,
       "secrets" -> Json.obj(
         "dlog" -> gcr.dlogs.asJson,
-        "dht" -> gcr.dhts.asJson,
-        "inputsRaw" -> gcr.inputs.asJson,
-        "dataInputsRaw" -> gcr.dataInputs.asJson
-      )
+        "dht" -> gcr.dhts.asJson
+      ),
+      "inputsRaw" -> gcr.inputs.asJson,
+      "dataInputsRaw" -> gcr.dataInputs.asJson
     )
   }
 

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -15,6 +15,7 @@ import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
 import org.ergoplatform.wallet.Constants
 import org.ergoplatform.wallet.Constants.ScanId
 import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
+import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.http.api.ApiError.{BadRequest, NotExists}
 import scorex.core.api.http.ApiResponse
 import scorex.util.encode.Base16
@@ -219,12 +220,18 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
     val utx = gcr.unsignedTx
     val externalSecretsOpt = gcr.externalSecretsOpt
-    val extInputsOpt = gcr.inputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-    val extDataInputsOpt = gcr.dataInputs.map(ErgoWalletServiceUtils.stringsToBoxes)
+    val externalBoxes = for {
+      inputs <- parseExternalBoxes(gcr.inputs, utx.inputs.map(_.boxId), "Input")
+      dataInputs <- parseExternalBoxes(gcr.dataInputs, utx.dataInputs.map(_.boxId), "Data input")
+    } yield inputs -> dataInputs
 
-    withWalletOp(_.generateCommitmentsFor(utx, externalSecretsOpt, extInputsOpt, extDataInputsOpt).map(_.response)) {
-      case Failure(e) => BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
-      case Success(thb) => ApiResponse(thb)
+    externalBoxes match {
+      case Failure(e) => invalidExternalBoxes(e)
+      case Success((extInputsOpt, extDataInputsOpt)) =>
+        withWalletOp(_.generateCommitmentsFor(utx, externalSecretsOpt, extInputsOpt, extDataInputsOpt).map(_.response)) {
+          case Failure(e) => BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
+          case Success(thb) => ApiResponse(thb)
+        }
     }
   }
 
@@ -237,6 +244,20 @@ case class WalletApiRoute(readersHolder: ActorRef,
       } yield boxes :+ box
     }
 
+  private def parseExternalBoxes(rawBoxesOpt: Option[Seq[String]],
+                                 expectedIds: Seq[ErgoBox.BoxId],
+                                 kind: String): Try[Option[Seq[ErgoBox]]] = rawBoxesOpt match {
+    case None => Success(None)
+    case Some(rawBoxes) =>
+      for {
+        boxes <- parseExternalBoxes(rawBoxes)
+        _ <- ErgoProvingInterpreter.validateBoxIds(kind, expectedIds, boxes)
+      } yield Some(boxes)
+  }
+
+  private def invalidExternalBoxes(e: Throwable): Route =
+    BadRequest(s"Invalid external boxes: ${Option(e.getMessage).getOrElse(e.toString)}")
+
   def signTransactionR: Route = (path("transaction" / "sign")
     & post & entity(as[TransactionSigningRequest])) { tsr =>
 
@@ -246,23 +267,16 @@ case class WalletApiRoute(readersHolder: ActorRef,
     val hints = tsr.hints
 
     def signWithReaders(r: Readers): Future[Try[ErgoTransaction]] = {
-      if (tsr.inputs.isDefined) {
-        val decodedBoxes = for {
-          boxesToSpend <- parseExternalBoxes(tsr.inputs.get)
-          dataBoxes <- parseExternalBoxes(tsr.dataInputs.getOrElse(Seq.empty))
-        } yield boxesToSpend -> dataBoxes
+      val decodedBoxes = for {
+        boxesToSpendOpt <- parseExternalBoxes(tsr.inputs, tx.inputs.map(_.boxId), "Input")
+        dataBoxesOpt <- parseExternalBoxes(tsr.dataInputs, tx.dataInputs.map(_.boxId), "Data input")
+      } yield boxesToSpendOpt -> dataBoxesOpt
 
-        decodedBoxes match {
-          case Success((boxesToSpend, dataBoxes))
-              if boxesToSpend.size == tx.inputs.size && dataBoxes.size == tx.dataInputs.size =>
-            r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes))
-          case Success(_) =>
-            Future(Failure(new Exception("Input boxes provided do not match transaction inputs")))
-          case Failure(e) =>
-            Future(Failure(new Exception("Can't parse input boxes provided", e)))
-        }
-      } else {
-        r.w.signTransaction(tx, secrets, hints, None, None)
+      decodedBoxes match {
+        case Success((boxesToSpendOpt, dataBoxesOpt)) =>
+          r.w.signTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt)
+        case Failure(e) =>
+          Future(Failure(new Exception("Invalid external boxes", e)))
       }
     }
 
@@ -491,11 +505,17 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def extractHintsR: Route = (path("extractHints") & post & entity(as[HintExtractionRequest])) { her =>
-    withWallet { w =>
-      val extInputsOpt = her.inputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-      val extDataInputsOpt = her.dataInputs.map(ErgoWalletServiceUtils.stringsToBoxes)
+    val externalBoxes = for {
+      inputs <- parseExternalBoxes(her.inputs, her.tx.inputs.map(_.boxId), "Input")
+      dataInputs <- parseExternalBoxes(her.dataInputs, her.tx.dataInputs.map(_.boxId), "Data input")
+    } yield inputs -> dataInputs
 
-      w.extractHints(her.tx, her.real, her.simulated, extInputsOpt, extDataInputsOpt).map(_.transactionHintsBag)
+    externalBoxes match {
+      case Failure(e) => invalidExternalBoxes(e)
+      case Success((extInputsOpt, extDataInputsOpt)) =>
+        withWallet { w =>
+          w.extractHints(her.tx, her.real, her.simulated, extInputsOpt, extDataInputsOpt).map(_.transactionHintsBag)
+        }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -14,13 +14,17 @@ import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
 import org.ergoplatform.wallet.Constants
 import org.ergoplatform.wallet.boxes.ErgoBoxSerializer
+import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.http.api.ApiError.{BadRequest, NotExists}
 import scorex.core.api.http.ApiResponse
 import scorex.util.encode.Base16
+import scorex.util.serialization.VLQByteBufferReader
 
+import java.nio.ByteBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 import akka.http.scaladsl.server.MissingQueryParamRejection
 import org.ergoplatform.sdk.SecretString
 
@@ -218,14 +222,48 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
     val utx = gcr.unsignedTx
     val externalSecretsOpt = gcr.externalSecretsOpt
-    val extInputsOpt = gcr.inputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-    val extDataInputsOpt = gcr.dataInputs.map(ErgoWalletServiceUtils.stringsToBoxes)
+    val externalBoxes = for {
+      inputs <- parseExternalBoxes(gcr.inputs, utx.inputs.map(_.boxId), "Input")
+      dataInputs <- parseExternalBoxes(gcr.dataInputs, utx.dataInputs.map(_.boxId), "Data input")
+    } yield inputs -> dataInputs
 
-    withWalletOp(_.generateCommitmentsFor(utx, externalSecretsOpt, extInputsOpt, extDataInputsOpt).map(_.response)) {
-      case Failure(e) => BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
-      case Success(thb) => ApiResponse(thb)
+    externalBoxes match {
+      case Failure(e) => invalidExternalBoxes(e)
+      case Success((extInputsOpt, extDataInputsOpt)) =>
+        withWalletOp(_.generateCommitmentsFor(utx, externalSecretsOpt, extInputsOpt, extDataInputsOpt).map(_.response)) {
+          case Failure(e) => BadRequest(s"Bad request $gcr. ${Option(e.getMessage).getOrElse(e.toString)}")
+          case Success(thb) => ApiResponse(thb)
+        }
     }
   }
+
+  private def parseExternalBoxes(rawBoxes: Seq[String]): Try[Seq[ErgoBox]] =
+    rawBoxes.foldLeft(Try(Seq.empty[ErgoBox])) { case (acc, rawBox) =>
+      for {
+        boxes <- acc
+        bytes <- Base16.decode(rawBox)
+        box <- Try {
+          val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+          val parsed = ErgoBoxSerializer.parse(reader)
+          require(reader.remaining == 0, "External box bytes contain trailing data")
+          parsed
+        }
+      } yield boxes :+ box
+    }
+
+  private def parseExternalBoxes(rawBoxesOpt: Option[Seq[String]],
+                                 expectedIds: Seq[ErgoBox.BoxId],
+                                 kind: String): Try[Option[Seq[ErgoBox]]] = rawBoxesOpt match {
+    case None => Success(None)
+    case Some(rawBoxes) =>
+      for {
+        boxes <- parseExternalBoxes(rawBoxes)
+        _ <- ErgoProvingInterpreter.validateBoxIds(kind, expectedIds, boxes)
+      } yield Some(boxes)
+  }
+
+  private def invalidExternalBoxes(e: Throwable): Route =
+    BadRequest(s"Invalid external boxes: ${Option(e.getMessage).getOrElse(e.toString)}")
 
   def signTransactionR: Route = (path("transaction" / "sign")
     & post & entity(as[TransactionSigningRequest])) { tsr =>
@@ -236,19 +274,16 @@ case class WalletApiRoute(readersHolder: ActorRef,
     val hints = tsr.hints
 
     def signWithReaders(r: Readers): Future[Try[ErgoTransaction]] = {
-      if (tsr.inputs.isDefined) {
-        val boxesToSpend = tsr.inputs.get
-          .flatMap(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry).toOption)
-        val dataBoxes = tsr.dataInputs.getOrElse(Seq.empty)
-          .flatMap(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry).toOption)
+      val decodedBoxes = for {
+        boxesToSpendOpt <- parseExternalBoxes(tsr.inputs, tx.inputs.map(_.boxId), "Input")
+        dataBoxesOpt <- parseExternalBoxes(tsr.dataInputs, tx.dataInputs.map(_.boxId), "Data input")
+      } yield boxesToSpendOpt -> dataBoxesOpt
 
-        if (boxesToSpend.size == tx.inputs.size && dataBoxes.size == tx.dataInputs.size) {
-          r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes))
-        } else {
-          Future(Failure(new Exception("Can't parse input boxes provided")))
-        }
-      } else {
-        r.w.signTransaction(tx, secrets, hints, None, None)
+      decodedBoxes match {
+        case Success((boxesToSpendOpt, dataBoxesOpt)) =>
+          r.w.signTransaction(tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt)
+        case Failure(e) =>
+          Future(Failure(new Exception("Invalid external boxes", e)))
       }
     }
 
@@ -479,11 +514,22 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def extractHintsR: Route = (path("extractHints") & post & entity(as[HintExtractionRequest])) { her =>
-    withWallet { w =>
-      val extInputsOpt = her.inputs.map(ErgoWalletServiceUtils.stringsToBoxes)
-      val extDataInputsOpt = her.dataInputs.map(ErgoWalletServiceUtils.stringsToBoxes)
+    val externalBoxes = for {
+      inputs <- parseExternalBoxes(her.inputs, her.tx.inputs.map(_.boxId), "Input")
+      dataInputs <- parseExternalBoxes(her.dataInputs, her.tx.dataInputs.map(_.boxId), "Data input")
+    } yield inputs -> dataInputs
 
-      w.extractHints(her.tx, her.real, her.simulated, extInputsOpt, extDataInputsOpt).map(_.transactionHintsBag)
+    externalBoxes match {
+      case Failure(e) => invalidExternalBoxes(e)
+      case Success((extInputsOpt, extDataInputsOpt)) =>
+        withWalletOp { w =>
+          w.extractHints(her.tx, her.real, her.simulated, extInputsOpt, extDataInputsOpt)
+            .map(result => Try(result.transactionHintsBag))
+            .recover { case NonFatal(e) => Failure(e) }
+        } {
+          case Failure(e) => BadRequest(s"Unable to resolve transaction boxes: ${Option(e.getMessage).getOrElse(e.toString)}")
+          case Success(hints) => ApiResponse(hints)
+        }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -228,6 +228,15 @@ case class WalletApiRoute(readersHolder: ActorRef,
     }
   }
 
+  private def parseExternalBoxes(rawBoxes: Seq[String]): Try[Seq[ErgoBox]] =
+    rawBoxes.foldLeft(Try(Seq.empty[ErgoBox])) { case (acc, rawBox) =>
+      for {
+        boxes <- acc
+        bytes <- Base16.decode(rawBox)
+        box <- ErgoBoxSerializer.parseBytesTry(bytes)
+      } yield boxes :+ box
+    }
+
   def signTransactionR: Route = (path("transaction" / "sign")
     & post & entity(as[TransactionSigningRequest])) { tsr =>
 
@@ -238,15 +247,19 @@ case class WalletApiRoute(readersHolder: ActorRef,
 
     def signWithReaders(r: Readers): Future[Try[ErgoTransaction]] = {
       if (tsr.inputs.isDefined) {
-        val boxesToSpend = tsr.inputs.get
-          .flatMap(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry).toOption)
-        val dataBoxes = tsr.dataInputs.getOrElse(Seq.empty)
-          .flatMap(in => Base16.decode(in).flatMap(ErgoBoxSerializer.parseBytesTry).toOption)
+        val decodedBoxes = for {
+          boxesToSpend <- parseExternalBoxes(tsr.inputs.get)
+          dataBoxes <- parseExternalBoxes(tsr.dataInputs.getOrElse(Seq.empty))
+        } yield boxesToSpend -> dataBoxes
 
-        if (boxesToSpend.size == tx.inputs.size && dataBoxes.size == tx.dataInputs.size) {
-          r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes))
-        } else {
-          Future(Failure(new Exception("Can't parse input boxes provided")))
+        decodedBoxes match {
+          case Success((boxesToSpend, dataBoxes))
+              if boxesToSpend.size == tx.inputs.size && dataBoxes.size == tx.dataInputs.size =>
+            r.w.signTransaction(tx, secrets, hints, Some(boxesToSpend), Some(dataBoxes))
+          case Success(_) =>
+            Future(Failure(new Exception("Input boxes provided do not match transaction inputs")))
+          case Failure(e) =>
+            Future(Failure(new Exception("Can't parse input boxes provided", e)))
         }
       } else {
         r.w.signTransaction(tx, secrets, hints, None, None)

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -21,7 +21,7 @@ import org.ergoplatform.utils.ScorexEncoding
 import scorex.util.ScorexLogging
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 class ErgoWalletActor(settings: ErgoSettings,
                       parameters: Parameters,
@@ -386,8 +386,10 @@ class ErgoWalletActor(settings: ErgoSettings,
       sender() ! txTry
 
     case ExtractHints(tx, real, simulated, boxesToSpendOpt, dataBoxesOpt) =>
-      val bag = ergoWalletService.extractHints(state, tx, real, simulated, boxesToSpendOpt, dataBoxesOpt)
-      sender() ! ExtractHintsResult(bag)
+      Try(ergoWalletService.extractHints(state, tx, real, simulated, boxesToSpendOpt, dataBoxesOpt)) match {
+        case Success(bag) => sender() ! ExtractHintsResult(bag)
+        case Failure(e) => sender() ! akka.actor.Status.Failure(e)
+      }
 
     case DeriveKey(encodedPath) =>
       ergoWalletService.deriveKeyFromPath(state, encodedPath, ergoAddressEncoder) match {

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.syntax._
 import io.circe.{Decoder, Json}
+import org.ergoplatform.http.api.requests.HintExtractionRequest
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs, WalletApiRoute}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequestEncoder, PaymentRequest, PaymentRequestEncoder, _}
@@ -122,6 +123,48 @@ class WalletApiRouteSpec extends AnyFlatSpec
     }
 
     Post(prefix + "/transaction/sign", request) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject invalid external box bytes in commitment request" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val request = GenerateCommitmentsRequest(
+      tsr.unsignedTx,
+      None,
+      Some(tsr.inputs.get :+ "zz"),
+      tsr.dataInputs
+    )
+
+    Post(prefix + "/generateCommitments", request.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject a valid external input box from another transaction" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val expectedInputs = tsr.inputs.get
+    val differentInput = Iterator
+      .continually(ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get.inputs.get.head)
+      .find(_ != expectedInputs.head)
+      .get
+    val request = GenerateCommitmentsRequest(
+      tsr.unsignedTx,
+      None,
+      Some(expectedInputs.updated(0, differentInput)),
+      tsr.dataInputs
+    )
+
+    Post(prefix + "/generateCommitments", request.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject invalid external box bytes in hint extraction request" in {
+    val tx = ErgoNodeTransactionGenerators.validErgoTransactionGen.sample.get._2
+    val request = HintExtractionRequest(tx, Seq.empty, Seq.empty, Some(Seq("zz")), None)
+
+    Post(prefix + "/extractHints", request.asJson) ~> route ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -115,6 +115,17 @@ class WalletApiRouteSpec extends AnyFlatSpec
     }
   }
 
+  it should "reject invalid external box bytes in sign request" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val request = tsr.asJson.mapObject { obj =>
+      obj.add("inputsRaw", (tsr.inputs.get :+ "zz").asJson)
+    }
+
+    Post(prefix + "/transaction/sign", request) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "generate & send payment transaction" in {
     Post(prefix + "/payment/send", Seq(paymentRequest).asJson) ~> route ~> check {
       status shouldBe StatusCodes.OK

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.syntax._
 import io.circe.{Decoder, Json}
+import org.ergoplatform.http.api.requests.HintExtractionRequest
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs, WalletApiRoute}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequestEncoder, PaymentRequest, PaymentRequestEncoder, _}
@@ -113,6 +114,78 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Post(prefix + "/transaction/sign", tsr.asJson) ~> r ~> check {
       status shouldBe StatusCodes.OK
       responseAs[ErgoTransaction].id shouldBe tsr.unsignedTx.id
+    }
+  }
+
+  it should "reject invalid external box bytes in sign request" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val request = tsr.asJson.mapObject { obj =>
+      obj.add("inputsRaw", (tsr.inputs.get :+ "zz").asJson)
+    }
+
+    Post(prefix + "/transaction/sign", request) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject external box bytes with trailing data in sign request" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val tailedInputs = tsr.inputs.get.updated(0, tsr.inputs.get.head + "00")
+    val request = tsr.asJson.mapObject(_.add("inputsRaw", tailedInputs.asJson))
+
+    Post(prefix + "/transaction/sign", request) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject invalid external box bytes in commitment request" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val request = GenerateCommitmentsRequest(
+      tsr.unsignedTx,
+      None,
+      Some(tsr.inputs.get :+ "zz"),
+      tsr.dataInputs
+    )
+
+    Post(prefix + "/generateCommitments", request.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject a valid external input box for another transaction input" in {
+    val tsr = ErgoNodeTransactionGenerators.transactionSigningRequestGen(true).sample.get
+    val expectedInputs = tsr.inputs.get
+    val request = GenerateCommitmentsRequest(
+      tsr.unsignedTx,
+      None,
+      Some(expectedInputs.updated(0, expectedInputs(1))),
+      tsr.dataInputs
+    )
+
+    Post(prefix + "/generateCommitments", request.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject invalid external box bytes in hint extraction request" in {
+    val tx = ErgoNodeTransactionGenerators.validErgoTransactionGen.sample.get._2
+    val request = HintExtractionRequest(tx, Seq.empty, Seq.empty, Some(Seq("zz")), None)
+
+    Post(prefix + "/extractHints", request.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject hint extraction when referenced boxes are unavailable" in {
+    val tx = ErgoNodeTransactionGenerators.validErgoTransactionGen.sample.get._2
+    val request = HintExtractionRequest(tx, Seq.empty, Seq.empty, None, None)
+
+    Post(prefix + "/extractHints", request.asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+
+    Get(prefix + "/balances") ~> route ~> check {
+      status shouldBe StatusCodes.OK
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -1127,4 +1127,17 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
     }
   }
 
+  property("keep the wallet actor responsive when hint boxes are unavailable") {
+    withFixture { implicit w =>
+      val tx = org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.validErgoTransactionGen.sample.get._2
+
+      val failure = intercept[IllegalArgumentException] {
+        await(wallet.extractHints(tx, Seq.empty, Seq.empty, None, None))
+      }
+
+      failure.getMessage should include ("Input box count")
+      await(wallet.getWalletStatus).initialized shouldBe true
+    }
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/serialization/JsonSerializationSpec.scala
@@ -115,4 +115,19 @@ class JsonSerializationSpec extends ErgoCorePropertyTest
     }
   }
 
+  property("generateCommitmentsRequest roundtrip with external boxes") {
+    forAll(transactionSigningRequestGen(true)) { signingRequest =>
+      val request = GenerateCommitmentsRequest(
+        signingRequest.unsignedTx,
+        Some(signingRequest.externalSecrets),
+        Some(Seq("input-box")),
+        Some(Seq("data-input-box"))
+      )
+
+      val parsedRequest = request.asJson.as[GenerateCommitmentsRequest].toOption.get
+
+      parsedRequest shouldBe request
+    }
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -31,7 +31,7 @@ import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators
 import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.{augWalletTransactionForScanGen, augWalletTransactionGen, boxesHolderGen}
 import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.wallet.boxes.{ChainStatus, TrackedBox}
-import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
+import org.ergoplatform.wallet.interpreter.{ErgoProvingInterpreter, TransactionHintsBag}
 import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.ergoplatform.wallet.utils.TestFileUtils
 import org.scalacheck.Gen
@@ -270,6 +270,12 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
         sender() ! ergoWalletService.signTransaction(Some(prover), tx, secrets, hints, boxesToSpendOpt, dataBoxesOpt, parameters, sc) { boxId =>
           utxoState.versionedBoxHolder.get(ByteArrayWrapper(boxId))
         }
+
+      case ExtractHints(_, _, _, None, None) =>
+        sender() ! akka.actor.Status.Failure(new IllegalArgumentException("Referenced transaction boxes are unavailable"))
+
+      case ExtractHints(_, _, _, _, _) =>
+        sender() ! ExtractHintsResult(TransactionHintsBag.empty)
     }
   }
 


### PR DESCRIPTION
Bind externally supplied input and data-input boxes to the transaction by exact count, order and ID before signing, commitment generation or hint extraction. Every supplied box is strictly decoded, including rejection of unread trailing bytes. Malformed, mismatched or unavailable boxes return BadRequest without restarting the wallet actor. Canonical requests remain accepted, and GenerateCommitmentsRequest JSON encoding matches its decoder.

Previously, commitment generation could use a valid box from another transaction, hint extraction could truncate missing boxes, and an unavailable fallback box could restart the actor and time out the request. This could produce unusable commitments or incomplete hint bags; it does not authorize an invalid spend. This contribution consolidates and supersedes [#2392](https://github.com/ergoplatform/ergo/pull/2392).

Head `24f047ea341b9b5bd8221538fd1186336a858cb3` preserves the [original wallet implementation](https://github.com/a-shannon/ergo/commit/543f8d4fb1f2e11279da891dedf0695a3446b0ad) and all its direct tests. The new [four-file IT support increment](https://github.com/a-shannon/ergo/compare/543f8d4fb1f2e11279da891dedf0695a3446b0ad...24f047ea341b9b5bd8221538fd1186336a858cb3) reuses exact [K](https://github.com/a-shannon/ergo/commit/a1c1bd26e89ec2f24d5c52acc1fdd35346d65371), owned by [#2511](https://github.com/ergoplatform/ergo/pull/2511), on shared [H](https://github.com/a-shannon/ergo/commit/0f9f75c1fc1df3ff3309482b83c0475a05cdd7a2), owned by [#2535](https://github.com/ergoplatform/ergo/pull/2535). These exact prerequisites can be reviewed once without importing either owner's whole branch. No wallet or other production code changes in this increment.

At the previous head, [CI run 33916347630](https://github.com/ergoplatform/ergo/actions/runs/33916347630) passed 12/13 IT cases; ForkResolutionSpec reached its fifteen-minute timeout. The last recorded configuration group was isolated mining, so the failing phase and cause remain unestablished. K adds bounded phase and node observations while preserving the fixed target, independently latched per-node acceptance and original deadline. It does not claim to fix the underlying stall.

Historical owning validation passed 64 wallet tests, 35 WalletApiRouteSpec cases, 8 JsonSerializationSpec cases, 14 ErgoWalletServiceSpec cases and 28 ErgoWalletSpec cases. The actual new composition passed normal integration-test compilation and 37/37 focused tests: H observers 32 and K diagnostics 5. Independent composition review found no blockers. These focused checks did not run Docker; new-head native CI remains a separate gate, tracked in [#2533](https://github.com/ergoplatform/ergo/issues/2533).
