### PR TITLE
Enforce chainSlice range limit

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -141,7 +141,7 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
   def getChainSliceR: Route = (pathPrefix("chainSlice") & chainPagination) { (fromHeight, toHeight) =>
     if (toHeight < fromHeight) {
       BadRequest("toHeight < fromHeight")
-    } else if (fromHeight - toHeight > MaxHeaders) {
+    } else if (toHeight.toLong - fromHeight.toLong > MaxHeaders) {
       BadRequest(s"No more than $MaxHeaders headers can be requested")
     } else {
       ApiResponse(getChainSlice(fromHeight, toHeight))

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -84,6 +84,12 @@ class BlocksApiRouteSpec
     }
   }
 
+  it should "reject chain slice ranges above the maximum headers limit" in {
+    Get(prefix + "/chainSlice?fromHeight=0&toHeight=16385") ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "get block by header id" in {
     Get(prefix + "/" + headerIdString) ~> route ~> check {
       status shouldBe StatusCodes.OK


### PR DESCRIPTION
## Summary
- Enforce the `/blocks/chainSlice` maximum range check in the correct direction.
- Use `Long` arithmetic for the range width to avoid `Int` overflow edge cases.
- Add route coverage for an over-limit chain-slice request.

## Tests
- `sbt "testOnly org.ergoplatform.http.routes.BlocksApiRouteSpec"`
