### PR TITLE
Reject invalid inbound NiPoPoW parameters

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowAlgos.scala
@@ -98,6 +98,8 @@ class NipopowAlgos(val chainSettings: ChainSettings) {
     * end function
     */
   def bestArg(chain: Seq[Header])(m: Int): Int = {
+    require(m >= 1, s"$m < 1")
+
     @scala.annotation.tailrec
     def loop(level: Int, acc: Seq[(Int, Int)] = Seq.empty): Seq[(Int, Int)] =
       if (level == 0) {

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProof.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProof.scala
@@ -72,7 +72,8 @@ case class NipopowProof(popowAlgos: NipopowAlgos,
     * @return true if the proof is valid
     */
   lazy val isValid: Boolean = {
-    this.hasValidConnections &&
+    PoPowParams(m, k, continuous).isSuccess &&
+      this.hasValidConnections &&
       this.hasValidHeights &&
       this.hasValidProofs &&
       this.hasValidDifficultyHeaders &&

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProof.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/NipopowProof.scala
@@ -72,7 +72,7 @@ case class NipopowProof(popowAlgos: NipopowAlgos,
     * @return true if the proof is valid
     */
   lazy val isValid: Boolean = {
-    PoPowParams(m, k, continuous).isSuccess &&
+    PoPowParams.isValid(m, k) &&
       this.hasValidConnections &&
       this.hasValidHeights &&
       this.hasValidProofs &&

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/PoPowParams.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/popow/PoPowParams.scala
@@ -17,10 +17,12 @@ import scala.util.Try
 final class PoPowParams private (val m: Int, val k: Int, val continuous: Boolean, val minChainLength: Int)
 
 object PoPowParams {
+  def isValid(m: Int, k: Int): Boolean =
+    m >= 1 && k >= 1 && m.toLong + k.toLong <= Int.MaxValue
+
   def apply(m: Int, k: Int, continuous: Boolean): Try[PoPowParams] = Try {
-    require(m >= 1, s"$m < 1")
-    require(k >= 1, s"$k < 1")
-    new PoPowParams(m, k, continuous, Math.addExact(m, k))
+    require(isValid(m, k), s"Invalid NiPoPoW parameters: m=$m, k=$k")
+    new PoPowParams(m, k, continuous, m + k)
   }
 }
 

--- a/src/test/scala/org/ergoplatform/local/NipopowVerifierSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/NipopowVerifierSpec.scala
@@ -1,5 +1,8 @@
 package org.ergoplatform.local
 
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
 import org.ergoplatform.modifiers.history.popow.{PoPowHeader, PoPowParams}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.scalatest.matchers.should.Matchers
@@ -42,5 +45,50 @@ class NipopowVerifierSpec extends AnyPropSpec with Matchers {
       verifier.process(shortProof)
       verifier.bestChain.last.id shouldBe longestProof.headersChain.last.id
     }
+  }
+
+  property("rejects proofs with invalid security parameters") {
+    val baseChain = genChain(100)
+    val params = PoPowParams(5, 5, continuous = false).get
+    val proof = nipopowAlgos.prove(toPoPoWChain(baseChain))(params).get
+
+    Seq(
+      proof.copy(m = 0),
+      proof.copy(k = 0),
+      proof.copy(m = Int.MaxValue, k = 1)
+    ).foreach { invalidProof =>
+      val proofBytes = invalidProof.serializer.toBytes(invalidProof)
+      val receivedProof = invalidProof.serializer.parseBytes(proofBytes)
+      receivedProof.isValid shouldBe false
+
+      val verifier = new NipopowVerifier(Some(baseChain.head.id))
+      verifier.process(receivedProof) shouldBe ValidationError
+      verifier.bestChain shouldBe empty
+    }
+  }
+
+  property("returns when a duplicate invalid proof is processed") {
+    val baseChain = genChain(100)
+    val params = PoPowParams(5, 5, continuous = false).get
+    val invalidProof = nipopowAlgos.prove(toPoPoWChain(baseChain))(params).get.copy(m = 0)
+    val proofBytes = invalidProof.serializer.toBytes(invalidProof)
+    val receivedProof = invalidProof.serializer.parseBytes(proofBytes)
+    val verifier = new NipopowVerifier(Some(baseChain.head.id))
+
+    val firstResult = verifier.process(receivedProof)
+    val secondResult = new AtomicReference[NipopowProofVerificationResult]()
+    val completed = new CountDownLatch(1)
+    val worker = new Thread(new Runnable {
+      override def run(): Unit =
+        try secondResult.set(verifier.process(receivedProof))
+        finally completed.countDown()
+    })
+    worker.setDaemon(true)
+    worker.start()
+
+    completed.await(2, TimeUnit.SECONDS) shouldBe true
+    firstResult shouldBe ValidationError
+    secondResult.get() shouldBe ValidationError
+    verifier.bestChain shouldBe empty
   }
 }

--- a/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
@@ -1,5 +1,8 @@
 package org.ergoplatform.modifiers.history
 
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicReference
+
 import org.ergoplatform.modifiers.history.popow.{NipopowAlgos, NipopowProof, PoPowHeader, PoPowParams}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.scalacheck.Gen
@@ -23,6 +26,26 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
     PoPowParams(Int.MaxValue, 1, continuous = false) shouldBe 'failure
 
     PoPowParams(1, 1, continuous = false).get.minChainLength shouldBe 2
+  }
+
+  property("bestArg rejects a non-positive security parameter without looping") {
+    val completed = new CountDownLatch(1)
+    val error = new AtomicReference[Throwable]()
+    val worker = new Thread(new Runnable {
+      override def run(): Unit =
+        try {
+          nipopowAlgos.bestArg(Seq.empty)(0)
+        } catch {
+          case t: Throwable => error.set(t)
+        } finally {
+          completed.countDown()
+        }
+    })
+    worker.setDaemon(true)
+    worker.start()
+
+    completed.await(2, TimeUnit.SECONDS) shouldBe true
+    error.get() shouldBe a[IllegalArgumentException]
   }
 
   property("updateInterlinks") {

--- a/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/history/PoPowAlgosSpec.scala
@@ -21,20 +21,26 @@ class PoPowAlgosSpec extends AnyPropSpec with Matchers {
   private def toPoPoWChain = (c: Seq[ErgoFullBlock]) => c.map(b => PoPowHeader.fromBlock(b).get)
 
   property("PoPowParams rejects invalid minimum chain lengths") {
+    PoPowParams.isValid(0, 1) shouldBe false
+    PoPowParams.isValid(1, 0) shouldBe false
+    PoPowParams.isValid(Int.MaxValue, 1) shouldBe false
+
     PoPowParams(0, 1, continuous = false) shouldBe 'failure
     PoPowParams(1, 0, continuous = false) shouldBe 'failure
     PoPowParams(Int.MaxValue, 1, continuous = false) shouldBe 'failure
 
+    PoPowParams.isValid(Int.MaxValue - 1, 1) shouldBe true
     PoPowParams(1, 1, continuous = false).get.minChainLength shouldBe 2
   }
 
   property("bestArg rejects a non-positive security parameter without looping") {
+    val algos = nipopowAlgos
     val completed = new CountDownLatch(1)
     val error = new AtomicReference[Throwable]()
     val worker = new Thread(new Runnable {
       override def run(): Unit =
         try {
-          nipopowAlgos.bestArg(Seq.empty)(0)
+          algos.bestArg(Seq.empty)(0)
         } catch {
           case t: Throwable => error.set(t)
         } finally {


### PR DESCRIPTION
## Summary

- validate received NiPoPoW `m` and `k` through the canonical `PoPowParams` rules before proof admission
- make `bestArg` fail fast for an invalid security parameter
- add binary round-trip and bounded-termination regression coverage

## Why

PR #2379 validates locally constructed and REST-generated proofs, but deserialized proofs are constructed directly. This adds the corresponding consumer-side parameter validation and keeps scoring inside its supported domain.

## Tests

- `NipopowVerifierSpec`
- `PoPowAlgosSpec`
- `PoPowAlgosWithDBSpec`
- `PopowProcessorSpecification`
- `SerializationTests`
- `NipopowApiRoutesSpec`

35 affected tests passed.

## Scope

- no wire-format change
- no change to valid proof selection
- binding a received proof to configured or requested parameters remains separate
