### PR TITLE
Fix v6 parameter matching call order

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
@@ -221,7 +221,7 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
               currentValidationState
                 .validate(exBlockVersion, calculatedParams.blockVersion == header.version, InvalidModifier(s"${calculatedParams.blockVersion} == ${header.version}", extension.id, extension.modifierTypeId))
                 .validateNoFailure(exMatchParameters, Parameters.matchParameters(parsedParams, calculatedParams), extension.id, extension.modifierTypeId)
-                .validateNoFailure(exMatchParameters60, Parameters.matchParameters60(parsedParams, calculatedParams, header.version), extension.id, extension.modifierTypeId)
+                .validateNoFailure(exMatchParameters60, Parameters.matchParameters60(calculatedParams, parsedParams, header.version), extension.id, extension.modifierTypeId)
                 .validate(exMatchValidationSettings, parsedSettings == calculatedSettings, InvalidModifier(s"$parsedSettings vs $calculatedSettings", extension.id, extension.modifierTypeId))
           }.result
       }.result

--- a/ergo-core/src/test/scala/org/ergoplatform/settings/VotingSpecification.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/settings/VotingSpecification.scala
@@ -180,6 +180,50 @@ class VotingSpecification extends ErgoCorePropertyTest {
     esc41.currentParameters.storageFeeFactor shouldBe (kInit - Parameters.StorageFeeFactorStep)
   }
 
+  property("version 6 parameter matching should require calculated parameters") {
+    val versionBefore60 = (Header.Interpreter60Version - 1).toByte
+    val unknownParameter = 42.toByte
+
+    val pre60Extra = processParameters(versionBefore60, _.updated(unknownParameter, 100))
+    val exact60 = processParameters(Header.Interpreter60Version, identity)
+    val extra60 = processParameters(
+      Header.Interpreter60Version,
+      _.updated(unknownParameter, 100)
+    )
+    val missingKnown60 = processParameters(
+      Header.Interpreter60Version,
+      _ - StorageFeeFactorIncrease
+    )
+    val missingSubblocks60 = processParameters(
+      Header.Interpreter60Version,
+      _ - SubblocksPerBlockIncrease
+    )
+    val mismatchedKnown60 = processParameters(
+      Header.Interpreter60Version,
+      table => table.updated(StorageFeeFactorIncrease, table(StorageFeeFactorIncrease) + 1)
+    )
+
+    val results = Seq(
+      "pre-6 extra parameter rejected" -> pre60Extra.isFailure,
+      "version 6 exact parameters accepted" -> exact60.isSuccess,
+      "version 6 extra parameter accepted" -> extra60.isSuccess,
+      "version 6 missing known parameter rejected" -> missingKnown60.isFailure,
+      "version 6 missing subblocks parameter rejected" -> missingSubblocks60.isFailure,
+      "version 6 mismatched known parameter rejected" -> mismatchedKnown60.isFailure
+    )
+
+    results shouldBe results.map { case (description, _) => description -> true }
+    pre60Extra.failed.get.getMessage should include(
+      "At the beginning of the epoch, the extension should contain all the system parameters"
+    )
+    Seq(missingKnown60, missingSubblocks60).foreach { result =>
+      result.failed.get.getMessage should include("Parameters differ in size")
+    }
+    mismatchedKnown60.failed.get.getMessage should include(
+      s"Calculated and received parameters differ in parameter $StorageFeeFactorIncrease"
+    )
+  }
+
   /**
     * A test which is ensuring that approved soft-fork activates properly.
     * For the test, we have:
@@ -389,6 +433,54 @@ class VotingSpecification extends ErgoCorePropertyTest {
     }
     val extension = (upcoming.currentParameters.toExtensionCandidate ++ upcoming.validationSettings.toExtensionCandidate).toExtension(headerId)
     esc.process(header, Some(extension))
+  }
+
+  private def processParameters(
+    version: Byte,
+    receivedTable: Map[Byte, Int] => Map[Byte, Int]
+  ): Try[ErgoStateContext] = {
+    val currentParams = Parameters(
+      2,
+      DefaultParameters.updated(BlockVersion, version),
+      ErgoValidationSettingsUpdate.empty
+    )
+    val currentValidationSettings = if (version >= Header.Interpreter60Version) {
+      validationSettingsNoIl.updated(
+        ErgoValidationSettingsUpdate(Seq(ValidationRules.exMatchParameters), Seq.empty)
+      )
+    } else {
+      validationSettingsNoIl
+    }
+    val header = defaultHeaderGen.sample.get.copy(
+      height = 4,
+      votes = Array.fill(3)(NoParameter),
+      version = version
+    )
+    val (calculatedParams, validationSettingsUpdate) = currentParams.update(
+      header.height,
+      forkVote = false,
+      Seq.empty,
+      ErgoValidationSettingsUpdate.empty,
+      votingSettings
+    )
+    val calculatedValidationSettings = currentValidationSettings.updated(validationSettingsUpdate)
+    val receivedParams = Parameters(
+      calculatedParams.height,
+      receivedTable(calculatedParams.parametersTable),
+      calculatedParams.proposedUpdate
+    )
+    val extension = (receivedParams.toExtensionCandidate ++
+      calculatedValidationSettings.toExtensionCandidate).toExtension(headerId)
+    val stateContext = new ErgoStateContext(
+      Seq.empty,
+      None,
+      genesisStateDigest,
+      currentParams,
+      currentValidationSettings,
+      VotingData.empty
+    )(updSettings)
+
+    stateContext.process(header, Some(extension))
   }
 
 }


### PR DESCRIPTION
## Summary

- pass locally calculated parameters as the required subset to
  `matchParameters60`;
- keep the pre-v6 strict parameter rule unchanged;
- cover the real epoch-extension processing path across the v6 activation
  boundary.

## Why

`matchParameters60` is directional: every parameter calculated by the local
node must exist with the same value in the received extension, while the
received extension may contain additional parameters unknown to the local
client.

The production caller supplied those operands in reverse order. As a result, a
v6 node could accept an epoch extension missing a locally required parameter
and reject an extension containing a legitimate new parameter.

The corrected order matches the contract documented in #2239 and exercised by
the helper-level tests in #2240. Neither PR changes the production call site.

## Tests

- `VotingSpecification` on Scala 2.11.12, 2.12.20 and 2.13.16: 11 passed on
  each version.
- `ergoCore/test` on Scala 2.11.12, 2.12.20 and 2.13.16: 105 passed and 2
  pre-existing tests ignored on each version.
- The regression matrix covers:
  - pre-v6 strict rejection of an extra parameter;
  - v6 exact parameters;
  - a v6 received superset;
  - a missing known parameter;
  - the v6-specific subblocks parameter missing;
  - a mismatched known value.

A broader local node run was interrupted by a native `leveldbjni` crash on
Windows/JDK 17 while opening a test database. The interrupted
`DigestStateSpecification` suite then passed 7/7 in isolation. GitHub CI uses
Linux and Java 8.
