### PR TITLE
Reject trailing P2P message payload bytes

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageBase.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageBase.scala
@@ -28,7 +28,7 @@ trait MessageBase[Content] {
     * Structured message content
     */
   lazy val data: Try[Content] = input match {
-    case Left(db) => spec.parseBytesTry(db)
+    case Left(db) => spec.parsePayloadBytesTry(db)
     case Right(d) => Success(d)
   }
 

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageSpec.scala
@@ -1,8 +1,10 @@
 package org.ergoplatform.network.message
 
+import java.nio.ByteBuffer
 import org.ergoplatform.network.Version
 import org.ergoplatform.network.message.MessageConstants._
 import org.ergoplatform.serialization.ErgoSerializer
+import scorex.util.serialization.VLQByteBufferReader
 
 /**
   * Base trait for app p2p messages in the network
@@ -24,6 +26,13 @@ trait MessageSpec[Content] extends ErgoSerializer[Content] {
     * Name of this message type. For debug purposes only.
     */
   val messageName: String
+
+  override def parseBytes(bytes: Array[Byte]): Content = {
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+    val result = parse(reader)
+    require(reader.remaining == 0, s"Unexpected trailing bytes in $messageName message")
+    result
+  }
 
   override def toString: String = s"MessageSpec($messageCode: $messageName)"
 }

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/MessageSpec.scala
@@ -1,8 +1,12 @@
 package org.ergoplatform.network.message
 
+import java.nio.ByteBuffer
 import org.ergoplatform.network.Version
 import org.ergoplatform.network.message.MessageConstants._
 import org.ergoplatform.serialization.ErgoSerializer
+import scorex.util.serialization.VLQByteBufferReader
+
+import scala.util.Try
 
 /**
   * Base trait for app p2p messages in the network
@@ -24,6 +28,21 @@ trait MessageSpec[Content] extends ErgoSerializer[Content] {
     * Name of this message type. For debug purposes only.
     */
   val messageName: String
