### PR TITLE
Harden REST defaults and wallet change address updates

### DIFF
--- a/ci/ergo.conf
+++ b/ci/ergo.conf
@@ -1,0 +1,7 @@
+# Replace the sentinel with a Blake2b256 API key hash to enable protected routes.
+ergo.node.mining = false
+
+scorex.restApi {
+  bindAddress = "127.0.0.1:9053"
+  apiKeyHash = "0000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/ci/release-binaries.py
+++ b/ci/release-binaries.py
@@ -84,7 +84,7 @@ Write-Host @"
 {SCRIPT_LOGO}
 
 "@ -ForegroundColor Red
-jre/bin/java -jar -Xmx4G {JAR_FILENAME} --mainnet -c ergo.conf 
+jre/bin/java -Xmx4G -jar {JAR_FILENAME} --mainnet -c ergo.conf
     """
     with open(f"{app_dir}/ergo-node.ps1", "w") as f:
        f.write(app_script)
@@ -106,7 +106,7 @@ cat << EOF
 
 EOF
 echo '\033[0m'
-./jre/bin/java -jar -Xmx4G {JAR_FILENAME} --mainnet -c ergo.conf
+./jre/bin/java -Xmx4G -jar {JAR_FILENAME} --mainnet -c ergo.conf
 exit
     """
     with open(f"{app_dir}/ergo-node.sh", "w") as f:
@@ -154,7 +154,7 @@ cat << EOF
 
 EOF
 echo '\033[0m'
-$SRC/jre/bin/java -jar -Xmx4G $SRC/{JAR_FILENAME} --mainnet -c $SRC/ergo.conf
+$SRC/jre/bin/java -Xmx4G -jar $SRC/{JAR_FILENAME} --mainnet -c $SRC/ergo.conf
 
 exit
     """
@@ -211,15 +211,7 @@ logging.warning(f"Starting release binaries for ergo-node")
 main_jre = get_main_jre(MAIN_JRE, JRE_SUBFOLDER)
 os.makedirs("release", exist_ok=True)
 
-ergo_conf = """
-ergo {
-    node {
-       mining = false
-    }
-}
-"""
-with open("ergo.conf", "w") as f:
-       f.write(ergo_conf)
+shutil.copyfile("ci/ergo.conf", "ergo.conf")
 
 with ThreadPool(JDKS.__len__()) as pool:
   pool.map(process_download, JDKS.items())

--- a/ergo-installer.sh
+++ b/ergo-installer.sh
@@ -5,6 +5,7 @@
 APP_DIR=~/ergo
 NODE_NAME=${USER}-$(hostname)
 API_KEY=
+API_KEY_FROM_ARGUMENT=no
 DEBIAN_INSTALLATION_RECOMMENDATIONS=
 TOR=no
 CONFIG_TEMPLATE="ergo.node.mining = false\nscorex.network.nodeName = \"<NODE_NAME>\"\nscorex.restApi.apiKeyHash = \"<API_KEY_HASH>\""
@@ -16,13 +17,15 @@ NODE_PARAMS="-Xmx$(awk '/MemTotal/ { printf "%.0f", $2*0.9 }' /proc/meminfo)K"
 while :; do
     case $1 in
         -h|-\?|--help)
-            echo "Usage: $0 --api-key=YOUR_API_KEY [--node-name=YOUR_NODE_NAME] [--app-dir=APP_DIR] [--mode=full|mining] [--tor]"
+            echo "Usage: $0 [--node-name=YOUR_NODE_NAME] [--app-dir=APP_DIR] [--mode=full|mining] [--tor]"
+            echo "The API key is requested using a hidden terminal prompt. The legacy --api-key option remains supported but can expose the key in process listings."
             exit
             ;;
 
         --api-key)
             if [ "$2" ]; then
                 API_KEY=$2
+                API_KEY_FROM_ARGUMENT=yes
                 shift
             else
                 echo 'ERROR: "--api-key" requires a non-empty option argument.'
@@ -31,6 +34,7 @@ while :; do
             ;;
         --api-key=?*)
             API_KEY=${1#*=} # Delete everything up to "=" and assign the remainder.
+            API_KEY_FROM_ARGUMENT=yes
             ;;
         --api-key=)         # Handle the case of an empty --api-key=
             echo 'ERROR: "--api-key" requires a non-empty option argument.'
@@ -112,9 +116,30 @@ if [ "$(echo "${APP_DIR}" | cut -c1-1)" != "/" ]; then
   exit 1
 fi
 
+if [ "${API_KEY_FROM_ARGUMENT}" = yes ]; then
+  echo 'WARN: --api-key may expose the key in process listings; omit it to use the hidden prompt.'
+fi
+
 if [ -z "${API_KEY}" ]; then
-  echo 'ERROR: "--api-key" is required and requires a non-empty option argument.'
-  exit 1
+  printf 'API key: ' > /dev/tty
+  TTY_STATE=$(stty -g < /dev/tty) || {
+    echo 'ERROR: Unable to read terminal state for API key input.'
+    exit 1
+  }
+  trap 'stty "${TTY_STATE}" < /dev/tty; printf "\n" > /dev/tty; exit 130' HUP INT TERM
+  if ! stty -echo < /dev/tty; then
+    echo 'ERROR: Unable to disable terminal echo for API key input.'
+    exit 1
+  fi
+  IFS= read -r API_KEY < /dev/tty
+  API_KEY_READ_STATUS=$?
+  stty "${TTY_STATE}" < /dev/tty
+  trap - HUP INT TERM
+  printf '\n' > /dev/tty
+  if [ "${API_KEY_READ_STATUS}" -ne 0 ] || [ -z "${API_KEY}" ]; then
+    echo 'ERROR: API key input must be non-empty.'
+    exit 1
+  fi
 fi
 
 if [ "${MODE}" != 'full' ] && [ "${MODE}" != 'mining' ]; then
@@ -122,7 +147,7 @@ if [ "${MODE}" != 'full' ] && [ "${MODE}" != 'mining' ]; then
   exit 1
 fi
 
-echo "Ergo node with config file will be installed into '${APP_DIR}' directory and will be named as '${NODE_NAME}' and has API key '${API_KEY}'."
+echo "Ergo node with config file will be installed into '${APP_DIR}' directory and will be named as '${NODE_NAME}'."
 
 
 # Check preinstalled software
@@ -178,16 +203,20 @@ echo "Latest known Ergo release: ${LATEST_ERGO_RELEASE}, downloading it to ${APP
 curl --silent -L ${ERGO_DOWNLOAD_URL} --output ${APP_DIR}/ergo.jar
 echo "Ergo was downloaded to ${APP_DIR}/ergo.jar"
 
-# First run of Ergo node, to create API key hash that later be added into config
-echo -n "Executing ergo node to obtain API key hash..."
-daemon --chdir=${APP_DIR} -- java -jar ${APP_DIR}/ergo.jar --mainnet
-PID=$(pgrep -f "daemon --chdir=${APP_DIR} -- java")
-while ! curl --output /dev/null --silent --head --fail http://localhost:9053; do sleep 1 && echo -n '.'; done;  # wait for node be ready with progress bar
-API_KEY_HASH=$(curl -X POST "http://localhost:9053/utils/hash/blake2b" -H  "accept: application/json" -H  "Content-Type: application/json" -d "\"${APP_KEY}\"" --silent | cut -c 2- | rev | cut -c 2- | rev)
-echo "\nAPI key hash obtained: ${API_KEY_HASH}"
-echo -n "Stopping Ergo node with PID=${PID}..."
-kill ${PID} && while kill -0 ${PID} > /dev/null 2>&1; do sleep 1 && echo -n '.'; done;  # wait for node exit with progress bar
-echo "\nStopped."
+# Hash the API key offline. Reading it from standard input keeps it out of
+# process arguments. b2sum supports installers running before the new helper
+# is present in the latest published Ergo JAR.
+API_KEY_HASH=$(printf '%s' "${API_KEY}" | java -cp "${APP_DIR}/ergo.jar" org.ergoplatform.tools.ApiKeyHash 2> /dev/null) || API_KEY_HASH=
+case ${API_KEY_HASH} in (*[!0-9a-f]*|'') API_KEY_HASH= ;; esac
+if [ ${#API_KEY_HASH} -ne 64 ]; then
+  API_KEY_HASH=$(printf '%s' "${API_KEY}" | b2sum -l 256 2> /dev/null | awk '{print $1}') || API_KEY_HASH=
+fi
+case ${API_KEY_HASH} in (*[!0-9a-f]*|'') API_KEY_HASH= ;; esac
+if [ ${#API_KEY_HASH} -ne 64 ]; then
+  echo 'ERROR: Failed to calculate a valid API key hash.'
+  exit 1
+fi
+echo "API key hash obtained."
 
 # Writing config file
 echo ${CONFIG_TEMPLATE} | sed "s/<NODE_NAME>/${NODE_NAME}/g" | sed "s/<API_KEY_HASH>/${API_KEY_HASH}/g" > ${APP_DIR}/application.conf

--- a/src/it/resources/devnetTemplate.conf
+++ b/src/it/resources/devnetTemplate.conf
@@ -56,8 +56,7 @@ scorex {
   restApi {
     bindAddress = "0.0.0.0:9051"
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # Integration-test-only hash of "integration-test-api-key".
+    apiKeyHash = "63c68b8d6e0eebf8ea45876a09e62d18efcbf4e25a95d8690f2c2f2285f2fb33"
   }
 }

--- a/src/it/scala/org/ergoplatform/it/RestApiFixtureSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/RestApiFixtureSpec.scala
@@ -1,0 +1,23 @@
+package org.ergoplatform.it
+
+import com.typesafe.config.ConfigFactory
+import org.ergoplatform.it.api.NodeApi.IntegrationTestApiKey
+import org.ergoplatform.tools.ApiKeyHash
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.api.http.ApiDirectives.{DisabledApiKeyHash, LegacyDefaultApiKeyHash}
+
+import java.io.File
+
+class RestApiFixtureSpec extends AnyFlatSpec with Matchers {
+
+  "Integration REST API fixture" should "use a dedicated non-default API key" in {
+    val configuredHash = ConfigFactory
+      .parseFile(new File("src/it/resources/devnetTemplate.conf"))
+      .getString("scorex.restApi.apiKeyHash")
+
+    configuredHash shouldBe ApiKeyHash.hash(IntegrationTestApiKey)
+    configuredHash should not be DisabledApiKeyHash
+    configuredHash should not be LegacyDefaultApiKeyHash
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/api/NodeApi.scala
+++ b/src/it/scala/org/ergoplatform/it/api/NodeApi.scala
@@ -49,13 +49,13 @@ trait NodeApi {
 
   def getWihApiKey(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
     _get(s"http://$restAddress:$nodeRestPort$path")
-      .setHeader("api_key", "hello")
+      .setHeader("api_key", IntegrationTestApiKey)
       .build()
   }
 
   def post(url: String, port: Int, path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] =
     retrying(f(
-      _post(s"$url:$port$path").setHeader("api_key", "hello")
+      _post(s"$url:$port$path").setHeader("api_key", IntegrationTestApiKey)
     ).build())
 
   def postJson[A: Encoder](path: String, body: A): Future[Response] =
@@ -156,6 +156,8 @@ trait NodeApi {
 }
 
 object NodeApi extends ScorexLogging {
+
+  private[it] val IntegrationTestApiKey = "integration-test-api-key"
 
   case class UnexpectedStatusCodeException(request: Request, response: Response)
     extends Exception(s"Request: ${request.getUrl}\n Unexpected status code (${response.getStatusCode}): " +

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -4394,6 +4394,7 @@ paths:
       security:
         - ApiKeyAuth: [api_key]
       summary: Update address to be used to send change to
+      description: The wallet must be unlocked and the address must be owned by the wallet.
       operationId: walletUpdateChangeAddress
       tags:
         - wallet
@@ -4411,6 +4412,12 @@ paths:
       responses:
         '200':
           description: Change address updated successfully
+        '400':
+          description: Wallet is locked or the address is not owned by the wallet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         default:
           description: Error
           content:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -416,12 +416,11 @@ scorex {
   # Node's REST API settings
   restApi {
     # Network address to bind to
-    bindAddress = "0.0.0.0:9052"
+    bindAddress = "127.0.0.1:9052"
 
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # The all-zero sentinel disables protected routes until an operator supplies a hash.
+    apiKeyHash = "0000000000000000000000000000000000000000000000000000000000000000"
 
     # Enable/disable CORS support.
     # This is an optional param. It would allow cors in case if this setting is set.

--- a/src/main/resources/devnet.conf
+++ b/src/main/resources/devnet.conf
@@ -65,6 +65,7 @@ scorex {
     ]
   }
   restApi {
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # The all-zero sentinel disables protected routes until an operator supplies a hash.
+    apiKeyHash = "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -144,11 +144,9 @@ scorex {
   }
   restApi {
 
-    # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # The all-zero sentinel disables protected routes until an operator supplies a hash.
+    apiKeyHash = "0000000000000000000000000000000000000000000000000000000000000000"
 
-    bindAddress = "0.0.0.0:9053"
+    bindAddress = "127.0.0.1:9053"
   }
 }

--- a/src/main/resources/testnet.conf
+++ b/src/main/resources/testnet.conf
@@ -100,9 +100,7 @@ scorex {
     penaltyScoreThreshold = 500000
   }
   restApi {
-    # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # The all-zero sentinel disables protected routes until an operator supplies a hash.
+    apiKeyHash = "0000000000000000000000000000000000000000000000000000000000000000"
   }
 }

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -10,6 +10,7 @@ import org.ergoplatform.http.api.requests.HintExtractionRequest
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.wallet._
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.ChangeAddressValidationException
 import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
 import org.ergoplatform.wallet.Constants
@@ -464,8 +465,13 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def updateChangeAddressR: Route = (path("updateChangeAddress") & post & p2pkAddress) { p2pk =>
-    withWallet { w =>
+    withWalletOp { w =>
       w.updateChangeAddress(p2pk)
+        .map[Either[ChangeAddressValidationException, Unit]](Right(_))
+        .recover { case e: ChangeAddressValidationException => Left(e) }
+    } {
+      case Right(_) => ApiResponse(())
+      case Left(e) => BadRequest(e.getMessage)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -8,6 +8,7 @@ import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.ErgoStateReader
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.ChangeAddressValidationException
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
 import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.settings._
@@ -408,12 +409,15 @@ class ErgoWalletActor(settings: ErgoSettings,
       }
 
     case UpdateChangeAddress(address) =>
-      state.storage.updateChangeAddress(address) match {
+      ergoWalletService.updateChangeAddress(state, address) match {
         case Success(_) =>
           sender() ! StatusReply.success(())
+        case Failure(t: ChangeAddressValidationException) =>
+          log.warn(t.getMessage)
+          sender() ! StatusReply.error(t)
         case Failure(t) =>
           log.error(s"Unable to update change address", t)
-          sender() ! StatusReply.error(s"Unable to update change address : ${t.getMessage}")
+          sender() ! StatusReply.error(t)
       }
 
     case RemoveScan(scanId) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -96,6 +96,17 @@ trait ErgoWalletService {
   def lockWallet(state: ErgoWalletState): ErgoWalletState
 
   /**
+    * Update the address used for wallet change outputs.
+    * @param state current wallet state
+    * @param address new change address
+    * @return Success when the address was persisted
+    */
+  def updateChangeAddress(
+    state: ErgoWalletState,
+    address: P2PKAddress
+  ): Try[Unit]
+
+  /**
     * Close it, recursively delete registryFolder from filesystem if present and create new registry
     * @param state current wallet state
     * @param settings settings read from config file
@@ -265,6 +276,18 @@ trait ErgoWalletService {
 
 }
 
+object ErgoWalletService {
+
+  sealed abstract class ChangeAddressValidationException(message: String)
+    extends IllegalArgumentException(message)
+
+  final class WalletLockedForChangeAddress
+    extends ChangeAddressValidationException("Wallet is locked")
+
+  final class ChangeAddressNotOwned
+    extends ChangeAddressValidationException("Change address is not owned by the wallet")
+}
+
 class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends ErgoWalletService with ErgoWalletSupport with FileUtils {
 
 
@@ -374,6 +397,20 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
   override def lockWallet(state: ErgoWalletState): ErgoWalletState = {
     state.secretStorageOpt.foreach(_.lock())
     state.copy(walletVars = state.walletVars.resetProver())
+  }
+
+  override def updateChangeAddress(
+    state: ErgoWalletState,
+    address: P2PKAddress
+  ): Try[Unit] = {
+    state.walletVars.proverOpt match {
+      case None =>
+        Failure(new ErgoWalletService.WalletLockedForChangeAddress)
+      case Some(_) if !state.walletVars.ownsAddress(address) =>
+        Failure(new ErgoWalletService.ChangeAddressNotOwned)
+      case Some(_) =>
+        state.storage.updateChangeAddress(address)
+    }
   }
 
   override def recreateRegistry(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] = {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -83,9 +83,16 @@ case class ErgoWalletState(
 
   def getChangeAddress(addrEncoder: ErgoAddressEncoder): Option[P2PKAddress] = {
     walletVars.proverOpt.map { prover =>
-      storage.readChangeAddress.getOrElse {
-        log.debug("Change address not specified. Using root address from wallet.")
-        P2PKAddress(prover.hdPubKeys.head.key)(addrEncoder)
+      val rootAddress = P2PKAddress(prover.hdPubKeys.head.key)(addrEncoder)
+      storage.readChangeAddress match {
+        case Some(address) if walletVars.ownsAddress(address) =>
+          address
+        case Some(_) =>
+          log.warn("Ignoring persisted change address that is not owned by the wallet")
+          rootAddress
+        case None =>
+          log.debug("Change address not specified. Using root address from wallet.")
+          rootAddress
       }
     }
   }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -36,6 +36,9 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
 
   val publicKeyAddresses: Seq[P2PKAddress] = stateCacheOpt.map(_.publicKeyAddresses).getOrElse(Seq.empty)
 
+  def ownsAddress(address: P2PKAddress): Boolean =
+    proverOpt.exists(_.hdPubKeys.exists(_.key.value.equals(address.pubkey.value)))
+
   val trackedBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.trackedBytes).getOrElse(Seq.empty)
 
   val miningScriptsBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.miningScriptsBytes).getOrElse(Seq.empty)

--- a/src/main/scala/org/ergoplatform/tools/ApiKeyHash.scala
+++ b/src/main/scala/org/ergoplatform/tools/ApiKeyHash.scala
@@ -1,0 +1,22 @@
+package org.ergoplatform.tools
+
+import org.ergoplatform.settings.Algos
+import scorex.crypto.hash.Blake2b256
+
+import scala.io.Source
+
+object ApiKeyHash {
+
+  def hash(apiKey: String): String = Algos.encoder.encode(Blake2b256(apiKey))
+
+  def main(args: Array[String]): Unit = {
+    val input = Source.fromInputStream(System.in, "UTF-8")
+    try {
+      val apiKey = input.mkString
+      require(apiKey.nonEmpty, "API key must not be empty")
+      println(hash(apiKey))
+    } finally {
+      input.close()
+    }
+  }
+}

--- a/src/main/scala/scorex/core/api/http/ApiDirectives.scala
+++ b/src/main/scala/scorex/core/api/http/ApiDirectives.scala
@@ -4,12 +4,15 @@ import akka.http.scaladsl.server.{AuthorizationFailedRejection, Directive0}
 import org.ergoplatform.settings.RESTApiSettings
 import org.ergoplatform.utils.ScorexEncoding
 import scorex.crypto.hash.Blake2b256
+import scorex.core.api.http.ApiDirectives.DisabledApiKeyHashes
 
 trait ApiDirectives extends CorsHandler with ScorexEncoding {
   val settings: RESTApiSettings
   val apiKeyHeaderName: String
 
   lazy val withAuth: Directive0 = optionalHeaderValueByName(apiKeyHeaderName).flatMap {
+    case _ if settings.apiKeyHash.exists(DisabledApiKeyHashes.contains) =>
+      reject(AuthorizationFailedRejection)
     case _ if settings.apiKeyHash.isEmpty => pass
     case None => reject(AuthorizationFailedRejection)
     case Some(key) =>
@@ -21,4 +24,15 @@ trait ApiDirectives extends CorsHandler with ScorexEncoding {
       }
   }
 
+}
+
+object ApiDirectives {
+  /** Explicitly disables routes guarded by [[ApiDirectives.withAuth]]. */
+  val DisabledApiKeyHash: String = "0" * 64
+
+  /** Hash of the public API key shipped by older node versions. */
+  val LegacyDefaultApiKeyHash: String =
+    "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+
+  val DisabledApiKeyHashes: Set[String] = Set(DisabledApiKeyHash, LegacyDefaultApiKeyHash)
 }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -1,15 +1,28 @@
 package org.ergoplatform.http.routes
 
+import akka.actor.{Actor, Props}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{Route, ValidationRejection}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.pattern.StatusReply
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.syntax._
 import io.circe.{Decoder, Json}
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs, WalletApiRoute}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.nodeView.ErgoReadersHolder.GetReaders
+import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages.UpdateChangeAddress
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.{
+  ChangeAddressNotOwned,
+  ChangeAddressValidationException,
+  WalletLockedForChangeAddress
+}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequestEncoder, PaymentRequest, PaymentRequestEncoder, _}
-import org.ergoplatform.nodeView.wallet.{AugWalletTransaction, ErgoAddressJsonEncoder}
+import org.ergoplatform.nodeView.wallet.{
+  AugWalletTransaction,
+  ErgoAddressJsonEncoder,
+  ErgoWalletReader
+}
 import org.ergoplatform.settings.{Args, ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.Stubs
 import org.ergoplatform.{ErgoAddress, Pay2SAddress}
@@ -61,6 +74,32 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Seq.empty,
     minerRewardDelay = 720
   )(settings.addressEncoder)
+
+  private val changeAddressBody = Json.obj(
+    "address" -> WalletActorStub.address.toString.asJson
+  )
+
+  private def changeAddressRoute(result: Either[Throwable, Unit]): Route = {
+    val walletActorRef = system.actorOf(Props(new Actor {
+      override def receive: Receive = {
+        case UpdateChangeAddress(_) =>
+          result match {
+            case Right(_) => sender() ! StatusReply.success(())
+            case Left(error) => sender() ! StatusReply.error(error)
+          }
+      }
+    }))
+    val walletReader = new ErgoWalletReader {
+      override val walletActor = walletActorRef
+    }
+    val readers = digestReaders.copy(w = walletReader)
+    val readersHolder = system.actorOf(Props(new Actor {
+      override def receive: Receive = {
+        case GetReaders => sender() ! readers
+      }
+    }))
+    Route.seal(WalletApiRoute(readersHolder, nodeViewRef, settings).route)
+  }
 
 
   it should "generate arbitrary transaction" in {
@@ -157,6 +196,36 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Post(prefix + "/unlock", Json.obj("pass" -> "1234".asJson)) ~> route ~> check {
       status shouldBe StatusCodes.OK
     }
+  }
+
+  it should "return bad request for invalid change address updates" in {
+    val failures: Seq[ChangeAddressValidationException] = Seq(
+      new WalletLockedForChangeAddress,
+      new ChangeAddressNotOwned
+    )
+
+    failures.foreach { failure =>
+      Post(prefix + "/updateChangeAddress", changeAddressBody) ~>
+        changeAddressRoute(Left(failure)) ~> check {
+          status shouldBe StatusCodes.BadRequest
+          val detail = responseAs[Json].hcursor.downField("detail").as[String]
+          detail shouldBe Right(failure.getMessage)
+        }
+    }
+  }
+
+  it should "keep unexpected change address failures as internal errors" in {
+    Post(prefix + "/updateChangeAddress", changeAddressBody) ~>
+      changeAddressRoute(Left(new RuntimeException("storage failure"))) ~> check {
+        status shouldBe StatusCodes.InternalServerError
+      }
+  }
+
+  it should "accept a valid change address update" in {
+    Post(prefix + "/updateChangeAddress", changeAddressBody) ~>
+      changeAddressRoute(Right(())) ~> check {
+        status shouldBe StatusCodes.OK
+      }
   }
 
   it should "check wallet" in {

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -5,6 +5,10 @@ import org.ergoplatform._
 import org.ergoplatform.db.DBSpec
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.{
+  ChangeAddressNotOwned,
+  WalletLockedForChangeAddress
+}
 import org.ergoplatform.nodeView.wallet.WalletScanLogic.ScanResults
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, PaymentRequest}
@@ -28,10 +32,11 @@ import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
 import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, SType}
+import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigmastate.helpers.TestingHelpers.testBox
 
 import scala.collection.compat.immutable.ArraySeq
-import scala.util.Random
+import scala.util.{Random, Success}
 
 class ErgoWalletServiceSpec
   extends ErgoCorePropertyTest
@@ -324,6 +329,94 @@ class ErgoWalletServiceSpec
         finalUnlockedState.secretStorageOpt.get.isLocked shouldBe false
         finalUnlockedState.storage.readAllKeys().size shouldBe 1
         finalUnlockedState.walletVars.proverOpt shouldNot be(empty)
+      }
+    }
+  }
+
+  property("change address update should require an unlocked wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val ownedAddress = unlockedState.walletVars.publicKeyAddresses.head
+        val lockedState = walletService.lockWallet(unlockedState)
+
+        val result = walletService.updateChangeAddress(lockedState, ownedAddress)
+
+        result.isFailure shouldBe true
+        result.failed.get shouldBe a[WalletLockedForChangeAddress]
+        result.failed.get.getMessage should include("locked")
+        lockedState.storage.readChangeAddress shouldBe empty
+      }
+    }
+  }
+
+  property("change address update should reject an address not owned by the wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val unownedAddress = P2PKAddress(
+          DLogProverInput.random().publicImage
+        )(settings.addressEncoder)
+
+        val result = walletService.updateChangeAddress(unlockedState, unownedAddress)
+
+        result.isFailure shouldBe true
+        result.failed.get shouldBe a[ChangeAddressNotOwned]
+        result.failed.get.getMessage should include("not owned")
+        unlockedState.storage.readChangeAddress shouldBe empty
+      }
+    }
+  }
+
+  property("change address update should accept an address owned by an unlocked wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val ownedAddress = unlockedState.walletVars.publicKeyAddresses.head
+
+        walletService.updateChangeAddress(
+          unlockedState,
+          ownedAddress
+        ) shouldBe Success(())
+        unlockedState.storage.readChangeAddress shouldBe Some(ownedAddress)
+      }
+    }
+  }
+
+  property("change address lookup should ignore a persisted unowned address") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val unownedAddress = P2PKAddress(
+          DLogProverInput.random().publicImage
+        )(settings.addressEncoder)
+        val rootAddress = P2PKAddress(
+          unlockedState.walletVars.proverOpt.get.hdPubKeys.head.key
+        )(settings.addressEncoder)
+
+        unlockedState.storage.updateChangeAddress(unownedAddress).get
+
+        unlockedState.getChangeAddress(settings.addressEncoder) shouldBe Some(rootAddress)
+        unlockedState.storage.readChangeAddress shouldBe Some(unownedAddress)
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -3,6 +3,10 @@ package org.ergoplatform.nodeView.wallet
 import org.ergoplatform._
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.{
+  ChangeAddressNotOwned,
+  WalletLockedForChangeAddress
+}
 import org.ergoplatform.nodeView.wallet.IdUtils._
 import org.ergoplatform.nodeView.wallet.persistence.{WalletDigest, WalletDigestSerializer}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, BurnTokensRequest, ExternalSecret, PaymentRequest}
@@ -41,6 +45,38 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
       val wd0 = WalletDigest(1, 0, assets)
       val bs = WalletDigestSerializer.toBytes(wd0)
       WalletDigestSerializer.parseBytes(bs).walletAssetBalances shouldBe wd0.walletAssetBalances
+    }
+  }
+
+  property(
+    "change address updates enforce wallet ownership and lock state through the actor"
+  ) {
+    withFixture { implicit w =>
+      val addresses = getPublicKeys
+      val initialStatus = await(wallet.getWalletStatus)
+      val alternateOwnedAddress =
+        addresses.find(address => !initialStatus.changeAddress.contains(address)).get
+
+      await(wallet.updateChangeAddress(alternateOwnedAddress))
+      await(wallet.getWalletStatus).changeAddress shouldBe Some(alternateOwnedAddress)
+
+      val unownedAddress = P2PKAddress(
+        DLogProverInput.random().publicImage
+      )(settings.addressEncoder)
+      val unownedFailure = await(wallet.updateChangeAddress(unownedAddress).failed)
+      unownedFailure shouldBe a[ChangeAddressNotOwned]
+      unownedFailure.getMessage should include("not owned")
+      await(wallet.getWalletStatus).changeAddress shouldBe Some(alternateOwnedAddress)
+
+      wallet.lockWallet()
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
+      eventually {
+        await(wallet.getWalletStatus).unlocked shouldBe false
+      }
+
+      val lockedFailure = await(wallet.updateChangeAddress(alternateOwnedAddress).failed)
+      lockedFailure shouldBe a[WalletLockedForChangeAddress]
+      lockedFailure.getMessage should include("locked")
     }
   }
 

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -62,7 +62,7 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
       )
     )
     settings.scorexSettings.restApi shouldBe RESTApiSettings(
-      bindAddress = new InetSocketAddress("0.0.0.0", 9052),
+      bindAddress = new InetSocketAddress("127.0.0.1", 9052),
       apiKeyHash = None,
       corsAllowedOrigin = Some("*"),
       timeout = 5.seconds,

--- a/src/test/scala/org/ergoplatform/settings/SecureRestApiDefaultsSpec.scala
+++ b/src/test/scala/org/ergoplatform/settings/SecureRestApiDefaultsSpec.scala
@@ -1,0 +1,106 @@
+package org.ergoplatform.settings
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.ergoplatform.tools.ApiKeyHash
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.api.http.ApiDirectives.{DisabledApiKeyHash, LegacyDefaultApiKeyHash}
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+class SecureRestApiDefaultsSpec extends AnyFlatSpec with Matchers {
+
+  private val restApiPrefix = "scorex.restApi"
+
+  private val applicationConfig =
+    ConfigFactory.parseFile(new File("src/main/resources/application.conf"))
+
+  private val mainnetConfig =
+    ConfigFactory
+      .parseFile(new File("src/main/resources/mainnet.conf"))
+      .withFallback(applicationConfig)
+
+  private val testnetConfig =
+    ConfigFactory
+      .parseFile(new File("src/main/resources/testnet.conf"))
+      .withFallback(applicationConfig)
+
+  private val devnetConfig =
+    ConfigFactory
+      .parseFile(new File("src/main/resources/devnet.conf"))
+      .withFallback(applicationConfig)
+
+  private val releaseBundleConfig =
+    ConfigFactory.parseFile(new File("ci/ergo.conf")).withFallback(mainnetConfig)
+
+  private def assertSafeDefaults(config: Config, expectedPort: Int): Unit = {
+    config.getString(s"$restApiPrefix.bindAddress") shouldBe s"127.0.0.1:$expectedPort"
+    config.getString(s"$restApiPrefix.apiKeyHash") shouldBe DisabledApiKeyHash
+  }
+
+  "REST API defaults" should "bind to loopback and disable protected routes" in {
+    assertSafeDefaults(applicationConfig, 9052)
+    assertSafeDefaults(mainnetConfig, 9053)
+    assertSafeDefaults(testnetConfig, 9052)
+    assertSafeDefaults(devnetConfig, 9052)
+  }
+
+  it should "keep release-bundle fallback settings fail-closed" in {
+    assertSafeDefaults(releaseBundleConfig, 9053)
+    releaseBundleConfig.getBoolean("ergo.node.mining") shouldBe false
+  }
+
+  it should "allow an operator to explicitly configure a non-default key and external bind" in {
+    val operatorHash = "1" * 64
+    val operatorConfig = ConfigFactory
+      .parseString(
+        s"""
+           |scorex.restApi {
+           |  bindAddress = "0.0.0.0:9053"
+           |  apiKeyHash = "$operatorHash"
+           |}
+           |""".stripMargin
+      )
+      .withFallback(mainnetConfig)
+
+    operatorConfig.getString(s"$restApiPrefix.bindAddress") shouldBe "0.0.0.0:9053"
+    operatorConfig.getString(s"$restApiPrefix.apiKeyHash") shouldBe operatorHash
+    operatorConfig.getString(s"$restApiPrefix.apiKeyHash") should not be LegacyDefaultApiKeyHash
+  }
+
+  it should "hash the installer API key offline without exposing it as a Java argument" in {
+    val installer = new String(
+      Files.readAllBytes(Paths.get("ergo-installer.sh")),
+      StandardCharsets.UTF_8
+    )
+
+    installer should include(
+      "printf '%s' \"${API_KEY}\" | java -cp \"${APP_DIR}/ergo.jar\" " +
+      "org.ergoplatform.tools.ApiKeyHash"
+    )
+    installer should include("stty -echo < /dev/tty")
+    installer should include("stty \"${TTY_STATE}\" < /dev/tty")
+    installer should include("IFS= read -r API_KEY < /dev/tty")
+    installer should include("b2sum -l 256")
+    installer should include("if [ " + "$" + "{#API_KEY_HASH} -ne 64 ]")
+    installer should not include "${APP_KEY}"
+    installer should not include "/utils/hash/blake2b"
+    installer should not include LegacyDefaultApiKeyHash
+  }
+
+  it should "place JVM options before the release-bundle jar argument" in {
+    val releaseGenerator = new String(
+      Files.readAllBytes(Paths.get("ci/release-binaries.py")),
+      StandardCharsets.UTF_8
+    )
+
+    releaseGenerator should include(" -Xmx4G -jar ")
+    releaseGenerator should not include " -jar -Xmx4G "
+  }
+
+  it should "calculate the same API key hash as the REST utility" in {
+    ApiKeyHash.hash("hello") shouldBe LegacyDefaultApiKeyHash
+  }
+}

--- a/src/test/scala/scorex/core/api/http/ApiDirectivesSpec.scala
+++ b/src/test/scala/scorex/core/api/http/ApiDirectivesSpec.scala
@@ -1,0 +1,63 @@
+package scorex.core.api.http
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.{Directives, Route}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.ergoplatform.tools.ApiKeyHash
+import org.ergoplatform.utils.ErgoNodeTestConstants
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.api.http.ApiDirectives.{DisabledApiKeyHash, LegacyDefaultApiKeyHash}
+
+class ApiDirectivesSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
+
+  private def protectedRoute(apiKeyHash: String): Route = {
+    val directives: ApiDirectives = new ApiDirectives {
+      override val settings = ErgoNodeTestConstants.settings.scorexSettings.restApi.copy(
+        apiKeyHash = Some(apiKeyHash)
+      )
+      override val apiKeyHeaderName: String = "api_key"
+    }
+    Route.seal(directives.withAuth {
+      Directives.complete(StatusCodes.OK)
+    })
+  }
+
+  "The disabled API key hash" should "reject protected routes with or without a key" in {
+    Get() ~> protectedRoute(DisabledApiKeyHash) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+
+    Get().addHeader(RawHeader("api_key", "anything")) ~> protectedRoute(
+      DisabledApiKeyHash
+    ) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+
+  it should "reject the legacy public default key" in {
+    Get().addHeader(RawHeader("api_key", "hello")) ~>
+    protectedRoute(LegacyDefaultApiKeyHash) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+
+  it should "allow an explicitly configured operator key" in {
+    val operatorKey = "operator-test-key"
+
+    Get().addHeader(RawHeader("api_key", operatorKey)) ~>
+    protectedRoute(ApiKeyHash.hash(operatorKey)) ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  it should "reject an incorrect key for an explicitly configured operator hash" in {
+    val operatorKeyHash = ApiKeyHash.hash("operator-test-key")
+
+    Get().addHeader(RawHeader("api_key", "wrong-key")) ~>
+    protectedRoute(operatorKeyHash) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+}


### PR DESCRIPTION
Found while reviewing the v6.0.4 release candidate in #2293.

## Summary

- Bind shipped REST profiles and release-bundle configuration to loopback by default.
- Replace the public default API-key hash with an explicit disabled sentinel, and reject both that sentinel and the legacy public default hash on protected routes.
- Hash installer API keys offline from standard input instead of starting a temporary node. The default flow uses a hidden terminal prompt and restores the original terminal state; the legacy `--api-key` option remains available with a process-list exposure warning.
- Require the wallet to be unlocked and the requested change address to be owned by its active prover before persisting it.
- Ignore a pre-existing persisted unowned change address when resolving change outputs, falling back to the wallet root address.
- Return HTTP 400 for expected change-address validation failures while preserving HTTP 500 for unexpected storage or internal failures.
- Ship fail-closed configuration in generated release bundles and place JVM options before `-jar` in generated launchers.

## Security invariants

1. Protected REST routes remain unavailable while a shipped disabled hash or the legacy public default hash is configured.
2. Exposing the REST API externally requires an explicit operator bind address and API-key configuration.
3. A wallet change address can only be selected from keys controlled by the currently unlocked wallet.
4. Persisted values created before this validation cannot redirect the resolver to an unowned address.
5. The normal installer path does not expose the API key through terminal echo or Java process arguments.

## Operator impact

- The default REST bind changes to loopback: port `9053` for mainnet and `9052` for the other bundled profiles.
- Operators intentionally exposing the API must explicitly configure the external bind and should provide transport protection and firewall controls.
- Configurations still using the legacy public default API key must generate a new key and replace its hash. Protected routes now fail closed with the legacy hash.
- `/wallet/updateChangeAddress` now requires an unlocked wallet and a wallet-owned P2PK address. Invalid requests receive HTTP 400.
- The installer still accepts `--api-key` for compatibility, but the hidden interactive prompt is the recommended path.

## Validation

- Wallet route, service, actor, state, and transaction-resolver suites: 77 tests, 0 failures.
- REST settings, release bundle, hash, and authorization suites: 17 tests, 0 failures.
- `DigestStateSpecification` isolated retry: 7 tests, 0 failures.
- Final fat-JAR assembly and offline API-key helper smoke test.
- Bash and dash installer syntax checks.
- Python release-generator AST and OpenAPI YAML parsing.
- scalafmt 2.3.2 and `git diff --check`.

A repository-wide local run on Windows encountered pre-existing native `leveldbjni` JVM crashes after repeated database lifecycle operations. `CandidateGeneratorSpec` also reports the same forced-cache failure on this branch and on an unmodified worktree at the exact v6.0.4 base. Upstream CI remains the authoritative repository-wide gate.

## Related work

This is complementary to #2408. That PR adds optional HTTPS/TLS transport and deployment guidance; this change addresses fail-closed bind/authentication defaults, installer key handling, and wallet change-address authorization. It does not replace the TLS work.
