### PR TITLE
Reject invalid first mining solutions without restart

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -251,28 +251,41 @@ class CandidateGenerator(
         } else {
           preSolution
         }
-      val result: StatusReply[Unit] = {
-        val newBlock = state.cachedCandidate
-          .map(candidate => completeBlock(candidate.candidateBlock, solution))
-          .filter(block => ergoSettings.chainSettings.powScheme.validate(block.header).isSuccess)
-          .getOrElse {
-            log.info(s"Using previous candidate as a solution: " + state.cachedPreviousCandidate)
-            completeBlock(state.cachedPreviousCandidate.get.candidateBlock, solution)
-          }
-        log.info(s"New block mined, header: ${newBlock.header}")
-        ergoSettings.chainSettings.powScheme.validate(newBlock.header) match {
-          case Success(_) =>
-            sendToNodeView(newBlock)
-            context.become(initialized(state.copy(solvedBlock = Some(newBlock))))
-            StatusReply.success(())
-          case Failure(exception) =>
-            log.warn(s"Removing candidates due to invalid block", exception)
-            context.become(initialized(state.copy(cachedCandidate = None, cachedPreviousCandidate = None)))
-            StatusReply.error(
-              new Exception(s"Invalid block mined: ${exception.getMessage}", exception)
-            )
+      val newBlockOpt = state.cachedCandidate
+        .map(candidate => completeBlock(candidate.candidateBlock, solution))
+        .filter(block => ergoSettings.chainSettings.powScheme.validate(block.header).isSuccess)
+        .orElse {
+          log.info(
+            s"Using previous candidate as a solution: ${state.cachedPreviousCandidate}"
+          )
+          state.cachedPreviousCandidate.map(candidate =>
+            completeBlock(candidate.candidateBlock, solution)
+          )
         }
-      }
+      val result: StatusReply[Unit] = newBlockOpt match {
+        case Some(newBlock) =>
+          log.info(s"New block mined, header: ${newBlock.header}")
+          ergoSettings.chainSettings.powScheme.validate(newBlock.header) match {
+            case Success(_) =>
+              sendToNodeView(newBlock)
+              context.become(initialized(state.copy(solvedBlock = Some(newBlock))))
+              StatusReply.success(())
+            case Failure(exception) =>
+              log.warn(s"Removing candidates due to invalid block", exception)
+              context.become(
+                initialized(
+                  state.copy(cachedCandidate = None, cachedPreviousCandidate = None)
+                )
+              )
+              StatusReply.error(
+                new Exception(s"Invalid block mined: ${exception.getMessage}", exception)
+              )
+          }
+        case None =>
+          StatusReply.error(
+            "Invalid solution for current candidate and no previous candidate available"
+          )
+        }
       log.info(s"Processed solution $solution with the result $result")
       sender() ! result
 

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -215,27 +215,42 @@ class CandidateGenerator(
         } else {
           preSolution
         }
-      val result: StatusReply[Unit] = {
-        val newBlock = state.cachedCandidate
-          .map(candidate => completeBlock(candidate.candidateBlock, solution))
-          .filter(block => ergoSettings.chainSettings.powScheme.validate(block.header).isSuccess)
-          .getOrElse {
-            log.info(s"Using previous candidate as a solution: " + state.cachedPreviousCandidate)
-            completeBlock(state.cachedPreviousCandidate.get.candidateBlock, solution)
-          }
-        log.info(s"New block mined, header: ${newBlock.header}")
-        ergoSettings.chainSettings.powScheme.validate(newBlock.header) match {
-          case Success(_) =>
-            sendToNodeView(newBlock)
-            context.become(initialized(state.copy(solvedBlock = Some(newBlock))))
-            StatusReply.success(())
-          case Failure(exception) =>
-            log.warn(s"Removing candidates due to invalid block", exception)
-            context.become(initialized(state.copy(cachedCandidate = None, cachedPreviousCandidate = None)))
-            StatusReply.error(
-              new Exception(s"Invalid block mined: ${exception.getMessage}", exception)
-            )
+      val newBlockOpt = state.cachedCandidate
+        .map(candidate => completeBlock(candidate.candidateBlock, solution))
+        .filter(block =>
+          ergoSettings.chainSettings.powScheme.validate(block.header).isSuccess
+        )
+        .orElse {
+          log.info(
+            s"Using previous candidate as a solution: ${state.cachedPreviousCandidate}"
+          )
+          state.cachedPreviousCandidate.map(candidate =>
+            completeBlock(candidate.candidateBlock, solution)
+          )
         }
+      val result: StatusReply[Unit] = newBlockOpt match {
+        case Some(newBlock) =>
+          log.info(s"New block mined, header: ${newBlock.header}")
+          ergoSettings.chainSettings.powScheme.validate(newBlock.header) match {
+            case Success(_) =>
+              sendToNodeView(newBlock)
+              context.become(initialized(state.copy(solvedBlock = Some(newBlock))))
+              StatusReply.success(())
+            case Failure(exception) =>
+              log.warn(s"Removing candidates due to invalid block", exception)
+              context.become(
+                initialized(
+                  state.copy(cachedCandidate = None, cachedPreviousCandidate = None)
+                )
+              )
+              StatusReply.error(
+                new Exception(s"Invalid block mined: ${exception.getMessage}", exception)
+              )
+          }
+        case None =>
+          StatusReply.error(
+            "Invalid solution for current candidate and no previous candidate available"
+          )
       }
       log.info(s"Processed solution $solution with the result $result")
       sender() ! result

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -36,6 +36,7 @@ import sigma.serialization.ErgoTreeSerializer
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 
 import scala.concurrent.duration._
+import scala.util.{Failure, Try}
 
 class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelpers with Eventually {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
@@ -63,6 +64,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
+  private class ToggleRejectingPowScheme(k: Int, n: Int)
+      extends DefaultFakePowScheme(k, n) {
+    @volatile var rejectSolutions: Boolean = false
+
+    override def validate(header: Header): Try[Unit] =
+      if (rejectSolutions) Failure(new Exception("Rejected by test PoW scheme"))
+      else super.validate(header)
+  }
+
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
     ActorSystem()
   ) {
@@ -84,6 +94,60 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
+    system.terminate()
+  }
+
+  it should "reject an invalid first solution without restarting" in new TestKit(
+    ActorSystem()
+  ) {
+    val testProbe = new TestProbe(system)
+    val powScheme = new ToggleRejectingPowScheme(
+      defaultSettings.chainSettings.powScheme.k,
+      defaultSettings.chainSettings.powScheme.n
+    )
+    val testSettings = defaultSettings.copy(
+      chainSettings = defaultSettings.chainSettings.copy(powScheme = powScheme),
+      directory =
+        s"${defaultSettings.directory}-invalid-first-${System.currentTimeMillis()}"
+    )
+    val viewHolderRef = ErgoNodeViewRef(testSettings)
+    val readersHolderRef = ErgoReadersHolderRef(viewHolderRef)
+    val candidateGenerator = CandidateGenerator(
+      defaultMinerSecret.publicImage,
+      readersHolderRef,
+      viewHolderRef,
+      testSettings
+    )
+
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+    val solution = powScheme
+      .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
+      .get
+      .header
+      .powSolution
+    powScheme.rejectSolutions = true
+
+    candidateGenerator.tell(solution, testProbe.ref)
+
+    testProbe.expectMsgPF(blockValidationDelay) {
+      case StatusReply.Error(error) =>
+        error.getMessage shouldBe
+          "Invalid solution for current candidate and no previous candidate available"
+    }
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val cachedCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+    cachedCandidate should be theSameInstanceAs candidate
     system.terminate()
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -29,6 +29,7 @@ import sigma.serialization.ErgoTreeSerializer
 import sigmastate.crypto.DLogProtocol.DLogProverInput
 
 import scala.concurrent.duration._
+import scala.util.{Failure, Try}
 
 class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelpers with Eventually {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
@@ -55,6 +56,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
+
+  private class ToggleRejectingPowScheme(k: Int, n: Int)
+      extends DefaultFakePowScheme(k, n) {
+    @volatile var rejectSolutions: Boolean = false
+
+    override def validate(header: Header): Try[Unit] =
+      if (rejectSolutions) Failure(new Exception("Rejected by test PoW scheme"))
+      else super.validate(header)
+  }
 
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
     ActorSystem()
@@ -167,6 +177,60 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         true
     }
 
+    system.terminate()
+  }
+
+  it should "reject an invalid first solution without restarting" in new TestKit(
+    ActorSystem()
+  ) {
+    val testProbe = new TestProbe(system)
+    val powScheme = new ToggleRejectingPowScheme(
+      defaultSettings.chainSettings.powScheme.k,
+      defaultSettings.chainSettings.powScheme.n
+    )
+    val testSettings = defaultSettings.copy(
+      chainSettings = defaultSettings.chainSettings.copy(powScheme = powScheme),
+      directory =
+        s"${defaultSettings.directory}-invalid-first-${System.currentTimeMillis()}"
+    )
+    val viewHolderRef = ErgoNodeViewRef(testSettings)
+    val readersHolderRef = ErgoReadersHolderRef(viewHolderRef)
+    val candidateGenerator = CandidateGenerator(
+      defaultMinerSecret.publicImage,
+      readersHolderRef,
+      viewHolderRef,
+      testSettings
+    )
+
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+    val solution = powScheme
+      .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
+      .get
+      .header
+      .powSolution
+    powScheme.rejectSolutions = true
+
+    candidateGenerator.tell(solution, testProbe.ref)
+
+    testProbe.expectMsgPF(blockValidationDelay) {
+      case StatusReply.Error(error) =>
+        error.getMessage shouldBe
+          "Invalid solution for current candidate and no previous candidate available"
+    }
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val cachedCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+    cachedCandidate should be theSameInstanceAs candidate
     system.terminate()
   }
 


### PR DESCRIPTION
## Summary

- Reject an invalid solution for the first cached mining candidate without dereferencing an absent previous candidate.
- Return a normal `StatusReply.Error` while preserving the current candidate template for later valid work.
- Add actor-level regression coverage for the exact error and cached-object identity.

## Root cause

When a solution failed validation against the current candidate, `CandidateGenerator` unconditionally retried it against `cachedPreviousCandidate.get`. The first generated candidate has no previous candidate, so an invalid solution threw `NoSuchElementException`, restarted the actor and returned no normal error to the external miner.

The fallback is now optional. If no previous candidate exists, the actor returns an error and keeps the valid candidate template. Current valid solutions, previous-candidate fallback, final PoW validation, block publication and solved-state transitions are unchanged.

## Related work

PR #2411 removes duplicate PoW validation on `master`, but still dereferences `cachedPreviousCandidate.get`; this change covers only the missing-previous branch on `v6.0.7`.

## Tests

- RED on `v6.0.7` (`e927ab38`): `NoSuchElementException: None.get`, followed by the expected-reply timeout.
- `CandidateGeneratorSpec`: 20/20 passed.
- `CandidateGeneratorPropSpec` + `MiningApiRouteSpec`: 23/23 passed.
- Total focused mining/API closure: 43/43 passed.
- Independent exact-diff review: no Critical or Important findings.
- `git diff --check` and the publication guard passed.