### PR TITLE
Reject trailing P2P modifier bytes

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionSerializer.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionSerializer.scala
@@ -5,8 +5,6 @@ import org.ergoplatform.serialization.ErgoSerializer
 import scorex.util.serialization.{Reader, Writer}
 import scorex.util.{bytesToId, idToBytes}
 
-import scala.annotation.nowarn
-
 object ExtensionSerializer extends ErgoSerializer[Extension] {
 
   override def serialize(obj: Extension, w: Writer): Unit = {
@@ -19,19 +17,18 @@ object ExtensionSerializer extends ErgoSerializer[Extension] {
     }
   }
 
-  @nowarn
   override def parse(r: Reader): Extension = {
     val startPosition = r.position
     val headerId = bytesToId(r.getBytes(Constants.ModifierIdSize))
     val fieldsSize = r.getUShort()
-    val fieldsView = (1 to fieldsSize).toStream.map { _ =>
+    val fields = (1 to fieldsSize).map { _ =>
       val key = r.getBytes(Extension.FieldKeySize)
       val length = r.getUByte()
+      val resultingSize = r.position - startPosition + length
+      require(resultingSize < Constants.MaxExtensionSizeMax)
       val value = r.getBytes(length)
       (key, value)
     }
-    val fields = fieldsView.takeWhile(_ => r.position - startPosition < Constants.MaxExtensionSizeMax)
-    require(r.position - startPosition < Constants.MaxExtensionSizeMax)
     Extension(headerId, fields, Some(r.position - startPosition))
   }
 

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/SerializationCoreTests.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/SerializationCoreTests.scala
@@ -1,16 +1,22 @@
 package org.ergoplatform.serialization
 
+import java.nio.ByteBuffer
+
 import org.ergoplatform.modifiers.ErgoNodeViewModifier
 import org.ergoplatform.modifiers.history._
-import org.ergoplatform.modifiers.history.extension.ExtensionSerializer
+import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSerializer}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.modifiers.mempool.ErgoTransactionSerializer
 import org.ergoplatform.nodeView.history.ErgoSyncInfoSerializer
 import org.ergoplatform.nodeView.state.ErgoStateContextSerializer
-import org.ergoplatform.settings.{ErgoValidationSettings, ErgoValidationSettingsSerializer, ErgoValidationSettingsUpdateSerializer}
+import org.ergoplatform.settings.{Constants, ErgoValidationSettings, ErgoValidationSettingsSerializer, ErgoValidationSettingsUpdateSerializer}
 import org.ergoplatform.utils.{ErgoCorePropertyTest, SerializationTests}
 import org.scalacheck.Gen
 import org.scalatest.Assertion
+import scorex.util.ModifierId
+import scorex.util.serialization.VLQByteBufferReader
+
+import scala.util.Try
 
 class SerializationCoreTests extends ErgoCorePropertyTest with SerializationTests {
   import org.ergoplatform.utils.generators.ErgoCoreGenerators._
@@ -46,6 +52,66 @@ class SerializationCoreTests extends ErgoCorePropertyTest with SerializationTest
 
   property("Extension serialization") {
     checkSerializationRoundtrip(extensionGen, ExtensionSerializer)
+  }
+
+  property("Extension parsing eagerly consumes every declared field") {
+    val extension = Extension(
+      ModifierId @@ ("00" * 32),
+      Seq(
+        Array[Byte](0, 1) -> Array.emptyByteArray,
+        Array[Byte](0, 2) -> Array[Byte](1, 2),
+        Array[Byte](0, 3) -> Array.fill[Byte](Extension.FieldValueMaxSize)(3)
+      )
+    )
+    val bytes = ExtensionSerializer.toBytes(extension)
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+    val parsed = ExtensionSerializer.parse(reader)
+
+    reader.remaining shouldBe 0
+    parsed.size shouldBe bytes.length
+    parsed.fields.size shouldBe extension.fields.size
+    parsed.fields.zip(extension.fields).foreach { case ((parsedKey, parsedValue), (expectedKey, expectedValue)) =>
+      parsedKey.sameElements(expectedKey) shouldBe true
+      parsedValue.sameElements(expectedValue) shouldBe true
+    }
+    ExtensionSerializer.toBytes(parsed).sameElements(bytes) shouldBe true
+    Try(ExtensionSerializer.parseBytes(bytes.dropRight(1))).isFailure shouldBe true
+
+    val suffix = Array[Byte](0x55, 0x66)
+    val readerWithSuffix = new VLQByteBufferReader(ByteBuffer.wrap(bytes ++ suffix))
+    val parsedWithSuffix = ExtensionSerializer.parse(readerWithSuffix)
+    readerWithSuffix.remaining shouldBe suffix.length
+    ExtensionSerializer.toBytes(parsedWithSuffix).sameElements(bytes) shouldBe true
+  }
+
+  property("Extension parsing enforces the defensive maximum size") {
+    val fieldCount = 15650
+    val lastIndex = fieldCount - 1
+    val prefixFields = (0 until lastIndex).map { i =>
+      Array[Byte]((i >>> 8).toByte, i.toByte) ->
+        Array.fill[Byte](Extension.FieldValueMaxSize)(i.toByte)
+    }
+
+    def serialized(lastValueLength: Int): Array[Byte] = {
+      val lastField =
+        Array[Byte]((lastIndex >>> 8).toByte, lastIndex.toByte) ->
+          Array.fill[Byte](lastValueLength)(lastIndex.toByte)
+      ExtensionSerializer.toBytes(
+        Extension(ModifierId @@ ("00" * 32), prefixFields :+ lastField)
+      )
+    }
+
+    val belowLimit = serialized(55)
+    belowLimit.length shouldBe Constants.MaxExtensionSizeMax - 1
+    Try(ExtensionSerializer.parseBytes(belowLimit)).isSuccess shouldBe true
+
+    val atLimit = serialized(56)
+    atLimit.length shouldBe Constants.MaxExtensionSizeMax
+    Try(ExtensionSerializer.parseBytes(atLimit)).isFailure shouldBe true
+
+    val aboveLimit = serialized(57)
+    aboveLimit.length shouldBe Constants.MaxExtensionSizeMax + 1
+    Try(ExtensionSerializer.parseBytes(aboveLimit)).isFailure shouldBe true
   }
 
   property("ErgoTransactionGen serialization") {

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.network
 
+import java.nio.ByteBuffer
+
 import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
@@ -36,13 +38,14 @@ import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSeriali
 import org.ergoplatform.modifiers.transaction.TooHighCostError
 import org.ergoplatform.serialization.{ErgoSerializer, ManifestSerializer, SubtreeSerializer}
 import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage.splitDigest
+import scorex.util.serialization.VLQByteBufferReader
 import sigma.VersionContext
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.{Failure, Random, Success}
+import scala.util.{Failure, Random, Success, Try}
 
 /**
   * Contains most top-level logic for p2p networking, communicates with lower-level p2p code and other parts of the
@@ -763,6 +766,13 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     }
   }
 
+  private def parseBytesExact[M](serializer: ErgoSerializer[M], bytes: Array[Byte]): Try[M] = Try {
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+    val result = serializer.parse(reader)
+    require(reader.remaining == 0, "Unexpected trailing modifier bytes")
+    result
+  }
+
   /**
     * Parse transaction coming from remote, filtering out immediately too big one, and send parsed transaction
     * to mempool for processing
@@ -775,7 +785,9 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 s"exceeds limit ${settings.nodeSettings.maxTransactionSize}")
     } else {
       // actual tree version is properly set in ErgoTreeSerializer inside
-      val parseResult = VersionContext.withVersions(activatedScriptVersion, activatedScriptVersion)(ErgoTransactionSerializer.parseBytesTry(bytes))
+      val parseResult = VersionContext.withVersions(activatedScriptVersion, activatedScriptVersion) {
+        parseBytesExact(ErgoTransactionSerializer, bytes)
+      }
       parseResult match {
         case Success(tx) if id == tx.id =>
           val utx = UnconfirmedTransaction(tx, bytes, Some(remote))
@@ -799,7 +811,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                                                 serializer: ErgoSerializer[M],
                                                 remote: ConnectedPeer): Iterable[M] = {
     modifiers.flatMap { case (id, bytes) =>
-      serializer.parseBytesTry(bytes) match {
+      parseBytesExact(serializer, bytes) match {
         case Success(mod) if id == mod.id =>
           Some(mod)
         case _ =>

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.network
 
+import java.nio.ByteBuffer
+
 import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorRefFactory, DeathPactException, OneForOneStrategy, Props}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
@@ -36,13 +38,14 @@ import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSeriali
 import org.ergoplatform.modifiers.transaction.TooHighCostError
 import org.ergoplatform.serialization.{ErgoSerializer, ManifestSerializer, SubtreeSerializer}
 import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage.splitDigest
+import scorex.util.serialization.VLQByteBufferReader
 import sigma.VersionContext
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.{Failure, Random, Success}
+import scala.util.{Failure, Random, Success, Try}
 
 /**
   * Contains most top-level logic for p2p networking, communicates with lower-level p2p code and other parts of the
@@ -790,7 +793,9 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                 s"exceeds limit ${settings.nodeSettings.maxTransactionSize}")
     } else {
       // actual tree version is properly set in ErgoTreeSerializer inside
-      val parseResult = VersionContext.withVersions(activatedScriptVersion, activatedScriptVersion)(ErgoTransactionSerializer.parseBytesTry(bytes))
+      val parseResult = VersionContext.withVersions(activatedScriptVersion, activatedScriptVersion) {
+        parseBytesExact(ErgoTransactionSerializer, bytes)
+      }
       parseResult match {
         case Success(tx) if id == tx.id =>
           val utx = UnconfirmedTransaction(tx, bytes, Some(remote))
@@ -815,7 +820,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                                                 serializer: ErgoSerializer[M],
                                                 remote: ConnectedPeer): Iterable[M] = {
     modifiers.flatMap { case (id, bytes) =>
-      serializer.parseBytesTry(bytes) match {
+      parseBytesExact(serializer, bytes) match {
         case Success(mod) if id == mod.id =>
           Some(mod)
         case _ =>
@@ -1658,6 +1663,13 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
+  private[network] def parseBytesExact[M](serializer: ErgoSerializer[M], bytes: Array[Byte]): Try[M] = Try {
+    val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+    val result = serializer.parse(reader)
+    require(reader.remaining == 0, "Unexpected trailing modifier bytes")
+    result
+  }
 
   private def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -2,10 +2,14 @@ package org.ergoplatform.network
 
 import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
 import akka.testkit.TestProbe
+import org.ergoplatform.modifiers.history.{ADProofsSerializer, BlockTransactions, BlockTransactionsSerializer}
+import org.ergoplatform.modifiers.history.extension.{Extension, ExtensionSerializer}
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
+import org.ergoplatform.modifiers.mempool.ErgoTransactionSerializer
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{GetNodeViewChanges, TransactionFromRemote}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
@@ -18,15 +22,16 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
-import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
+import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, SendToNetwork}
 import org.ergoplatform.network.message._
-import org.ergoplatform.network.peer.PeerInfo
+import org.ergoplatform.network.peer.{PeerInfo, PenaltyType}
 import scorex.core.network.{ConnectedPeer, DeliveryTracker}
 import scorex.util.bytesToId
 import org.ergoplatform.serialization.ErgoSerializer
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scorex.testkit.utils.AkkaFixture
+import sigma.VersionContext
 
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
@@ -59,6 +64,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
   private def withFixture2(testCode: Synchronizer2Fixture => Any): Unit = {
     val fixture = new Synchronizer2Fixture
+    try {
+      testCode(fixture)
+    }
+    finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  private def withTransactionIngressFixture(testCode: TransactionIngressFixture => Any): Unit = {
+    val fixture = new TransactionIngressFixture
     try {
       testCode(fixture)
     }
@@ -203,6 +218,41 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     )
   }
 
+  class TransactionIngressFixture extends AkkaFixture {
+    implicit val ec: ExecutionContextExecutor = system.dispatcher
+    val h = localHistoryGen.sample.get
+    val pool = ErgoMemPool.empty(settings)
+    val ncProbe = TestProbe("TransactionNetworkControllerProbe")
+    val viewHolderProbe = TestProbe("TransactionViewHolderProbe")
+    val pchProbe = TestProbe("TransactionPeerHandlerProbe")
+    val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
+    val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
+
+    deleteRecursive(ErgoHistory.historyDir(settings))
+    val synchronizer = system.actorOf(Props(
+      new SynchronizerMock(
+        ncProbe.ref,
+        viewHolderProbe.ref,
+        ErgoSyncInfoMessageSpec,
+        settings,
+        syncTracker,
+        deliveryTracker)
+    ))
+
+    viewHolderProbe.expectMsgType[GetNodeViewChanges](3.seconds)
+
+    val peerInfo = PeerInfo(defaultPeerSpec, System.currentTimeMillis())
+    val peer: ConnectedPeer = ConnectedPeer(
+      connectionIdGen.sample.get,
+      pchProbe.ref,
+      Some(peerInfo)
+    )
+    val tx = validErgoTransactionGenTemplate(0, 0).sample.get._2
+
+    viewHolderProbe.send(synchronizer, ChangedHistory(h))
+    viewHolderProbe.send(synchronizer, ChangedMempool(pool))
+  }
+
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - younger peer") {
     withFixture { ctx =>
       import ctx._
@@ -271,6 +321,97 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       eventually {
         deliveryTracker.status(olderChain.last.id, Header.modifierTypeId, Seq.empty) shouldBe Received
       }
+    }
+  }
+
+  property("NodeViewSynchronizer: rejects header bytes with trailing payload") {
+    withFixture { ctx =>
+      import ctx._
+      deliveryTracker.reset()
+      val header = chain.take(1001).last
+      deliveryTracker.setRequested(Header.modifierTypeId, header.id, peer)(_ => Cancellable.alreadyCancelled)
+      val modData = ModifiersData(Header.modifierTypeId, Map(header.id -> (header.bytes ++ Array(0: Byte))))
+      val modSpec = ModifiersSpec
+      synchronizer ! Message(modSpec, Left(modSpec.toBytes(modData)), Some(peer))
+
+      eventually {
+        deliveryTracker.status(header.id, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+      ncProbe.fishForMessage(3.seconds) {
+        case PenalizePeer(address, PenaltyType.MisbehaviorPenalty) =>
+          address == peer.connectionId.remoteAddress
+        case _ => false
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: transaction ingress accepts canonical bytes and rejects a trailing byte") {
+    withTransactionIngressFixture { ctx =>
+      import ctx._
+      val typeId = tx.modifierTypeId
+      val scriptVersion = Header.scriptFromBlockVersion(Header.InitialVersion)
+      val canonicalBytes = VersionContext.withVersions(scriptVersion, scriptVersion) {
+        ErgoTransactionSerializer.toBytes(tx)
+      }
+
+      def sendTransaction(bytes: Array[Byte]): Unit = {
+        val data = ModifiersData(typeId, Map(tx.id -> bytes))
+        viewHolderProbe.send(
+          synchronizer,
+          Message(ModifiersSpec, Left(ModifiersSpec.toBytes(data)), Some(peer))
+        )
+      }
+
+      deliveryTracker.setRequested(typeId, tx.id, peer)(_ => Cancellable.alreadyCancelled)
+      deliveryTracker.status(tx.id, typeId, Seq.empty) shouldBe Requested
+
+      sendTransaction(canonicalBytes)
+      val accepted = viewHolderProbe.expectMsgType[TransactionFromRemote](3.seconds)
+      accepted.unconfirmedTx.transaction shouldBe tx
+      accepted.unconfirmedTx.transactionBytes.exists(_.sameElements(canonicalBytes)) shouldBe true
+      accepted.unconfirmedTx.source shouldBe Some(peer)
+
+      sendTransaction(canonicalBytes ++ Array(0: Byte))
+      ncProbe.fishForMessage(3.seconds) {
+        case PenalizePeer(address, PenaltyType.MisbehaviorPenalty) =>
+          address == peer.connectionId.remoteAddress
+        case _ => false
+      }
+      viewHolderProbe.expectNoMessage(300.millis)
+
+      deliveryTracker.status(tx.id, typeId, Seq.empty) shouldBe Requested
+      viewHolderProbe.send(synchronizer, CheckDelivery(peer, typeId, tx.id))
+      eventually {
+        deliveryTracker.status(tx.id, typeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: exact modifier parsing accepts canonical bytes and rejects trailing bytes") {
+    def checkExact[M](serializer: ErgoSerializer[M], bytes: Array[Byte]): Unit = {
+      ErgoNodeViewSynchronizer.parseBytesExact(serializer, bytes).isSuccess shouldBe true
+      ErgoNodeViewSynchronizer.parseBytesExact(serializer, bytes ++ Array(0: Byte)).isFailure shouldBe true
+    }
+
+    val header = chain.take(1001).last
+    val tx = org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators.invalidErgoTransactionGen.sample.get
+    val blockTransactions = BlockTransactions(header.id, Header.InitialVersion, Seq(tx))
+    val adProofs = org.ergoplatform.utils.generators.ErgoCoreGenerators.randomADProofsGen.sample.get
+    val extension = Extension(
+      header.id,
+      Seq(
+        Array[Byte](0, 1) -> Array[Byte](1, 2),
+        Array[Byte](0, 2) -> Array[Byte](3, 4)
+      )
+    )
+    val scriptVersion = Header.scriptFromBlockVersion(Header.InitialVersion)
+
+    VersionContext.withVersions(scriptVersion, scriptVersion) {
+      checkExact(HeaderSerializer, HeaderSerializer.toBytes(header))
+      checkExact(ErgoTransactionSerializer, ErgoTransactionSerializer.toBytes(tx))
+      checkExact(BlockTransactionsSerializer, BlockTransactionsSerializer.toBytes(blockTransactions))
+      checkExact(ADProofsSerializer, ADProofsSerializer.toBytes(adProofs))
+      checkExact(ExtensionSerializer, ExtensionSerializer.toBytes(extension))
     }
   }
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -241,6 +241,22 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
+  property("NodeViewSynchronizer: rejects header bytes with trailing payload") {
+    withFixture { ctx =>
+      import ctx._
+      deliveryTracker.reset()
+      val olderChain = chain.take(1001)
+      val header = olderChain.last
+      deliveryTracker.setRequested(Header.modifierTypeId, header.id, peer)(_ => Cancellable.alreadyCancelled)
+      val modData = ModifiersData(Header.modifierTypeId, Map(header.id -> (header.bytes ++ Array(0: Byte))))
+      val modSpec = ModifiersSpec
+      synchronizer ! Message(modSpec, Left(modSpec.toBytes(modData)), Some(peer))
+      eventually {
+        deliveryTracker.status(header.id, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
   property("NodeViewSynchronizer: apply continuation header from syncV2 and download its block") {
     withFixture2 { ctx =>
       import ctx._


### PR DESCRIPTION
## Summary
- Reject unread trailing bytes inside each length-delimited P2P modifier body before its advertised ID is accepted.
- Apply exact parsing to transactions and all block-section serializers.
- Parse every declared Extension field eagerly, preserving valid multi-field extensions while enforcing the strict 1 MiB upper bound.
- Complement #2404, which performs the outer message-framing check.

## Validation
- RED: the permissive transaction parser accepted a tailed body; a non-strict Extension boundary accepted an exact 1 MiB payload.
- GREEN: SerializationCoreTests 15/15; ErgoNodeViewSynchronizerSpecification 29/29; affected node-network tests 59/59.
- Combined with #2404: core-network 7/7, serialization 15/15, node-network 65/65.
- Independent code, test-closure, and #2404 compatibility reviews found no actionable issue.