### PR TITLE
Remove only the transport peer on rejected handshakes

### DIFF
--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -423,7 +423,7 @@ class NetworkController(ergoSettings: ErgoSettings,
 
       if (shouldDrop) {
         connectedPeer.handlerRef ! CloseConnection
-        peerManagerRef ! RemovePeer(peerAddress)
+        peerManagerRef ! RemovePeer(remoteAddress)
         connections -= connectedPeer.connectionId.remoteAddress
       } else {
         val newPeerInfo = peerInfo.copy(lastStoredActivityTime = time())

--- a/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
@@ -3,6 +3,8 @@ package scorex.core.network
 import akka.actor.ActorRef
 import akka.io.Tcp
 import akka.testkit.{TestActorRef, TestProbe}
+import akka.util.ByteString
+import org.ergoplatform.network.{Handshake, HandshakeSerializer}
 import org.ergoplatform.network.message.MessageConstants.MessageCode
 import org.ergoplatform.network.peer.PeerInfo
 import org.ergoplatform.utils.ErgoCorePropertyTest
@@ -24,6 +26,8 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
     implicit val actorSystem = system
 
     val scorexContext: ScorexContext = ScorexContext(Seq.empty, None, None)
+
+    case class EstablishedConnection(connectionProbe: TestProbe, handlerRef: ActorRef)
 
     def createController(maxConnections: Int): (TestActorRef[NetworkController], TestProbe, TestProbe) = {
       val peerManagerProbe = TestProbe("PeerManager")
@@ -56,6 +60,33 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
       peerManagerProbe: TestProbe,
       remoteAddress: InetSocketAddress
     ): InetSocketAddress = {
+      beginIncomingConnection(controller, peerManagerProbe, remoteAddress)
+      remoteAddress
+    }
+
+    def establishIncomingConnectionWithHandler(
+      controller: TestActorRef[NetworkController],
+      peerManagerProbe: TestProbe,
+      remoteAddress: InetSocketAddress
+    ): EstablishedConnection = {
+      val connectionProbe = beginIncomingConnection(
+        controller,
+        peerManagerProbe,
+        remoteAddress
+      )
+
+      val handlerRef = connectionProbe.expectMsgType[Tcp.Register].handler
+      connectionProbe.expectMsg(Tcp.ResumeReading)
+      connectionProbe.expectMsgType[Tcp.Write]
+
+      EstablishedConnection(connectionProbe, handlerRef)
+    }
+
+    private def beginIncomingConnection(
+      controller: TestActorRef[NetworkController],
+      peerManagerProbe: TestProbe,
+      remoteAddress: InetSocketAddress
+    ): TestProbe = {
       val localAddress = settings.scorexSettings.network.bindAddress
       val connectionProbe = TestProbe("Connection")
 
@@ -66,7 +97,7 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
           controller ! ConnectionConfirmed(ConnectionId(remoteAddress, localAddress, Incoming), handlerRef)
       }
 
-      remoteAddress
+      connectionProbe
     }
 
     def establishOutgoingConnection(
@@ -268,6 +299,49 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
 
       connectionProbe.send(controller, Tcp.Connected(remoteAddress, localAddress))
       connectionProbe.expectMsg(Tcp.Close)
+    }
+  }
+
+  property("rejected handshake should remove only the transport peer") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections = 30)
+
+      val victimAddress = new InetSocketAddress("192.168.1.1", 9001)
+      val attackerAddress = new InetSocketAddress("192.168.1.2", 9002)
+      f.establishIncomingConnection(controller, peerManagerProbe, victimAddress)
+      val attackerConnection = f.establishIncomingConnectionWithHandler(
+        controller,
+        peerManagerProbe,
+        attackerAddress
+      )
+
+      val attackerHandshake = Handshake(
+        defaultPeerSpec.copy(declaredAddress = Some(victimAddress)),
+        System.currentTimeMillis()
+      )
+      attackerConnection.connectionProbe.send(
+        attackerConnection.handlerRef,
+        Tcp.Received(ByteString(HandshakeSerializer.toBytes(attackerHandshake)))
+      )
+
+      attackerConnection.connectionProbe.expectMsg(Tcp.ResumeReading)
+      peerManagerProbe.expectMsg(RemovePeer(attackerAddress))
+      attackerConnection.connectionProbe.expectMsg(Tcp.Abort)
+      peerManagerProbe.expectNoMessage(200.millis)
+
+      val localAddress = settings.scorexSettings.network.bindAddress
+      val duplicateVictimProbe = TestProbe("DuplicateVictim")
+      duplicateVictimProbe.send(controller, Tcp.Connected(victimAddress, localAddress))
+      duplicateVictimProbe.expectMsg(Tcp.Close)
+
+      val attackerReconnectProbe = TestProbe("AttackerReconnect")
+      attackerReconnectProbe.send(controller, Tcp.Connected(attackerAddress, localAddress))
+      peerManagerProbe.expectMsgPF(1.second) {
+        case ConfirmConnection(connectionId, connectionRef) =>
+          connectionId.remoteAddress shouldBe attackerAddress
+          connectionRef shouldBe attackerReconnectProbe.ref
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- remove the observed remote transport endpoint when a handshake is rejected;
- prevent a peer-declared address from selecting a different peer-database
  entry for removal;
- add a wire-level regression test that keeps the existing peer connected while
  closing and removing the rejected transport.

## Rationale

`NetworkController.handleHandshake` uses the address declared in the handshake
to detect duplicate peer identities. That value is supplied by the remote peer.
Reusing it as the operand of `RemovePeer` lets a rejected connection name an
existing peer and remove that peer's database entry.

The controller already has the rejected handler's observed
`connectionId.remoteAddress`. This change uses that transport endpoint only for
destructive cleanup, while leaving duplicate detection, handshake acceptance,
wire format and connection-map behavior unchanged.

## Tests

- `sbt "testOnly scorex.core.network.NetworkControllerSpec"` (12 passed)
- relevant network suites covering the controller, serializers and peer
  filtering (24 passed)

The regression serializes the attacker's handshake and delivers it through the
real `PeerConnectionHandler`. It verifies that the attacker transport is
aborted and removed, the existing peer remains connected, and the closed
transport's connection-map slot is released.
