### PR TITLE
Preserve asset issuance with token burn requests

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -324,7 +324,7 @@ trait ErgoWalletSupport extends ScorexLogging {
         require(outputs.forall(_.additionalTokens.forall(_._2 > 0)), "Non-positive asset value")
 
         val assetIssueBox = outputs
-          .zip(requests)
+          .zip(requestsWithoutBurnTokens)
           .filter(_._2.isInstanceOf[AssetIssueRequest])
           .map(_._1)
           .headOption

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransacti
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.wallet.WalletScanLogic.ScanResults
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
-import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, PaymentRequest}
+import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, BurnTokensRequest, PaymentRequest}
 import org.ergoplatform.nodeView.wallet.scanning.{EqualsScanningPredicate, ScanRequest, ScanWalletInteraction}
 import org.ergoplatform.sdk.SecretString
 import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedSecretKey}
@@ -28,6 +28,7 @@ import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
 import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, SType}
+import sigmastate.eval.Extensions._
 import sigmastate.helpers.TestingHelpers.testBox
 
 import scala.collection.compat.immutable.ArraySeq
@@ -270,6 +271,101 @@ class ErgoWalletServiceSpec
         signedTx.inputs.size shouldBe 1
         signedTx.outputs.size shouldBe 2
 
+      }
+    }
+  }
+
+  property("asset issuance should be independent of burn request order") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val wState = initialState(store, versionedStore)
+        val existingAssetAmount = 10L
+        val burnAmount = 3L
+        val issueAmount = 7L
+        val inputBoxes = boxesAvailable(
+          makeGenesisBlock(pks.head.pubkey, Seq(newAssetIdStub -> existingAssetAmount)),
+          pks.head.pubkey
+        )
+        val existingTokenId = inputBoxes.flatMap(_.additionalTokens.toArray).head._1
+        val encodedBoxes = inputBoxes.map(box => Base16.encode(ErgoBoxSerializer.toBytes(box)))
+        val burnRequest = BurnTokensRequest(Array(existingTokenId -> burnAmount))
+        val paymentRequest = PaymentRequest(pks.head, 1000000L, Array.empty, Map.empty)
+        val issueRequest = AssetIssueRequest(
+          address = pks.head,
+          valueOpt = Some(10000000L),
+          amount = issueAmount,
+          name = "test-name",
+          description = "test-description",
+          decimals = 4,
+          registers = Option.empty
+        )
+        val boxSelector = new ReplaceCompactCollectBoxSelector(
+          settings.walletSettings.maxInputs,
+          settings.walletSettings.optimalInputs,
+          None
+        )
+
+        val requestOrders = Seq(
+          Seq(burnRequest, issueRequest),
+          Seq(issueRequest, burnRequest)
+        ) ++ Seq(burnRequest, issueRequest, paymentRequest).permutations.toSeq
+
+        requestOrders.foreach { requests =>
+          val result = generateUnsignedTransaction(
+            wState,
+            boxSelector,
+            requests,
+            inputsRaw = encodedBoxes,
+            dataInputsRaw = Seq.empty
+          )
+          val requestOrder = requests.map(_.getClass.getSimpleName).mkString(", ")
+          withClue(s"request order: $requestOrder; failure: ${result.failed.map(_.getMessage).toOption}") {
+            result.isSuccess shouldBe true
+          }
+
+          val (tx, selectedInputs, _) = result.get
+          val issuedTokenId = selectedInputs.head.id.toTokenId
+          val issueOutputs = tx.outputCandidates.filter(
+            _.additionalTokens.toArray.exists { case (tokenId, _) => tokenId == issuedTokenId }
+          )
+          issueOutputs should have size 1
+          issueOutputs.head.value shouldBe issueRequest.valueOpt.get
+          issueOutputs.head.ergoTree shouldBe pks.head.script
+          issueOutputs.head.additionalTokens.toArray should contain(issuedTokenId -> issueAmount)
+          issueOutputs.head.additionalRegisters shouldBe Map(
+            ErgoBox.R4 -> ByteArrayConstant("test-name".getBytes("UTF-8")),
+            ErgoBox.R5 -> ByteArrayConstant("test-description".getBytes("UTF-8")),
+            ErgoBox.R6 -> ByteArrayConstant("4".getBytes("UTF-8"))
+          )
+
+          if (requests.contains(paymentRequest)) {
+            val paymentOutputs = tx.outputCandidates.filter(_.value == paymentRequest.value)
+            paymentOutputs should have size 1
+            paymentOutputs.head.ergoTree shouldBe pks.head.script
+            paymentOutputs.head.additionalTokens.toArray shouldBe empty
+            paymentOutputs.head.additionalRegisters shouldBe empty
+          }
+
+          selectedInputs
+            .flatMap(_.additionalTokens.toArray)
+            .collect { case (tokenId, amount) if tokenId == issuedTokenId => amount }
+            .sum shouldBe 0L
+          tx.outputCandidates
+            .flatMap(_.additionalTokens.toArray)
+            .collect { case (tokenId, amount) if tokenId == issuedTokenId => amount }
+            .sum shouldBe issueAmount
+
+          val selectedExistingAmount = selectedInputs
+            .flatMap(_.additionalTokens.toArray)
+            .collect { case (tokenId, amount) if tokenId == existingTokenId => amount }
+            .sum
+          val outputExistingAmount = tx.outputCandidates
+            .flatMap(_.additionalTokens.toArray)
+            .collect { case (tokenId, amount) if tokenId == existingTokenId => amount }
+            .sum
+          selectedExistingAmount - outputExistingAmount shouldBe burnAmount
+          selectedInputs.map(_.value).sum shouldBe tx.outputCandidates.map(_.value).sum
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- keep output candidates paired with the filtered request sequence that produced them
- preserve asset issuance when burn requests appear before it
- cover every burn/issue/payment ordering with token, metadata, payment, and ERG conservation checks

## Problem

Burn requests are removed before output candidates are built, but issuance detection paired those outputs with the original request list. A preceding burn request shifted the association, so the newly issued token was treated as an input requirement and valid transaction generation failed with `NotEnoughTokensError`.

## Tests

- `sbt "testOnly org.ergoplatform.nodeView.wallet.ErgoWalletServiceSpec"`
- `sbt "testOnly org.ergoplatform.nodeView.wallet.ErgoWalletSpec"`
