### PR TITLE
Add optional HTTPS/TLS support for the REST API

### DIFF
--- a/docs/https-api.md
+++ b/docs/https-api.md
@@ -1,0 +1,143 @@
+# Serving the node REST API over HTTPS
+
+By default the Ergo node serves its REST API over plain HTTP. Anyone able to
+observe the traffic between a client and the node can read the `api_key` header
+and any other sensitive data. To protect the API in transit you can either:
+
+1. **Terminate TLS at a reverse proxy** (nginx, Caddy, Traefik, …) in front of
+   the node — recommended for public deployments, and
+2. **Let the node terminate TLS itself** via the built-in HTTPS support
+   described below — convenient when you don't want to run a proxy.
+
+The node loads its certificate and private key from a Java keystore (PKCS12 or
+JKS). This guide covers both approaches.
+
+## Reverse proxy (TLS termination)
+
+Recommended for public deployments: run nginx/Caddy/Traefik in front of the node,
+let it terminate TLS, and forward requests to the node over loopback.
+
+The critical step is to **stop exposing the node's plain HTTP API directly**. The
+default `bindAddress = "0.0.0.0:9053"` listens on every interface, so even with a
+proxy in place, anyone who can reach the node's host on that port bypasses TLS and
+can intercept the `api_key`. Bind the API to loopback so only the proxy (running
+on the same host) can reach it:
+
+```hocon
+scorex {
+  restApi {
+    # Only the local reverse proxy can reach the plain HTTP API.
+    bindAddress = "127.0.0.1:9053"
+    apiKeyHash  = "<blake2b256 hash of your API key>"
+
+    # https stays disabled — the proxy terminates TLS.
+    # Advertise the proxy's public HTTPS endpoint:
+    publicUrl = "https://node.example.com"
+  }
+}
+```
+
+Additionally:
+
+- If the proxy runs on a different host, bind to the private interface the proxy
+  uses (not `0.0.0.0`) and firewall the API port so it is unreachable from the
+  public internet — e.g. `ufw deny 9053` / a security-group rule — allowing only
+  the proxy's address.
+- Configure the proxy to pass the request through unchanged (it forwards the
+  caller's `api_key` header to `http://127.0.0.1:9053`).
+
+## Native TLS in the node
+
+Convenient when you don't want to run a proxy: the node terminates TLS itself.
+
+```hocon
+scorex {
+  restApi {
+    bindAddress = "0.0.0.0:9053"
+    apiKeyHash  = "<blake2b256 hash of your API key>"
+
+    https {
+      enabled          = true
+      keyStorePath     = "/etc/ergo/ergo-api.p12"
+      # Prefer an environment variable over storing the password in the file:
+      keyStorePassword = ${?ERGO_API_KEYSTORE_PASSWORD}
+      keyStoreType     = "PKCS12"   # or "JKS"
+    }
+
+    # Advertise the HTTPS endpoint so peers/clients discover the node over TLS.
+    publicUrl = "https://node.example.com:9053"
+  }
+}
+```
+
+Notes:
+
+- When `https.enabled = false` (or the `https { }` block is absent) the API is
+  served over plain HTTP exactly as before — fully backward compatible.
+- `keyStoreType` defaults to `PKCS12` if omitted.
+- The keystore password is also used as the key (entry) password, so create the
+  keystore with a single password for both (the default for PKCS12).
+- A misconfigured keystore (missing file, wrong password/type) aborts node
+  startup with a clear configuration error before the rest of the node starts.
+- If `https.enabled = true` but `publicUrl` advertises a non-`https://` address,
+  the node **refuses to start** — clients discovering it would otherwise keep
+  sending the API key over plain HTTP. Set `publicUrl` to the matching `https://`
+  address, or, if you really intend the insecure combination, opt out explicitly
+  with `https.allowInsecurePublicUrl = true` (the node then only logs a warning).
+  TLS terminated by a reverse proxy is unaffected: leave `https.enabled = false`
+  and point `publicUrl` at the proxy's `https://` endpoint.
+- If `https.enabled = true` and `publicUrl` is unset, the node logs a warning
+  (clients won't discover the HTTPS endpoint) but still starts.
+
+## Creating a keystore
+
+### Self-signed certificate (development / private use)
+
+```bash
+keytool -genkeypair \
+  -alias ergo-api -keyalg RSA -keysize 2048 -validity 365 \
+  -storetype PKCS12 -keystore ergo-api.p12 \
+  -storepass "$ERGO_API_KEYSTORE_PASSWORD" \
+  -dname "CN=localhost" \
+  -ext "SAN=dns:localhost,ip:127.0.0.1"
+```
+
+The Subject Alternative Name (`-ext SAN=…`) is **required** by most modern
+clients and browsers — a certificate with only a `CN` is rejected. List every
+hostname and IP clients will use, e.g.
+`-ext "SAN=dns:node.example.com,dns:localhost,ip:127.0.0.1"`.
+
+### From a CA / Let's Encrypt certificate (production)
+
+Let's Encrypt (certbot) emits PEM files (`fullchain.pem`, `privkey.pem`).
+Convert them to a PKCS12 keystore with OpenSSL:
+
+```bash
+openssl pkcs12 -export \
+  -in  /etc/letsencrypt/live/node.example.com/fullchain.pem \
+  -inkey /etc/letsencrypt/live/node.example.com/privkey.pem \
+  -name ergo-api \
+  -out ergo-api.p12 \
+  -passout env:ERGO_API_KEYSTORE_PASSWORD
+```
+
+Re-run this conversion (and restart the node) on each certificate renewal.
+
+## Trusting the certificate from clients
+
+- **CA-issued certificate:** clients (curl, browsers, SDKs) trust it
+  automatically — no extra steps.
+- **Self-signed certificate:** clients will reject it unless they trust it
+  explicitly. Do **not** disable certificate verification in production (e.g.
+  `curl -k`), as that re-opens the interception risk this feature prevents.
+  Instead, distribute the certificate and add it to the client's trust store:
+
+  ```bash
+  # Export the certificate from the keystore:
+  keytool -exportcert -rfc -alias ergo-api \
+    -keystore ergo-api.p12 -storetype PKCS12 \
+    -storepass "$ERGO_API_KEYSTORE_PASSWORD" -file ergo-api.crt
+
+  # Then pin/trust it from the client, e.g. with curl:
+  curl --cacert ergo-api.crt https://node.example.com:9053/info
+  ```

--- a/ergo-core/src/main/scala/org/ergoplatform/settings/Settings.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/Settings.scala
@@ -12,12 +12,21 @@ import scala.concurrent.duration._
 
 case class LoggingSettings(level: String)
 
+case class ApiHttpsSettings(
+  enabled: Boolean,
+  keyStorePath: Option[String],
+  keyStorePassword: Option[String],
+  keyStoreType: Option[String],
+  allowInsecurePublicUrl: Option[Boolean]
+)
+
 case class RESTApiSettings(
   bindAddress: InetSocketAddress,
   apiKeyHash: Option[String],
   corsAllowedOrigin: Option[String],
   timeout: FiniteDuration,
-  publicUrl: Option[URL]
+  publicUrl: Option[URL],
+  https: Option[ApiHttpsSettings] = None
 )
 
 case class NetworkSettings(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -432,6 +432,29 @@ scorex {
 
     # node which exposes restApi in firewall should define publicly accessible URL of it
     # publicUrl = "https://example.com:80"
+
+    # Optional: serve the REST API over HTTPS/TLS instead of plain HTTP.
+    # When omitted or disabled, the API is served over plain HTTP (terminate TLS
+    # with a reverse proxy in that case). See docs/https-api.md for a full guide,
+    # including PKCS12 creation, converting Let's Encrypt PEM files, and client trust.
+    #
+    # Quick start - generate a self-signed keystore for local use (the SAN is
+    # required by modern clients; list every hostname/IP clients will connect to):
+    #   keytool -genkeypair -alias ergo-api -keyalg RSA -keysize 2048 -validity 365 \
+    #     -storetype PKCS12 -keystore ergo-api.p12 -storepass changeit \
+    #     -dname "CN=localhost" -ext "SAN=dns:localhost,ip:127.0.0.1"
+    #
+    # https {
+    #   enabled = true
+    #   keyStorePath = "/path/to/ergo-api.p12"
+    #   # Prefer supplying the password via an environment variable rather than in the file:
+    #   keyStorePassword = ${?ERGO_API_KEYSTORE_PASSWORD}
+    #   keyStoreType = "PKCS12"
+    # }
+    #
+    # If https is enabled, set publicUrl to the matching https:// address so peers
+    # and clients discover the node over HTTPS:
+    # publicUrl = "https://example.com:9053"
   }
 
   # P2P Network settings

--- a/src/main/resources/samples/local.conf.sample
+++ b/src/main/resources/samples/local.conf.sample
@@ -45,5 +45,22 @@ scorex {
 
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
     # apiKeyHash = "1111"
+
+    # Serve the REST API over HTTPS/TLS to protect the API key in transit.
+    # See docs/https-api.md for keystore creation and Let's Encrypt conversion.
+    # Generate a self-signed keystore for local use (the SAN is required by modern
+    # clients; list every hostname/IP clients will connect to):
+    #   keytool -genkeypair -alias ergo-api -keyalg RSA -keysize 2048 -validity 365 \
+    #     -storetype PKCS12 -keystore ergo-api.p12 -storepass changeit \
+    #     -dname "CN=localhost" -ext "SAN=dns:localhost,ip:127.0.0.1"
+    # https {
+    #   enabled = true
+    #   keyStorePath = "/path/to/ergo-api.p12"
+    #   keyStorePassword = ${?ERGO_API_KEYSTORE_PASSWORD}
+    #   keyStoreType = "PKCS12"
+    # }
+
+    # When https is enabled, advertise the matching https:// endpoint:
+    # publicUrl = "https://example.com:9053"
   }
 }

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -4,6 +4,7 @@ import akka.Done
 import akka.actor.{ActorRef, ActorSystem, CoordinatedShutdown}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.HttpsConnectionContext
 import org.ergoplatform.http._
 import org.ergoplatform.http.api._
 import org.ergoplatform.local._
@@ -13,7 +14,13 @@ import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ErgoSyncTracker}
 import org.ergoplatform.nodeView.history.ErgoSyncInfoMessageSpec
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
-import org.ergoplatform.settings.{Args, ErgoSettings, ErgoSettingsReader, NetworkType, ScorexSettings}
+import org.ergoplatform.settings.{
+  Args,
+  ErgoSettings,
+  ErgoSettingsReader,
+  NetworkType,
+  ScorexSettings
+}
 import scorex.core.api.http._
 import scorex.core.app.ScorexContext
 import scorex.core.network.NetworkController.ReceivableMessages.ShutdownNetwork
@@ -46,6 +53,14 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   implicit private def scorexSettings: ScorexSettings = ergoSettings.scorexSettings
 
+  // Build the REST API TLS context eagerly so a misconfigured keystore aborts
+  // startup cleanly here, before the actor system is bootstrapped.
+  private val apiHttpsContext: Option[HttpsConnectionContext] =
+    scorexSettings.restApi.https match {
+      case Some(https) if https.enabled => Some(ApiHttpsContext.fromSettings(https))
+      case _                            => None
+    }
+
   implicit private val actorSystem: ActorSystem = ActorSystem(
     scorexSettings.network.agentName
   )
@@ -61,7 +76,10 @@ class ErgoApp(args: Args) extends ScorexLogging {
   private val externalSocketAddress: Option[InetSocketAddress] = {
     scorexSettings.network.declaredAddress orElse {
       upnpGateway.map(u =>
-        new InetSocketAddress(u.externalAddress, scorexSettings.network.bindAddress.getPort)
+        new InetSocketAddress(
+          u.externalAddress,
+          scorexSettings.network.bindAddress.getPort
+        )
       )
     }
   }
@@ -130,15 +148,15 @@ class ErgoApp(args: Args) extends ScorexLogging {
         ModifiersSpec.messageCode           -> ergoNodeViewSynchronizerRef,
         ErgoSyncInfoMessageSpec.messageCode -> ergoNodeViewSynchronizerRef,
         // utxo set snapshot exchange related messages
-        GetSnapshotsInfoSpec.messageCode    -> ergoNodeViewSynchronizerRef,
-        SnapshotsInfoSpec.messageCode       -> ergoNodeViewSynchronizerRef,
-        GetManifestSpec.messageCode         -> ergoNodeViewSynchronizerRef,
-        ManifestSpec.messageCode            -> ergoNodeViewSynchronizerRef,
-        GetUtxoSnapshotChunkSpec.messageCode-> ergoNodeViewSynchronizerRef,
-        UtxoSnapshotChunkSpec.messageCode   -> ergoNodeViewSynchronizerRef,
+        GetSnapshotsInfoSpec.messageCode     -> ergoNodeViewSynchronizerRef,
+        SnapshotsInfoSpec.messageCode        -> ergoNodeViewSynchronizerRef,
+        GetManifestSpec.messageCode          -> ergoNodeViewSynchronizerRef,
+        ManifestSpec.messageCode             -> ergoNodeViewSynchronizerRef,
+        GetUtxoSnapshotChunkSpec.messageCode -> ergoNodeViewSynchronizerRef,
+        UtxoSnapshotChunkSpec.messageCode    -> ergoNodeViewSynchronizerRef,
         // nipopows exchange related messages
-        GetNipopowProofSpec.messageCode     -> ergoNodeViewSynchronizerRef,
-        NipopowProofSpec.messageCode        -> ergoNodeViewSynchronizerRef
+        GetNipopowProofSpec.messageCode -> ergoNodeViewSynchronizerRef,
+        NipopowProofSpec.messageCode    -> ergoNodeViewSynchronizerRef
       )
       // Launching PeerSynchronizer actor which is then registering itself at network controller
       if (ergoSettings.scorexSettings.network.peerDiscovery) {
@@ -181,26 +199,26 @@ class ErgoApp(args: Args) extends ScorexLogging {
     }
 
   private val apiRoutes: Seq[ApiRoute] = Seq(
-    EmissionApiRoute(ergoSettings),
-    ErgoUtilsApiRoute(ergoSettings),
-    BlockchainApiRoute(readersHolderRef, ergoSettings, indexerOpt),
-    ErgoPeersApiRoute(
-      peerManagerRef,
-      networkControllerRef,
-      syncTracker,
-      deliveryTracker,
-      scorexSettings.restApi
-    ),
-    InfoApiRoute(statsCollectorRef, scorexSettings.restApi),
-    BlocksApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
-    NipopowApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
-    TransactionsApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
-    WalletApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
-    UtxoApiRoute(readersHolderRef, scorexSettings.restApi),
-    ScriptApiRoute(readersHolderRef, ergoSettings),
-    ScanApiRoute(readersHolderRef, ergoSettings),
-    NodeApiRoute(ergoSettings)
-  ) ++ minerRefOpt.map(minerRef => MiningApiRoute(minerRef, ergoSettings)).toSeq
+      EmissionApiRoute(ergoSettings),
+      ErgoUtilsApiRoute(ergoSettings),
+      BlockchainApiRoute(readersHolderRef, ergoSettings, indexerOpt),
+      ErgoPeersApiRoute(
+        peerManagerRef,
+        networkControllerRef,
+        syncTracker,
+        deliveryTracker,
+        scorexSettings.restApi
+      ),
+      InfoApiRoute(statsCollectorRef, scorexSettings.restApi),
+      BlocksApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
+      NipopowApiRoute(nodeViewHolderRef, readersHolderRef, ergoSettings),
+      TransactionsApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
+      WalletApiRoute(readersHolderRef, nodeViewHolderRef, ergoSettings),
+      UtxoApiRoute(readersHolderRef, scorexSettings.restApi),
+      ScriptApiRoute(readersHolderRef, ergoSettings),
+      ScanApiRoute(readersHolderRef, ergoSettings),
+      NodeApiRoute(ergoSettings)
+    ) ++ minerRefOpt.map(minerRef => MiningApiRoute(minerRef, ergoSettings)).toSeq
 
   private val swaggerRoute = SwaggerRoute(scorexSettings.restApi, swaggerConfig)
   private val panelRoute   = NodePanelRoute()
@@ -253,10 +271,19 @@ class ErgoApp(args: Args) extends ScorexLogging {
     }
 
     val bindAddress = scorexSettings.restApi.bindAddress
-
-    Http()
+    val builder = Http()
       .newServerAt(bindAddress.getAddress.getHostAddress, bindAddress.getPort)
-      .bindFlow(httpService.compositeRoute)
+
+    val configuredBuilder = apiHttpsContext match {
+      case Some(httpsContext) =>
+        log.info(s"Serving REST API over HTTPS at ${bindAddress.toString}")
+        builder.enableHttps(httpsContext)
+      case None =>
+        log.info(s"Serving REST API over HTTP at ${bindAddress.toString}")
+        builder
+    }
+
+    configuredBuilder.bindFlow(httpService.compositeRoute)
   }
 }
 
