### PR TITLE
Validate NiPoPoW proof header PoW

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
@@ -75,6 +75,8 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
       Int.MaxValue
     }
 
+  def hasValidPow(header: Header): Boolean = powScheme.validate(header).isSuccess
+
   /**
     * Computes best score of a given chain.
     * The score value depends on number of µ-superblocks in the given chain.

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProof.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProof.scala
@@ -72,7 +72,11 @@ case class NipopowProof(popowAlgos: NipopowAlgos,
     * @return true if the proof is valid
     */
   lazy val isValid: Boolean = {
-    this.hasValidConnections && this.hasValidHeights && this.hasValidProofs && this.hasValidDifficultyHeaders
+    this.hasValidConnections &&
+      this.hasValidHeights &&
+      this.hasValidProofs &&
+      this.hasValidDifficultyHeaders &&
+      this.hasValidPow
   }
 
   /**
@@ -154,6 +158,8 @@ case class NipopowProof(popowAlgos: NipopowAlgos,
     prefix.forall(_.checkInterlinksProof()) &&
       suffixHead.checkInterlinksProof()
   }
+
+  lazy val hasValidPow: Boolean = headersChain.forall(popowAlgos.hasValidPow)
 
 }
 

--- a/src/main/scala/org/ergoplatform/http/api/InfoApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/InfoApiRoute.scala
@@ -1,7 +1,6 @@
 package org.ergoplatform.http.api
 
 import akka.actor.{ActorRef, ActorRefFactory}
-import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import io.circe.syntax._

--- a/src/test/scala/org/ergoplatform/nodeView/history/PopowProcessorSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/PopowProcessorSpecification.scala
@@ -1,19 +1,38 @@
 package org.ergoplatform.nodeView.history
 
+import org.ergoplatform.mining.AutolykosPowScheme
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.popow.PoPowHeader
 import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.NipopowSettings
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.wallet.utils.FileUtils
 import scorex.util.ModifierId
 
-class PopowProcessorSpecification extends ErgoCorePropertyTest {
+class PopowProcessorSpecification extends ErgoCorePropertyTest with FileUtils {
   import org.ergoplatform.utils.HistoryTestHelpers._
+  import org.ergoplatform.utils.ErgoNodeTestConstants.{settings => baseSettings}
   import org.ergoplatform.utils.generators.ChainGenerator._
 
   private def genHistory(genesisIdOpt: Option[ModifierId], popowBootstrap: Boolean) =
     generateHistory(verifyTransactions = true, StateType.Utxo, PoPoWBootstrap = popowBootstrap, blocksToKeep = -1,
                     epochLength = 10000, useLastEpochs = 3, initialDiffOpt = None, genesisIdOpt)
       .ensuring(_.bestFullBlockOpt.isEmpty)
+
+  private def genRealPowHistory(genesisIdOpt: Option[ModifierId],
+                                realPowScheme: AutolykosPowScheme): ErgoHistory = {
+    val realPowSettings = baseSettings.copy(
+      directory = createTempDir.getAbsolutePath,
+      chainSettings = baseSettings.chainSettings.copy(powScheme = realPowScheme, genesisId = genesisIdOpt),
+      nodeSettings = baseSettings.nodeSettings.copy(
+        stateType = StateType.Utxo,
+        verifyTransactions = true,
+        blocksToKeep = -1,
+        nipopowSettings = NipopowSettings(nipopowBootstrap = true, p2pNipopows = 1)
+      )
+    )
+    ErgoHistory.readOrGenerate(realPowSettings)(null).ensuring(_.bestFullBlockOpt.isEmpty)
+  }
 
   val toPoPoWChain = (c: Seq[ErgoFullBlock]) => c.map(b => PoPowHeader.fromBlock(b).get)
 
@@ -30,6 +49,24 @@ class PopowProcessorSpecification extends ErgoCorePropertyTest {
     receiverHistory.applyPopowProof(popowProof)
     receiverHistory.headersHeight shouldBe senderHistory.headersHeight
     receiverHistory.bestHeaderOpt.get shouldBe senderHistory.bestHeaderOpt.get
+  }
+
+  property("popow proof application rejects headers failing real Autolykos validation") {
+    val senderHistory = genHistory(None, popowBootstrap = false)
+    val senderChain = genChain(80, senderHistory)
+    applyChain(senderHistory, senderChain)
+
+    val popowProofBytes = senderHistory.popowProofBytes().get
+    val realPowScheme = new AutolykosPowScheme(baseSettings.chainSettings.powScheme.k, baseSettings.chainSettings.powScheme.n)
+    val receiverHistory = genRealPowHistory(senderHistory.bestHeaderAtHeight(1).map(_.id), realPowScheme)
+    val popowProof = receiverHistory.nipopowSerializer.parseBytes(popowProofBytes)
+
+    popowProof.headersChain.exists(h => realPowScheme.validate(h).isFailure) shouldBe true
+
+    receiverHistory.headersHeight shouldBe 0
+    receiverHistory.applyPopowProof(popowProof)
+    receiverHistory.headersHeight shouldBe 0
+    receiverHistory.bestHeaderOpt shouldBe None
   }
 
 }


### PR DESCRIPTION
## Summary

- Reject NiPoPoW proofs when any header fails Autolykos PoW validation.
- Enforce the check before bootstrap proof headers can be inserted into history.
- Add regression coverage for invalid-PoW proof material.
- Remove a stale `InfoApiRoute` import that prevents the 6.0.5 node and integration-test builds under fatal warnings.

## Relationship to #2379

#2379 validates NiPoPoW `m` and `k` parameter bounds. This PR covers the independent proof-header PoW validation invariant.

## Scope

The NiPoPoW change is intentionally limited to the PoW validation needed for the 6.0.5 candidate. It excludes the `maxLevelOf` arithmetic changes tracked separately in #2332. The build-only import cleanup is kept in a separate commit.

## Tests

- `sbt "testOnly org.ergoplatform.nodeView.history.PopowProcessorSpecification"`
- `sbt "testOnly org.ergoplatform.local.NipopowVerifierSpec org.ergoplatform.http.routes.NipopowApiRoutesSpec org.ergoplatform.modifiers.history.PoPowAlgosSpec org.ergoplatform.modifiers.history.PoPowAlgosWithDBSpec org.ergoplatform.nodeView.history.PopowProcessorSpecification"`
- `sbt -Denv=test clean ++2.12.20 compile`
- Regression verified failing before the fix and passing after it.
- Publication guard on the final commit range.
