### PR TITLE
Limit block header id batches

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -190,7 +190,11 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
   }
 
   def getFullBlockByHeaderIdsR: Route = (post & path("headerIds") & modifierIds) { ids =>
-    ApiResponse(getFullBlockByHeaderIds(ids))
+    if (ids.length > MaxHeaders) {
+      BadRequest(s"No more than $MaxHeaders headers can be requested")
+    } else {
+      ApiResponse(getFullBlockByHeaderIds(ids))
+    }
   }
 
 }

--- a/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/BlocksApiRoute.scala
@@ -181,7 +181,11 @@ case class BlocksApiRoute(viewHolderRef: ActorRef, readersHolder: ActorRef, ergo
   }
 
   def getFullBlockByHeaderIdsR: Route = (post & path("headerIds") & modifierIds) { ids =>
-    ApiResponse(getFullBlockByHeaderIds(ids))
+    if (ids.length > MaxHeaders) {
+      BadRequest(s"No more than $MaxHeaders headers can be requested")
+    } else {
+      ApiResponse(getFullBlockByHeaderIds(ids))
+    }
   }
 
 }

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -114,6 +114,14 @@ class BlocksApiRouteSpec
     }
   }
 
+  it should "reject too many block header ids" in {
+    val absentHeaderId = "0000000000000000000000000000000000000000000000000000000000000000"
+
+    Post(prefix + "/headerIds", Seq.fill(16385)(absentHeaderId).asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
   it should "get header by header id" in {
     Get(prefix + "/" + headerIdString + "/header") ~> route ~> check {
       status shouldBe StatusCodes.OK

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -120,6 +120,28 @@ class BlocksApiRouteSpec
     }
   }
 
+  it should "accept the maximum number of block header ids" in {
+    val absentHeaderId = "0000000000000000000000000000000000000000000000000000000000000000"
+
+    Post(prefix + "/headerIds", Seq.fill(16384)(absentHeaderId).asJson) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Seq[ErgoFullBlock]] shouldBe empty
+    }
+  }
+
+  it should "reject block header id batches above the maximum" in {
+    val absentHeaderId = "0000000000000000000000000000000000000000000000000000000000000000"
+
+    Post(prefix + "/headerIds", Seq.fill(16385)(absentHeaderId).asJson) ~> route ~> check {
+      status shouldBe StatusCodes.BadRequest
+      val response = responseAs[Json].hcursor
+      response.get[Int]("error") shouldBe Right(StatusCodes.BadRequest.intValue)
+      response.get[String]("reason") shouldBe Right("bad.request")
+      response.get[String]("detail") shouldBe
+        Right("No more than 16384 headers can be requested")
+    }
+  }
+
   it should "get header by header id" in {
     Get(prefix + "/" + headerIdString + "/header") ~> route ~> check {
       status shouldBe StatusCodes.OK


### PR DESCRIPTION
## Summary
- Reject /blocks/headerIds requests containing more than MaxHeaders (16,384) IDs before block lookups begin.
- Preserve the existing behavior at the exact limit and for ordinary batches.
- Keep this focused on the headerIds endpoint; the former chainSlice issue is already fixed by #2401.

## Validation
- RED on current master: 11/12 passed; the 16,385-ID request returned 200 instead of 400.
- GREEN: BlocksApiRouteSpec 12/12.
- Boundary coverage: 16,384 IDs returns 200 with an empty result for absent IDs; 16,385 returns the exact 400 bad.request response.
- Independent code and test review found no actionable issue.