@@ -289,8 +316,6 @@ object ErgoApp extends ScorexLogging {
 
   /** Intentional user invoked remote shutdown */
   case object RemoteShutdown extends CoordinatedShutdown.Reason
-
-
 
   /** hard application exit in case actor system is not started yet*/
   def forceStopApplication(code: Int = 1): Nothing = sys.exit(code)

--- a/src/main/scala/org/ergoplatform/http/ApiHttpsContext.scala
+++ b/src/main/scala/org/ergoplatform/http/ApiHttpsContext.scala
@@ -1,0 +1,71 @@
+package org.ergoplatform.http
+
+import akka.http.scaladsl.{ConnectionContext, HttpsConnectionContext}
+import org.ergoplatform.settings.ApiHttpsSettings
+import scorex.util.ScorexLogging
+
+import java.io.FileInputStream
+import java.security.{KeyStore, SecureRandom}
+import javax.net.ssl.{KeyManagerFactory, SSLContext}
+import scala.util.control.NonFatal
+
+/**
+  * Builds a server-side TLS context for the REST API from a Java keystore
+  * (PKCS12 or JKS) holding the server certificate and private key.
+  */
+object ApiHttpsContext extends ScorexLogging {
+
+  private val DefaultKeyStoreType = "PKCS12"
+
+  /**
+    * Build the HTTPS context from settings, failing fast with a clear,
+    * operator-facing message if the keystore is misconfigured or unreadable.
+    * Intended to be called during startup, before the rest of the node is
+    * bootstrapped, so a bad configuration aborts cleanly.
+    */
+  def fromSettings(settings: ApiHttpsSettings): HttpsConnectionContext = {
+    val keyStorePath = settings.keyStorePath.getOrElse(
+      configError(
+        "scorex.restApi.https.keyStorePath must be set when https.enabled = true"
+      )
+    )
+    val password = settings.keyStorePassword
+      .getOrElse(
+        configError(
+          "scorex.restApi.https.keyStorePassword must be set when https.enabled = true"
+        )
+      )
+      .toCharArray
+    val keyStoreType = settings.keyStoreType.getOrElse(DefaultKeyStoreType)
+
+    try {
+      val keyStore       = KeyStore.getInstance(keyStoreType)
+      val keyStoreStream = new FileInputStream(keyStorePath)
+      try {
+        keyStore.load(keyStoreStream, password)
+      } finally {
+        keyStoreStream.close()
+      }
+
+      val keyManagerFactory = KeyManagerFactory.getInstance(
+        KeyManagerFactory.getDefaultAlgorithm
+      )
+      keyManagerFactory.init(keyStore, password)
+
+      val sslContext = SSLContext.getInstance("TLS")
+      sslContext.init(keyManagerFactory.getKeyManagers, null, new SecureRandom)
+
+      log.info(s"Loaded REST API TLS keystore from $keyStorePath")
+      ConnectionContext.httpsServer(sslContext)
+    } catch {
+      case NonFatal(e) =>
+        configError(
+          s"Failed to initialize REST API HTTPS from keystore '$keyStorePath' " +
+          s"(type $keyStoreType): ${e.getMessage}"
+        )
+    }
+  }
+
+  private def configError(msg: String): Nothing =
+    throw new IllegalArgumentException(s"Malformed REST API HTTPS configuration: $msg")
+}

--- a/src/main/scala/org/ergoplatform/settings/ErgoSettingsReader.scala
+++ b/src/main/scala/org/ergoplatform/settings/ErgoSettingsReader.scala
@@ -18,7 +18,8 @@ import scala.util.Try
 /**
   * Functions to read configs (ErgoSettings instances)
   */
-object ErgoSettingsReader extends ScorexLogging
+object ErgoSettingsReader
+  extends ScorexLogging
   with PowSchemeReaders
   with NodeConfigurationReaders
   with SettingsReaders {
@@ -27,22 +28,28 @@ object ErgoSettingsReader extends ScorexLogging
     fromConfig(readConfig(args), args.networkTypeOpt)
   }
 
-  def fromConfig(config: Config, desiredNetworkTypeOpt: Option[NetworkType] = None): ErgoSettings = {
-    val directory = config.as[String](s"$configPath.directory")
+  def fromConfig(
+    config: Config,
+    desiredNetworkTypeOpt: Option[NetworkType] = None
+  ): ErgoSettings = {
+    val directory       = config.as[String](s"$configPath.directory")
     val networkTypeName = config.as[String](s"$configPath.networkType")
-    val networkType = NetworkType.fromString(networkTypeName)
+    val networkType = NetworkType
+      .fromString(networkTypeName)
       .getOrElse(throw new Error(s"Unknown `networkType = $networkTypeName`"))
-    val nodeSettings = config.as[NodeConfigurationSettings](s"$configPath.node")
-    val chainSettings = config.as[ChainSettings](s"$configPath.chain")
+    val nodeSettings   = config.as[NodeConfigurationSettings](s"$configPath.node")
+    val chainSettings  = config.as[ChainSettings](s"$configPath.chain")
     val walletSettings = config.as[WalletSettings](s"$configPath.wallet")
-    val cacheSettings = config.as[CacheSettings](s"$configPath.cache")
+    val cacheSettings  = config.as[CacheSettings](s"$configPath.cache")
     val scorexSettings = config.as[ScorexSettings](scorexConfigPath)
-    val votingTargets = VotingTargets.fromConfig(config)
+    val votingTargets  = VotingTargets.fromConfig(config)
 
     overrideLogLevel(scorexSettings.logging.level)
 
     if (nodeSettings.stateType == Digest && nodeSettings.mining) {
-      log.error("Malformed configuration file was provided! Mining is not possible with digest state. Aborting!")
+      log.error(
+        "Malformed configuration file was provided! Mining is not possible with digest state. Aborting!"
+      )
       ErgoApp.forceStopApplication()
     }
 
@@ -64,7 +71,8 @@ object ErgoSettingsReader extends ScorexLogging
   // Helper method to read user-provided `configFile` with network-specific `fallbackConfig`
   // to be used for default fallback values before reference.conf (which is the last resort)
   private def configWithOverrides(configFile: File, fallbackConfig: Option[File]) = {
-    val firstFallBack = fallbackConfig.map(ConfigFactory.parseFile).getOrElse(ConfigFactory.empty())
+    val firstFallBack =
+      fallbackConfig.map(ConfigFactory.parseFile).getOrElse(ConfigFactory.empty())
 
     val cfg = ConfigFactory.parseFile(configFile)
 
@@ -73,13 +81,19 @@ object ErgoSettingsReader extends ScorexLogging
     // Check that user-provided Ergo directory exists and has write access (if provided at all)
     val userDirOpt = Try(cfg.getString("ergo.directory")).toOption
     userDirOpt.foreach { ergoDirName =>
-      require(new File(s"$ergoDirName").canWrite, s"Folder $ergoDirName does not exist or not writable")
+      require(
+        new File(s"$ergoDirName").canWrite,
+        s"Folder $ergoDirName does not exist or not writable"
+      )
     }
 
     // Check that user-provided wallet secret directory exists and has read access (if provided at all)
     val walletKeystoreDirOpt = Try(cfg.getString(keystorePath)).toOption
     walletKeystoreDirOpt.foreach { secretDirName =>
-      require(new File(s"$secretDirName").canRead, s"Folder $secretDirName does not exist or not readable")
+      require(
+        new File(s"$secretDirName").canRead,
+        s"Folder $secretDirName does not exist or not readable"
+      )
     }
 
     val fullConfig = ConfigFactory
@@ -93,28 +107,33 @@ object ErgoSettingsReader extends ScorexLogging
     // If user provided only ergo.directory but not ergo.wallet.secretStorage.secretDir in his config,
     // set ergo.wallet.secretStorage.secretDir like in reference.conf (so ergo.directory + "/wallet/keystore")
     // Otherwise, a user may have an issue, especially with Powershell it seems from reports.
-    userDirOpt.map { userDir =>
-      if(walletKeystoreDirOpt.isEmpty) {
-        fullConfig.withValue(keystorePath, ConfigValueFactory.fromAnyRef(userDir + "/wallet/keystore"))
-      } else {
-        fullConfig
+    userDirOpt
+      .map { userDir =>
+        if (walletKeystoreDirOpt.isEmpty) {
+          fullConfig.withValue(
+            keystorePath,
+            ConfigValueFactory.fromAnyRef(userDir + "/wallet/keystore")
+          )
+        } else {
+          fullConfig
+        }
       }
-    }.getOrElse(fullConfig)
+      .getOrElse(fullConfig)
   }
 
   private def readConfig(args: Args): Config = {
 
     val networkConfigFileOpt = args.networkTypeOpt
       .flatMap { networkType =>
-        val confName = s"${networkType.verboseName}.conf"
+        val confName    = s"${networkType.verboseName}.conf"
         val classLoader = ClassLoader.getSystemClassLoader
-        val destDir = System.getProperty("java.io.tmpdir") + "/"
+        val destDir     = System.getProperty("java.io.tmpdir") + "/"
 
         Option(classLoader.getResourceAsStream(confName))
           .map { stream =>
-            val source = Channels.newChannel(stream)
+            val source  = Channels.newChannel(stream)
             val fileOut = new File(destDir, confName)
-            val dest = new FileOutputStream(fileOut)
+            val dest    = new FileOutputStream(fileOut)
             dest.getChannel.transferFrom(source, 0, Long.MaxValue)
 
             source.close()
@@ -134,8 +153,11 @@ object ErgoSettingsReader extends ScorexLogging
       if file.exists
     } yield file
 
-    networkConfigFileOpt.flatMap(_ => args.networkTypeOpt).fold(log.warn("Running without network config"))(
-      x => log.info(s"Running in ${x.verboseName} network mode"))
+    networkConfigFileOpt
+      .flatMap(_ => args.networkTypeOpt)
+      .fold(log.warn("Running without network config"))(x =>
+        log.info(s"Running in ${x.verboseName} network mode")
+      )
 
     (networkConfigFileOpt, userConfigFileOpt) match {
       // if no user config is supplied, the library will handle overrides/application/reference automatically
@@ -157,41 +179,97 @@ object ErgoSettingsReader extends ScorexLogging
   }
 
   protected[settings] def invalidRestApiUrl(url: URL): Boolean =
-    Try(url.toURI).map { uri =>
-      val inetAddress = InetAddress.getByName(url.getHost)
-      Option(uri.getQuery).exists(_.nonEmpty) ||
+    Try(url.toURI)
+      .map { uri =>
+        val inetAddress = InetAddress.getByName(url.getHost)
+        Option(uri.getQuery).exists(_.nonEmpty) ||
         Option(uri.getPath).exists(_.nonEmpty) ||
         Option(uri.getFragment).exists(_.nonEmpty) ||
         inetAddress.isAnyLocalAddress ||
         inetAddress.isLoopbackAddress ||
         inetAddress.isSiteLocalAddress
-    }.getOrElse(false)
+      }
+      .getOrElse(false)
 
-  private def consistentSettings(settings: ErgoSettings,
-                                 desiredNetworkTypeOpt: Option[NetworkType]): ErgoSettings = {
+  /** Whether the node serves TLS itself but advertises a non-HTTPS publicUrl that
+    * peers and clients would discover, letting them keep sending the API key over
+    * plain HTTP. This is treated as a fatal misconfiguration unless the operator
+    * explicitly opts out via scorex.restApi.https.allowInsecurePublicUrl = true.
+    * TLS terminated by a reverse proxy is unaffected (https.enabled is left false).
+    */
+  private def httpsWithInsecurePublicUrl(restApi: RESTApiSettings): Boolean = {
+    val allowInsecure = restApi.https.flatMap(_.allowInsecurePublicUrl).getOrElse(false)
+    restApi.https.exists(_.enabled) &&
+    !allowInsecure &&
+    restApi.publicUrl.exists(_.getProtocol != "https")
+  }
+
+  private def warnOnInsecurePublicUrl(restApi: RESTApiSettings): Unit =
+    if (restApi.https.exists(_.enabled)) {
+      val allowInsecure = restApi.https.flatMap(_.allowInsecurePublicUrl).getOrElse(false)
+      restApi.publicUrl match {
+        case Some(url) if url.getProtocol != "https" && allowInsecure =>
+          log.warn(
+            s"scorex.restApi.https is enabled but scorex.restApi.publicUrl advertises a " +
+            s"non-HTTPS URL ($url); allowed because allowInsecurePublicUrl = true, but peers " +
+            s"and clients may send the API key over plain HTTP."
+          )
+        case None =>
+          log.warn(
+            "scorex.restApi.https is enabled but scorex.restApi.publicUrl is not set; " +
+            "clients discovering this node will not learn its HTTPS endpoint."
+          )
+        case _ => // https publicUrl (ok), or non-https without opt-out (fatal, see below)
+      }
+    }
+
+  private def consistentSettings(
+    settings: ErgoSettings,
+    desiredNetworkTypeOpt: Option[NetworkType]
+  ): ErgoSettings = {
     val nodeSettings = settings.nodeSettings
+    warnOnInsecurePublicUrl(settings.scorexSettings.restApi)
     if (nodeSettings.keepVersions < 0) {
       failWithError("nodeSettings.keepVersions should not be negative")
     } else if (!nodeSettings.verifyTransactions && !nodeSettings.stateType.requireProofs) {
-      failWithError("Can not use UTXO state when nodeSettings.verifyTransactions is false")
+      failWithError(
+        "Can not use UTXO state when nodeSettings.verifyTransactions is false"
+      )
     } else if (desiredNetworkTypeOpt.exists(_ != settings.networkType)) {
-      failWithError(s"Malformed network config. Desired networkType is `${desiredNetworkTypeOpt.get}`, " +
-        s"but one declared in config is `${settings.networkType}`")
-    } else if(settings.networkType.isMainNet &&
-      nodeSettings.mining &&
-      !settings.chainSettings.reemission.checkReemissionRules) {
-      failWithError(s"Mining is enabled, but ergo.chain.reemission.checkReemissionRules = false , set it to true")
+      failWithError(
+        s"Malformed network config. Desired networkType is `${desiredNetworkTypeOpt.get}`, " +
+        s"but one declared in config is `${settings.networkType}`"
+      )
+    } else if (settings.networkType.isMainNet &&
+               nodeSettings.mining &&
+               !settings.chainSettings.reemission.checkReemissionRules) {
+      failWithError(
+        s"Mining is enabled, but ergo.chain.reemission.checkReemissionRules = false , set it to true"
+      )
     } else if (settings.scorexSettings.restApi.publicUrl.exists(invalidRestApiUrl)) {
-      failWithError(s"scorex.restApi.publicUrl should not contain query, path or fragment and should not " +
-        s"be local or loopback address : ${settings.scorexSettings.restApi.publicUrl.get}")
+      failWithError(
+        s"scorex.restApi.publicUrl should not contain query, path or fragment and should not " +
+        s"be local or loopback address : ${settings.scorexSettings.restApi.publicUrl.get}"
+      )
+    } else if (httpsWithInsecurePublicUrl(settings.scorexSettings.restApi)) {
+      failWithError(
+        s"scorex.restApi.https is enabled but scorex.restApi.publicUrl advertises a non-HTTPS " +
+        s"URL (${settings.scorexSettings.restApi.publicUrl.get}); clients discovering this node " +
+        s"would send the API key over plain HTTP. Set publicUrl to an https:// address, or set " +
+        s"scorex.restApi.https.allowInsecurePublicUrl = true to override."
+      )
     } else if (settings.nodeSettings.utxoSettings.p2pUtxoSnapshots <= 0) {
       failWithError(s"p2pUtxoSnapshots <= 0, must be 1 at least")
     } else if (settings.nodeSettings.extraIndex && settings.nodeSettings.isFullBlocksPruned) {
-      failWithError(s"Extra indexes could be enabled only if there is no blockchain pruning")
+      failWithError(
+        s"Extra indexes could be enabled only if there is no blockchain pruning"
+      )
     } else if (nodeSettings.nipopowSettings.nipopowBootstrap &&
-      !(nodeSettings.utxoSettings.utxoBootstrap || nodeSettings.blocksToKeep >= 0)) {
-      failWithError("nodeSettings.popowBootstrap can be set only if " +
-        "nodeSettings.utxoBootstrap is set or nodeSettings.blocksToKeep >=0")
+               !(nodeSettings.utxoSettings.utxoBootstrap || nodeSettings.blocksToKeep >= 0)) {
+      failWithError(
+        "nodeSettings.popowBootstrap can be set only if " +
+        "nodeSettings.utxoBootstrap is set or nodeSettings.blocksToKeep >=0"
+      )
     } else if (nodeSettings.nipopowSettings.nipopowBootstrap && settings.chainSettings.genesisId.isEmpty) {
       failWithError("nodeSettings.popowBootstrap is set but genesisId is not")
     } else {
@@ -205,8 +283,8 @@ object ErgoSettingsReader extends ScorexLogging
   }
 
   /**
-   * Override the log level at runtime with values provided in config/user provided config.
-   */
+    * Override the log level at runtime with values provided in config/user provided config.
+    */
   private def overrideLogLevel(level: String): Unit = level match {
     case "TRACE" | "ERROR" | "INFO" | "WARN" | "DEBUG" =>
       log.info(s"Log level set to $level")
@@ -216,4 +294,3 @@ object ErgoSettingsReader extends ScorexLogging
     case _ => log.warn("No log level configuration provided")
   }
 }
-


### PR DESCRIPTION
Closes #1217

## Summary

The node currently serves its REST API over plain HTTP only, so the `api_key` header and other sensitive data can be intercepted on the wire. This adds **opt-in** TLS termination in the node, plus an operator guide covering both the native-TLS and reverse-proxy paths.

Behavior is fully backward compatible: with no `https` block (or `enabled = false`) the API is served over plain HTTP exactly as before.

## What's included

- **Config** — new optional `scorex.restApi.https` block:
  ```hocon
  https {
    enabled          = true
    keyStorePath     = "/etc/ergo/ergo-api.p12"
    keyStorePassword = ${?ERGO_API_KEYSTORE_PASSWORD}
    keyStoreType     = "PKCS12"   # defaults to PKCS12
  }
  ```
  Keystore fields are optional so `https { enabled = false }` parses without a keystore.

- **TLS context** — `ApiHttpsContext` loads a PKCS12/JKS keystore into an Akka `HttpsConnectionContext`. Built eagerly at startup (before the actor system boots), so a missing/wrong keystore fails fast with a clear *"Malformed REST API HTTPS configuration: …"* error instead of a half-running node.

- **Server binding** — `ErgoApp` calls `enableHttps(...)` when configured, otherwise binds plain HTTP; logs which mode it serves.

- **Fail-closed `publicUrl` check** — since `publicUrl` is advertised to peers/clients, enabling HTTPS while advertising a non-`https://` `publicUrl` now **aborts startup**. Operators must fix `publicUrl` or set the explicit escape hatch `scorex.restApi.https.allowInsecurePublicUrl = true`. Unset `publicUrl` (with HTTPS on) logs a warning. Reverse-proxy setups (`https.enabled = false`) are unaffected.

- **Operator guide** (`docs/https-api.md`) — covers:
  - **Reverse proxy** (recommended for public deployments): bind the plain API to `127.0.0.1` + firewall guidance so the raw HTTP port isn't exposed past the proxy.
  - **Native TLS**: self-signed keystore via `keytool` (with required SAN), Let's Encrypt PEM → PKCS12 conversion, env-var password, and client trust (export cert + `curl --cacert`, with an explicit "don't disable verification" warning).
  - Mirrored quick-start snippets in `application.conf` and `local.conf.sample`.

## Notes

- Akka HTTP 10.2.4 (already a dependency) provides the TLS support — no new dependencies.
- The keystore password doubles as the key-entry password (standard for PKCS12); documented rather than adding a separate `keyPassword` field.
