### PR TITLE
Prevent wallet double-spends by reserving inputs on send requests

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -4991,6 +4991,12 @@ paths:
       security:
         - ApiKeyAuth: [api_key]
       summary: Generate and send arbitrary transaction
+      description: Inputs of the generated transaction are reserved, so they are not
+        selected by consequent send requests; the reservation is lifted when the
+        transaction gets into the mempool or is rejected by it (transactions obtained
+        via /wallet/transaction/generate are not reserving inputs, so clients
+        broadcasting transactions themselves should not generate conflicting
+        transactions)
       operationId: walletTransactionGenerateAndSend
       tags:
         - wallet
@@ -5026,6 +5032,12 @@ paths:
       security:
         - ApiKeyAuth: [api_key]
       summary: Generate and send payment transaction (default fee of 0.001 Erg is used)
+      description: Inputs of the generated transaction are reserved, so they are not
+        selected by consequent send requests; the reservation is lifted when the
+        transaction gets into the mempool or is rejected by it (transactions obtained
+        via /wallet/transaction/generate are not reserving inputs, so clients
+        broadcasting transactions themselves should not generate conflicting
+        transactions)
       operationId: walletPaymentTransactionGenerateAndSend
       tags:
         - wallet

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -159,11 +159,27 @@ case class WalletApiRoute(readersHolder: ActorRef,
                                             inputsRaw: Seq[String],
                                             dataInputsRaw: Seq[String],
                                             verifyFn: ErgoTransaction => Future[Try[UnconfirmedTransaction]],
-                                            processFn: UnconfirmedTransaction => Route): Route = {
-    withWalletOp(_.generateTransaction(requests, inputsRaw, dataInputsRaw).flatMap(txTry => txTry match {
-      case Success(tx) => verifyFn(tx)
-      case Failure(e) => Future(Failure[UnconfirmedTransaction](e))
-    })) {
+                                            processFn: UnconfirmedTransaction => Route,
+                                            send: Boolean): Route = {
+    withWalletOp { w =>
+      val generationF =
+        if (send) {
+          w.generateTransactionForSend(requests, inputsRaw, dataInputsRaw)
+        } else {
+          w.generateTransaction(requests, inputsRaw, dataInputsRaw)
+        }
+      generationF.flatMap {
+        case Success(tx) =>
+          verifyFn(tx).map {
+            case f@Failure(_) if send =>
+              // transaction is not going to be broadcast, releasing inputs reserved for it
+              w.releaseReservedInputs(tx.id)
+              f
+            case other => other
+          }
+        case Failure(e) => Future(Failure[UnconfirmedTransaction](e))
+      }
+    } {
       case Failure(e) => BadRequest(s"Bad request $requests. ${Option(e.getMessage).getOrElse(e.toString)}")
       case Success(tx) => processFn(tx)
     }
@@ -177,7 +193,8 @@ case class WalletApiRoute(readersHolder: ActorRef,
       inputsRaw,
       dataInputsRaw,
       tx => Future(Success(UnconfirmedTransaction(tx, source = None))),
-      utx => ApiResponse(utx.transaction)
+      utx => ApiResponse(utx.transaction),
+      send = false
     )
   }
 
@@ -195,7 +212,8 @@ case class WalletApiRoute(readersHolder: ActorRef,
                               dataInputsRaw: Seq[String]): Route = {
     generateTransactionAndProcess(requests, inputsRaw, dataInputsRaw,
       tx => verifyTransaction(tx, readersHolder, ergoSettings),
-      validTx => sendLocalTransactionRoute(nodeViewActorRef, validTx)
+      validTx => sendLocalTransactionRoute(nodeViewActorRef, validTx),
+      send = true
     )
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -4,7 +4,8 @@ import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor._
 import akka.pattern.StatusReply
 import org.ergoplatform.ErgoBox._
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState}
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState, DeclinedTransaction, FailedTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.ErgoStateReader
@@ -64,6 +65,10 @@ class ErgoWalletActor(settings: ErgoSettings,
       case Success(state) =>
         context.system.eventStream.subscribe(self, classOf[ChangedState])
         context.system.eventStream.subscribe(self, classOf[ChangedMempool])
+        // transactions rejected by the mempool are releasing inputs possibly reserved
+        // for them during generation
+        context.system.eventStream.subscribe(self, classOf[FailedTransaction])
+        context.system.eventStream.subscribe(self, classOf[DeclinedTransaction])
         self ! ReadWallet(state)
       case Failure(ex) =>
         log.error("Unable to initialize wallet", ex)
@@ -226,8 +231,11 @@ class ErgoWalletActor(settings: ErgoSettings,
       val dustLimit = settings.walletSettings.dustLimit
       val newWalletBoxes = WalletScanLogic.extractWalletOutputs(tx, None, state.walletVars, dustLimit)
       val inputs = WalletScanLogic.extractInputBoxes(tx)
-      val newState = state.copy(offChainRegistry =
-        state.offChainRegistry.updateOnTransaction(newWalletBoxes, inputs, state.walletVars.externalScans)
+      val newState = state.copy(
+        offChainRegistry =
+          state.offChainRegistry.updateOnTransaction(newWalletBoxes, inputs, state.walletVars.externalScans),
+        // inputs possibly reserved for the transaction are tracked by the registry now
+        reservedInputs = state.reservedInputs - tx.id
       )
       context.become(loadedWallet(newState))
 
@@ -273,7 +281,17 @@ class ErgoWalletActor(settings: ErgoSettings,
                 log.error(errorMsg, ex)
                 state.copy(error = Some(errorMsg))
               case Success(updatedState) =>
-                updatedState
+                // recent input reservations are kept, so send requests being verified and
+                // broadcast outside of the wallet stay protected across block boundaries;
+                // only reservations old enough to be provably leaked are dropped, e.g. left
+                // by a send request which died between generation and broadcast (reservations
+                // of transactions which got to the mempool are already removed by ScanOffChain)
+                val prunedReservations = updatedState.reservedInputs.filter {
+                  case (_, reservation) =>
+                    updatedState.getWalletHeight - reservation.height <=
+                      ErgoWalletActor.ReservedInputsTtlBlocks
+                }
+                updatedState.copy(reservedInputs = prunedReservations)
             }
           context.become(loadedWallet(newState))
         } else if (nextBlockHeight < newBlock.height) {
@@ -363,9 +381,34 @@ class ErgoWalletActor(settings: ErgoSettings,
       val status = WalletStatus(isSecretSet, isUnlocked, changeAddress, height, lastError)
       sender() ! status
 
-    case GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign) =>
+    case GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign, reserveInputs) =>
       val txTry = ergoWalletService.generateTransaction(state, boxSelector, requests, inputsRaw, dataInputsRaw, sign)
+      txTry match {
+        case Success(tx: ErgoTransaction) if reserveInputs =>
+          // reserve inputs, so transactions generated before this one is accepted to the
+          // mempool (and scanned via ScanOffChain) can not double-spend them
+          log.info(s"Reserving inputs of generated transaction ${tx.id}")
+          val reservation =
+            ErgoWalletState.ReservedInputs(state.getWalletHeight, WalletScanLogic.extractInputBoxes(tx))
+          context.become(
+            loadedWallet(state.copy(reservedInputs = state.reservedInputs + (tx.id -> reservation)))
+          )
+        case _ =>
+      }
       sender() ! txTry
+
+    case ReleaseReservedInputs(txId) =>
+      if (state.reservedInputs.contains(txId)) {
+        log.info(s"Releasing reserved inputs of transaction $txId")
+        context.become(loadedWallet(state.copy(reservedInputs = state.reservedInputs - txId)))
+      }
+
+    // transaction rejected by the mempool, releasing inputs possibly reserved for it
+    case FailedTransaction(utx, _) =>
+      self ! ReleaseReservedInputs(utx.id)
+
+    case DeclinedTransaction(utx) =>
+      self ! ReleaseReservedInputs(utx.id)
 
     case GenerateCommitmentsFor(unsignedTx, externalSecretsOpt, externalInputsOpt, externalDataInputsOpt) =>
       val resultTry = ergoWalletService.generateCommitments(state, unsignedTx, externalSecretsOpt, externalInputsOpt, externalDataInputsOpt)
@@ -502,6 +545,14 @@ class ErgoWalletActor(settings: ErgoSettings,
 }
 
 object ErgoWalletActor extends ScorexLogging {
+
+  /**
+    * For how many blocks input reservations of generated transactions are kept.
+    * Reservations are normally removed when the transaction gets to the mempool or is
+    * rejected, so only leaked ones (e.g. left by a send request which died between
+    * generation and broadcast) live that long
+    */
+  val ReservedInputsTtlBlocks: Int = 2
 
   /** Start actor and register its proper closing into coordinated shutdown */
   def apply(settings: ErgoSettings,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -65,11 +65,31 @@ object ErgoWalletActorMessages {
    * @param inputsRaw
    * @param dataInputsRaw
    * @param sign
+   * @param reserveInputs - reserve inputs of the generated transaction, so consequent
+   *                        generation requests will not select them. Used by the send API
+   *                        endpoints which broadcast the transaction right away; pure
+   *                        generation endpoints do not reserve anything, so clients
+   *                        broadcasting transactions themselves are responsible for not
+   *                        generating conflicting transactions. A reservation is converted
+   *                        into normal off-chain state once the transaction gets into the
+   *                        mempool, and released when the transaction is rejected by the
+   *                        mempool or via ReleaseReservedInputs; leaked reservations are
+   *                        pruned after ErgoWalletActor.ReservedInputsTtlBlocks blocks
    */
   final case class GenerateTransaction(requests: Seq[TransactionGenerationRequest],
                                        inputsRaw: Seq[String],
                                        dataInputsRaw: Seq[String],
-                                       sign: Boolean)
+                                       sign: Boolean,
+                                       reserveInputs: Boolean)
+
+  /**
+   * Release inputs reserved during transaction generation, making them available to
+   * consequent generation requests (used when a generated transaction is not sent
+   * to the mempool, e.g. it failed verification)
+   *
+   * @param txId - identifier of a transaction which inputs are to be released
+   */
+  final case class ReleaseReservedInputs(txId: ModifierId)
 
   /**
    * Request to generate commitments for an unsigned transaction

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -100,8 +100,28 @@ trait ErgoWalletReader extends NodeViewComponent {
   def generateTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
                           dataInputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
-    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = true))
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = true, reserveInputs = false))
       .mapTo[Try[ErgoTransaction]]
+
+  /**
+    * Generate signed transaction which is going to be broadcast right away. Unlike
+    * `generateTransaction`, inputs of the transaction are reserved, so consequent
+    * generation requests will not select them and can not produce a double-spend.
+    * If the transaction is not sent to the mempool afterwards, the reservation
+    * must be released via `releaseReservedInputs`
+    */
+  def generateTransactionForSend(requests: Seq[TransactionGenerationRequest],
+                                 inputsRaw: Seq[String] = Seq.empty,
+                                 dataInputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = true, reserveInputs = true))
+      .mapTo[Try[ErgoTransaction]]
+
+  /**
+    * Release inputs reserved by `generateTransactionForSend`, to be called when the
+    * generated transaction is not sent to the mempool (e.g. it failed verification)
+    */
+  def releaseReservedInputs(txId: ModifierId): Unit =
+    walletActor ! ReleaseReservedInputs(txId)
 
   def generateCommitmentsFor(unsignedErgoTransaction: UnsignedErgoTransaction,
                              externalSecretsOpt: Option[Seq[ExternalSecret]],
@@ -114,7 +134,8 @@ trait ErgoWalletReader extends NodeViewComponent {
   def generateUnsignedTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
                           dataInputsRaw: Seq[String] = Seq.empty): Future[Try[UnsignedErgoTransaction]] =
-    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = false)).mapTo[Try[UnsignedErgoTransaction]]
+    (walletActor ? GenerateTransaction(requests, inputsRaw, dataInputsRaw, sign = false, reserveInputs = false))
+      .mapTo[Try[UnsignedErgoTransaction]]
 
 
   def signTransaction(tx: UnsignedErgoTransaction,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -6,12 +6,12 @@ import org.ergoplatform._
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoStateContext, ErgoStateReader, UtxoStateReader}
-import org.ergoplatform.nodeView.wallet.ErgoWalletState.FilterFn
+import org.ergoplatform.nodeView.wallet.ErgoWalletState.{FilterFn, ReservedInputs}
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.boxes.{BoxSelector, TrackedBox}
 import org.ergoplatform.wallet.secrets.JsonSecretStorage
-import scorex.util.ScorexLogging
+import scorex.util.{ModifierId, ScorexLogging}
 
 import scala.util.Try
 
@@ -28,8 +28,15 @@ case class ErgoWalletState(
     parameters: Parameters,
     maxInputsToUse: Int,
     error: Option[String] = None,
-    rescanInProgress: Boolean
+    rescanInProgress: Boolean,
+    // inputs of generated transactions not known to be in the mempool yet, txId -> reservation;
+    // a reservation is converted into normal off-chain state when the transaction is scanned
+    // off-chain, and removed when the transaction is rejected by the mempool
+    reservedInputs: Map[ModifierId, ReservedInputs] = Map.empty
   ) extends ScorexLogging {
+
+  private lazy val reservedBoxIds: Set[IdUtils.EncodedBoxId] =
+    reservedInputs.values.flatMap(_.boxIds).toSet
 
   /**
     * This filter is selecting boxes which are onchain and not spent offchain yet or created offchain
@@ -44,6 +51,11 @@ case class ErgoWalletState(
     }
 
     val bid = trackedBox.box.id
+
+    // check that box is not an input of a generated transaction not in the mempool yet
+    def notReserved: Boolean = {
+      !reservedBoxIds.contains(IdUtils.EncodedBoxId @@@ trackedBox.boxId)
+    }
 
     // double-check that box is not spent yet by inputs of mempool transactions
     def notInInputs: Boolean = {
@@ -60,7 +72,7 @@ case class ErgoWalletState(
       }
     }
 
-    preStatus && notInInputs && inOutputs
+    preStatus && notReserved && notInInputs && inOutputs
   }
 
   // Secret is set in form of keystore file of testMnemonic in the config
@@ -127,6 +139,15 @@ case class ErgoWalletState(
 }
 
 object ErgoWalletState {
+
+  /**
+    * Inputs reserved by a generated transaction until the transaction is known to the
+    * mempool
+    *
+    * @param height - wallet height at the moment of reservation
+    * @param boxIds - ids of reserved input boxes
+    */
+  final case class ReservedInputs(height: Height, boxIds: Seq[IdUtils.EncodedBoxId])
 
   private type FilterFn = TrackedBox => Boolean
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -1,7 +1,8 @@
 package org.ergoplatform.nodeView.wallet
 
 import org.ergoplatform._
-import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.FailedTransaction
 import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
 import org.ergoplatform.nodeView.wallet.IdUtils._
 import org.ergoplatform.nodeView.wallet.persistence.{WalletDigest, WalletDigestSerializer}
@@ -91,6 +92,99 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
         tx3.inputs.foreach { in =>
           tx2.inputs.exists(tx2In => tx2In.boxId sameElements in.boxId) shouldBe false
         }
+      }
+    }
+  }
+
+  property("do not select inputs reserved by a previous generation request") {
+    withFixture { implicit w =>
+      val address = getPublicKeys.head
+      val genesisBlock = makeGenesisBlock(address.pubkey)
+      applyBlock(genesisBlock) shouldBe 'success
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.second, 100.millis)
+      val confirmedBalance = eventually {
+        val balance = getConfirmedBalances.walletBalance
+        balance should be > 0L
+        balance
+      }
+      // spend the whole confirmed balance, so a second request can not pick other on-chain boxes
+      val req = Seq(PaymentRequest(address, confirmedBalance, Array.empty, Map.empty))
+      val tx1 = await(wallet.generateTransactionForSend(req)).get
+      // immediate second request, no off-chain scan or mempool update happened in between;
+      // without input reservation it would select the same inputs as tx1 (double-spend),
+      // with inputs of tx1 reserved there is nothing to spend until tx1 is in the mempool
+      val tx2Try = await(wallet.generateTransactionForSend(req))
+      tx2Try shouldBe 'failure
+      // rejection of the transaction by the mempool releases the reservation
+      w.actorSystem.eventStream.publish(
+        FailedTransaction(UnconfirmedTransaction(tx1, source = None), new Exception("rejected"))
+      )
+      val tx2 = eventually {
+        await(wallet.generateTransactionForSend(req)).get
+      }
+      // releasing the reservation explicitly (as the send endpoint does when a generated
+      // transaction fails verification) also makes the inputs available again
+      await(wallet.generateTransactionForSend(req)) shouldBe 'failure
+      wallet.releaseReservedInputs(tx2.id)
+      val tx3 = eventually {
+        await(wallet.generateTransactionForSend(req)).get
+      }
+      tx3.inputs.foreach { in =>
+        tx1.inputs.exists(_.boxId sameElements in.boxId) shouldBe true
+      }
+      // reservation is converted into normal off-chain state when the transaction
+      // gets into the mempool
+      wallet.scanOffchain(tx3)
+      eventually {
+        getBalancesWithUnconfirmed.walletBalance shouldBe confirmedBalance
+      }
+    }
+  }
+
+  property("input reservations survive a block and are pruned after TTL") {
+    withFixture { implicit w =>
+      val address = getPublicKeys.head
+      val genesisBlock = makeGenesisBlock(address.pubkey)
+      applyBlock(genesisBlock) shouldBe 'success
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.second, 100.millis)
+      eventually {
+        getConfirmedBalances.walletBalance should be > 0L
+      }
+
+      // seed a chain of anyone-can-spend boxes for building filler blocks
+      // which do not touch wallet boxes
+      val seedTx = await(wallet.generateTransaction(
+        Seq(PaymentRequest(Pay2SAddress(TrueTree), MinBoxValue, Array.empty, Map.empty))
+      )).get
+      val seedBlock = makeNextBlock(getUtxoState, Seq(seedTx))
+      applyBlock(seedBlock) shouldBe 'success
+      val confirmedBalance = eventually {
+        getConfirmedBalances.height shouldBe seedBlock.height
+        getConfirmedBalances.walletBalance
+      }
+
+      var fillerBox = seedTx.outputs.find(_.ergoTree.bytes sameElements TrueTree.bytes).get
+      def applyFillerBlock(): Int = {
+        val fillerTx = makeTx(Seq(fillerBox), emptyProverResult, fillerBox.value, TrueTree)
+        fillerBox = fillerTx.outputs.head
+        val block = makeNextBlock(getUtxoState, Seq(fillerTx))
+        applyBlock(block) shouldBe 'success
+        block.height
+      }
+
+      val req = Seq(PaymentRequest(address, confirmedBalance, Array.empty, Map.empty))
+      await(wallet.generateTransactionForSend(req)) shouldBe 'success
+      // a fresh reservation is not dropped by a block boundary, so send requests being
+      // verified or broadcast when a block arrives stay protected
+      val height1 = applyFillerBlock()
+      eventually {
+        getConfirmedBalances.height shouldBe height1
+        await(wallet.generateTransactionForSend(req)) shouldBe 'failure
+      }
+      // a reservation whose transaction never got to the mempool is pruned after TTL
+      (0 until ErgoWalletActor.ReservedInputsTtlBlocks).foreach(_ => applyFillerBlock())
+      eventually {
+        await(wallet.generateTransactionForSend(req)) shouldBe 'success
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -260,7 +260,7 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
       case ReadScans =>
         sender() ! ReadScansResponse(apps.values.toSeq)
 
-      case GenerateTransaction(_, _, _, _) =>
+      case GenerateTransaction(_, _, _, _, _) =>
         val input = inputGen.sample.value
         val tx = ErgoTransaction(IndexedSeq(input), IndexedSeq(ergoBoxCandidateGen.sample.value))
         sender() ! Success(tx)


### PR DESCRIPTION
Closes #1211 

## Summary

When two `/wallet/payment/send` or `/wallet/transaction/send` requests arrive faster than the mempool acceptance roundtrip, both calls see identical unspent boxes and generate conflicting transactions. This PR closes the race atomically using the wallet actor's existing message-serialization guarantee.

**Root cause:** `GenerateTransaction` selected boxes from the current actor state but never updated it. The state update only came later via the async `ScanOffChain` message, leaving a window where any queued `GenerateTransaction` could pick the same boxes.

**Fix:** On send endpoints, after a successful generation the actor stamps the selected inputs as *reserved* (`ErgoWalletState.reservedInputs`) and calls `context.become` before replying. Because the actor processes one message at a time, the next `GenerateTransaction` already sees the reservation in `walletFilter.notReserved` — no locks, no extra synchronization.

**Reservation lifecycle** (all paths covered):
- `ScanOffChain` (mempool accepted) — converts reservation to normal off-chain state
- `FailedTransaction` / `DeclinedTransaction` events — releases reservation immediately
- Route verify/broadcast failure — explicit `releaseReservedInputs` call before returning the error
- TTL prune on `ScanOnChain` (block scan) — releases any leaked reservation older than 2 blocks

**Scope:** only `/wallet/payment/send` and `/wallet/transaction/send` reserve inputs. `/wallet/transaction/generate` and `/wallet/transaction/generateUnsigned` remain side-effect-free — clients that broadcast externally own their own sequencing.

**Limitations:**
- Two concurrent sends that both supply the **same explicit `inputsRaw`** can still conflict; explicit-input callers are responsible for their own sequencing.
- Reservations are in-memory only — a node restart drops them; the mempool `spentInputs` check resumes protecting against double-spends once readers reconnect.
- A reservation created just before a node crash or pipeline hang will block those inputs for up to 2 blocks (~4 min) before the TTL prune recovers them.

Two new properties in `ErgoWalletSpec`:
1. Second `generateTransactionForSend` fails while first is reserved; `FailedTransaction` event and explicit `releaseReservedInputs` both restore selectability.
2. Reservation survives a block boundary (protecting in-flight sends) and is pruned after `ReservedInputsTtlBlocks = 2` blocks (recovering from crashed pipelines).