+
+  /**
+    * Whether this framed payload intentionally accepts extension bytes that its
+    * current parser does not understand.
+    */
+  protected def allowTrailingPayloadBytes: Boolean = false
+
+  final def parsePayloadBytesTry(bytes: Array[Byte]): Try[Content] = Try {
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+    val result = parse(reader)
+    if (!allowTrailingPayloadBytes) {
+      require(reader.remaining == 0, s"Unexpected trailing bytes in $messageName message")
+    }
+    result
+  }
 
   override def toString: String = s"MessageSpec($messageCode: $messageName)"
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/network/HandshakeSpecification.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/network/HandshakeSpecification.scala
@@ -8,10 +8,13 @@ import scorex.util.encode.Base16
 class HandshakeSpecification extends ErgoCorePropertyTest {
   import org.ergoplatform.network.DecodingUtils._
 
+  private val handshakeBytes = Base16.decode(
+    "bcd2919cee2e076572676f726566030306126572676f2d6d61696e6e65742d332e332e36000210040001000102067f000001ae46"
+  ).get
+
   property("handshake test vectors") {
     // bytes got from a real node
-    val hsBase16 = "bcd2919cee2e076572676f726566030306126572676f2d6d61696e6e65742d332e332e36000210040001000102067f000001ae46"
-    val hsBytes = Base16.decode(hsBase16).get
+    val hsBytes = handshakeBytes
 
     val agentName = "ergoref"
 
@@ -90,6 +93,10 @@ class HandshakeSpecification extends ErgoCorePropertyTest {
     val secondFeatureId = getUByte(bb)
 
     secondFeatureId shouldBe 2 // local address feature id
+  }
+
+  property("handshake parsing remains prefix-compatible with a raw TCP chunk") {
+    HandshakeSerializer.parseBytesTry(handshakeBytes ++ Array(0: Byte)).isSuccess shouldBe true
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackIsolationSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackIsolationSpec.scala
@@ -1,0 +1,58 @@
+package org.ergoplatform.it
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.io.Tcp
+import akka.testkit.{ExplicitlyTriggeredScheduler, TestActorRef, TestProbe}
+import com.typesafe.config.ConfigFactory
+import org.ergoplatform.network.message.MessageConstants.MessageCode
+import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.RandomPeerExcluding
+import org.ergoplatform.settings.ScorexSettings
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController
+
+import java.net.InetSocketAddress
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+class DeepRollBackIsolationSpec extends AnyFlatSpec with Matchers {
+  "Isolated rollback mining" should "disable automatic peer selection and reject incoming connections" in {
+    val ordinaryConfig = ConfigFactory.load()
+    val isolatedNetwork = ScorexSettings.fromConfig(
+      DeepRollBackSpec.isolatedMiningConfig.withFallback(ordinaryConfig).resolve()).network
+    ScorexSettings.fromConfig(ordinaryConfig).network.maxConnections should be > 0
+
+    implicit val system: ActorSystem = ActorSystem("RollbackIsolation", ConfigFactory.parseString(
+      "akka.scheduler.implementation = akka.testkit.ExplicitlyTriggeredScheduler"))
+    implicit val ec: ExecutionContext = system.dispatcher
+    try {
+      def controller(maxConnections: Int): (TestActorRef[NetworkController], TestProbe) = {
+        val peers = TestProbe()
+        val tcp = TestProbe()
+        val controllerSettings = settings.copy(scorexSettings = settings.scorexSettings.copy(
+          network = settings.scorexSettings.network.copy(maxConnections = maxConnections)))
+        val ref = TestActorRef(new NetworkController(controllerSettings, peers.ref,
+          ScorexContext(Seq.empty, None, None), tcp.ref, _ => Map.empty[MessageCode, ActorRef]))
+        tcp.expectMsgType[Tcp.Bind]
+        ref ! Tcp.Bound(controllerSettings.scorexSettings.network.bindAddress)
+        (ref, peers)
+      }
+
+      val (isolated, isolatedPeers) = controller(isolatedNetwork.maxConnections)
+      val (_, ordinaryPeers) = controller(maxConnections = 1)
+      system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler].timePasses(5.seconds)
+      ordinaryPeers.expectMsgType[RandomPeerExcluding](3.seconds)
+      isolatedPeers.expectNoMessage(200.millis)
+
+      val incoming = TestProbe()
+      incoming.send(isolated, Tcp.Connected(new InetSocketAddress("127.0.0.2", 9000),
+        settings.scorexSettings.network.bindAddress))
+      incoming.expectMsg(Tcp.Close)
+      isolatedPeers.expectNoMessage(200.millis)
+    } finally {
+      Await.result(system.terminate(), 10.seconds)
+    }
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -2,13 +2,15 @@ package org.ergoplatform.it
 
 import java.io.File
 import java.util.concurrent.TimeoutException
-import com.typesafe.config.Config
-import org.ergoplatform.it.api.NodeApi.NodeInfo
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.{NodeInfo, nodeInfoDecoder}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.freespec.AnyFreeSpec
 import scala.async.Async
-import scala.concurrent.{Await, Future, blocking}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
@@ -45,41 +47,114 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(allowLocalConfig)
 
+  private val observations = new ConvergenceObservations
+  private val seedObservations = new ConvergenceObservations
+  @volatile private var lastSeedObservation = "Initial seed has not been sampled"
+
+  private def waitForSettledSeed(
+    nodeA: Node,
+    nodeB: Node,
+    timeout: FiniteDuration
+  ): Future[(NodeInfo, NodeInfo)] = {
+    def infoProbe(node: Node): seedObservations.Probe[NodeInfo] =
+      seedObservations.probe(node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+        require(response.getStatusCode == 200, "Unexpected seed observation status")
+        node.ergoJsonAnswerAs[NodeInfo](response.getResponseBody)
+      })
+
+    val probeA = infoProbe(nodeA)
+    val probeB = infoProbe(nodeB)
+    def describe(result: Either[String, NodeInfo]): String = result.fold(
+      error => s"errorClass=$error",
+      info => s"headersHeight=${info.bestHeaderHeightOpt}; fullHeight=${info.bestBlockHeightOpt}; " +
+        s"headerId=${info.bestHeaderIdOpt.map(ConvergenceObservations.headerId)}; " +
+        s"fullId=${info.bestBlockIdOpt.map(ConvergenceObservations.headerId)}; mining=${info.isMining}")
+    seedObservations.until(timeout.fromNow, 1.second, 5.seconds) { budget =>
+      probeA.sample(budget).zip(probeB.sample(budget)).map { pair =>
+        lastSeedObservation = s"A=${describe(pair._1)}; B=${describe(pair._2)}"
+        log.info(s"Initial shared-chain readiness: $lastSeedObservation")
+        pair
+      }
+    } {
+      case (Right(a), Right(b)) =>
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, ErgoHistoryUtils.GenesisHeight)
+      case _ => false
+    }(
+      s"Initial chain did not settle with mining disabled and matching full/header tips; $lastSeedObservation"
+    ).map { case (a, b) => (a.toOption.get, b.toOption.get) }
+  }
+
+  private case class NodeSnapshot(info: Option[NodeInfo])
+  private val probes = scala.collection.mutable.Map.empty[
+    Node, (observations.Probe[NodeInfo], observations.Probe[Int])]
+
+  @volatile private var lastObservation = "No node pair observed"
+  private var recentObservations = Vector.empty[String]
+
+  private def remember(phase: String, label: String, endpoint: String, summary: String): Unit = synchronized {
+    val observation = s"$phase $label $endpoint sampledAt=${System.currentTimeMillis()} $summary"
+    recentObservations = (recentObservations :+ observation).takeRight(12)
+    lastObservation = recentObservations.mkString("; ")
+    log.info(observation)
+  }
+
+  private def snapshot(phase: String, label: String, node: Node, budget: FiniteDuration): Future[NodeSnapshot] = {
+    val (statusProbe, peerProbe) = probes.getOrElseUpdate(node, (
+      observations.probe(node.singleGet("/info", _.setRequestTimeout(5000))
+        .map { r =>
+          require(r.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[NodeInfo](r.getResponseBody)
+        }),
+      observations.probe(node.singleGet("/peers/connected", _.setRequestTimeout(5000)).map { r =>
+        require(r.getStatusCode == 200, "Unexpected observation status")
+        node.ergoJsonAnswerAs[Json](r.getResponseBody).asArray.getOrElse(
+          throw new IllegalArgumentException("Expected peer array")).size
+      })
+    ))
+    val status = statusProbe.sample(budget).map {
+      case Right(info) =>
+        val summary = Json.obj(
+          "headersHeight" -> info.bestHeaderHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "fullHeight" -> info.bestBlockHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "bestHeaderId" -> info.bestHeaderIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null),
+          "bestFullHeaderId" -> info.bestBlockIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null)
+        )
+        remember(phase, label, "status", summary.noSpaces)
+        Some(info)
+      case Left(error) =>
+        remember(phase, label, "status", s"errorClass=$error")
+        None
+    }
+    val peers = peerProbe.sample(budget).map { result =>
+      val summary = result.fold(error => s"errorClass=$error", count => s"connectedPeerCount=$count")
+      remember(phase, label, "peers", summary)
+    }
+    status.zip(peers).map { case (info, _) => NodeSnapshot(info) }
+  }
+
+  private def observeNodes(
+    phase: String,
+    nodeA: Node,
+    nodeB: Node,
+    budget: FiniteDuration = 5.seconds
+  ): Future[(NodeSnapshot, NodeSnapshot)] = {
+    snapshot(phase, "A", nodeA, budget).zip(snapshot(phase, "B", nodeB, budget))
+  }
+
   private def waitForSameBestBlock(
     nodeA: Node,
     nodeB: Node,
     minHeight: Int,
     timeout: FiniteDuration
   ): Future[(NodeInfo, NodeInfo)] = {
-    def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo): Boolean = {
-      val sameHeight =
-        infoA.bestBlockHeightOpt.nonEmpty &&
-          infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
-      val sameBlock =
-        infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
-      val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
-      sameHeight && sameBlock && highEnough
-    }
-
-    def retryAfterDelay(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      Future {
-        blocking(Thread.sleep(1000))
-      }.flatMap(_ => loop(deadline))
-
-    def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
-        if (sameBestBlock(infoA, infoB)) {
-          Future.successful((infoA, infoB))
-        } else if (deadline.isOverdue()) {
-          Future.failed(new TimeoutException(
-            s"Nodes did not converge to the same best full block at height >= $minHeight"
-          ))
-        } else {
-          retryAfterDelay(deadline)
-        }
-      }
-
-    loop(timeout.fromNow)
+    observations.until(timeout.fromNow, 1.second, 5.seconds)(
+      budget => observeNodes("convergence", nodeA, nodeB, budget)
+    ) { case (a, b) =>
+      a.info.exists(infoA => b.info.exists(infoB => ConvergenceObservations.sameBestBlock(infoA, infoB, minHeight)))
+    }(
+      s"Nodes did not converge to the same best full block at height >= $minHeight; " +
+        s"recent observations: $lastObservation"
+    ).map { case (a, b) => (a.info.get, b.info.get) }
   }
 
   "Deep rollback handling" in {
@@ -100,34 +175,44 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       val genesisAGen = Async.await(minerAGen.headerIdsByHeight(ErgoHistoryUtils.GenesisHeight)).head
       val genesisBGen = Async.await(minerBGen.headerIdsByHeight(ErgoHistoryUtils.GenesisHeight)).head
 
-      val minerAGenBestHeight = Async.await(minerAGen.fullHeight)
-      val minerBGenBestHeight = Async.await(minerBGen.fullHeight)
-
-      log.info("heightA: " + minerAGenBestHeight)
-      log.info("heightB: " + minerBGenBestHeight)
-
       genesisAGen shouldBe genesisBGen
+      Async.await(observeNodes("initial shared chain", minerAGen, minerBGen))
 
-      // 2. Stop all nodes
+      // Freeze the producer while B can still retrieve every header's full block.
       docker.stopNode(minerAGen.containerId)
+      val minerASeed: Node = docker.startDevNetNode(minerAConfigNonGen,
+        specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
+      val (seedA, seedB) = Async.await(waitForSettledSeed(minerASeed, minerBGen, 2.minutes))
+      val seedHeight = seedA.bestBlockHeightOpt.get
+      require(seedHeight < chainLength,
+        s"Initial shared chain already reached $seedHeight; isolated node B must mine to $chainLength")
+      log.info(s"Settled shared chain: heightA=$seedHeight, heightB=${seedB.bestBlockHeightOpt.get}")
+
+      // 2. Stop the restarted A and B only after both have the complete shared seed.
+      docker.stopNode(minerASeed.containerId)
       docker.stopNode(minerBGen.containerId)
 
-      val minerAIsolated: Node = docker.startDevNetNode(minerAConfig, isolatedPeersConfig,
+      val minerAIsolated: Node = docker.startDevNetNode(DeepRollBackSpec.isolatedMiningConfig.withFallback(minerAConfig), isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
 
       // 1. Let nodeA mine `chainLength + delta` blocks in isolation
       Async.await(minerAIsolated.waitForHeight(chainLength + delta))
 
-      val minerBIsolated: Node = docker.startDevNetNode(minerBConfig, isolatedPeersConfig,
+      val minerBIsolated: Node = docker.startDevNetNode(DeepRollBackSpec.isolatedMiningConfig.withFallback(minerBConfig), isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
+      Async.await(observeNodes("isolated miners started", minerAIsolated, minerBIsolated))
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
       Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
+
+      Async.await(minerAIsolated.connectedPeers) shouldBe empty
+      Async.await(minerBIsolated.connectedPeers) shouldBe empty
 
       log.info("Mining phase done")
 
       val minerABestHeight = Async.await(minerAIsolated.fullHeight)
       val minerBBestHeight = Async.await(minerBIsolated.fullHeight)
+      Async.await(observeNodes("isolated mining complete", minerAIsolated, minerBIsolated))
 
       docker.stopNode(minerAIsolated.containerId)
       docker.stopNode(minerBIsolated.containerId)
@@ -143,7 +228,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerB: Node = docker.startDevNetNode(minerBConfigNonGen,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
-
+      Async.await(observeNodes("restarted without mining", minerA, minerB))
 
       val isMiningAOpt = Async.await(minerA.info).isMining
       log.info("isminingA: " + isMiningAOpt)
@@ -162,7 +247,23 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
-    Await.result(result, 20.minutes)
+    try {
+      Await.result(result, 20.minutes)
+    } catch {
+      case error: TimeoutException =>
+        log.error(s"Deep rollback timed out; last initial-seed observation: $lastSeedObservation")
+        log.error(s"Deep rollback timed out; last observation: $lastObservation")
+        throw error
+    } finally {
+      seedObservations.close()
+      observations.close()
+    }
   }
 
+}
+
+object DeepRollBackSpec {
+  // The retained peer database survives restarts. Disable automatic outgoing connections
+  // and incoming admission during mining; final restarts use the ordinary node configs.
+  private[it] val isolatedMiningConfig: Config = ConfigFactory.parseString("scorex.network.maxConnections = 0")
 }

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
@@ -1,0 +1,57 @@
+package org.ergoplatform.it
+
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ForkResolutionDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  import ForkResolutionDiagnostics._
+
+  "Fork observations" should "retain independently accepted results while later selections change" in {
+    val first = latch(Vector.fill[Option[String]](4)(None), Vector(Some("a"), None, Some("a"), None))
+    val later = latch(first, Vector(None, Some("a"), None, Some("a")))
+    later shouldBe Vector.fill(4)(Some("a"))
+    latch(later, Vector.fill(4)(Some("b"))) shouldBe later
+  }
+
+  it should "retain missing results until their own predicate succeeds" in {
+    latch(Vector(Some("a"), None), Vector(None, None)) shouldBe Vector(Some("a"), None)
+  }
+
+  it should "report the fixed target separately from the current selected header" in {
+    val target = "ab" * 32
+    val current = "cd" * 32
+    val snapshot = Snapshot(Right(NodeInfo(None, None, Some(25), Some(20), None, Some(false))),
+      Right(3), Right(Seq(current, target)), Right(20), reachable = true)
+    val text = describe("match-anchor", 2, Some(10), Some(target), snapshot)
+    text should include(s"fixed=Some($target)")
+    text should include(s"selected=$current")
+    text should include("headerHeight=Some(25) fullHeight=Some(20) mining=Some(false)")
+    text should include("peerCount=3")
+  }
+
+  it should "exclude response text, addresses and paths from observed fields" in {
+    val payload = "http://example.invalid/private/location"
+    val snapshot = Snapshot(Right(NodeInfo(Some(payload), Some(payload), Some(1), Some(1), Some(payload), None)),
+      Left(payload), Right(Seq(payload)), Right(1), reachable = true)
+    val text = describe("match-anchor", 0, Some(1), Some(payload), snapshot)
+    text should not include payload
+    text should include("peerErrorClass=ObservationError")
+    text should include("selected=invalid-header-id")
+    text should include("fixed=Some(invalid-header-id)")
+    describe("initial-height", 0, None, None,
+      Snapshot(Left("TimeoutException"), Left("IOException"), Left("ParsingFailure"),
+        Left("TimeoutException"), reachable = false)) should
+      include("statusErrorClass=TimeoutException peerErrorClass=IOException headerErrorClass=ParsingFailure")
+  }
+
+  it should "keep supplementary failures out of the startup and height acceptance gates" in {
+    val snapshot = Snapshot(Left("ParsingFailure"), Left("TimeoutException"), Left("IOException"),
+      Right(20), reachable = true)
+    startupReached(snapshot) shouldBe Some(())
+    heightReached(20)(snapshot) shouldBe Some(20)
+    heightReached(21)(snapshot) shouldBe None
+    heightReached(20)(snapshot.copy(fullHeight = Left("ParsingFailure"))) shouldBe None
+    startupReached(snapshot.copy(reachable = false)) shouldBe None
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
@@ -1,20 +1,24 @@
 package org.ergoplatform.it
 
 import java.io.File
-import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
 import com.typesafe.config.Config
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.NodeInfo
 import org.ergoplatform.it.container.Docker.{ExtraConfig, noExtraConfig}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.scalatest.concurrent.Eventually
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.async.Async
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Try
+import scala.util.control.NonFatal
 
-class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite with Eventually {
+class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite {
+
+  import ForkResolutionDiagnostics._
 
   val nodesQty: Int = 4
 
@@ -43,24 +47,107 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
 
   def localVolume(n: Int): String = s"$localDataDir/fork-resolution-spec/node-$n/data"
 
+  private var phase = "initial-start"
+  private var recent = Vector.empty[String]
+  private val active = new AtomicBoolean(true)
+
+  private def enter(next: String): Unit = synchronized {
+    requireActive()
+    phase = next
+    log.info(s"Fork resolution phase=$phase")
+  }
+
+  private def remember(entry: String): Unit = synchronized {
+    recent = (recent :+ entry).takeRight(nodesQty * 3)
+  }
+
+  private def evidence: String = synchronized { s"phase=$phase; ${recent.mkString("; ")}" }
+
   def clearPeerDatabases(): Unit = {
-    volumesMapping.foreach { case (localVolume, remoteVolume) =>
+    volumesMapping.zipWithIndex.foreach { case ((localVolume, remoteVolume), index) =>
+      requireActive()
+      remember(s"phase=$phase node=$index operation=clear-peers")
       docker.removeFromMountedVolume(localVolume, remoteVolume, "peers")
     }
   }
 
-  def startNodesWithBinds(nodeConfigs: List[Config],
+  private def startNodesWithBinds(nodeConfigs: List[Config], observations: ConvergenceObservations,
+                          deadline: Option[Deadline] = None,
                           configEnrich: ExtraConfig = noExtraConfig): List[Node] = {
-    log.trace(s"Starting ${nodeConfigs.size} containers")
-    val nodes: Try[List[Node]] = nodeConfigs
+    val nodes = nodeConfigs
       .map(_.withFallback(specialDataDirConfig(remoteVolume)))
       .zip(volumesMapping)
-      .map { case (cfg, vol) => docker.startDevNetNode(cfg, configEnrich, Some(vol)) }
-      .sequence
-    implicit val patienceConfig: PatienceConfig = PatienceConfig((nodeConfigs.size * 2).seconds, 3.second)
-    eventually {
-      Await.result(Future.traverse(nodes.get)(_.waitForStartup), 180.seconds)
+      .zipWithIndex.map { case ((cfg, vol), index) =>
+        requireActive()
+        deadline.foreach(d => requireTime(d))
+        remember(s"phase=$phase node=$index operation=start")
+        docker.startDevNetNode(cfg, configEnrich, Some(vol)).get
+      }
+    val startupDeadline = deadline.map(d => d.timeLeft.min(180.seconds).fromNow).getOrElse(180.seconds.fromNow)
+    waitFor(nodes, observations, startupDeadline, None, None)(startupReached)
+    nodes
+  }
+
+  private def requireTime(deadline: Deadline): Unit = {
+    requireActive()
+    if (deadline.isOverdue()) throw new java.util.concurrent.TimeoutException("Fork resolution deadline")
+  }
+
+  private def requireActive(): Unit = {
+    if (!active.get()) throw new java.util.concurrent.CancellationException("Fork resolution finished")
+  }
+
+  private def waitFor[A](nodes: List[Node], observations: ConvergenceObservations, deadline: Deadline,
+                         headerHeight: Option[Int], fixedSample: Option[String])
+                        (accept: Snapshot => Option[A]): Vector[A] = {
+    val currentPhase = phase
+    val probes = nodes.map { node =>
+      def json(path: String): Future[Json] = {
+        requireTime(deadline)
+        node.singleGet(path, _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[Json](response.getResponseBody)
+        }
+      }
+      val status = observations.probe {
+        requireTime(deadline)
+        node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          val parsed = Try(node.ergoJsonAnswerAs[Json](response.getResponseBody))
+          val info = parsed.flatMap(j => Try(j.as[NodeInfo].fold(throw _, identity)))
+            .toEither.left.map(_.getClass.getSimpleName)
+          // Height gates retain NodeApi.fullHeight's exact field/default semantics.
+          val height = parsed.flatMap(j => Try(j.hcursor.downField("fullHeight").as[Option[Int]]
+            .fold(throw _, identity).getOrElse(0))).toEither.left.map(_.getClass.getSimpleName)
+          (info, height)
+        }
+      }
+      val peers = observations.probe(json("/peers/connected").map(_.asArray.get.size))
+      val headers = headerHeight.map { height =>
+        observations.probe(json(s"/blocks/at/$height").map(_.as[Seq[String]].fold(throw _, identity)))
+      }
+      (status, peers, headers)
     }
+    var accepted = Vector.fill[Option[A]](nodes.size)(None)
+    val result = observations.until(deadline, 100.millis, 5.seconds) { budget =>
+      requireTime(deadline)
+      Future.traverse(probes.zipWithIndex) { case ((status, peers, headers), index) =>
+        val infoResult = status.sample(budget)
+        val peerResult = peers.sample(budget)
+        val headerResult = headers.map(_.sample(budget)).getOrElse(Future.successful(Right(Seq.empty[String])))
+        infoResult.zip(peerResult).zip(headerResult).map { case ((status, peerCount), ids) =>
+          val snapshot = Snapshot(status.flatMap(_._1), peerCount, ids,
+            status.flatMap(_._2), status.isRight)
+          remember(describe(currentPhase, index, headerHeight, fixedSample, snapshot) +
+            s" sampledAt=${System.currentTimeMillis()}")
+          accept(snapshot)
+        }
+      }.map { observed =>
+        accepted = latch(accepted, observed.toVector)
+        accepted
+      }
+    }(_.forall(_.isDefined))(s"Fork resolution did not complete; $evidence")
+    Await.result(result, deadline.timeLeft.max(Duration.Zero)).map(_.get)
   }
 
   // Testing scenario:
@@ -71,38 +158,84 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
   // 5. Check that nodes reached consensus on created forks;
   it should "Fork resolution after isolated mining" in {
 
-    log.info(minerConfig.toString)
-    onlineSyncNodesConfig.foreach(x => log.info(x.toString))
-
-    val nodes: List[Node] = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig)
-
-    val result = Async.async {
-      val initMaxHeight = Async.await(Future.traverse(nodes)(_.fullHeight).map(_.max))
-      Async.await(Future.traverse(nodes)(_.waitForHeight(initMaxHeight + commonChainLength, 100.millis)))
-      val isolatedNodes = Async.await {
-        nodes.foreach(node => docker.stopNode(node.containerId))
+    val observations = new ConvergenceObservations
+    try {
+      enter("initial-start")
+      val nodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations)
+      // Match the original budget: initial startup precedes the 15-minute scenario deadline.
+      val deadline = 15.minutes.fromNow
+      val result = Future {
+        enter("initial-height")
+        val initMaxHeight = waitFor(nodes, observations, deadline, None, None)(_.fullHeight.toOption).max
+        val forkHeight = initMaxHeight + commonChainLength + forkLength
+        enter(s"common-height target=${initMaxHeight + commonChainLength}")
+        waitFor(nodes, observations, deadline, Some(initMaxHeight + commonChainLength), None)(
+          heightReached(initMaxHeight + commonChainLength))
+        def stop(current: List[Node]): Unit = current.zipWithIndex.foreach { case (node, index) =>
+          requireTime(deadline)
+          remember(s"phase=$phase node=$index operation=stop")
+          docker.stopNode(node.containerId)
+        }
+        enter("isolate-stop")
+        stop(nodes)
+        enter("isolate-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: offlineMiningNodesConfig, isolatedPeersConfig))
-      }
-      val forkHeight = initMaxHeight + commonChainLength + forkLength
-      Async.await(Future.traverse(isolatedNodes)(_.waitForHeight(forkHeight, 100.millis)))
-      val regularNodes = Async.await {
-        isolatedNodes.foreach(node => docker.stopNode(node.containerId))
+        enter("isolate-start")
+        val isolatedNodes = startNodesWithBinds(minerConfig +: offlineMiningNodesConfig,
+          observations, Some(deadline), isolatedPeersConfig)
+        enter(s"isolated-height target=$forkHeight")
+        waitFor(isolatedNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight))
+        enter("reconnect-stop")
+        stop(isolatedNodes)
+        enter("reconnect-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: onlineSyncNodesConfig))
+        enter("reconnect-start")
+        val regularNodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations, Some(deadline))
+        enter(s"reconnected-height target=${forkHeight + syncLength}")
+        waitFor(regularNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight + syncLength))
+        enter("select-anchor")
+        val sample = waitFor(regularNodes.take(1), observations, deadline, Some(forkHeight), None)(
+          _.headers.toOption).head.headOption.value
+        enter("match-anchor")
+        val headers = waitFor(regularNodes, observations, deadline, Some(forkHeight), Some(sample))(
+          _.headers.toOption.filter(_.headOption.contains(sample)))
+        val headerIdsAtSameHeight = headers.map(_.headOption.value)
+        headerIdsAtSameHeight should contain only sample
+        log.info(s"Fork resolution completed; $evidence")
       }
-      Async.await(Future.traverse(regularNodes)(_.waitForHeight(forkHeight + syncLength, 100.millis)))
-      val sample = Async.await(regularNodes.head.headerIdsByHeight(forkHeight)).headOption.value
-      val headers = Async.await(Future.traverse(regularNodes) { node =>
-        node.waitFor[Seq[String]](_.headerIdsByHeight(forkHeight), _.headOption.contains(sample), 100.millis)
-      })
-
-      log.debug(s"Headers at height $forkHeight: ${headers.mkString(",")}")
-      val headerIdsAtSameHeight = headers.map(_.headOption.value)
-      headerIdsAtSameHeight should contain only sample
+      Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    } catch {
+      case NonFatal(error) =>
+        log.error(s"Fork resolution failed errorClass=${error.getClass.getSimpleName}; $evidence")
+        throw error
+    } finally {
+      active.set(false)
+      observations.close()
     }
-
-    Await.result(result, 15.minutes)
   }
 
+}
+
+private[it] object ForkResolutionDiagnostics {
+  final case class Snapshot(info: Either[String, NodeInfo], peers: Either[String, Int],
+                            headers: Either[String, Seq[String]], fullHeight: Either[String, Int],
+                            reachable: Boolean)
+
+  def startupReached(snapshot: Snapshot): Option[Unit] = if (snapshot.reachable) Some(()) else None
+
+  def heightReached(target: Int)(snapshot: Snapshot): Option[Int] =
+    snapshot.fullHeight.toOption.filter(_ >= target)
+
+  def latch[A](previous: Vector[Option[A]], observed: Vector[Option[A]]): Vector[Option[A]] =
+    previous.zip(observed).map { case (accepted, current) => accepted.orElse(current) }
+
+  def describe(phase: String, index: Int, height: Option[Int], fixedSample: Option[String], snapshot: Snapshot): String = {
+    def error(value: String): String = if (value.matches("[A-Za-z0-9_$]+")) value else "ObservationError"
+    val info = snapshot.info.fold(e => s"statusErrorClass=${error(e)}", value =>
+      s"headerHeight=${value.bestHeaderHeightOpt} fullHeight=${value.bestBlockHeightOpt} mining=${value.isMining}")
+    val peers = snapshot.peers.fold(e => s"peerErrorClass=${error(e)}", count => s"peerCount=$count")
+    val selected = snapshot.headers.fold(e => s"headerErrorClass=${error(e)}", ids =>
+      s"selected=${ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing")}")
+    s"phase=$phase node=$index height=$height fixed=${fixedSample.map(ConvergenceObservations.headerId)} $info $peers $selected"
+  }
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -1,8 +1,9 @@
 package org.ergoplatform.it
 
 import com.typesafe.config.Config
+import io.circe.Json
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.ergoplatform.it.util.ConvergenceObservations
+import org.ergoplatform.it.util.{ConvergenceObservations, UtxoSyncFailureDiagnostics}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -75,7 +76,12 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
     catch {
       case error: java.util.concurrent.TimeoutException =>
         log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
-        throw error
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(error, nodes.map { node => () =>
+          node.singleGet("/info", _.setRequestTimeout(2000)).map { response =>
+            require(response.getStatusCode == 200, "Unexpected diagnostic status")
+            node.ergoJsonAnswerAs[Json](response.getResponseBody)
+          }
+        })(snapshot => log.error(s"UTXO post-failure diagnostics: $snapshot"))
     } finally observations.close()
   }
 

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  /** Both nodes report mining disabled and share a completely applied selected header tip. */
+  def sameFullyAppliedNonMiningBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean =
+    infoA.isMining.contains(false) && infoB.isMining.contains(false) &&
+      sameBestBlock(infoA, infoB, minHeight) &&
+      infoA.bestBlockIdOpt.exists(_.nonEmpty) &&
+      infoA.bestHeaderHeightOpt == infoA.bestBlockHeightOpt &&
+      infoB.bestHeaderHeightOpt == infoB.bestBlockHeightOpt &&
+      infoA.bestHeaderIdOpt == infoA.bestBlockIdOpt &&
+      infoB.bestHeaderIdOpt == infoB.bestBlockIdOpt
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,145 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  "Fully applied block agreement" should "accept a complete shared tip at the minimum height" in {
+    val info = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 12) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 13) shouldBe false
+  }
+
+  it should "reject a shared 21-header 12-full-block seed despite full-block agreement" in {
+    val lagging = NodeInfo(Some("header21"), Some("block12"), Some(21), Some(12), None, Some(false))
+    ConvergenceObservations.sameBestBlock(lagging, lagging, 1) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(lagging, lagging, 1) shouldBe false
+  }
+
+  private val completeSeed = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+
+  Seq[(String, NodeInfo => NodeInfo)](
+    "missing header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = None)),
+    "missing full-block height" -> ((info: NodeInfo) => info.copy(bestBlockHeightOpt = None)),
+    "missing header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = None)),
+    "missing full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = None)),
+    "different header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = Some("other"))),
+    "different full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = Some("other"))),
+    "different header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = Some(21))),
+    "unknown mining status" -> ((info: NodeInfo) => info.copy(isMining = None)),
+    "active mining" -> ((info: NodeInfo) => info.copy(isMining = Some(true)))
+  ).foreach { case (fault, change) =>
+    Seq("A", "B").foreach { side =>
+      it should s"reject $fault on node $side independently" in {
+        val (a, b) = if (side == "A") (change(completeSeed), completeSeed)
+                     else (completeSeed, change(completeSeed))
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, 1) shouldBe false
+      }
+    }
+  }
+
+  it should "reject two empty tip identifiers" in {
+    val empty = completeSeed.copy(bestHeaderIdOpt = Some(""), bestBlockIdOpt = Some(""))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(empty, empty, 1) shouldBe false
+  }
+
+  it should "reject different complete tips at the same height" in {
+    val other = completeSeed.copy(bestHeaderIdOpt = Some("other"), bestBlockIdOpt = Some("other"))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  it should "reject different complete heights independently of matching IDs" in {
+    val other = completeSeed.copy(bestHeaderHeightOpt = Some(13), bestBlockHeightOpt = Some(13))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  "Full block agreement" should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
@@ -1,0 +1,60 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/** Additional observations after failure, with their own bound and no effect on the assertion. */
+object UtxoSyncFailureDiagnostics {
+  private val requestBudget = 2.seconds
+  private val collectionBudget = 2500.millis
+  private val numericFields = Seq("headersHeight", "fullHeight", "headersScore", "fullBlocksScore", "peersCount")
+  private val headerFields = Seq("bestHeaderId", "bestFullHeaderId", "genesisBlockId")
+
+  def project(node: Int, sampledAt: Long, response: Either[String, Json]): Json = {
+    val identity = Seq("node" -> Json.fromInt(node), "sampledAt" -> Json.fromLong(sampledAt))
+    def failed(errorClass: String): Json = {
+      val safeClass = if (errorClass.matches("[A-Za-z_$][A-Za-z0-9_$]{0,127}")) errorClass else "ObservationFailure"
+      Json.obj((identity :+ ("errorClass" -> Json.fromString(safeClass))): _*)
+    }
+    response match {
+      case Left(errorClass) => failed(errorClass)
+      case Right(body) if !body.isObject => failed("InvalidInfoResponse")
+      case Right(body) =>
+        def field(name: String)(decode: Json => Option[Json]): (String, Json) = {
+          val value = body.hcursor.downField(name).focus match {
+            case None => Json.Null
+            case Some(value) if value.isNull => Json.Null
+            case Some(value) => decode(value).getOrElse(Json.fromString("invalid"))
+          }
+          name -> value
+        }
+        val numbers = numericFields.map(name => field(name) { value =>
+          value.asNumber.flatMap(_.toBigInt).filter(_ >= 0).map(Json.fromBigInt)
+        })
+        val headers = headerFields.map(name => field(name) { value =>
+          value.asString.map(id => Json.fromString(ConvergenceObservations.headerId(id)))
+        })
+        val mining = field("isMining")(_.asBoolean.map(Json.fromBoolean))
+        Json.obj((identity ++ numbers ++ headers :+ mining): _*)
+    }
+  }
+
+  def rethrowAfterCapture(original: TimeoutException, requests: Seq[() => Future[Json]])
+                         (emit: String => Unit)(implicit ec: ExecutionContext): Unit = {
+    try {
+      val observations = new ConvergenceObservations
+      try {
+        val snapshots = requests.zipWithIndex.map { case (request, index) =>
+          observations.probe(Future(request()).flatMap(response => response))
+            .sample(requestBudget).map(response => project(index, System.currentTimeMillis(), response))
+        }
+        // This bound starts only after the synchronization assertion has already failed.
+        val result = Await.result(Future.sequence(snapshots), collectionBudget)
+        emit(Json.arr(result: _*).noSpaces)
+      } finally observations.close()
+    } finally throw original
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
@@ -1,0 +1,111 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class UtxoSyncFailureDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private val marker = "untrusted-extra-value"
+  private val header = "ab" * 32
+
+  "Failure diagnostics" should "preserve only typed diagnostic fields and exact cumulative scores" in {
+    val score = BigInt("123456789012345678901234567890")
+    val body = Json.obj(
+      "headersHeight" -> Json.fromInt(13), "fullHeight" -> Json.fromInt(9),
+      "headersScore" -> Json.fromBigInt(score), "fullBlocksScore" -> Json.fromBigInt(score - 4),
+      "bestHeaderId" -> Json.fromString(header), "bestFullHeaderId" -> Json.fromString(header),
+      "genesisBlockId" -> Json.fromString(header), "isMining" -> Json.True,
+      "peersCount" -> Json.fromInt(3), "name" -> Json.fromString(marker),
+      "address" -> Json.fromString(marker), "sampledAt" -> Json.fromString(marker))
+    val result = UtxoSyncFailureDiagnostics.project(2, 123L, Right(body))
+    result.hcursor.get[BigInt]("headersScore") shouldBe Right(score)
+    result.hcursor.get[BigInt]("fullBlocksScore") shouldBe Right(score - 4)
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right(header)
+    result.hcursor.get[Int]("headersHeight") shouldBe Right(13)
+    result.hcursor.get[Int]("fullHeight") shouldBe Right(9)
+    result.hcursor.get[Boolean]("isMining") shouldBe Right(true)
+    result.hcursor.get[Int]("peersCount") shouldBe Right(3)
+    result.hcursor.get[Int]("node") shouldBe Right(2)
+    result.hcursor.get[Long]("sampledAt") shouldBe Right(123L)
+    result.asObject.get.keys.toSet shouldBe Set("node", "sampledAt", "headersHeight", "fullHeight",
+      "headersScore", "fullBlocksScore", "bestHeaderId", "bestFullHeaderId", "genesisBlockId", "isMining", "peersCount")
+    result.noSpaces should not include marker
+  }
+
+  it should "mark malformed fields and preserve missing fields without copying their contents" in {
+    val body = Json.obj("headersHeight" -> Json.fromString(marker), "fullHeight" -> Json.fromInt(-1),
+      "headersScore" -> Json.arr(Json.fromString(marker)), "isMining" -> Json.fromString(marker),
+      "bestHeaderId" -> Json.fromString(marker), "genesisBlockId" -> Json.obj("secret" -> Json.fromString(marker)))
+    val result = UtxoSyncFailureDiagnostics.project(0, 1L, Right(body))
+    Seq("headersHeight", "fullHeight", "headersScore", "isMining", "genesisBlockId").foreach { key =>
+      result.hcursor.get[String](key) shouldBe Right("invalid")
+    }
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right("invalid-header-id")
+    Seq("fullBlocksScore", "peersCount", "bestFullHeaderId").foreach { key =>
+      result.hcursor.downField(key).focus shouldBe Some(Json.Null)
+    }
+    result.noSpaces should not include marker
+    UtxoSyncFailureDiagnostics.project(0, 1L, Right(Json.fromString(marker)))
+      .hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    UtxoSyncFailureDiagnostics.project(0, 1L, Left("bad/class: " + marker)).noSpaces should not include marker
+  }
+
+  it should "retain the original timeout when transport or request creation fails" in {
+    val original = new TimeoutException("original assertion")
+    var captured = ""
+    val requests = Seq[() => Future[Json]](
+      () => Future.successful(Json.obj("name" -> Json.fromString(marker))),
+      () => Future.failed(new IOException(marker)),
+      () => throw new IllegalStateException(marker),
+      () => Future.successful(Json.fromString(marker)))
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, requests)(value => captured = value)
+    }
+    (thrown eq original) shouldBe true
+    val snapshots = parse(captured).toOption.get.asArray.get
+    snapshots.size shouldBe 4
+    snapshots.map(_.hcursor.get[Int]("node").toOption.get) shouldBe Vector(0, 1, 2, 3)
+    snapshots(1).hcursor.get[String]("errorClass") shouldBe Right("IOException")
+    snapshots(2).hcursor.get[String]("errorClass") shouldBe Right("IllegalStateException")
+    snapshots(3).hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    captured should not include marker
+  }
+
+  it should "retain the original timeout if emitting diagnostics fails" in {
+    val original = new TimeoutException("original assertion")
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, Seq(() => Future.successful(Json.obj()))) { _ =>
+        throw new IllegalArgumentException(marker)
+      }
+    }
+    (thrown eq original) shouldBe true
+  }
+
+  it should "start all pending requests and finish collection under its separate bound" in {
+    val original = new TimeoutException("original assertion")
+    val started = new AtomicInteger(0)
+    val pending = Seq.fill(4)(Promise[Json]())
+    var captured = ""
+    val thrown = intercept[TimeoutException] {
+      Await.result(Future {
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, pending.map { promise => () =>
+          started.incrementAndGet()
+          promise.future
+        })(value => captured = value)
+      }, 4.seconds)
+    }
+    (thrown eq original) shouldBe true
+    started.get() shouldBe 4
+    parse(captured).toOption.get.asArray.get.foreach { snapshot =>
+      snapshot.hcursor.get[String]("errorClass") shouldBe Right("TimeoutException")
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -75,7 +75,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private var syncInfoV1CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV1)] = Option.empty
 
-  private var syncInfoV2CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV2)] = Option.empty
+  private val syncInfoV2Cache = new SyncInfoV2Cache
 
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 
@@ -315,14 +315,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   /** Get V2 sync info from cache or load it from history and add to cache */
   private def getV2SyncInfo(history: ErgoHistory, full: Boolean): ErgoSyncInfoV2 = {
-    val headersHeight = history.headersHeight
-    syncInfoV2CacheByHeadersHeight
-      .collect { case (height, syncInfo) if height == headersHeight => syncInfo }
-      .getOrElse {
-        val v2SyncInfo = history.syncInfoV2(full)
-        syncInfoV2CacheByHeadersHeight = Some(headersHeight -> v2SyncInfo)
-        v2SyncInfo
-      }
+    syncInfoV2Cache.getOrElseUpdate(history.bestHeaderIdOpt, full)(history.syncInfoV2(full))
   }
 
   /**
@@ -1658,6 +1651,22 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
+  /** Single-entry cache owned by the synchronizer actor. */
+  private[network] final class SyncInfoV2Cache {
+    private var cached: Option[(Option[ModifierId], Boolean, ErgoSyncInfoV2)] = None
+
+    def getOrElseUpdate(bestHeaderId: Option[ModifierId], full: Boolean)
+                       (build: => ErgoSyncInfoV2): ErgoSyncInfoV2 = {
+      cached.collect {
+        case (tip, mode, info) if tip == bestHeaderId && mode == full => info
+      }.getOrElse {
+        val info = build
+        cached = Some((bestHeaderId, full, info))
+        info
+      }
+    }
+  }
 
   private def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,

--- a/src/main/scala/org/ergoplatform/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/org/ergoplatform/network/message/BasicMessagesRepo.scala
@@ -66,6 +66,8 @@ class PeersSpec(peersLimit: Int) extends MessageSpecV1[Seq[PeerSpec]] {
 object GetSnapshotsInfoSpec extends MessageSpecV1[Unit] {
   private val SizeLimit = 100
 
+  override protected def allowTrailingPayloadBytes: Boolean = true
+
   override val messageCode: MessageCode = 76: Byte
 
   override val messageName: String = "GetSnapshotsInfo"

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -369,6 +369,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
           applyFromCacheLoop(headersCache)
 
+          // Newly accepted headers may unblock sections received before their headers.
+          applyFromCacheLoop(modifiersCache)
+
           val cleared = headersCache.cleanOverfull()
           val upd = BlockSectionsProcessingCacheUpdate(
             headersCache.size,

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -403,8 +403,14 @@ trait ErgoHistoryReader
       }
 
       val headers = offsets.flatMap(offset => bestHeaderAtHeight(h - offset))
+      // Keep a shared starting point in full summaries when it is available locally.
+      val genesisAnchor = if (full) {
+        bestHeaderAtHeight(GenesisHeight).filterNot(genesis => headers.exists(_.id == genesis.id)).toSeq
+      } else {
+        Seq.empty
+      }
 
-      ErgoSyncInfoV2(headers)
+      ErgoSyncInfoV2(headers.toSeq ++ genesisAnchor)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -71,7 +71,7 @@ trait ToDownloadProcessor
             val toDownload = headersAtThisHeight.flatMap(requiredModifiersForHeader).filter { case (mtid, mid) => condition(mtid, mid) }
             // add new modifiers to download to accumulator
             val newAcc = toDownload.foldLeft(acc) { case (newAcc, (mType, mId)) => newAcc.adjust(mType)(_.fold(Vector(mId))(_ :+ mId)) }
-            continuation(height + 1, newAcc, maxHeight)
+            if (height == maxHeight) newAcc else continuation(height + 1, newAcc, maxHeight)
           } else {
             acc
           }
@@ -84,8 +84,21 @@ trait ToDownloadProcessor
         // do not download full blocks if no headers-chain synced yet or SPV mode
         Map.empty
       case Some(fb) if farAwayFromBeingSynced(fb) =>
-        // when far away from blockchain tip
-        continuation(fb.height + 1, Map.empty, fb.height + FullBlocksToDownloadAhead)
+        // A different best headers-chain may need block sections below the old full-chain tip.
+        val commonAncestor = if (isInBestChain(fb.id)) {
+          None
+        } else {
+          val parentSteps = Math.max(0L, nodeSettings.keepVersions.toLong)
+          val limit = Math.min(fb.height.toLong, parentSteps + 1L).toInt
+          headerChainBack(limit, fb.header, h => isInBestChain(h.id)).headOption
+            .filter(h => isInBestChain(h.id))
+        }
+        val fromHeight = commonAncestor
+          .map(h => Math.max(minimalFullBlockHeight, h.height + 1))
+          .getOrElse(fb.height + 1)
+        // Extending the scan backward must preserve forward progress beyond the existing full-chain tip.
+        val maxHeight = Math.min(fb.height.toLong + FullBlocksToDownloadAhead, Int.MaxValue.toLong).toInt
+        continuation(fromHeight, Map.empty, maxHeight)
       case Some(fb) =>
         // when blockchain is about to be synced,
         // download children blocks of last 100 full blocks applied to the best chain, to get block sections from forks

--- a/src/main/scala/scorex/core/network/Synchronizer.scala
+++ b/src/main/scala/scorex/core/network/Synchronizer.scala
@@ -23,7 +23,7 @@ trait Synchronizer extends ScorexLogging {
     source: ConnectedPeer
   ): Try[Unit] = {
     // attempt to parse the message
-    spec.parseBytesTry(msgBytes) match {
+    spec.parsePayloadBytesTry(msgBytes) match {
       // if a message could be parsed, match the type of content found and ensure a handler is defined
       case Success(content) =>
         val parsedMsg = (spec, content, source)

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -6,8 +6,9 @@ import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
-import org.ergoplatform.nodeView.mempool.ErgoMemPool
+import org.ergoplatform.nodeView.mempool.{ErgoMemPool, ErgoMemPoolReader}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
@@ -67,7 +68,27 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  class NodeViewHolderMock extends ErgoNodeViewHolder[UtxoState](settings)
+  private def isolatedNodeSettings(prototype: ErgoSettings): ErgoSettings = {
+    val directory = createTempDir
+    prototype.copy(directory = directory.getAbsolutePath,
+      walletSettings = prototype.walletSettings.copy(secretStorage =
+        prototype.walletSettings.secretStorage.copy(
+          secretDir = new java.io.File(directory, "keystore").getAbsolutePath)))
+  }
+
+  class NodeViewHolderMock(nodeSettings: ErgoSettings) extends ErgoNodeViewHolder[UtxoState](nodeSettings)
+
+  class InjectedReadersNodeViewHolder(nodeSettings: ErgoSettings,
+                                     injectedHistory: ErgoHistoryReader,
+                                     injectedMempool: ErgoMemPoolReader) extends NodeViewHolderMock(nodeSettings) {
+    // This fixture owns its history and mempool; startup replies must use those same readers.
+    override protected def getNodeViewChanges: Receive = {
+      case request: GetNodeViewChanges =>
+        if (request.history) sender() ! ChangedHistory(injectedHistory)
+        super.getNodeViewChanges(request.copy(history = false, mempool = false))
+        if (request.mempool) sender() ! ChangedMempool(injectedMempool)
+    }
+  }
 
   class SynchronizerMock(networkControllerRef: ActorRef,
                          viewHolderRef: ActorRef,
@@ -129,7 +150,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val h = localHistoryGen.sample.get
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     val s = localStateGen.sample.get
-    val settings = ErgoSettingsReader.read()
+    val settings = isolatedNodeSettings(ErgoSettingsReader.read())
     val pool = ErgoMemPool.empty(settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
@@ -138,9 +159,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new InjectedReadersNodeViewHolder(settings, h, pool)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -174,15 +193,14 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   }
 
   class Synchronizer2Fixture extends AkkaFixture {
+    val settings: ErgoSettings = isolatedNodeSettings(org.ergoplatform.utils.ErgoNodeTestConstants.settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock(settings)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -509,6 +527,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - unknown peer") {
     withFixture { ctx =>
       import ctx._
+
+      // Replay a late startup request before observing the peer response. The fixture's
+      // injected history and mempool must not be replaced by the holder's empty readers.
+      val startupReaders = TestProbe("StartupReaders")
+      startupReaders.send(nodeViewHolder,
+        GetNodeViewChanges(history = true, state = false, vault = false, mempool = true))
+      val changedHistory = startupReaders.expectMsgType[ChangedHistory](3.seconds)
+      val changedMempool = startupReaders.expectMsgType[ChangedMempool](3.seconds)
+      synchronizer ! changedHistory
+      synchronizer ! changedMempool
 
       val sync = ErgoSyncInfoV2(Seq(altchain.last))
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -510,14 +510,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }
@@ -545,14 +547,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }

--- a/src/test/scala/org/ergoplatform/network/InvSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/InvSpecification.scala
@@ -74,4 +74,14 @@ class InvSpecification extends ErgoCorePropertyTest {
     checkSum shouldBe hash.Blake2b256(Array(modifierTypeId, headersCount.toByte) ++ headerId).take(4)
   }
 
+  property("inv parser rejects trailing payload bytes") {
+    val invSpec = InvSpec
+    val headerId = Array.fill(16)(1: Byte) ++ Array.fill(16)(2: Byte)
+    val headerIdEncoded = ModifierId @@ Base16.encode(headerId)
+    val invData = InvData(Header.modifierTypeId, Seq(headerIdEncoded))
+    val payload = invSpec.toBytes(invData)
+
+    invSpec.parseBytesTry(payload ++ Array(0: Byte)).isFailure shouldBe true
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/network/MessageSpecSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/MessageSpecSpecification.scala
@@ -1,0 +1,118 @@
+package org.ergoplatform.network
+
+import java.net.InetSocketAddress
+import akka.actor.ActorRef
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.network.message.{
+  GetNipopowProofSpec,
+  GetSnapshotsInfoSpec,
+  InvData,
+  InvSpec,
+  Message,
+  MessageSpec,
+  NipopowProofData,
+  NipopowProofSpec
+}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.core.network.{ConnectedPeer, ConnectionId, Incoming, Synchronizer}
+import scorex.util.ModifierId
+import scorex.util.encode.Base16
+
+class MessageSpecSpecification extends ErgoCorePropertyTest {
+
+  private class TestSynchronizer extends Synchronizer {
+    var handled: Boolean = false
+    var penalized: Boolean = false
+
+    def handle(spec: MessageSpec[Any], bytes: Array[Byte], source: ConnectedPeer) =
+      parseAndHandle({ case _ => handled = true }, spec, bytes, source)
+
+    override protected def penalizeMaliciousPeer(peer: ConnectedPeer): Unit = penalized = true
+  }
+
+  private val peer = ConnectedPeer(
+    ConnectionId(
+      new InetSocketAddress("127.0.0.1", 9030),
+      new InetSocketAddress("127.0.0.1", 9031),
+      Incoming
+    ),
+    ActorRef.noSender,
+    None
+  )
+
+  property("framed message parsers reject trailing payload bytes") {
+    val headerId = Array.fill(16)(1: Byte) ++ Array.fill(16)(2: Byte)
+    val headerIdEncoded = ModifierId @@ Base16.encode(headerId)
+    val payload = InvSpec.toBytes(InvData(Header.modifierTypeId, Seq(headerIdEncoded)))
+
+    Message(InvSpec, Left(payload ++ Array(0: Byte)), None).data.isFailure shouldBe true
+  }
+
+  property("the inbound synchronizer rejects and penalizes trailing payload bytes") {
+    val headerId = Array.fill(16)(1: Byte) ++ Array.fill(16)(2: Byte)
+    val headerIdEncoded = ModifierId @@ Base16.encode(headerId)
+    val payload = InvSpec.toBytes(InvData(Header.modifierTypeId, Seq(headerIdEncoded)))
+
+    val synchronizer = new TestSynchronizer
+    synchronizer
+      .handle(InvSpec.asInstanceOf[MessageSpec[Any]], payload ++ Array(0: Byte), peer)
+      .isFailure shouldBe true
+    synchronizer.handled shouldBe false
+    synchronizer.penalized shouldBe true
+  }
+
+  property("the inbound synchronizer preserves valid framed payload extensions") {
+    val headerId = Array.fill(16)(1: Byte) ++ Array.fill(16)(2: Byte)
+    val headerIdEncoded = ModifierId @@ Base16.encode(headerId)
+    val invPayload = InvSpec.toBytes(InvData(Header.modifierTypeId, Seq(headerIdEncoded)))
+    val invSynchronizer = new TestSynchronizer
+
+    invSynchronizer
+      .handle(InvSpec.asInstanceOf[MessageSpec[Any]], invPayload, peer)
+      .isSuccess shouldBe true
+    invSynchronizer.handled shouldBe true
+    invSynchronizer.penalized shouldBe false
+
+    val snapshotsSynchronizer = new TestSynchronizer
+    snapshotsSynchronizer
+      .handle(GetSnapshotsInfoSpec.asInstanceOf[MessageSpec[Any]], Array.fill[Byte](99)(1), peer)
+      .isSuccess shouldBe true
+    snapshotsSynchronizer.handled shouldBe true
+    snapshotsSynchronizer.penalized shouldBe false
+
+    val nipopowPayload = GetNipopowProofSpec
+      .toBytes(NipopowProofData(m = 1, k = 1, headerId = None))
+      .dropRight(1) ++ Array[Byte](3, 1, 2, 3)
+    val nipopowSynchronizer = new TestSynchronizer
+    nipopowSynchronizer
+      .handle(GetNipopowProofSpec.asInstanceOf[MessageSpec[Any]], nipopowPayload, peer)
+      .isSuccess shouldBe true
+    nipopowSynchronizer.handled shouldBe true
+    nipopowSynchronizer.penalized shouldBe false
+  }
+
+  property("extensible empty request payloads preserve bounded extension bytes") {
+    Message(GetSnapshotsInfoSpec, Left(Array.fill[Byte](99)(1)), None).data.isSuccess shouldBe true
+    Message(GetSnapshotsInfoSpec, Left(Array.fill[Byte](100)(1)), None).data.isFailure shouldBe true
+  }
+
+  property("nipopow request payloads accept declared extensions but reject malformed tails") {
+    val spec = GetNipopowProofSpec
+    val payload = spec.toBytes(NipopowProofData(m = 1, k = 1, headerId = None))
+    val withDeclaredExtension = payload.dropRight(1) ++ Array[Byte](3, 1, 2, 3)
+
+    Message(spec, Left(withDeclaredExtension), None).data.isSuccess shouldBe true
+    Message(spec, Left(withDeclaredExtension ++ Array(4: Byte)), None).data.isFailure shouldBe true
+    Message(spec, Left(payload.dropRight(1) ++ Array[Byte](2, 1)), None).data.isFailure shouldBe true
+  }
+
+  property("nipopow proof payloads accept declared extensions but reject malformed tails") {
+    val spec = NipopowProofSpec
+    val payload = spec.toBytes(Array(1: Byte))
+    val withDeclaredExtension = payload.dropRight(1) ++ Array[Byte](3, 1, 2, 3)
+
+    Message(spec, Left(withDeclaredExtension), None).data.isSuccess shouldBe true
+    Message(spec, Left(withDeclaredExtension ++ Array(4: Byte)), None).data.isFailure shouldBe true
+    Message(spec, Left(payload.dropRight(1) ++ Array[Byte](2, 1)), None).data.isFailure shouldBe true
+  }
+}

--- a/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.network
+
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.SyncInfoV2Cache
+import org.ergoplatform.nodeView.history.ErgoSyncInfoV2
+import org.ergoplatform.utils.generators.ChainGenerator.genHeaderChain
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class SyncInfoV2CacheSpec extends AnyPropSpec with Matchers {
+  private val headers = genHeaderChain(3, diffBitsOpt = None, useRealTs = false).headers
+  private val tip = headers.last
+  private val fullSummary = ErgoSyncInfoV2(Seq(tip, headers.head))
+  private val reducedSummary = ErgoSyncInfoV2(Seq(tip))
+
+  property("reuse a summary only for the same tip and requested mode") {
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+      cache.getOrElseUpdate(Some(tip.id), full) {
+        fail("An unchanged tip and mode should reuse the cached summary")
+      } shouldBe expected
+    }
+  }
+
+  property("alternating reduced and full requests preserves each requested summary") {
+    val cache = new SyncInfoV2Cache
+    Seq(false, true, false, true).foreach { full =>
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+    }
+  }
+
+  property("a different best header at the same height replaces the cached summary") {
+    val otherTip = genHeaderChain(1, prefixOpt = Some(headers(1)),
+      diffBitsOpt = None, useRealTs = false).last
+    otherTip.height shouldBe tip.height
+    otherTip.id should not be tip.id
+
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val original = if (full) fullSummary else reducedSummary
+      val replacement = ErgoSyncInfoV2(if (full) Seq(otherTip, headers.head) else Seq(otherTip))
+      cache.getOrElseUpdate(Some(tip.id), full)(original) shouldBe original
+      cache.getOrElseUpdate(Some(otherTip.id), full)(replacement) shouldBe replacement
+      cache.getOrElseUpdate(Some(otherTip.id), full) {
+        fail("The replacement tip should now be cached")
+      } shouldBe replacement
+    }
+  }
+
+  property("empty history and populated history do not share cached summaries") {
+    val cache = new SyncInfoV2Cache
+    val empty = ErgoSyncInfoV2(Nil)
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+    cache.getOrElseUpdate(None, full = true) {
+      fail("An unchanged empty history should reuse its summary")
+    } shouldBe empty
+    cache.getOrElseUpdate(Some(tip.id), full = true)(fullSummary) shouldBe fullSummary
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
@@ -1,0 +1,158 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NetworkObjectTypeId, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.{BlockTransactions, HeaderChain}
+import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.initSettings
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators.invalidErgoTransactionGen
+import scorex.util.ModifierId
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
+
+  // These in-memory records exercise scheduling, not block or chain validation.
+  private val template = defaultHeaderGen.sample.get
+  private val transaction = invalidErgoTransactionGen.sample.get
+  private val maximumHeightHeader = template.copy(height = Int.MaxValue)
+  private val bestChain = (1 to 300).foldLeft(Vector.empty[Header]) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.lastOption.map(_.id).getOrElse(Header.GenesisParentId))
+  }
+  private val oldChain = (21 to 60).foldLeft(bestChain.take(20)) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.last.id, timestamp = template.timestamp + 1)
+  }
+
+  private class SchedulingReader(fullHeader: Header,
+                                 retainedVersions: Int = 50,
+                                 minimumHeight: Int = 1,
+                                 synced: Boolean = true,
+                                 verify: Boolean = true,
+                                 tipHeight: Int = 300,
+                                 missingHeader: Option[ModifierId] = None) extends ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = initSettings.copy(nodeSettings = initSettings.nodeSettings.copy(
+      keepVersions = retainedVersions, verifyTransactions = verify, stateType = StateType.Utxo))
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Scheduling snapshots do not process sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Scheduling snapshots do not validate sections")
+
+    private val headersById = (bestChain ++ oldChain :+ maximumHeightHeader).map(h => h.id -> h).toMap
+    var traversals: Vector[(Int, ModifierId)] = Vector.empty
+    var heightLookups: Vector[Int] = Vector.empty
+    override def bestFullBlockOpt: Option[ErgoFullBlock] = Some(ErgoFullBlock(fullHeader,
+      BlockTransactions(fullHeader.id, fullHeader.version, Seq(transaction)), Extension(fullHeader.id, Seq.empty), None))
+    override def bestHeaderIdOpt: Option[ModifierId] = Some(bestChain(tipHeight - 1).id)
+    override def estimatedTip(): Option[Int] = Some(tipHeight)
+    override def minimalFullBlockHeight: Int = minimumHeight
+    override def isHeadersChainSynced: Boolean = synced
+    override def isInBestChain(id: ModifierId): Boolean = bestChain.exists(_.id == id)
+    override def headerIdsAtHeight(height: Int): Seq[ModifierId] = {
+      heightLookups :+= height
+      (bestChain :+ maximumHeightHeader).find(_.height == height).map(_.id).toSeq
+    }
+    override def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T] =
+      headersById.get(id).filterNot(h => missingHeader.contains(h.id)).collect { case section: T => section }
+    override def headerChainBack(limit: Int, startHeader: Header, until: Header => Boolean): HeaderChain = {
+      traversals :+= limit -> startHeader.id
+      super.headerChainBack(limit, startHeader, until)
+    }
+  }
+
+  private def expected(reader: SchedulingReader, heights: Range): Map[NetworkObjectTypeId.Value, Seq[ModifierId]] =
+    heights.flatMap(h => reader.requiredModifiersForHeader(bestChain(h - 1)))
+      .groupBy(_._1).map { case (kind, sections) => kind -> sections.map(_._2) }
+
+  private val acceptAll: (NetworkObjectTypeId.Value, ModifierId) => Boolean = (_, _) => true
+
+  property("linear far-behind downloads retain the forward window without walking history") {
+    val reader = new SchedulingReader(bestChain(59))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe empty
+  }
+
+  property("ancestor scheduling extends backward without shortening the forward window") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 40)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
+    reader.traversals shouldBe Vector(41 -> oldChain.last.id)
+  }
+
+  property("a truncated traversal does not infer a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 39)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(40 -> oldChain.last.id)
+  }
+
+  property("non-positive retention does not walk to a parent") {
+    Seq(0, -1, Int.MinValue).foreach { retained =>
+      val reader = new SchedulingReader(oldChain.last, retainedVersions = retained)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+      reader.traversals shouldBe Vector(1 -> oldChain.last.id)
+    }
+  }
+
+  property("a missing parent does not turn a partial traversal into a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, missingHeader = Some(oldChain(39).id))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(51 -> oldChain.last.id)
+  }
+
+  property("ancestor scheduling respects the minimum retained full-block height") {
+    Seq(30, 253).foreach { minimumHeight =>
+      val reader = new SchedulingReader(oldChain.last, minimumHeight = minimumHeight)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, minimumHeight to 252)
+    }
+  }
+
+  property("maximum retention does not overflow the traversal bound") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = Int.MaxValue)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
+    reader.traversals shouldBe Vector(60 -> oldChain.last.id)
+  }
+
+  property("a download window ending at the maximum height terminates without wrapping") {
+    val fullHeader = oldChain.last.copy(height = Int.MaxValue - 191)
+    val reader = new SchedulingReader(fullHeader, minimumHeight = Int.MaxValue) {
+      override def estimatedTip(): Option[Int] = Some(Int.MaxValue)
+    }
+    val sections = reader.requiredModifiersForHeader(maximumHeightHeader)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe
+      sections.groupBy(_._1).map { case (kind, entries) => kind -> entries.map(_._2) }
+    reader.heightLookups shouldBe Vector(Int.MaxValue)
+  }
+
+  property("ancestor scheduling preserves per-type caps and the section filter") {
+    val reader = new SchedulingReader(oldChain.last)
+    val firstSections = reader.requiredModifiersForHeader(bestChain(20))
+    val excluded = firstSections.head._2
+    val result = reader.nextModifiersToDownload(2, (_, id) => id != excluded)
+    val all = expected(reader, 21 to 22)
+    result shouldBe all.map { case (kind, ids) => kind -> ids.filterNot(_ == excluded) }
+    result.values.foreach(_.size should be <= 2)
+  }
+
+  property("unsynced and non-verifying readers do not schedule sections or walk history") {
+    Seq(new SchedulingReader(oldChain.last, synced = false), new SchedulingReader(oldChain.last, verify = false))
+      .foreach { reader =>
+        reader.nextModifiersToDownload(1000, acceptAll) shouldBe empty
+        reader.traversals shouldBe empty
+      }
+  }
+
+  property("near-tip scheduling retains its existing lookback without walking history") {
+    val reader = new SchedulingReader(oldChain.last, tipHeight = 100)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 1 to 300)
+    reader.traversals shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
@@ -1,0 +1,193 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.HeaderChain
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.HistoryTestHelpers.generateHistory
+import org.ergoplatform.utils.generators.ChainGenerator.{applyHeaderChain, genHeaderChain}
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import scorex.crypto.hash.Digest32
+
+import scala.util.Try
+
+class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
+
+  private def newHistory(): ErgoHistory =
+    generateHistory(
+      verifyTransactions = false,
+      stateType = StateType.Digest,
+      PoPoWBootstrap = false,
+      blocksToKeep = 0,
+      epochLength = 1000
+    )
+
+  private def checkRoundtrip(summary: ErgoSyncInfoV2): Unit = {
+    val bytes = ErgoSyncInfoSerializer.toBytes(summary)
+    val decoded = ErgoSyncInfoSerializer.parseBytes(bytes).asInstanceOf[ErgoSyncInfoV2]
+    decoded.lastHeaders.map(_.id) shouldBe summary.lastHeaders.map(_.id)
+    decoded.height shouldBe summary.height
+    ErgoSyncInfoSerializer.toBytes(decoded).sameElements(bytes) shouldBe true
+  }
+
+  // These snapshots exercise summary selection, not header or chain validity.
+  private def snapshotReader(headers: Seq[Header]): ErgoHistoryReader = new ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = null
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Summary snapshots do not process block sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Summary snapshots do not validate block sections")
+    override def bestHeaderOpt: Option[Header] = headers.sortBy(_.height).lastOption
+    override def headersHeight: Int = bestHeaderOpt.map(_.height).getOrElse(0)
+    override def isEmpty: Boolean = headers.isEmpty
+    override def bestHeaderAtHeight(height: Int): Option[Header] = headers.find(_.height == height)
+  }
+
+  property("full and reduced sync summaries remain empty for empty history") {
+    val history = newHistory()
+    try {
+      Seq(true, false).foreach { full =>
+        val summary = history.syncInfoV2(full)
+        summary.lastHeaders shouldBe empty
+        summary.nonEmpty shouldBe false
+        summary.height shouldBe None
+        checkRoundtrip(summary)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("linear history summaries retain recent samples and exactly one genesis anchor") {
+    var history = newHistory()
+    try {
+      val chain = genHeaderChain(17, history, diffBitsOpt = None, useRealTs = false)
+      val expectedHeights = Seq(
+        1 -> Seq(1),
+        2 -> Seq(2, 1),
+        10 -> Seq(10, 1),
+        17 -> Seq(17, 1)
+      )
+      var appliedHeight = 0
+      expectedHeights.foreach { case (height, heights) =>
+        history = applyHeaderChain(history, HeaderChain(chain.headers.slice(appliedHeight, height)))
+        appliedHeight = height
+        history.headersHeight shouldBe height
+
+        val full = history.syncInfoV2(full = true)
+        val expectedIds = heights.map(h => chain.headers(h - 1).id)
+        full.lastHeaders.map(_.id) shouldBe expectedIds
+        full.lastHeaders.map(_.height) shouldBe heights
+        full.lastHeaders.head.id shouldBe history.bestHeaderOpt.get.id
+        full.lastHeaders.last.id shouldBe chain.head.id
+        full.lastHeaders.count(_.id == chain.head.id) shouldBe 1
+        full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+        full.lastHeaders.size should be <= 5
+        full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+        full.height shouldBe Some(height)
+        checkRoundtrip(full)
+
+        val reduced = history.syncInfoV2(full = false)
+        reduced.lastHeaders.map(_.id) shouldBe Seq(chain.headers(height - 1).id)
+        reduced.height shouldBe Some(height)
+        checkRoundtrip(reduced)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("full summary snapshots preserve sparse samples and deduplicate the genesis anchor") {
+    val template = defaultHeaderGen.sample.get
+    val cases = Seq(
+      Seq(129, 113, 1),
+      Seq(513, 497, 385, 1),
+      Seq(600, 584, 472, 88, 1)
+    )
+    cases.foreach { heights =>
+      val headers = heights.map(height => template.copy(height = height))
+      val reader = snapshotReader(headers)
+      val full = reader.syncInfoV2(full = true)
+      full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+      full.lastHeaders.map(_.height) shouldBe heights
+      full.lastHeaders.count(_.height == 1) shouldBe 1
+      full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+      full.lastHeaders.size should be <= 5
+      full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+      full.height shouldBe Some(heights.head)
+      checkRoundtrip(full)
+
+      val reduced = reader.syncInfoV2(full = false)
+      reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+      checkRoundtrip(reduced)
+    }
+  }
+
+  property("full summary preserves available samples when genesis is unavailable") {
+    val template = defaultHeaderGen.sample.get
+    val headers = Seq(600, 584, 472, 88).map(height => template.copy(height = height))
+    val reader = snapshotReader(headers)
+    reader.bestHeaderAtHeight(1) shouldBe None
+    val full = reader.syncInfoV2(full = true)
+    full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+    full.height shouldBe Some(600)
+    checkRoundtrip(full)
+    val reduced = reader.syncInfoV2(full = false)
+    reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+    checkRoundtrip(reduced)
+  }
+
+  Seq((3, 9, 13), (18, 249, 70)).foreach { case (sharedHeight, heightA, heightB) =>
+    property(s"full summaries recover both fork continuations after shared height $sharedHeight at tips $heightA/$heightB") {
+      var historyA = newHistory()
+      var historyB = newHistory()
+      try {
+        // Exercise stored header histories and the actual summary/continuation methods.
+        // Full block application and network delivery are separate integration contracts.
+        val shared = genHeaderChain(sharedHeight, historyA, diffBitsOpt = None, useRealTs = false)
+        val branchA = genHeaderChain(heightA - sharedHeight, prefixOpt = Some(shared.last),
+          control = historyA.difficultyCalculator, extensionHash = Digest32 @@ Array.fill[Byte](32)(1),
+          diffBitsOpt = None, useRealTs = false).headers.tail
+        val branchB = genHeaderChain(heightB - sharedHeight, prefixOpt = Some(shared.last),
+          control = historyB.difficultyCalculator, extensionHash = Digest32 @@ Array.fill[Byte](32)(2),
+          diffBitsOpt = None, useRealTs = false).headers.tail
+        val chainA = shared.headers ++ branchA
+        val chainB = shared.headers ++ branchB
+        historyA = applyHeaderChain(historyA, HeaderChain(chainA))
+        historyB = applyHeaderChain(historyB, HeaderChain(chainB))
+        historyA.headersHeight shouldBe heightA
+        historyB.headersHeight shouldBe heightB
+        branchA.head.id should not be branchB.head.id
+        historyA.contains(branchB.head.id) shouldBe false
+        historyB.contains(branchA.head.id) shouldBe false
+
+        Seq((historyA, historyB, chainA), (historyB, historyA, chainB)).foreach {
+          case (local, peer, localChain) =>
+            val sparseHeaders = ErgoHistoryReader.FullV2SyncOffsets.toSeq
+              .flatMap(offset => peer.bestHeaderAtHeight(peer.headersHeight - offset))
+            sparseHeaders should not be empty
+            sparseHeaders.exists(header => local.contains(header.id)) shouldBe false
+            local.continuationIdsV2(ErgoSyncInfoV2(sparseHeaders), size = 400) shouldBe empty
+
+            val full = peer.syncInfoV2(full = true)
+            checkRoundtrip(full)
+            val continuation = local.continuationIdsV2(full, size = 400)
+            continuation.map(_._2) shouldBe localChain.tail.map(_.id)
+            continuation.map(_._1).distinct shouldBe Seq(Header.modifierTypeId)
+            continuation.map(_._2) should contain(localChain(sharedHeight).id)
+            full.lastHeaders.last.id shouldBe shared.head.id
+        }
+      } finally {
+        try historyA.closeStorage() finally historyB.closeStorage()
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/HeaderBodyCacheWakeupSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/HeaderBodyCacheWakeupSpec.scala
@@ -1,0 +1,68 @@
+package org.ergoplatform.nodeView.viewholder
+
+import akka.testkit.TestProbe
+import org.ergoplatform.core.idToVersion
+import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.BlockSectionsProcessingCacheUpdate
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.ModifiersFromRemote
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
+import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestConfig, NodeViewTestOps}
+import org.ergoplatform.utils.fixtures.NodeViewFixture
+import org.ergoplatform.utils.generators.ValidBlocksGenerators._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class HeaderBodyCacheWakeupSpec extends ErgoCorePropertyTest with NodeViewTestOps {
+  import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+
+  Seq(StateType.Utxo, StateType.Digest).foreach { stateType =>
+    property(s"remote header wakes already cached block sections in $stateType state") {
+      val fixture = new NodeViewFixture(
+        NodeViewTestConfig(stateType, verifyTransactions = true, popowBootstrap = false).toSettings,
+        parameters)
+      import fixture._
+      val (generationState, boxes) = createUtxoState(fixture.settings)
+      try {
+        val prefix = validFullBlock(None, generationState, boxes)
+        val afterPrefix = WrappedUtxoState(generationState, boxes, fixture.settings)
+          .applyModifier(prefix)(_ => ()).get
+        val next = validFullBlock(Some(prefix), afterPrefix)
+        applyBlock(prefix).isSuccess shouldBe true
+        getCurrentState.version shouldBe idToVersion(prefix.id)
+
+        val cacheProbe = TestProbe()(actorSystem)
+        actorSystem.eventStream.subscribe(cacheProbe.ref, classOf[BlockSectionsProcessingCacheUpdate])
+        val sections: Seq[BlockSection] = Seq(next.blockTransactions, next.extension, next.adProofs.get)
+        sections.map(_.modifierTypeId).distinct.size shouldBe 3
+        sections.zipWithIndex.foreach { case (section, index) =>
+          nodeViewHolderRef ! ModifiersFromRemote(Seq(section))
+          val cached = cacheProbe.expectMsgType[BlockSectionsProcessingCacheUpdate](5.seconds)
+          cached.blockSectionsCacheSize shouldBe index + 1
+          cached.cleared._2 shouldBe empty
+        }
+        val beforeHeader = getCurrentView
+        beforeHeader.history.contains(next.header.id) shouldBe false
+        sections.foreach(section => beforeHeader.history.contains(section.id) shouldBe false)
+        beforeHeader.state.version shouldBe idToVersion(prefix.id)
+
+        // The cache-update event is an actor-processing barrier, not another drain trigger.
+        // No body section is resent after its prerequisite header arrives.
+        nodeViewHolderRef ! ModifiersFromRemote(Seq(next.header))
+        val afterHeader = cacheProbe.expectMsgType[BlockSectionsProcessingCacheUpdate](5.seconds)
+        afterHeader.headersCacheSize shouldBe 0
+        val current = getCurrentView
+        current.history.getFullBlock(next.header).map(_.id) shouldBe Some(next.id)
+        sections.foreach(section => current.history.contains(section.id) shouldBe true)
+        current.history.bestFullBlockIdOpt shouldBe Some(next.id)
+        current.state.version shouldBe idToVersion(next.id)
+        current.state.rootDigest.toSeq shouldBe next.header.stateRoot.toSeq
+        afterHeader.blockSectionsCacheSize shouldBe 0
+      } finally {
+        generationState.closeStorage()
+        Await.result(actorSystem.terminate(), 15.seconds)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reject unread bytes at the framed P2P payload boundary used by inbound synchronizers. Raw handshake parsing remains prefix-compatible, explicitly bounded GetSnapshotsInfo extensions remain accepted, and declared NiPoPoW extensions are preserved while surplus or truncated payload bytes are rejected. Live ingress regressions cover rejection, no handler dispatch and peer penalty.

Head `0d22182f877ac3497032a0ba93699b24ab306731` targets `master` and preserves the [original implementation and direct tests](https://github.com/a-shannon/ergo/commit/5a1b39da1bffc4fcae550be02c790c1c8fa0ce82). The [preceding three-file review increment](https://github.com/a-shannon/ergo/compare/29cc59ba5d034574367836e346c6787f88933ceb...d9940fc052df1ac580a049a96ec83fdb5792cdbe) reuses the selected-header observer and bounded failure diagnostics from [T](https://github.com/a-shannon/ergo/commit/0679fc061f13ad2169241e3ea9d96db7bcf5dba7), on [U](https://github.com/a-shannon/ergo/commit/bcfcd61166151d8000ae2a05a62fa4f389aa7126), owned by [#2535](https://github.com/ergoplatform/ergo/pull/2535). No additional production change is introduced by this increment.

The observer compares each node's nonempty selected header at the original height. `/blocks/at/{height}` also retains orphaned alternatives, so flattening every returned ID incorrectly demanded that all retained forks disappear. Persistent selected-header disagreement still fails under the shared fifteen-minute deadline; the five-block scenario remains. On failure, typed diagnostics are collected under a separate 2.5-second bound while preserving the original timeout. The final composition passed normal integration-test compilation and all five diagnostics tests. Independent source review found no blockers. Identical H32 and node49 inputs retain their preceding results; no broad suite was rerun for this IT-only increment.

The [earlier prerequisite increment](https://github.com/a-shannon/ergo/compare/b236cc787d01c91264eb2a854f334bc1644ed8d6...29cc59ba5d034574367836e346c6787f88933ceb) remains unchanged. It reuses [G](https://github.com/a-shannon/ergo/commit/d62c945a4d6314c54a7b57f18a94aee8fd258aa7), owned by [#2511](https://github.com/ergoplatform/ergo/pull/2511), and [X](https://github.com/a-shannon/ergo/commit/a772a5cbf666584db3ed981838dbc11223d502ed), owned by [#2549](https://github.com/ergoplatform/ergo/pull/2549). Review [R](https://github.com/a-shannon/ergo/commit/76e5ec4bfc377334fdced4bd60a61df06e6b4cb6), owned by #2535, before G; merge the owning synchronization corrections before this consumer. The small common commits avoid importing whole owner PRs. The preceding composition passed 49 focused tests covering synchronization, V2 cache, stored histories, download scheduling and cached-body wake-up.

Existing [D](https://github.com/a-shannon/ergo/commit/71f33c6e45a9394557cf3af1bfb422cbc53d26cf) establishes a fully applied non-mining seed and explicit isolation for DeepRollBackSpec. [K](https://github.com/a-shannon/ergo/commit/a1c1bd26e89ec2f24d5c52acc1fdd35346d65371) adds bounded ForkResolution observations on [H](https://github.com/a-shannon/ergo/commit/0f9f75c1fc1df3ff3309482b83c0475a05cdd7a2). Their assertions, deadlines and restored connectivity are preserved. H/D33, H/K37 and historical owner core7 plus node/network81 evidence remain qualified by their original inputs.

At head `29cc59ba`, [native IT](https://github.com/ergoplatform/ergo/actions/runs/34742202901/job/103683679815) still failed the old flattened-header assertion. That failure supports this observer correction; it does not establish an unrelated production defect or full end-to-end success. Native CI for the new head remains a separate pending gate in [the tracker](https://github.com/ergoplatform/ergo/issues/2533).

The [latest one-file test increment](https://github.com/a-shannon/ergo/compare/d9940fc052df1ac580a049a96ec83fdb5792cdbe...0d22182f877ac3497032a0ba93699b24ab306731) reuses the exact forced-cache fixture already reviewed in [#2384](https://github.com/ergoplatform/ergo/pull/2384), extracted as focused [shared support](https://github.com/a-shannon/ergo/commit/7b0d6ea849284c71e88bc27a9b87cb2482c8279f). At the preceding head, [native node tests](https://github.com/ergoplatform/ergo/actions/runs/34749910228/job/103704459323) passed831/832; the sole failure received a legitimate LocalBlockApplied event between the initial mining acknowledgement and a candidate reply. The fixed-reader case still applies a real valid block to UTXO state, creates real history and invokes real candidate generation. It retains reply deadlines and strengthens cache checks with unforced object identity, forced new-object identity, expected parent and timestamp assertions. The owning framed-payload rejection and live-ingress tests are unchanged.

Normal Scala 2.12 compilation and all 20/20 CandidateGeneratorSpec cases passed on this exact composition, with no failures, ignored cases or aborted suites. Independent review confirmed the one-file merge is byte-identical to the reviewed #2384 support and production CandidateGenerator is unchanged. The earlier T5/native integration success and unaffected ingress/synchronization evidence remain input-qualified; no broad suite was replayed for this test-only join. Native CI on the promoted head remains separate.
