### PR TITLE
Reject trailing bytes in ErgoTree route filters

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -17,7 +17,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome._
 import scorex.util.encode.Base16
 import sigma.ast.ErgoTree
-import sigma.serialization.ErgoTreeSerializer
+import sigma.serialization.{ErgoTreeSerializer, SigmaSerializer}
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
@@ -78,7 +78,18 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   private def handleErgoTree(value: String): Directive1[ErgoTree] = {
     Base16.decode(fromJsonOrPlain(value)) match {
       case Success(bytes) =>
-        provide(ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes))
+        Try {
+          val reader = SigmaSerializer.startReader(bytes)
+          val tree = ErgoTreeSerializer.DefaultSerializer
+            .deserializeErgoTree(reader, SigmaSerializer.MaxPropositionSize)
+          if (reader.position != bytes.length) {
+            throw new IllegalArgumentException("ErgoTree bytes contain trailing data")
+          }
+          tree
+        } match {
+          case Success(tree) => provide(tree)
+          case Failure(e)    => reject(ValidationRejection(e.getMessage))
+        }
       case _ => reject(ValidationRejection("Invalid hex data"))
     }
 

--- a/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ErgoBaseApiRoute.scala
@@ -17,7 +17,7 @@ import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome._
 import scorex.util.encode.Base16
 import sigma.ast.ErgoTree
-import sigma.serialization.ErgoTreeSerializer
+import sigma.serialization.{ErgoTreeSerializer, SigmaSerializer}
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
@@ -69,7 +69,18 @@ trait ErgoBaseApiRoute extends ApiRoute with ApiCodecs {
   private def handleErgoTree(value: String): Directive1[ErgoTree] = {
     Base16.decode(fromJsonOrPlain(value)) match {
       case Success(bytes) =>
-        provide(ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes))
+        Try {
+          val reader = SigmaSerializer.startReader(bytes)
+          val tree = ErgoTreeSerializer.DefaultSerializer
+            .deserializeErgoTree(reader, SigmaSerializer.MaxPropositionSize)
+          if (reader.position != bytes.length) {
+            throw new IllegalArgumentException("ErgoTree bytes contain trailing data")
+          }
+          tree
+        } match {
+          case Success(tree) => provide(tree)
+          case Failure(e)    => reject(ValidationRejection(e.getMessage))
+        }
       case _ => reject(ValidationRejection("Invalid hex data"))
     }
 

--- a/src/test/scala/org/ergoplatform/http/routes/BlockchainApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlockchainApiRouteSpec.scala
@@ -1,0 +1,50 @@
+package org.ergoplatform.http.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{Route, ValidationRejection}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import org.ergoplatform.http.api.BlockchainApiRoute
+import org.ergoplatform.utils.Stubs
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.util.encode.Base16
+import sigma.serialization.ErgoTreeSerializer
+
+class BlockchainApiRouteSpec
+  extends AnyFlatSpec
+  with Matchers
+  with ScalatestRouteTest
+  with FailFastCirceSupport
+  with Stubs {
+  import org.ergoplatform.utils.ErgoCoreTestConstants._
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+
+  private val prefix = "/blockchain"
+  private val routeSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(extraIndex = true))
+  private val route: Route = BlockchainApiRoute(digestReadersRef, routeSettings, indexerOpt = None).route
+  private val sealedRoute: Route = Route.seal(route)
+  private val treeSerializer = ErgoTreeSerializer.DefaultSerializer
+
+  it should "accept a canonical ErgoTree filter body" in {
+    val treeHex = Base16.encode(treeSerializer.serializeErgoTree(feeProp))
+
+    Post(prefix + "/box/byErgoTree", treeHex) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  it should "reject malformed ErgoTree filter bodies" in {
+    Post(prefix + "/box/byErgoTree", "00") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject ErgoTree filter bodies with trailing bytes" in {
+    val treeHex = Base16.encode(treeSerializer.serializeErgoTree(feeProp))
+
+    Post(prefix + "/box/byErgoTree", treeHex + "00") ~> route ~> check {
+      rejection shouldEqual ValidationRejection("ErgoTree bytes contain trailing data", None)
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/http/routes/BlockchainApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlockchainApiRouteSpec.scala
@@ -1,0 +1,43 @@
+package org.ergoplatform.http.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{Route, ValidationRejection}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
+import org.ergoplatform.http.api.BlockchainApiRoute
+import org.ergoplatform.utils.Stubs
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.util.encode.Base16
+import sigma.serialization.ErgoTreeSerializer
+
+class BlockchainApiRouteSpec
+  extends AnyFlatSpec
+  with Matchers
+  with ScalatestRouteTest
+  with FailFastCirceSupport
+  with Stubs {
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+  import org.ergoplatform.utils.ErgoCoreTestConstants._
+
+  private val prefix = "/blockchain"
+  private val routeSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(extraIndex = true))
+  private val route: Route = BlockchainApiRoute(digestReadersRef, routeSettings, indexerOpt = None).route
+  private val treeSerializer = ErgoTreeSerializer.DefaultSerializer
+
+  it should "accept a canonical ErgoTree filter body" in {
+    val treeHex = Base16.encode(treeSerializer.serializeErgoTree(feeProp))
+
+    Post(prefix + "/box/byErgoTree", treeHex) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  it should "reject ErgoTree filter bodies with trailing bytes" in {
+    val treeHex = Base16.encode(treeSerializer.serializeErgoTree(feeProp))
+
+    Post(prefix + "/box/byErgoTree", treeHex + "00") ~> route ~> check {
+      rejection shouldEqual ValidationRejection("ErgoTree bytes contain trailing data", None)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Reject malformed ErgoTree filter bodies through the shared Blockchain REST parser instead of surfacing a server error.
- Reject valid ErgoTree encodings that leave unread trailing bytes.
- Keep canonical filter behavior unchanged for both Blockchain consumers.

## Validation
- RED: 1/3 passed; malformed bytes returned `500` and trailing bytes returned `200`.
- GREEN: 3/3 passed with the exact trailing-data validation rejection.
- Independent replay: 3/3 passed.

## Relationship to other PRs
- This carries the shared Blockchain parser half of #2386; #2399 carries its Utils GET/POST half.
- #2382 creates the same route-spec file for separate paging validation.
