### PR TITLE
Reject invalid EC point JSON

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/http/api/ApiCodecs.scala
@@ -73,7 +73,8 @@ trait ApiCodecs extends JsonCodecs {
     for {
       str <- cursor.as[String]
       bytes <- fromTry(Algos.decode(str))
-    } yield groupElemFromBytes(bytes)
+      point <- fromTry(Try(groupElemFromBytes(bytes)))
+    } yield point
   }
 
   implicit val ecPointEncoder: Encoder[EcPointType] = Encoder.instance({ point: EcPointType =>

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/JsonSerializationCoreSpec.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.serialization
 
 import io.circe.syntax._
-import io.circe.ACursor
+import io.circe.{ACursor, Json}
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.ErgoBox.{AdditionalRegisters, NonMandatoryRegisterId}
 import org.ergoplatform.http.api.ApiCodecs
@@ -59,6 +59,18 @@ class JsonSerializationCoreSpec extends ErgoCorePropertyTest
       val parsedSecret = json.as[DhtSecretKey].toOption.get
       parsedSecret shouldBe wrappedSecret
     }
+  }
+
+  property("invalid dht secret group element bytes should fail decoding") {
+    val json = Json.obj(
+      "secret" -> "01".asJson,
+      "g" -> "00".asJson,
+      "h" -> "00".asJson,
+      "u" -> "00".asJson,
+      "v" -> "00".asJson
+    )
+
+    json.as[DhtSecretKey].isLeft shouldBe true
   }
 
   private def checkTrackedBox(c: ACursor, b: TrackedBox)(implicit opts: Detalization) = {


### PR DESCRIPTION
## Summary
- Wrap EC point byte conversion in the JSON decoder so invalid point bytes fail as a normal decoding error.
- Add regression coverage for malformed DHT secret group element bytes.

## Tests
- `sbt "ergoCore/testOnly org.ergoplatform.serialization.JsonSerializationCoreSpec"`
- `sbt "testOnly org.ergoplatform.serialization.JsonSerializationSpec"`