### PR TITLE
Fix custom mining public key handling

### DIFF
--- a/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -26,8 +26,18 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
       val b = pow.getB(h.nBits)
       val hbs = Ints.toByteArray(h.height)
       val N = pow.calcN(h)
-      val newHeader = pow.checkNonces(ver, hbs, msg, sk, x, b, N, 0, 1000)
-        .map(s => h.copy(powSolution = s)).get
+
+      def findHeader(message: Array[Byte], expected: Header => Boolean): Header = {
+        (0L until 100000L by 1000L).iterator
+          .flatMap { startNonce =>
+            pow.checkNonces(ver, hbs, message, sk, x, b, N, startNonce, startNonce + 1000)
+              .map(s => h.copy(powSolution = s))
+          }
+          .find(expected)
+          .getOrElse(fail("Unable to find a PoW solution matching test expectation"))
+      }
+
+      val newHeader = findHeader(msg, pow.validate(_).isSuccess)
       pow.validate(newHeader) shouldBe 'success
 
       if(ver > Header.InitialVersion) {
@@ -35,8 +45,8 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
         require(HeaderSerializer.bytesWithoutPow(h).last == 0)
         val msg2 = Blake2b256(HeaderSerializer.bytesWithoutPow(h).dropRight(1))
 
-        val newHeader2 = pow.checkNonces(ver, hbs, msg2, sk, x, b, N, 0, 1000)
-          .map(s => h.copy(powSolution = s)).get
+        // A solution mined against the legacy message can still meet the current target by chance.
+        val newHeader2 = findHeader(msg2, pow.validate(_).isFailure)
         pow.validate(newHeader2) shouldBe 'failure
       }
     }

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -2461,6 +2461,20 @@ components:
       items:
         $ref: '#/components/schemas/ErgoTransaction'
 
+    MiningRequest:
+      description: Block candidate request with mandatory transactions and miner public key
+      type: object
+      required:
+        - txs
+        - pk
+      properties:
+        txs:
+          $ref: '#/components/schemas/Transactions'
+        pk:
+          type: string
+          description: Hex-encoded miner public key to use for block rewards
+          example: '02a7955281885bf0f0ca4a48678848cad8dc5b328ce8bc1d4481d041c98e891ff3'
+
     TransactionsWithInputBoxes:
       description: List of ErgoTransaction augmented with input boxes
       type: array
@@ -5127,6 +5141,34 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Transactions'
+      responses:
+        '200':
+          description: External candidate
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkMessage'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /mining/candidateWithTxsAndPk:
+    post:
+      security:
+        - ApiKeyAuth: [api_key]
+      summary: Request block candidate with custom miner public key
+      operationId: miningRequestBlockCandidateWithMandatoryTransactionsAndPk
+      tags:
+        - mining
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MiningRequest'
       responses:
         '200':
           description: External candidate

--- a/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/MiningApiRoute.scala
@@ -5,20 +5,18 @@ import akka.http.scaladsl.server.Route
 import akka.pattern.ask
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
-import org.bouncycastle.util.encoders.Hex
 import org.ergoplatform.http.api.requests.MiningRequest
 import org.ergoplatform.mining.CandidateGenerator.Candidate
-import org.ergoplatform.mining.{AutolykosSolution, CandidateGenerator, ErgoMiner}
+import org.ergoplatform.mining.{AutolykosSolution, CandidateGenerator, ErgoMiner, groupElemFromBytes}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.wallet.ErgoAddressJsonEncoder
-import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
+import org.ergoplatform.settings.{Algos, ErgoSettings, RESTApiSettings}
 import org.ergoplatform.{ErgoAddress, ErgoTreePredef, Pay2SAddress}
 import scorex.core.api.http.ApiResponse
 import sigma.data.ProveDlog
-import sigma.serialization.GroupElementSerializer
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 case class MiningApiRoute(miner: ActorRef,
                           ergoSettings: ErgoSettings)
