### PR TITLE
Validate transaction builder input ids

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.wallet.transactions
 
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform._
-import org.ergoplatform.sdk.wallet.{AssetUtils, TokensMap}
+import org.ergoplatform.sdk.wallet.{AssetUtils, Constants, TokensMap}
 import org.ergoplatform.wallet.boxes.{BoxSelector, DefaultBoxSelector}
 import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
@@ -74,12 +74,7 @@ object TransactionBuilder {
         )
         paymentBoxes ++ Vector(feeBox, changeBox)
       }
-    val unsignedInputs = inputIds
-      .flatMap { id =>
-        Base16.decode(id)
-          .map(x => new UnsignedInput(ADKey @@ x))
-          .toOption
-      }.toIndexedSeq
+    val unsignedInputs = unsignedInputsFromIds(inputIds)
 
     new UnsignedErgoLikeTransaction(
       unsignedInputs,
@@ -128,13 +123,7 @@ object TransactionBuilder {
       Array.empty[(ErgoBox.TokenId, Long)].toColl,
       Map.empty
     )
-    val unsignedInputs = inputIds
-      .flatMap { id =>
-        Base16.decode(id)
-          .map(x => new UnsignedInput(ADKey @@ x))
-          .toOption
-      }
-      .toIndexedSeq
+    val unsignedInputs = unsignedInputsFromIds(inputIds)
 
     val dataInputs = IndexedSeq.empty
     val outputs = if (changeAmt == 0) {
@@ -161,6 +150,15 @@ object TransactionBuilder {
 
   def tokensMapToColl(tokens: TokensMap): Coll[(TokenId, Long)] =
     tokens.toArray.map {t => t._1.toTokenId -> t._2}.toColl
+
+  private def unsignedInputsFromIds(inputIds: Array[String]): IndexedSeq[UnsignedInput] =
+    inputIds.map { id =>
+      val bytes = Base16.decode(id)
+        .getOrElse(throw new IllegalArgumentException("Input id should be valid hex"))
+      require(bytes.length == Constants.ModifierIdLength,
+        s"Input id should be ${Constants.ModifierIdLength} bytes")
+      new UnsignedInput(ADKey @@ bytes)
+    }.toIndexedSeq
 
   private def validateStatelessChecks(inputs: IndexedSeq[ErgoBox], dataInputs: IndexedSeq[DataInput],
     outputCandidates: Seq[ErgoBoxCandidate]): Unit = {

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
@@ -127,4 +127,40 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
       t => t.getMessage.contains("createFeeOutput should be defined"))
   }
 
+  property("paymentTransaction rejects invalid input ids") {
+    val address = P2PKAddress(rootSecret.privateInput.publicImage)
+
+    def build(inputId: String): UnsignedErgoLikeTransaction =
+      TransactionBuilder.paymentTransaction(
+        address,
+        address,
+        minBoxValue,
+        minBoxValue,
+        0,
+        Array(inputId),
+        currentHeight)
+
+    Seq("00", "not-hex").foreach { inputId =>
+      assertExceptionThrown(build(inputId), t => t.isInstanceOf[IllegalArgumentException])
+    }
+  }
+
+  property("multiPaymentTransaction rejects invalid input ids") {
+    val address = P2PKAddress(rootSecret.privateInput.publicImage)
+    val payments = java.util.Collections.singletonList(TransactionBuilder.Payment(address, minBoxValue))
+
+    def build(inputId: String): UnsignedErgoLikeTransaction =
+      TransactionBuilder.multiPaymentTransaction(
+        Array(inputId),
+        minBoxValue,
+        payments,
+        address,
+        0,
+        currentHeight)
+
+    Seq("00", "not-hex").foreach { inputId =>
+      assertExceptionThrown(build(inputId), t => t.isInstanceOf[IllegalArgumentException])
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary
- Decode `paymentTransaction` and `multiPaymentTransaction` input ids strictly instead of dropping malformed ids.
- Reject non-hex and non-32-byte input ids before constructing unsigned inputs.
- Add regression coverage for both payment builder entry points.

## Tests
- `sbt "ergoWallet/testOnly org.ergoplatform.wallet.transactions.TransactionBuilderSpec"`