### PR TITLE
Bound per-peer outbound buffering

### DIFF
--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -4,14 +4,19 @@ import akka.actor.{Actor, ActorRef, Cancellable, Props, SupervisorStrategy}
 import akka.io.Tcp
 import akka.io.Tcp._
 import akka.util.{ByteString, CompactByteString}
-import org.ergoplatform.network.{Handshake, HandshakeSerializer, PeerSpec, Version}
 import org.ergoplatform.network.Version.Eip37ForkVersion
-import scorex.core.app.ScorexContext
-import scorex.core.network.NetworkController.ReceivableMessages.{Handshaked, PenalizePeer}
-import scorex.core.network.PeerConnectionHandler.ReceivableMessages
+import org.ergoplatform.network.{Handshake, HandshakeSerializer, PeerSpec, Version}
+import org.ergoplatform.network.message.MessageConstants.{
+  ChecksumLength,
+  HeaderLength,
+  MaxMessageSize
+}
 import org.ergoplatform.network.message.MessageSerializer
 import org.ergoplatform.network.peer.{PeerInfo, PenaltyType}
 import org.ergoplatform.settings.ScorexSettings
+import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController.ReceivableMessages.{Handshaked, PenalizePeer}
+import scorex.core.network.PeerConnectionHandler.ReceivableMessages
 import scorex.util.ScorexLogging
 
 import scala.annotation.tailrec
