### PR TITLE
Respect configured CORS origins

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -423,9 +423,9 @@ scorex {
     # Change it!
     apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
 
-    # Enable/disable CORS support.
-    # This is an optional param. It would allow cors in case if this setting is set.
-    # If this setting will be omitted cors will be prohibited.
+    # Allowed CORS origin. Use "*" to allow browser requests from any origin,
+    # set a specific origin to allow only that browser origin to read
+    # cross-origin responses, or set null to disable CORS.
     corsAllowedOrigin = "*"
 
     # request processing timeout

--- a/src/main/scala/org/ergoplatform/http/ErgoHttpService.scala
+++ b/src/main/scala/org/ergoplatform/http/ErgoHttpService.scala
@@ -2,14 +2,9 @@ package org.ergoplatform.http
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
-import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.directives.RouteDirectives
 import scorex.core.api.http.{ApiErrorHandler, ApiRejectionHandler, ApiRoute, CorsHandler}
-import akka.http.scaladsl.model.headers._
-
-import scala.collection.immutable
 
 final case class ErgoHttpService(
   apiRoutes: Seq[ApiRoute],
@@ -21,20 +16,16 @@ final case class ErgoHttpService(
 
   def exceptionHandler: ExceptionHandler = ApiErrorHandler.exceptionHandler
 
-  private val corsResponseHeaders: List[ModeledHeader] = List[ModeledHeader](
-    `Access-Control-Allow-Origin`.*,
-    `Access-Control-Allow-Credentials`(true),
-    `Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With", "api_key",
+  override protected def corsAllowedOrigin: Option[String] =
+    swaggerRoute.settings.corsAllowedOrigin
+
+  override protected def corsAllowedHeaders: Seq[String] =
+    super.corsAllowedHeaders ++ Seq(
       "openai-conversation-id",
       "openai-ephemeral-user-id",
       "baggage",
       "sentry-trace"
     )
-  )
-
-  override def respondWithHeaders(responseHeaders: immutable.Seq[HttpHeader]): Directive0 = {
-    super.respondWithHeaders(corsResponseHeaders)
-  }
 
   val compositeRoute: Route =
     handleRejections(rejectionHandler) {

--- a/src/main/scala/scorex/core/api/http/ApiDirectives.scala
+++ b/src/main/scala/scorex/core/api/http/ApiDirectives.scala
@@ -9,6 +9,8 @@ trait ApiDirectives extends CorsHandler with ScorexEncoding {
   val settings: RESTApiSettings
   val apiKeyHeaderName: String
 
+  override protected def corsAllowedOrigin: Option[String] = settings.corsAllowedOrigin
+
   lazy val withAuth: Directive0 = optionalHeaderValueByName(apiKeyHeaderName).flatMap {
     case _ if settings.apiKeyHash.isEmpty => pass
     case None => reject(AuthorizationFailedRejection)

--- a/src/main/scala/scorex/core/api/http/CompositeHttpService.scala
+++ b/src/main/scala/scorex/core/api/http/CompositeHttpService.scala
@@ -12,6 +12,8 @@ case class CompositeHttpService(system: ActorSystem, routes: Seq[ApiRoute], sett
 
   implicit val actorSystem: ActorSystem = system
 
+  override protected def corsAllowedOrigin: Option[String] = settings.corsAllowedOrigin
+
   val swaggerService: SwaggerConfigRoute = new SwaggerConfigRoute(swaggerConf: String, settings: RESTApiSettings)
 
   val redirectToSwagger: Route = path("" | "/") {

--- a/src/main/scala/scorex/core/api/http/CorsHandler.scala
+++ b/src/main/scala/scorex/core/api/http/CorsHandler.scala
@@ -13,18 +13,35 @@ import akka.http.scaladsl.server.{Directive0, Directives, Route}
   */
 trait CorsHandler extends Directives {
 
-  private val corsResponseHeaders: List[ModeledHeader] = List[ModeledHeader](
-    `Access-Control-Allow-Origin`.*,
-    `Access-Control-Allow-Credentials`(true),
-    `Access-Control-Allow-Headers`("Authorization", "Content-Type", "X-Requested-With", "api_key")
-  )
+  protected def corsAllowedOrigin: Option[String] = Some("*")
 
-  def corsHandler(r: Route): Route = addAccessControlHeaders {
-    preflightRequestHandler ~ r
+  protected def corsAllowedHeaders: Seq[String] =
+    Seq("Authorization", "Content-Type", "X-Requested-With", "api_key")
+
+  private lazy val corsResponseHeaders: List[ModeledHeader] =
+    corsAllowedOrigin.toList.flatMap {
+      case "*" =>
+        List[ModeledHeader](
+          `Access-Control-Allow-Origin`.*,
+          `Access-Control-Allow-Headers`(corsAllowedHeaders: _*)
+        )
+      case origin =>
+        List[ModeledHeader](
+          `Access-Control-Allow-Origin`(HttpOrigin(origin)),
+          `Access-Control-Allow-Credentials`(true),
+          `Access-Control-Allow-Headers`(corsAllowedHeaders: _*)
+        )
+    }
+
+  def corsHandler(r: Route): Route = corsAllowedOrigin.fold(r) { _ =>
+    addAccessControlHeaders {
+      preflightRequestHandler ~ r
+    }
   }
 
   def addCorsHeaders(response: HttpResponse): HttpResponse =
-    response.withHeaders(corsResponseHeaders)
+    if (corsResponseHeaders.isEmpty) response
+    else response.withHeaders(corsResponseHeaders)
 
   private def addAccessControlHeaders: Directive0 =
     respondWithHeaders(corsResponseHeaders)

--- a/src/test/scala/org/ergoplatform/http/ErgoHttpServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/ErgoHttpServiceSpec.scala
@@ -1,0 +1,116 @@
+package org.ergoplatform.http
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.ergoplatform.settings.RESTApiSettings
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+
+class ErgoHttpServiceSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
+
+  private val endpoint = "/api-docs/swagger.conf"
+
+  private def serviceRoute(corsAllowedOrigin: Option[String]): Route = {
+    val settings = RESTApiSettings(
+      bindAddress = new InetSocketAddress("127.0.0.1", 9053),
+      apiKeyHash = None,
+      corsAllowedOrigin = corsAllowedOrigin,
+      timeout = 5.seconds,
+      publicUrl = None
+    )
+    ErgoHttpService(
+      apiRoutes = Seq.empty,
+      swaggerRoute = SwaggerRoute(settings, "{}"),
+      panelRoute = NodePanelRoute()
+    ).compositeRoute
+  }
+
+  private def headerValue(response: HttpResponse, name: String): Option[String] =
+    response.headers.find(_.is(name)).map(_.value())
+
+  "ErgoHttpService" should "honor the configured CORS origin" in {
+    val configuredOrigin = "https://trusted.example"
+
+    Get(endpoint)
+      .addHeader(RawHeader("Origin", configuredOrigin)) ~>
+      serviceRoute(Some(configuredOrigin)) ~> check {
+      status shouldBe StatusCodes.OK
+      headerValue(response, "access-control-allow-origin") shouldBe Some(configuredOrigin)
+      headerValue(response, "access-control-allow-credentials") shouldBe Some("true")
+    }
+  }
+
+  it should "omit credentials for the wildcard CORS origin" in {
+    Get(endpoint)
+      .addHeader(RawHeader("Origin", "https://example.org")) ~>
+      serviceRoute(Some("*")) ~> check {
+      status shouldBe StatusCodes.OK
+      headerValue(response, "access-control-allow-origin") shouldBe Some("*")
+      headerValue(response, "access-control-allow-credentials") shouldBe None
+    }
+  }
+
+  it should "not reflect an untrusted request origin" in {
+    val configuredOrigin = "https://trusted.example"
+
+    Get(endpoint)
+      .addHeader(RawHeader("Origin", "https://evil.example")) ~>
+      serviceRoute(Some(configuredOrigin)) ~> check {
+      status shouldBe StatusCodes.OK
+      headerValue(response, "access-control-allow-origin") shouldBe Some(configuredOrigin)
+    }
+  }
+
+  it should "disable CORS handling when no origin is configured" in {
+    Get(endpoint)
+      .addHeader(RawHeader("Origin", "https://example.org")) ~>
+      serviceRoute(None) ~> check {
+      status shouldBe StatusCodes.OK
+      headerValue(response, "access-control-allow-origin") shouldBe None
+      headerValue(response, "access-control-allow-headers") shouldBe None
+    }
+
+    Options(endpoint)
+      .addHeader(RawHeader("Origin", "https://example.org"))
+      .addHeader(RawHeader("Access-Control-Request-Method", "GET")) ~>
+      serviceRoute(None) ~> check {
+      status.isFailure() shouldBe true
+      headerValue(response, "access-control-allow-origin") shouldBe None
+    }
+  }
+
+  it should "preserve the supported preflight methods and headers" in {
+    val configuredOrigin = "https://trusted.example"
+
+    Options(endpoint)
+      .addHeader(RawHeader("Origin", configuredOrigin))
+      .addHeader(RawHeader("Access-Control-Request-Method", "POST"))
+      .addHeader(RawHeader("Access-Control-Request-Headers", "api_key, sentry-trace")) ~>
+      serviceRoute(Some(configuredOrigin)) ~> check {
+      status shouldBe StatusCodes.OK
+      headerValue(response, "access-control-allow-origin") shouldBe Some(configuredOrigin)
+
+      val allowedMethods = headerValue(response, "access-control-allow-methods")
+        .toSeq.flatMap(_.split(",")).map(_.trim).toSet
+      allowedMethods shouldBe Set("OPTIONS", "POST", "PUT", "GET", "DELETE")
+
+      val allowedHeaders = headerValue(response, "access-control-allow-headers")
+        .toSeq.flatMap(_.split(",")).map(_.trim).toSet
+      allowedHeaders shouldBe Set(
+        "Authorization",
+        "Content-Type",
+        "X-Requested-With",
+        "api_key",
+        "openai-conversation-id",
+        "openai-ephemeral-user-id",
+        "baggage",
+        "sentry-trace"
+      )
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -70,6 +70,17 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
     )
   }
 
+  property("should read null CORS origin as disabled") {
+    val config = ConfigFactory
+      .parseString("scorex.restApi.corsAllowedOrigin = null")
+      .withFallback(ConfigFactory.load())
+      .resolve()
+
+    ErgoSettingsReader
+      .fromConfig(config)
+      .scorexSettings.restApi.corsAllowedOrigin shouldBe None
+  }
+
   property("should read user settings from json file") {
     val settings = ErgoSettingsReader.read(Args(Some("src/test/resources/settings.json"), None))
     settings.nodeSettings shouldBe NodeConfigurationSettings(


### PR DESCRIPTION
## Summary

- Apply `scorex.restApi.corsAllowedOrigin` to the node HTTP service.
- Keep the current `"*"` default while omitting credentials for wildcard responses.
- Support an exact configured origin and allow `null` to disable CORS handling.
- Preserve the existing preflight methods and allowed headers, including plugin headers.

## Problem

`ErgoHttpService` replaced the shared CORS headers with a hardcoded `Access-Control-Allow-Origin: *`. As a result, an exact configured origin and a disabled CORS setting were both ignored. The wildcard response also included `Access-Control-Allow-Credentials: true`, which browsers cannot use for credentialed CORS requests.

This change fixes the browser CORS policy configuration. It does not change server-side API key authentication, and the default origin remains `"*"` for backport compatibility.

## Behavior

| `corsAllowedOrigin` | Response behavior |
| --- | --- |
| `"*"` | `Access-Control-Allow-Origin: *`, without `Access-Control-Allow-Credentials` |
| exact origin | the configured origin, with credentials allowed |
| `null` | no CORS response headers and no generic preflight interception |

## Regression evidence

Before the fix, the HTTP regression test fails on current `v6.0.6` because an exact configured origin still produces `Some("*")` instead of the configured value. After the fix, the tests cover exact origins, hostile-origin non-reflection, wildcard semantics, disabled CORS, preflight methods, and all existing allowed headers.

## Validation

- `ErgoHttpServiceSpec` + `ErgoSettingsSpecification`: 13/13 passed.
- Full HTTP route closure: 134/134 passed.
- Independent exact-diff and web-security reviews: no Critical or Important findings.
- `git diff --check` and the publication guard passed.