@@ -27,10 +25,17 @@ case class MiningApiRoute(miner: ActorRef,
   val settings: RESTApiSettings = ergoSettings.scorexSettings.restApi
 
   implicit val addressEncoder: Encoder[ErgoAddress] = ErgoAddressJsonEncoder(ergoSettings.chainSettings).encoder
+  private implicit val proveDlogDecoder: Decoder[ProveDlog] = Decoder.instance { implicit cursor =>
+    for {
+      str <- cursor.as[String]
+      bytes <- fromTry(Algos.decode(str))
+      pk <- fromTry(Try(ProveDlog(groupElemFromBytes(bytes))))
+    } yield pk
+  }
   implicit val miningRequestDecoder: Decoder[MiningRequest] = { cursor =>
     for {
       txs <- cursor.downField("txs").as[Seq[ErgoTransaction]]
-      pk <- cursor.downField("pk").as[String]
+      pk <- cursor.downField("pk").as[ProveDlog]
     } yield MiningRequest(txs, pk)
   }
   override val route: Route = pathPrefix("mining") {
@@ -65,16 +70,10 @@ case class MiningApiRoute(miner: ActorRef,
 
   def candidateWithTxsAndPkR: Route = (path("candidateWithTxsAndPk")
     & post & entity(as[MiningRequest]) & withAuth) { txsAndPk =>
-    val tryPk = Try(GroupElementSerializer.fromBytes(Hex.decode(txsAndPk.pk)))
-    val result = tryPk match {
-      case Failure(_) =>
-        Future.failed(new Exception("Could not decode hexadecimal string for given public key"))
-      case Success(pk) =>
-        val prepareCmd = CandidateGenerator.GenerateCandidate(txsAndPk.txs, reply = true,
-          forced = false, Some(ProveDlog.apply(pk)))
-        miner.askWithStatus(prepareCmd).mapTo[Candidate].map(_.externalVersion)
-    }
-    ApiResponse(result)
+    val prepareCmd = CandidateGenerator.GenerateCandidate(txsAndPk.txs, reply = true,
+      forced = false, Some(txsAndPk.pk))
+    val candidateF = miner.askWithStatus(prepareCmd).mapTo[Candidate].map(_.externalVersion)
+    ApiResponse(candidateF)
   }
 
   def solutionR: Route = (path("solution") & post & entity(as[AutolykosSolution])) { solution =>

--- a/src/main/scala/org/ergoplatform/http/api/requests/MiningRequest.scala
+++ b/src/main/scala/org/ergoplatform/http/api/requests/MiningRequest.scala
@@ -1,11 +1,12 @@
 package org.ergoplatform.http.api.requests
 
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import sigma.data.ProveDlog
 
 /**
   * Represents a request to generate a candidate with the given transactions and miner public key.
   *
   * @param txs      Transactions to include in the block candidate
-  * @param pk       String Hexadecimal representation of public key to use as minerPk
+  * @param pk       Public key to use as minerPk
   */
-case class MiningRequest(txs: Seq[ErgoTransaction], pk: String)
+case class MiningRequest(txs: Seq[ErgoTransaction], pk: ProveDlog)

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -154,7 +154,8 @@ class CandidateGenerator(
 
     case gen @ GenerateCandidate(txsToInclude, reply, forced, optPk) =>
       val senderOpt = if (reply) Some(sender()) else None
-      if (!forced && cachedFor(state.cachedCandidate, txsToInclude)) {
+      val effectiveMinerPk = optPk.getOrElse(minerPk)
+      if (!forced && cachedFor(state.cachedCandidate, txsToInclude, effectiveMinerPk)) {
         senderOpt.foreach(_ ! StatusReply.success(state.cachedCandidate.get))
       } else {
         val start = System.currentTimeMillis()
@@ -162,7 +163,7 @@ class CandidateGenerator(
           state.hr,
           state.sr,
           state.mpr,
-          optPk.getOrElse(minerPk),
+          effectiveMinerPk,
           txsToInclude,
           ergoSettings
         ) match {
@@ -198,20 +199,24 @@ class CandidateGenerator(
 
     case preSolution: AutolykosSolution
         if state.solvedBlock.isEmpty && state.cachedCandidate.nonEmpty =>
-      // Inject node pk if it is not externally set (in Autolykos 2)
-      val solution =
+      // Inject candidate pk if it is not externally set (in Autolykos 2)
+      def solutionFor(candidate: Candidate): AutolykosSolution =
         if (CryptoFacade.isInfinityPoint(preSolution.pk)) {
-          AutolykosSolution(minerPk.value, preSolution.w, preSolution.n, preSolution.d)
+          AutolykosSolution(candidate.externalVersion.pk.value, preSolution.w, preSolution.n, preSolution.d)
         } else {
           preSolution
         }
+
+      def complete(candidate: Candidate): ErgoFullBlock =
+        completeBlock(candidate.candidateBlock, solutionFor(candidate))
+
       val result: StatusReply[Unit] = {
         val newBlock = state.cachedCandidate
-          .map(candidate => completeBlock(candidate.candidateBlock, solution))
+          .map(complete)
           .filter(block => ergoSettings.chainSettings.powScheme.validate(block.header).isSuccess)
           .getOrElse {
             log.info(s"Using previous candidate as a solution: " + state.cachedPreviousCandidate)
-            completeBlock(state.cachedPreviousCandidate.get.candidateBlock, solution)
+            complete(state.cachedPreviousCandidate.get)
           }
         log.info(s"New block mined, header: ${newBlock.header}")
         ergoSettings.chainSettings.powScheme
@@ -229,7 +234,7 @@ class CandidateGenerator(
             )
         }
       }
-      log.info(s"Processed solution $solution with the result $result")
+      log.info(s"Processed solution $preSolution with the result $result")
       sender() ! result
 
     case _: AutolykosSolution =>
@@ -296,12 +301,14 @@ object CandidateGenerator extends ScorexLogging {
   /** checks that current candidate block is cached with given `txs` */
   def cachedFor(
     candidateOpt: Option[Candidate],
-    txs: Seq[ErgoTransaction]
+    txs: Seq[ErgoTransaction],
+    minerPk: ProveDlog
   ): Boolean = {
     candidateOpt.isDefined && candidateOpt.exists { c =>
-      txs.isEmpty || (txs.size == c.txsToInclude.size && txs.forall(
+      c.externalVersion.pk == minerPk &&
+      (txs.isEmpty || (txs.size == c.txsToInclude.size && txs.forall(
         c.txsToInclude.contains
-      ))
+      )))
     }
   }
 
@@ -356,9 +363,13 @@ object CandidateGenerator extends ScorexLogging {
     val miningTimes =
       timestamps.sorted
         .sliding(2, 1)
-        .map { case IndexedSeq(prev, next) => next - prev }
+        .collect { case IndexedSeq(prev, next) => next - prev }
         .toVector
-    Math.round(miningTimes.sum / miningTimes.length.toDouble).millis
+    if (miningTimes.nonEmpty) {
+      Math.round(miningTimes.sum / miningTimes.length.toDouble).millis
+    } else {
+      1000.millis
+    }
   }
 
   /** Get average count of transactions per block */
@@ -857,6 +868,7 @@ object CandidateGenerator extends ScorexLogging {
     )
 
     val verifier: ErgoInterpreter = ErgoInterpreter(upcomingContext.currentParameters)
+    val allowIntraBlockSpending = upcomingContext.blockVersion >= Header.Interpreter60Version
 
     @tailrec
     def loop(
@@ -869,18 +881,23 @@ object CandidateGenerator extends ScorexLogging {
       val currentCosted = acc ++ lastFeeTx
       def current: Seq[ErgoTransaction] = currentCosted.map(_._1)
 
-      val stateWithTxs = us.withTransactions(current)
+      val validationState =
+        if (allowIntraBlockSpending) {
+          us.withTransactions(current)
+        } else {
+          us
+        }
 
       mempoolTxs.headOption match {
         case Some(tx) =>
-          if (!inputsNotSpent(tx, stateWithTxs) || doublespend(current, tx)) {
+          if (!inputsNotSpent(tx, validationState) || doublespend(current, tx)) {
             //mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
             //do these checks before validating the scripts to save time
             log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
             loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
           } else {
             // check validity and calculate transaction cost
-            stateWithTxs.validateWithCost(
+            validationState.validateWithCost(
               tx,
               upcomingContext,
               maxBlockCost,
@@ -908,7 +925,7 @@ object CandidateGenerator extends ScorexLogging {
                       case Failure(e) =>
                         log.warn(
                           s"Fee collecting tx is invalid, not including it, " +
-                            s"details: ${e.getMessage} from ${stateWithTxs.stateContext}"
+                            s"details: ${e.getMessage} from ${validationState.stateContext}"
                         )
                         current -> invalidTxs
                     }

--- a/src/test/scala/org/ergoplatform/http/routes/MiningApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/MiningApiRouteSpec.scala
@@ -8,12 +8,16 @@ import io.circe.Json
 import io.circe.syntax._
 import org.ergoplatform.http.api.MiningApiRoute
 import org.ergoplatform.mining.AutolykosSolution
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.settings.ErgoSettings
 import org.ergoplatform.utils.Stubs
 import org.ergoplatform.utils.generators.ErgoCoreGenerators.genECPoint
 import org.ergoplatform.{ErgoTreePredef, Pay2SAddress}
+import org.bouncycastle.util.BigIntegers
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scorex.util.encode.Base16
+import sigmastate.crypto.DLogProtocol.DLogProverInput
 
 import scala.util.Try
 
@@ -38,6 +42,44 @@ class MiningApiRouteSpec
     Get(prefix + "/candidate") ~> route ~> check {
       status shouldBe StatusCodes.OK
       Try(responseAs[Json]) shouldBe 'success
+    }
+  }
+
+  it should "return requested candidate with a custom miner public key" in {
+    val customPk = DLogProverInput(
+      BigIntegers.fromUnsignedByteArray("custom route miner".getBytes())
+    ).publicImage
+    val customPkHex = Base16.encode(customPk.pkBytes)
+    val request = Json.obj(
+      "txs" -> Seq.empty[ErgoTransaction].asJson,
+      "pk" -> customPkHex.asJson
+    )
+
+    Post(prefix + "/candidateWithTxsAndPk", request) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("pk").as[String] shouldEqual Right(customPkHex)
+    }
+  }
+
+  it should "reject candidate requests with an invalid custom miner public key" in {
+    val request = Json.obj(
+      "txs" -> Seq.empty[ErgoTransaction].asJson,
+      "pk" -> "not-a-public-key".asJson
+    )
+
+    Post(prefix + "/candidateWithTxsAndPk", request) ~> Route.seal(route) ~> check {
+      status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "reject candidate requests with malformed custom miner public key bytes" in {
+    val request = Json.obj(
+      "txs" -> Seq.empty[ErgoTransaction].asJson,
+      "pk" -> "00".asJson
+    )
+
+    Post(prefix + "/candidateWithTxsAndPk", request) ~> Route.seal(route) ~> check {
+      status shouldBe StatusCodes.BadRequest
     }
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -15,7 +15,7 @@ import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
-import org.ergoplatform.settings.NetworkType.DevNet60
+import org.ergoplatform.settings.NetworkType.{DevNet, DevNet60}
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
@@ -41,6 +41,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   private val candidateGenDelay: FiniteDuration    = 3.seconds
   private val blockValidationDelay: FiniteDuration = 2.seconds
 
+  private def publicImageFromString(value: String): ProveDlog =
+    DLogProverInput(BigIntegers.fromUnsignedByteArray(value.getBytes())).publicImage
+
   val defaultSettings: ErgoSettings = {
     val empty = ErgoSettingsReader.read()
     val nodeSettings = empty.nodeSettings.copy(
@@ -54,6 +57,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings)
   }
 
+  private val defaultSettings50 = defaultSettings.copy(networkType = DevNet, directory = defaultSettings.directory + "50")
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
@@ -170,6 +174,98 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
+  it should "not reuse cached candidate for a different miner public key" in new TestKit(
+    ActorSystem()
+  ) {
+    val testProbe = new TestProbe(system)
+
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+
+    val candidateGenerator: ActorRef =
+      CandidateGenerator(
+        defaultMinerSecret.publicImage,
+        readersHolderRef,
+        viewHolderRef,
+        defaultSettings
+      )
+
+    expectNoMessage(1.second)
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+
+    testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        candidate.externalVersion.pk shouldBe defaultMinerPk
+    }
+
+    val customMinerPk = publicImageFromString("custom miner public key")
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false, Some(customMinerPk)),
+      testProbe.ref
+    )
+
+    testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        candidate.externalVersion.pk shouldBe customMinerPk
+        candidate.candidateBlock.transactions.last.outputs.last.propositionBytes shouldBe
+          ErgoTreePredef.rewardOutputScript(
+            emission.settings.minerRewardDelay,
+            customMinerPk
+          ).bytes
+    }
+
+    system.terminate()
+  }
+
+  it should "use custom candidate public key when external Autolykos v2 solution omits pk" in new TestKit(
+    ActorSystem()
+  ) {
+    val testProbe = new TestProbe(system)
+    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+
+    val candidateGenerator: ActorRef =
+      CandidateGenerator(
+        defaultMinerSecret.publicImage,
+        readersHolderRef,
+        viewHolderRef,
+        defaultSettings60
+      )
+
+    val customMinerPk = publicImageFromString("custom autolykos v2 miner")
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false, Some(customMinerPk)),
+      testProbe.ref
+    )
+
+    testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        candidate.externalVersion.pk shouldBe customMinerPk
+        val block = defaultSettings60.chainSettings.powScheme
+          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
+          .get
+        val solutionWithoutPk = block.header.powSolution.copy(pk = AutolykosSolution.pkForV2)
+
+        candidateGenerator.tell(solutionWithoutPk, testProbe.ref)
+        testProbe.fishForMessage(blockValidationDelay) {
+          case StatusReply.Success(()) =>
+            testProbe.expectMsgPF(candidateGenDelay) {
+              case FullBlockApplied(header) if header.id != block.header.parentId =>
+                header.powSolution.pk shouldBe customMinerPk.value
+            }
+            true
+          case FullBlockApplied(header) if header.id != block.header.parentId =>
+            header.powSolution.pk shouldBe customMinerPk.value
+            testProbe.expectMsg(StatusReply.Success(()))
+            true
+        }
+    }
+
+    system.terminate()
+  }
+
   it should "regenerate candidate periodically" in new TestKit(
     ActorSystem()
   ) {
@@ -221,8 +317,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // build new transaction that uses miner's reward as input
-    val prop: ProveDlog =
-      DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
+    val prop: ProveDlog = publicImageFromString("test")
     val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
     val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
@@ -311,8 +406,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // build new transaction that uses miner's reward as input
-    val prop: ProveDlog =
-      DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
+    val prop: ProveDlog = publicImageFromString("test")
     val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
     val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
@@ -417,8 +511,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // build new transaction that uses miner's reward as input
-    val prop: ProveDlog =
-      DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
+    val prop: ProveDlog = publicImageFromString("test")
     val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
     val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
@@ -481,7 +574,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   ) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings50)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -489,7 +582,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        defaultSettings50
       )
 
     val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
@@ -501,7 +594,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = defaultSettings50.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         // let's pretend we are mining at least a bit so it is realistic
@@ -557,7 +650,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = defaultSettings50.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)

--- a/src/test/scala/org/ergoplatform/utils/Stubs.scala
+++ b/src/test/scala/org/ergoplatform/utils/Stubs.scala
@@ -112,9 +112,13 @@ trait Stubs extends ErgoTestHelpers with TestFileUtils {
 
   class MinerStub extends Actor {
     def receive: Receive = {
-      case CandidateGenerator.GenerateCandidate(_, reply, _, _) =>
+      case CandidateGenerator.GenerateCandidate(_, reply, _, optPk) =>
         if (reply) {
-          val candidate = Candidate(null, externalWorkMessage, Seq.empty) // API does not use CandidateBlock
+          val candidate = Candidate(
+            null,
+            externalWorkMessage.copy(pk = optPk.getOrElse(pk)),
+            Seq.empty
+          ) // API does not use CandidateBlock
           sender() ! StatusReply.success(candidate)
         }
       case _: AutolykosSolution => sender() ! StatusReply.success(())


### PR DESCRIPTION
﻿## Summary
- Prevent cached mining candidates from being reused across different requested miner public keys.
- Use the candidate public key when completing Autolykos v2 solutions that omit `pk`.
- Decode `/mining/candidateWithTxsAndPk` public keys through the request decoder so malformed keys are rejected as bad requests.
- Document `/mining/candidateWithTxsAndPk` in OpenAPI.

## Local verification
- `sbt "testOnly org.ergoplatform.mining.CandidateGeneratorSpec -- -z custom"`
- `sbt "testOnly org.ergoplatform.mining.CandidateGeneratorSpec -- -z reuse"`
- `sbt "testOnly org.ergoplatform.http.routes.MiningApiRouteSpec"`
- `git diff --check`

The full `sbt test` suite is intentionally left to GitHub CI because it is very long locally for this repository.