@@ -27,6 +32,7 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
   extends Actor with ScorexLogging {
 
   import PeerConnectionHandler.ReceivableMessages._
+  import PeerConnectionHandler.{MaxBufferedOutboundBytes, MaxBufferedOutboundMessages}
 
   private val networkSettings = scorexSettings.network
   private val connection = connectionDescription.connection
@@ -47,6 +53,8 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
   private var chunksBuffer: ByteString = CompactByteString.empty
 
   private var outMessagesBuffer: TreeMap[Long, ByteString] = TreeMap.empty
+
+  private var outMessagesBufferBytes: Long = 0L
 
   private var outMessagesCounter: Long = 0
 
@@ -179,7 +187,10 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
       writeFirst()
 
     case ReceivableMessages.Ack(id) =>
-      outMessagesBuffer -= id
+      outMessagesBuffer.get(id).foreach { msg =>
+        outMessagesBuffer -= id
+        outMessagesBufferBytes -= msg.length
+      }
       if (outMessagesBuffer.nonEmpty){
         writeFirst()
       } else {
@@ -226,7 +237,22 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
   }
 
   private def buffer(id: Long, msg: ByteString): Unit = {
-    outMessagesBuffer += id -> msg
+    val previousMessage = outMessagesBuffer.get(id)
+    val previousLength = previousMessage.fold(0)(_.length)
+    val candidateBytes = outMessagesBufferBytes - previousLength + msg.length
+    val candidateMessages = outMessagesBuffer.size + previousMessage.fold(1)(_ => 0)
+    if (candidateBytes > MaxBufferedOutboundBytes ||
+        candidateMessages > MaxBufferedOutboundMessages) {
+      log.warn(s"Buffered outbound data for $connectionId would exceed its limit " +
+        s"($candidateMessages messages, $candidateBytes bytes), aborting the connection")
+      outMessagesBuffer = TreeMap.empty
+      outMessagesBufferBytes = 0L
+      connection ! Abort
+      context.stop(self)
+    } else {
+      outMessagesBuffer += id -> msg
+      outMessagesBufferBytes = candidateBytes
+    }
   }
 
   private def writeFirst(): Unit = {
@@ -258,6 +284,14 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
 }
 
 object PeerConnectionHandler {
+
+  // Keep one maximum serialized frame per peer. Backpressured snapshot transfers
+  // retry instead of retaining their entire application-level in-flight window.
+  private[network] val MaxBufferedOutboundBytes: Long =
+    MaxMessageSize.toLong + HeaderLength + ChecksumLength
+
+  // Independently bound collection overhead from small messages.
+  private[network] val MaxBufferedOutboundMessages: Int = 64
 
   object ReceivableMessages {
     

--- a/src/test/scala/scorex/core/network/PeerConnectionHandlerSpecification.scala
+++ b/src/test/scala/scorex/core/network/PeerConnectionHandlerSpecification.scala
@@ -1,0 +1,164 @@
+package scorex.core.network
+
+import akka.io.Tcp
+import akka.testkit.{TestActorRef, TestProbe}
+import akka.util.ByteString
+import org.ergoplatform.network.message.{
+  GetPeersSpec,
+  Message,
+  MessageSpec,
+  UtxoSnapshotChunkSpec
+}
+import org.ergoplatform.network.{Handshake, HandshakeSerializer}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.{defaultPeerSpec, settings}
+import scorex.core.app.ScorexContext
+import scorex.testkit.utils.AkkaFixture
+
+import java.net.InetSocketAddress
+import scala.concurrent.Await
+import scala.concurrent.duration.{Duration, DurationInt}
+
+class PeerConnectionHandlerSpecification extends ErgoCorePropertyTest {
+  private final class ConnectedHandler(val connection: TestProbe,
+                                       val watcher: TestProbe,
+                                       val handler: TestActorRef[PeerConnectionHandler])
+
+  private def withConnectedHandler(
+    messageSpecs: Seq[MessageSpec[_]],
+    localPort: Int
+  )(test: ConnectedHandler => Unit): Unit = {
+    val fixture = new AkkaFixture
+    try {
+      implicit val system = fixture.system
+      implicit val ec = system.dispatcher
+      val connection = TestProbe("connection")
+      val controller = TestProbe("controller")
+      val localAddress = new InetSocketAddress("127.0.0.1", localPort)
+      val remoteAddress = new InetSocketAddress("127.0.0.1", localPort + 1)
+      val description = ConnectionDescription(
+        connection.ref,
+        ConnectionId(remoteAddress, localAddress, Incoming),
+        Some(localAddress),
+        Seq.empty
+      )
+      val handler = TestActorRef(new PeerConnectionHandler(
+        settings.scorexSettings,
+        controller.ref,
+        ScorexContext(messageSpecs, None, None),
+        description
+      ))
+
+      connection.expectMsgType[Tcp.Register]
+      connection.expectMsg(Tcp.ResumeReading)
+      connection.expectMsgType[Tcp.Write]
+
+      val handshake = HandshakeSerializer.toBytes(
+        Handshake(defaultPeerSpec, System.currentTimeMillis())
+      )
+      connection.send(handler, Tcp.Received(ByteString(handshake)))
+      controller.expectMsgType[NetworkController.ReceivableMessages.Handshaked]
+      connection.expectMsg(Tcp.ResumeReading)
+      controller.watch(handler)
+
+      test(new ConnectedHandler(connection, controller, handler))
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  property("abort before a fifth maximum snapshot frame is retained") {
+    withConnectedHandler(Seq(UtxoSnapshotChunkSpec), localPort = 9083) { fixture =>
+      val chunkMessage = Message(
+        UtxoSnapshotChunkSpec,
+        Right(Array.fill[Byte](3999996)(1)),
+        None
+      )
+      fixture.handler ! chunkMessage
+      val failedWrite = fixture.connection.expectMsgType[Tcp.Write]
+      failedWrite.data.length shouldEqual 4000013
+      fixture.connection.send(fixture.handler, Tcp.CommandFailed(failedWrite))
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+
+      (2 to 4).foreach { id =>
+        val write = Tcp.Write(
+          failedWrite.data,
+          PeerConnectionHandler.ReceivableMessages.Ack(id)
+        )
+        fixture.connection.send(fixture.handler, Tcp.CommandFailed(write))
+        fixture.connection.expectMsg(Tcp.ResumeWriting)
+      }
+      fixture.connection.expectNoMessage(200.millis)
+
+      val overLimitWrite = Tcp.Write(
+        failedWrite.data,
+        PeerConnectionHandler.ReceivableMessages.Ack(5)
+      )
+      fixture.connection.send(
+        fixture.handler,
+        Tcp.CommandFailed(overLimitWrite)
+      )
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+      fixture.connection.expectMsg(1.second, Tcp.Abort)
+      fixture.watcher.expectTerminated(fixture.handler)
+    }
+  }
+
+  property("abort before more than 64 outbound messages are buffered") {
+    withConnectedHandler(Seq(GetPeersSpec), localPort = 9093) { fixture =>
+      val getPeersMessage = Message(GetPeersSpec, Right(()), None)
+      fixture.handler ! getPeersMessage
+      val failedWrite = fixture.connection.expectMsgType[Tcp.Write]
+      fixture.connection.send(fixture.handler, Tcp.CommandFailed(failedWrite))
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+
+      (1 until PeerConnectionHandler.MaxBufferedOutboundMessages)
+        .foreach(_ => fixture.handler ! getPeersMessage)
+      fixture.connection.expectNoMessage(200.millis)
+
+      fixture.handler ! getPeersMessage
+      fixture.connection.expectMsg(1.second, Tcp.Abort)
+      fixture.watcher.expectTerminated(fixture.handler)
+    }
+  }
+
+  property("account retried and acknowledged writes exactly") {
+    withConnectedHandler(Seq(GetPeersSpec), localPort = 9103) { fixture =>
+      val maxSizedWrite = Tcp.Write(
+        ByteString(new Array[Byte](
+          PeerConnectionHandler.MaxBufferedOutboundBytes.toInt
+        )),
+        PeerConnectionHandler.ReceivableMessages.Ack(1)
+      )
+      fixture.connection.send(fixture.handler, Tcp.CommandFailed(maxSizedWrite))
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+      fixture.connection.expectNoMessage(200.millis)
+
+      val replacementWrite = Tcp.Write(
+        ByteString(new Array[Byte](9)),
+        PeerConnectionHandler.ReceivableMessages.Ack(1)
+      )
+      fixture.connection.send(
+        fixture.handler,
+        Tcp.CommandFailed(replacementWrite)
+      )
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+      fixture.connection.expectNoMessage(200.millis)
+
+      fixture.connection.send(fixture.handler, Tcp.WritingResumed)
+      val retriedWrite = fixture.connection.expectMsgType[Tcp.Write]
+      retriedWrite.data.length shouldEqual 9
+      retriedWrite.ack shouldEqual PeerConnectionHandler.ReceivableMessages.Ack(1)
+      fixture.connection.send(
+        fixture.handler,
+        PeerConnectionHandler.ReceivableMessages.Ack(1)
+      )
+
+      fixture.handler ! Message(GetPeersSpec, Right(()), None)
+      val nextWrite = fixture.connection.expectMsgType[Tcp.Write]
+      fixture.connection.send(fixture.handler, Tcp.CommandFailed(nextWrite))
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+      fixture.connection.expectNoMessage(200.millis)
+    }
+  }
+}

--- a/src/test/scala/scorex/core/network/PeerConnectionHandlerSpecification.scala
+++ b/src/test/scala/scorex/core/network/PeerConnectionHandlerSpecification.scala
@@ -123,42 +123,45 @@ class PeerConnectionHandlerSpecification extends ErgoCorePropertyTest {
   }
 
   property("account retried and acknowledged writes exactly") {
-    withConnectedHandler(Seq(GetPeersSpec), localPort = 9103) { fixture =>
-      val maxSizedWrite = Tcp.Write(
-        ByteString(new Array[Byte](
-          PeerConnectionHandler.MaxBufferedOutboundBytes.toInt
-        )),
-        PeerConnectionHandler.ReceivableMessages.Ack(1)
+    withConnectedHandler(
+      Seq(UtxoSnapshotChunkSpec),
+      localPort = 9103
+    ) { fixture =>
+      val chunkMessage = Message(
+        UtxoSnapshotChunkSpec,
+        Right(Array.fill[Byte](3999996)(1)),
+        None
       )
-      fixture.connection.send(fixture.handler, Tcp.CommandFailed(maxSizedWrite))
-      fixture.connection.expectMsg(Tcp.ResumeWriting)
-      fixture.connection.expectNoMessage(200.millis)
+      fixture.handler ! chunkMessage
+      val failedWrite = fixture.connection.expectMsgType[Tcp.Write]
+      failedWrite.data.length shouldEqual 4000013
+      failedWrite.ack shouldEqual PeerConnectionHandler.ReceivableMessages.Ack(1)
 
-      val replacementWrite = Tcp.Write(
-        ByteString(new Array[Byte](9)),
-        PeerConnectionHandler.ReceivableMessages.Ack(1)
-      )
-      fixture.connection.send(
-        fixture.handler,
-        Tcp.CommandFailed(replacementWrite)
-      )
+      fixture.connection.send(fixture.handler, Tcp.CommandFailed(failedWrite))
       fixture.connection.expectMsg(Tcp.ResumeWriting)
+
+      (2 to 4).foreach(_ => fixture.handler ! chunkMessage)
       fixture.connection.expectNoMessage(200.millis)
 
       fixture.connection.send(fixture.handler, Tcp.WritingResumed)
       val retriedWrite = fixture.connection.expectMsgType[Tcp.Write]
-      retriedWrite.data.length shouldEqual 9
+      retriedWrite.data shouldEqual failedWrite.data
       retriedWrite.ack shouldEqual PeerConnectionHandler.ReceivableMessages.Ack(1)
+      fixture.connection.send(fixture.handler, Tcp.CommandFailed(retriedWrite))
+      fixture.connection.expectMsg(Tcp.ResumeWriting)
+      fixture.connection.expectNoMessage(200.millis)
+
+      fixture.connection.send(fixture.handler, Tcp.WritingResumed)
+      val finalRetry = fixture.connection.expectMsgType[Tcp.Write]
+      finalRetry.data shouldEqual failedWrite.data
+      finalRetry.ack shouldEqual PeerConnectionHandler.ReceivableMessages.Ack(1)
       fixture.connection.send(
         fixture.handler,
         PeerConnectionHandler.ReceivableMessages.Ack(1)
       )
 
-      fixture.handler ! Message(GetPeersSpec, Right(()), None)
       val nextWrite = fixture.connection.expectMsgType[Tcp.Write]
-      fixture.connection.send(fixture.handler, Tcp.CommandFailed(nextWrite))
-      fixture.connection.expectMsg(Tcp.ResumeWriting)
-      fixture.connection.expectNoMessage(200.millis)
+      nextWrite.ack shouldEqual PeerConnectionHandler.ReceivableMessages.Ack(2)
     }
   }
 }


### PR DESCRIPTION
## Summary

- bound serialized outbound data retained for one backpressured peer by bytes
  and message count
- abort the connection before accepting an entry that would exceed either
  limit
- keep accounting exact across failed-write retries and acknowledgements

## Root cause

After a TCP `CommandFailed(Write(...))`, `PeerConnectionHandler` switched to an
ACK-based buffering mode. Every later outbound message was serialized and kept
in an unbounded `TreeMap` while the peer remained backpressured. A peer that
stopped reading could therefore make one connection retain serialized data
without a fixed ceiling.

This complements #2306: that change bounds individual inbound P2P messages,
while this change bounds aggregate outbound data retained for one peer.

## Limits and behavior

- byte limit: 16,388,621 bytes, equal to one maximum payload plus its framing
- message limit: 64 buffered entries
- overflow: clear retained state, send `Tcp.Abort`, and stop the handler
- no peer penalty, wire-format change, protocol-version change, or consensus
  change

An honestly slow peer may be disconnected and retry elsewhere rather than keep
an unbounded share of node heap. In particular, the transport does not retain
an entire application-level snapshot window after sustained backpressure.

## Tests

- `PeerConnectionHandlerSpecification`: 3/3 passed
- relevant network selection: 17 suites, 73/73 passed
- `DigestStateSpecification`: 7/7 passed in isolation
- mutation control: naive retry byte addition makes the retry property fail on
  an unexpected `Tcp.Abort`; replacement-aware accounting passes

The regression tests cover the byte boundary, the independent message-count
boundary, four maximum valid snapshot frames below the cap and the fifth above
it, a failed retransmission with the same ACK id without double-counting, exact
ACK removal, and ordered progress to the next buffered write.
