### PR TITLE
Fix fee estimation bounds

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -323,7 +323,8 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
         case _ => None
       }
 
-    loop(waitMinutes = 0).getOrElse(settings.nodeSettings.minimalFeeAmount)
+    val recommendedFee = loop(waitMinutes = 0).getOrElse(settings.nodeSettings.minimalFeeAmount)
+    math.max(recommendedFee, settings.nodeSettings.minimalFeeAmount)
   }
 
   /**
@@ -346,8 +347,9 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
 
     // Time since statistics measurement interval (needed to calculate average tx rate)
     val elapsed = System.currentTimeMillis() - stats.startMeasurement
-    if (stats.takenTxns != 0) {
-      elapsed * posInPool / stats.takenTxns
+    val cappedElapsed = math.max(0L, math.min(elapsed, MemPoolStatistics.measurementIntervalMsec.toLong))
+    if (stats.takenTxns > 0) {
+      cappedElapsed * posInPool / stats.takenTxns
     } else {
       0
     }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -10,6 +10,7 @@ import org.ergoplatform.settings.{ErgoSettings, ErgoValidationSettingsUpdate, Pa
 import org.ergoplatform.utils.{ErgoTestHelpers, RandomWrapper}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scorex.crypto.authds.ADKey
 import scorex.util.encode.Base16
 import sigma.ast.ByteArrayConstant
 import sigma.interpreter.{ContextExtension, ProverResult}
@@ -23,6 +24,13 @@ class ErgoMemPoolSpec extends AnyFlatSpec
   import org.ergoplatform.utils.generators.ErgoCoreGenerators._
   import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators._
   import org.ergoplatform.utils.generators.ValidBlocksGenerators._
+
+  private def feeTx(inputSeed: Byte, fee: Long): ErgoTransaction = {
+    ErgoTransaction(
+      IndexedSeq(new Input(ADKey @@ Array.fill(32)(inputSeed), emptyProverResult)),
+      IndexedSeq(new ErgoBoxCandidate(fee, feeProp, creationHeight = 0))
+    )
+  }
 
   it should "accept valid transaction" in {
     val (us, bh) = createUtxoState(settings)
@@ -415,6 +423,31 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     }
     pool.size shouldBe 0
     pool.stats.takenTxns shouldBe (family_depth + 1) * txs.size
+  }
+
+  it should "not recommend fee below node minimal fee" in {
+    val feeSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(minimalFeeAmount = 1000000L))
+    val minimalFee = feeSettings.nodeSettings.minimalFeeAmount
+    val now = System.currentTimeMillis()
+    val lowFeeHistogram = FeeHistogramBin(nTxns = 1, totalFee = minimalFee / 2) ::
+      List.fill(MemPoolStatistics.nHistogramBins - 1)(FeeHistogramBin(0, 0))
+    val stats = MemPoolStatistics(now, takenTxns = 1, snapTime = now, histogram = lowFeeHistogram)
+    val pool = new ErgoMemPool(OrderedTxPool.empty(feeSettings), stats, SortingOption.FeePerByte)(feeSettings)
+
+    pool.getRecommendedFee(expectedWaitTimeMinutes = 0, txSize = 1024) shouldBe minimalFee
+  }
+
+  it should "not let idle uptime dominate expected wait time" in {
+    val feeSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(minimalFeeAmount = 1000000L))
+    val minimalFee = feeSettings.nodeSettings.minimalFeeAmount
+    val poolWithHigherFeeTx = ErgoMemPool.empty(feeSettings)
+      .put(UnconfirmedTransaction(feeTx(inputSeed = 1, fee = minimalFee * 100), None))
+    val now = System.currentTimeMillis()
+    val staleMeasurementStart = now - 365L * 24 * 60 * 60 * 1000
+    val staleStats = MemPoolStatistics(staleMeasurementStart, takenTxns = 1, snapTime = now)
+    val pool = new ErgoMemPool(poolWithHigherFeeTx.pool, staleStats, SortingOption.FeePerByte)(feeSettings)
+
+    pool.getExpectedWaitTime(txFee = minimalFee, txSize = 1024) should be <= MemPoolStatistics.measurementIntervalMsec.toLong
   }
 
   it should "put not adding transaction twice" in {


### PR DESCRIPTION
﻿Closes #1884.

## Summary
- Floor recommended fees at the configured node minimal fee so `/transactions/getFee` cannot recommend a fee below the accepted minimum.
- Cap expected wait-time calculations to the mempool statistics window so long node idle uptime does not dominate the estimate.
- Keep HTTP parameter validation separate from #2374; this PR fixes the core mempool estimation behavior.

## Tests
- sbt "testOnly org.ergoplatform.nodeView.mempool.ErgoMemPoolSpec"
- sbt "testOnly org.ergoplatform.http.routes.TransactionApiRouteSpec"
- publication guard