### PR TITLE
Reject trailing bytes in utils conversions

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ErgoUtilsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoUtilsApiRoute.scala
@@ -15,7 +15,7 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 
 import java.security.SecureRandom
-import scala.util.Failure
+import scala.util.{Failure, Try}
 import sigma.serialization.{ErgoTreeSerializer, GroupElementSerializer, SigmaSerializer}
 
 class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
@@ -69,9 +69,17 @@ class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
   def rawToAddressR: Route = (get & path("rawToAddress" / Segment)) { pubKeyHex =>
     Base16
       .decode(pubKeyHex)
-      .flatMap(pkBytes =>
-        GroupElementSerializer.parseTry(SigmaSerializer.startReader(pkBytes))
-      )
+      .flatMap { pkBytes =>
+        val reader = SigmaSerializer.startReader(pkBytes)
+        GroupElementSerializer.parseTry(reader).flatMap { pkPoint =>
+          Try {
+            if (reader.position != pkBytes.length) {
+              throw new IllegalArgumentException("Public key bytes contain trailing data")
+            }
+            pkPoint
+          }
+        }
+      }
       .map(pkPoint => P2PKAddress(ProveDlog(pkPoint)))
       .fold(
         e => BadRequest(e.getMessage),
@@ -94,7 +102,14 @@ class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
     Base16
       .decode(ergoTreeHex)
       .flatMap { etBytes =>
-        ergoAddressEncoder.fromProposition(treeSerializer.deserializeErgoTree(etBytes))
+        Try {
+          val reader = SigmaSerializer.startReader(etBytes)
+          val tree = treeSerializer.deserializeErgoTree(reader, SigmaSerializer.MaxPropositionSize)
+          if (reader.position != etBytes.length) {
+            throw new IllegalArgumentException("ErgoTree bytes contain trailing data")
+          }
+          tree
+        }.flatMap(ergoAddressEncoder.fromProposition)
       }
       .fold(
         e => BadRequest(e.getMessage),

--- a/src/main/scala/org/ergoplatform/http/api/ErgoUtilsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoUtilsApiRoute.scala
@@ -15,7 +15,7 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 
 import java.security.SecureRandom
-import scala.util.Failure
+import scala.util.{Failure, Try}
 import sigma.serialization.{ErgoTreeSerializer, GroupElementSerializer, SigmaSerializer}
 
 class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
@@ -69,9 +69,15 @@ class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
   def rawToAddressR: Route = (get & path("rawToAddress" / Segment)) { pubKeyHex =>
     Base16
       .decode(pubKeyHex)
-      .flatMap(pkBytes =>
-        GroupElementSerializer.parseTry(SigmaSerializer.startReader(pkBytes))
-      )
+      .flatMap { pkBytes =>
+        val reader = SigmaSerializer.startReader(pkBytes)
+        GroupElementSerializer.parseTry(reader).flatMap { pkPoint =>
+          Try {
+            require(reader.position == pkBytes.length, "Public key bytes contain trailing data")
+            pkPoint
+          }
+        }
+      }
       .map(pkPoint => P2PKAddress(ProveDlog(pkPoint)))
       .fold(
         e => BadRequest(e.getMessage),
@@ -94,7 +100,10 @@ class ErgoUtilsApiRoute(val ergoSettings: ErgoSettings)(
     Base16
       .decode(ergoTreeHex)
       .flatMap { etBytes =>
-        ergoAddressEncoder.fromProposition(treeSerializer.deserializeErgoTree(etBytes))
+        val reader = SigmaSerializer.startReader(etBytes)
+        val tree = treeSerializer.deserializeErgoTree(reader, SigmaSerializer.MaxPropositionSize)
+        require(reader.position == etBytes.length, "ErgoTree bytes contain trailing data")
+        ergoAddressEncoder.fromProposition(tree)
       }
       .fold(
         e => BadRequest(e.getMessage),

--- a/src/test/scala/org/ergoplatform/http/routes/UtilsApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/UtilsApiRouteSpec.scala
@@ -121,11 +121,27 @@ class UtilsApiRouteSpec extends AnyFlatSpec
     }
   }
 
+  it should "reject raw public keys with trailing bytes" in {
+    val raw = Base16.encode(p2pkaddress.contentBytes)
+
+    Get(s"$prefix/rawToAddress/${raw}00") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "derive address from ErgoTree (p2pk)" in {
     val et = Base16.encode(treeSerializer.serializeErgoTree(p2pkaddress.script))
     Get(s"$prefix/ergoTreeToAddress/$et") ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(p2pkaddress.toString())
+    }
+  }
+
+  it should "reject ErgoTree bytes with trailing data" in {
+    val et = Base16.encode(treeSerializer.serializeErgoTree(p2pkaddress.script))
+
+    Get(s"$prefix/ergoTreeToAddress/${et}00") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 

--- a/src/test/scala/org/ergoplatform/http/routes/UtilsApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/UtilsApiRouteSpec.scala
@@ -29,6 +29,7 @@ class UtilsApiRouteSpec extends AnyFlatSpec
 
   val restApiSettings = RESTApiSettings(new InetSocketAddress("localhost", 8080), None, None, 10.seconds, None)
   val route: Route = ErgoUtilsApiRoute(settings).route
+  val sealedRoute: Route = Route.seal(route)
   val p2pkaddress = P2PKAddress(defaultMinerPk)(settings.addressEncoder)
   val p2shaddress = Pay2SHAddress(feeProp)(settings.addressEncoder)
   val p2saddress = Pay2SAddress(feeProp)(settings.addressEncoder)
@@ -40,6 +41,47 @@ class UtilsApiRouteSpec extends AnyFlatSpec
     Get(s"$prefix/ergoTreeToAddress/$et") ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(p2saddress.toString())
+    }
+  }
+
+  it should "derive address from ErgoTree through POST" in {
+    val et = Base16.encode(treeSerializer.serializeErgoTree(p2saddress.script))
+
+    Post(s"$prefix/ergoTreeToAddress", Json.fromString(et)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(p2saddress.toString())
+    }
+  }
+
+  it should "reject malformed ErgoTree data through GET" in {
+    Get(s"$prefix/ergoTreeToAddress/00") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject malformed ErgoTree data through POST" in {
+    Post(s"$prefix/ergoTreeToAddress", Json.fromString("00")) ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject ErgoTree bytes with trailing data through GET" in {
+    val et = Base16.encode(treeSerializer.serializeErgoTree(p2saddress.script))
+
+    Get(s"$prefix/ergoTreeToAddress/${et}00") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[Json].hcursor.downField("detail").as[String] shouldEqual
+        Right("ErgoTree bytes contain trailing data")
+    }
+  }
+
+  it should "reject ErgoTree bytes with trailing data through POST" in {
+    val et = Base16.encode(treeSerializer.serializeErgoTree(p2saddress.script))
+
+    Post(s"$prefix/ergoTreeToAddress", Json.fromString(et + "00")) ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[Json].hcursor.downField("detail").as[String] shouldEqual
+        Right("ErgoTree bytes contain trailing data")
     }
   }
 
@@ -118,6 +160,16 @@ class UtilsApiRouteSpec extends AnyFlatSpec
       val json = responseAs[Json]
       val c = json.hcursor
       c.downField("address").as[String] shouldEqual Right(p2pkaddress.toString())
+    }
+  }
+
+  it should "reject raw public keys with trailing bytes" in {
+    val raw = Base16.encode(p2pkaddress.contentBytes)
+
+    Get(s"$prefix/rawToAddress/${raw}00") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[Json].hcursor.downField("detail").as[String] shouldEqual
+        Right("Public key bytes contain trailing data")
     }
   }
 


### PR DESCRIPTION
## Summary
- Reject `/utils/rawToAddress/{pubkeyHex}` inputs that parse a public key but leave trailing bytes.
- Reject trailing bytes through both GET and POST `/utils/ergoTreeToAddress` paths.
- Preserve `400 Bad Request` for malformed ErgoTree bytes and keep canonical conversions unchanged.

## Validation
- RED: 13/16 passed; the three trailing-byte cases returned `200 OK`.
- GREEN: 16/16 passed with exact error details for unread suffixes.
- Independent replay: 16/16 passed.

## Relationship to other PRs
- This carries the Utils half of #2386; #2400 carries the shared Blockchain ErgoTree parser half.
- #2467 and #2374 touch the same Utils files for separate behavior.
