### PR TITLE
Reject oversized P2P message payload lengths

### DIFF
--- a/src/main/scala/org/ergoplatform/network/message/MessageSerializer.scala
+++ b/src/main/scala/org/ergoplatform/network/message/MessageSerializer.scala
@@ -6,9 +6,14 @@ import scorex.core.network.{ConnectedPeer, MaliciousBehaviorException}
 import scorex.crypto.hash.Blake2b256
 import scala.util.Try
 
+object MessageSerializer {
+  val MaxPayloadLength: Int = ModifiersSpec.maxMessageSize * 4
+}
+
 class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
 
   import MessageConstants.{ChecksumLength, HeaderLength, MagicLength}
+  import MessageSerializer.MaxPayloadLength
 
   import scala.language.existentials
 
@@ -49,7 +54,14 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
         throw MaliciousBehaviorException("Data length is negative!")
       }
 
-      if (length != 0 && byteString.length < length + HeaderLength + ChecksumLength) {
+      if (length > MaxPayloadLength) {
+        throw MaliciousBehaviorException(s"Data length $length exceeds max payload length $MaxPayloadLength")
+      }
+
+      val messageLength =
+        HeaderLength.toLong + (if (length == 0) 0L else ChecksumLength.toLong + length.toLong)
+
+      if (byteString.length.toLong < messageLength) {
         None
       } else {
         //peer is from another network

--- a/src/test/scala/org/ergoplatform/network/InvSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/InvSpecification.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.network
 
 import java.nio.ByteBuffer
 
+import akka.util.ByteString
 import com.google.common.primitives.Ints
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.utils.ErgoCorePropertyTest
@@ -72,6 +73,16 @@ class InvSpecification extends ErgoCorePropertyTest {
 
     // validating checksum
     checkSum shouldBe hash.Blake2b256(Array(modifierTypeId, headersCount.toByte) ++ headerId).take(4)
+  }
+
+  property("inv parser rejects oversized declared payload length") {
+    val magic = Array(1: Byte, 0: Byte, 2: Byte, 4: Byte)
+    val ms = new MessageSerializer(Seq(InvSpec), magic)
+
+    val oversizedLength = 16 * 1024 * 1024
+    val msgHeader = ByteString(magic ++ Array(InvSpec.messageCode) ++ Ints.toByteArray(oversizedLength))
+
+    ms.deserialize(msgHeader, None).isFailure shouldBe true
   }
 
 }


### PR DESCRIPTION
## Summary

- Reject P2P message frames whose declared payload length exceeds the largest supported payload before buffering the full body.
- Keep the cap aligned with the existing `ModifiersSpec` ADProof reserve, which is currently the widest valid P2P payload envelope.
- Compute the expected full frame length with `Long` arithmetic before deciding whether a frame is still incomplete.

## Tests

- `sbt "testOnly org.ergoplatform.network.InvSpecification -- -z oversized"`
- `sbt "testOnly org.ergoplatform.network.InvSpecification org.ergoplatform.network.RequestModifiersSpecification org.ergoplatform.network.ModifiersSpecification org.ergoplatform.network.ErgoSyncInfoSpecification"`
- `sbt "testOnly org.ergoplatform.network.* scorex.core.network.*"`
