### PR TITLE
Count pending inbound connections toward the limit

### DIFF
--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -63,6 +63,7 @@ class NetworkController(ergoSettings: ErgoSettings,
 
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]
   private var unconfirmedConnections = Set.empty[InetSocketAddress]
+  private var unconfirmedIncomingConnections = Map.empty[InetSocketAddress, ActorRef]
 
   private val mySessionIdFeature = SessionIdPeerFeature(networkSettings.magicBytes)
   /**
@@ -168,6 +169,17 @@ class NetworkController(ergoSettings: ErgoSettings,
           Option(peer.connectionId.remoteAddress.getAddress).contains(blacklistedIp)
         }.toSeq
         peersToClose.foreach(_.handlerRef ! CloseConnection)
+
+        val pendingToClose = unconfirmedIncomingConnections.iterator.collect {
+          case (address, connectionRef)
+            if Option(address.getAddress).contains(blacklistedIp) =>
+            address -> connectionRef
+        }.toSeq
+        pendingToClose.foreach { case (address, connectionRef) =>
+          unconfirmedIncomingConnections -= address
+          context.unwatch(connectionRef)
+          connectionRef ! Close
+        }
       }
   }
 
@@ -179,13 +191,20 @@ class NetworkController(ergoSettings: ErgoSettings,
       log.info(s"Unconfirmed connection: ($remoteAddress, $localAddress) => $connectionId")
       if (connectionDirection.isOutgoing) {
         createPeerConnectionHandler(connectionId, sender())
+      } else if (unconfirmedIncomingConnections.contains(remoteAddress)) {
+        log.warn(s"Connection to peer $remoteAddress is already pending")
+        sender() ! Close
       } else {
-        val incomingCount = connections.values.count(_.connectionId.direction.isIncoming)
+        val incomingCount = connections.values.count(_.connectionId.direction.isIncoming) +
+          unconfirmedIncomingConnections.size
         if (incomingCount >= incomingLimit) {
           log.info(s"Incoming connection from $remoteAddress denied: too many incoming connections ($incomingCount)")
           sender() ! Close
         } else {
-          peerManagerRef ! ConfirmConnection(connectionId, sender())
+          val connectionRef = sender()
+          unconfirmedIncomingConnections += remoteAddress -> connectionRef
+          context.watch(connectionRef)
+          peerManagerRef ! ConfirmConnection(connectionId, connectionRef)
         }
       }
 
@@ -194,11 +213,39 @@ class NetworkController(ergoSettings: ErgoSettings,
       sender() ! Close
 
     case ConnectionConfirmed(connectionId, handlerRef) =>
-      log.info(s"Connection confirmed to $connectionId")
-      createPeerConnectionHandler(connectionId, handlerRef)
+      if (connectionId.direction.isIncoming) {
+        val remoteAddress = connectionId.remoteAddress
+        if (unconfirmedIncomingConnections.get(remoteAddress).contains(handlerRef)) {
+          unconfirmedIncomingConnections -= remoteAddress
+          context.unwatch(handlerRef)
+          val incomingCount = connections.values.count(_.connectionId.direction.isIncoming)
+          if (incomingCount >= incomingLimit) {
+            log.info(s"Incoming connection from $remoteAddress denied: too many incoming connections ($incomingCount)")
+            handlerRef ! Close
+          } else {
+            log.info(s"Connection confirmed to $connectionId")
+            createPeerConnectionHandler(connectionId, handlerRef)
+          }
+        } else {
+          log.info(s"Ignoring stale incoming connection confirmation from $remoteAddress")
+          handlerRef ! Close
+        }
+      } else {
+        log.info(s"Connection confirmed to $connectionId")
+        createPeerConnectionHandler(connectionId, handlerRef)
+      }
 
     case ConnectionDenied(connectionId, handlerRef) =>
       log.info(s"Incoming connection from ${connectionId.remoteAddress} denied")
+      if (connectionId.direction.isIncoming) {
+        val remoteAddress = connectionId.remoteAddress
+        if (unconfirmedIncomingConnections.get(remoteAddress).contains(handlerRef)) {
+          unconfirmedIncomingConnections -= remoteAddress
+          context.unwatch(handlerRef)
+        } else {
+          log.info(s"Ignoring stale incoming connection denial from $remoteAddress")
+        }
+      }
       handlerRef ! Close
 
     case Handshaked(connectedPeer) =>
@@ -222,6 +269,14 @@ class NetworkController(ergoSettings: ErgoSettings,
       }
 
     case Terminated(ref) =>
+      val pendingAddress = unconfirmedIncomingConnections.collectFirst {
+        case (address, connectionRef) if connectionRef == ref => address
+      }
+      pendingAddress.foreach { address =>
+        log.info(s"Pending incoming connection from $address terminated")
+        unconfirmedIncomingConnections -= address
+      }
+
       connectionForHandler(ref) match {
         case Some(connectedPeer) =>
           log.info(s"Terminating connection to $connectedPeer")
@@ -229,11 +284,16 @@ class NetworkController(ergoSettings: ErgoSettings,
           connections -= remoteAddress
           unconfirmedConnections -= remoteAddress
           context.system.eventStream.publish(DisconnectedPeer(connectedPeer))
-        case None =>
+        case None if pendingAddress.isEmpty =>
           log.warn(s"No connection found for $ref during termination")
+        case None => ()
       }
 
     case _: ConnectionClosed =>
+      val connectionRef = sender()
+      unconfirmedIncomingConnections =
+        unconfirmedIncomingConnections.filterNot { case (_, ref) => ref == connectionRef }
+      context.unwatch(connectionRef)
       log.info("Denied connection has been closed")
   }
 

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -63,6 +63,7 @@ class NetworkController(ergoSettings: ErgoSettings,
 
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]
   private var unconfirmedConnections = Set.empty[InetSocketAddress]
+  private var pendingIncomingConnections = Set.empty[ActorRef]
 
   private val mySessionIdFeature = SessionIdPeerFeature(networkSettings.magicBytes)
   /**
@@ -180,12 +181,19 @@ class NetworkController(ergoSettings: ErgoSettings,
       if (connectionDirection.isOutgoing) {
         createPeerConnectionHandler(connectionId, sender())
       } else {
-        val incomingCount = connections.values.count(_.connectionId.direction.isIncoming)
-        if (incomingCount >= incomingLimit) {
-          log.info(s"Incoming connection from $remoteAddress denied: too many incoming connections ($incomingCount)")
+        val establishedCount = connections.values.count(_.connectionId.direction.isIncoming)
+        val pendingCount = pendingIncomingConnections.size
+        // Admission reserves a slot; confirmation transfers it to connections.
+        // Established incoming handlers + pending raw connections <= incomingLimit.
+        if (establishedCount + pendingCount >= incomingLimit) {
+          log.info(s"Incoming connection from $remoteAddress denied: too many incoming connections " +
+            s"($establishedCount established, $pendingCount pending, limit $incomingLimit)")
           sender() ! Close
         } else {
-          peerManagerRef ! ConfirmConnection(connectionId, sender())
+          val connectionRef = sender()
+          pendingIncomingConnections += connectionRef
+          context.watch(connectionRef)
+          peerManagerRef ! ConfirmConnection(connectionId, connectionRef)
         }
       }
 
@@ -194,11 +202,24 @@ class NetworkController(ergoSettings: ErgoSettings,
       sender() ! Close
 
     case ConnectionConfirmed(connectionId, handlerRef) =>
-      log.info(s"Connection confirmed to $connectionId")
-      createPeerConnectionHandler(connectionId, handlerRef)
+      if (!connectionId.direction.isIncoming || pendingIncomingConnections.contains(handlerRef)) {
+        releasePendingIncoming(handlerRef)
+        if (connectionForPeerAddress(connectionId.remoteAddress).isEmpty) {
+          log.info(s"Connection confirmed to $connectionId")
+          createPeerConnectionHandler(connectionId, handlerRef)
+        } else {
+          // Distinct raw sockets can share a remote endpoint on different local
+          // addresses. Do not replace the handler already stored for that peer.
+          handlerRef ! Close
+        }
+      } else {
+        log.info(s"Ignoring stale incoming connection confirmation from ${connectionId.remoteAddress}")
+        handlerRef ! Close
+      }
 
     case ConnectionDenied(connectionId, handlerRef) =>
       log.info(s"Incoming connection from ${connectionId.remoteAddress} denied")
+      releasePendingIncoming(handlerRef)
       handlerRef ! Close
 
     case Handshaked(connectedPeer) =>
@@ -222,6 +243,8 @@ class NetworkController(ergoSettings: ErgoSettings,
       }
 
     case Terminated(ref) =>
+      val wasPending = pendingIncomingConnections.contains(ref)
+      pendingIncomingConnections -= ref
       connectionForHandler(ref) match {
         case Some(connectedPeer) =>
           log.info(s"Terminating connection to $connectedPeer")
@@ -229,12 +252,20 @@ class NetworkController(ergoSettings: ErgoSettings,
           connections -= remoteAddress
           unconfirmedConnections -= remoteAddress
           context.system.eventStream.publish(DisconnectedPeer(connectedPeer))
-        case None =>
+        case None if !wasPending =>
           log.warn(s"No connection found for $ref during termination")
+        case None => ()
       }
 
     case _: ConnectionClosed =>
       log.info("Denied connection has been closed")
+  }
+
+  private def releasePendingIncoming(ref: ActorRef): Unit = {
+    if (pendingIncomingConnections.contains(ref)) {
+      pendingIncomingConnections -= ref
+      context.unwatch(ref)
+    }
   }
 
   //calls from API / application

--- a/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
@@ -81,21 +81,31 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
       EstablishedConnection(connectionProbe, handlerRef)
     }
 
+    def beginPendingIncomingConnection(
+      controller: TestActorRef[NetworkController],
+      peerManagerProbe: TestProbe,
+      remoteAddress: InetSocketAddress
+    ): (TestProbe, ConfirmConnection) = {
+      val localAddress = settings.scorexSettings.network.bindAddress
+      val connectionProbe = TestProbe("Connection")
+
+      connectionProbe.send(controller, Tcp.Connected(remoteAddress, localAddress))
+      val confirmation = peerManagerProbe.expectMsgType[ConfirmConnection](1.second)
+
+      connectionProbe -> confirmation
+    }
+
     private def beginIncomingConnection(
       controller: TestActorRef[NetworkController],
       peerManagerProbe: TestProbe,
       remoteAddress: InetSocketAddress
     ): TestProbe = {
-      val localAddress = settings.scorexSettings.network.bindAddress
-      val connectionProbe = TestProbe("Connection")
-
-      connectionProbe.send(controller, Tcp.Connected(remoteAddress, localAddress))
-
-      peerManagerProbe.expectMsgPF(1.second) {
-        case ConfirmConnection(_, handlerRef) =>
-          controller ! ConnectionConfirmed(ConnectionId(remoteAddress, localAddress, Incoming), handlerRef)
-      }
-
+      val (connectionProbe, confirmation) =
+        beginPendingIncomingConnection(controller, peerManagerProbe, remoteAddress)
+      peerManagerProbe.send(
+        controller,
+        ConnectionConfirmed(confirmation.connectionId, confirmation.handlerRef)
+      )
       connectionProbe
     }
 
@@ -392,6 +402,270 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
     }
   }
 
+  property("pending incoming confirmations should count toward the incoming limit") {
+    withFixture { f =>
+      implicit val system = f.system
+      val maxConnections = 10
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections)
+      val incomingLimit = Math.max(maxConnections / 2, maxConnections - NetworkController.OutgoingConnections)
+
+      (1 to incomingLimit).foreach { i =>
+        f.beginPendingIncomingConnection(
+          controller,
+          peerManagerProbe,
+          new InetSocketAddress(s"203.0.113.$i", 9000 + i)
+        )
+      }
+
+      val overflowConnection = TestProbe("PendingOverflow")
+      overflowConnection.send(
+        controller,
+        Tcp.Connected(
+          new InetSocketAddress("198.51.100.99", 9999),
+          settings.scorexSettings.network.bindAddress
+        )
+      )
+      overflowConnection.expectMsg(Tcp.Close)
+      peerManagerProbe.expectNoMessage(200.millis)
+    }
+  }
+
+  property("denied pending incoming connection should release its slot") {
+    withFixture { f =>
+      implicit val system = f.system
+      val maxConnections = 10
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections)
+      val incomingLimit = Math.max(maxConnections / 2, maxConnections - NetworkController.OutgoingConnections)
+      val (deniedConnection, denial) = f.beginPendingIncomingConnection(
+        controller,
+        peerManagerProbe,
+        new InetSocketAddress("203.0.113.1", 9001)
+      )
+
+      (2 to incomingLimit).foreach { i =>
+        f.beginPendingIncomingConnection(
+          controller,
+          peerManagerProbe,
+          new InetSocketAddress(s"203.0.113.$i", 9000 + i)
+        )
+      }
+
+      peerManagerProbe.send(
+        controller,
+        ConnectionDenied(denial.connectionId, denial.handlerRef)
+      )
+      deniedConnection.expectMsg(Tcp.Close)
+
+      val replacement = TestProbe("DeniedSlotReplacement")
+      val replacementAddress = new InetSocketAddress("198.51.100.10", 9100)
+      replacement.send(
+        controller,
+        Tcp.Connected(replacementAddress, settings.scorexSettings.network.bindAddress)
+      )
+      peerManagerProbe.expectMsgPF(1.second) {
+        case ConfirmConnection(connectionId, connectionRef) =>
+          connectionId.remoteAddress shouldBe replacementAddress
+          connectionRef shouldBe replacement.ref
+      }
+    }
+  }
+
+  property("closed pending incoming connection should release its slot") {
+    withFixture { f =>
+      implicit val system = f.system
+      val maxConnections = 10
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections)
+      val incomingLimit = Math.max(maxConnections / 2, maxConnections - NetworkController.OutgoingConnections)
+      val (closedConnection, _) = f.beginPendingIncomingConnection(
+        controller,
+        peerManagerProbe,
+        new InetSocketAddress("203.0.113.1", 9001)
+      )
+
+      (2 to incomingLimit).foreach { i =>
+        f.beginPendingIncomingConnection(
+          controller,
+          peerManagerProbe,
+          new InetSocketAddress(s"203.0.113.$i", 9000 + i)
+        )
+      }
+
+      closedConnection.send(controller, Tcp.PeerClosed)
+      closedConnection.send(
+        controller,
+        NetworkController.ReceivableMessages.GetPeersStatus
+      )
+      closedConnection.expectMsgType[org.ergoplatform.network.peer.PeersStatus]
+
+      val replacement = TestProbe("ClosedSlotReplacement")
+      val replacementAddress = new InetSocketAddress("198.51.100.11", 9101)
+      replacement.send(
+        controller,
+        Tcp.Connected(replacementAddress, settings.scorexSettings.network.bindAddress)
+      )
+      peerManagerProbe.expectMsgPF(1.second) {
+        case ConfirmConnection(connectionId, connectionRef) =>
+          connectionId.remoteAddress shouldBe replacementAddress
+          connectionRef shouldBe replacement.ref
+      }
+    }
+  }
+
+  property("terminated pending incoming connection should release its slot") {
+    withFixture { f =>
+      implicit val system = f.system
+      val maxConnections = 10
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections)
+      val incomingLimit = Math.max(maxConnections / 2, maxConnections - NetworkController.OutgoingConnections)
+      val (terminatedConnection, _) = f.beginPendingIncomingConnection(
+        controller,
+        peerManagerProbe,
+        new InetSocketAddress("203.0.113.1", 9001)
+      )
+
+      (2 to incomingLimit).foreach { i =>
+        f.beginPendingIncomingConnection(
+          controller,
+          peerManagerProbe,
+          new InetSocketAddress(s"203.0.113.$i", 9000 + i)
+        )
+      }
+
+      val terminationProbe = TestProbe("PendingTermination")
+      terminationProbe.watch(terminatedConnection.ref)
+      f.system.stop(terminatedConnection.ref)
+      terminationProbe.expectTerminated(terminatedConnection.ref)
+
+      val replacement = TestProbe("TerminatedSlotReplacement")
+      val replacementAddress = new InetSocketAddress("198.51.100.11", 9101)
+      peerManagerProbe.awaitAssert({
+        replacement.send(
+          controller,
+          Tcp.Connected(replacementAddress, settings.scorexSettings.network.bindAddress)
+        )
+        peerManagerProbe.expectMsgPF(200.millis) {
+          case ConfirmConnection(connectionId, connectionRef) =>
+            connectionId.remoteAddress shouldBe replacementAddress
+            connectionRef shouldBe replacement.ref
+        }
+      }, 2.seconds, 50.millis)
+    }
+  }
+
+  property("stale incoming confirmation should not replace a new pending connection") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections = 10)
+      val remoteAddress = new InetSocketAddress("203.0.113.20", 9020)
+      val (firstConnection, firstConfirmation) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, remoteAddress)
+
+      firstConnection.send(controller, Tcp.PeerClosed)
+      firstConnection.send(controller, NetworkController.ReceivableMessages.GetPeersStatus)
+      firstConnection.expectMsgType[org.ergoplatform.network.peer.PeersStatus]
+
+      val (_, secondConfirmation) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, remoteAddress)
+
+      peerManagerProbe.send(
+        controller,
+        ConnectionConfirmed(firstConfirmation.connectionId, firstConfirmation.handlerRef)
+      )
+      firstConnection.expectMsg(Tcp.Close)
+
+      val duplicate = TestProbe("ConfirmationDuplicate")
+      duplicate.send(
+        controller,
+        Tcp.Connected(remoteAddress, settings.scorexSettings.network.bindAddress)
+      )
+      duplicate.expectMsg(Tcp.Close)
+      peerManagerProbe.expectNoMessage(200.millis)
+      secondConfirmation.connectionId.remoteAddress shouldBe remoteAddress
+    }
+  }
+
+  property("stale incoming denial should not release a new pending connection") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections = 10)
+      val remoteAddress = new InetSocketAddress("203.0.113.21", 9021)
+      val (firstConnection, firstConfirmation) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, remoteAddress)
+
+      firstConnection.send(controller, Tcp.PeerClosed)
+      firstConnection.send(controller, NetworkController.ReceivableMessages.GetPeersStatus)
+      firstConnection.expectMsgType[org.ergoplatform.network.peer.PeersStatus]
+
+      val (_, secondConfirmation) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, remoteAddress)
+
+      peerManagerProbe.send(
+        controller,
+        ConnectionDenied(firstConfirmation.connectionId, firstConfirmation.handlerRef)
+      )
+      firstConnection.expectMsg(Tcp.Close)
+
+      val duplicate = TestProbe("DenialDuplicate")
+      duplicate.send(
+        controller,
+        Tcp.Connected(remoteAddress, settings.scorexSettings.network.bindAddress)
+      )
+      duplicate.expectMsg(Tcp.Close)
+      peerManagerProbe.expectNoMessage(200.millis)
+      secondConfirmation.connectionId.remoteAddress shouldBe remoteAddress
+    }
+  }
+
+  property("duplicate pending incoming connection should be rejected") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections = 10)
+      val remoteAddress = new InetSocketAddress("203.0.113.22", 9022)
+      f.beginPendingIncomingConnection(controller, peerManagerProbe, remoteAddress)
+
+      val duplicate = TestProbe("PendingDuplicate")
+      duplicate.send(
+        controller,
+        Tcp.Connected(remoteAddress, settings.scorexSettings.network.bindAddress)
+      )
+      duplicate.expectMsg(Tcp.Close)
+      peerManagerProbe.expectNoMessage(200.millis)
+    }
+  }
+
+  property("blacklisting should close pending incoming connections for the banned IP") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections = 10)
+      val firstAddress = new InetSocketAddress("192.0.2.40", 9040)
+      val secondAddress = new InetSocketAddress("192.0.2.40", 9041)
+      val unrelatedAddress = new InetSocketAddress("198.51.100.40", 9042)
+      val (firstConnection, _) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, firstAddress)
+      val (secondConnection, _) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, secondAddress)
+      val (unrelatedConnection, _) =
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, unrelatedAddress)
+
+      peerManagerProbe.send(controller, Blacklisted(firstAddress))
+
+      firstConnection.expectMsg(Tcp.Close)
+      secondConnection.expectMsg(Tcp.Close)
+      unrelatedConnection.expectNoMessage(200.millis)
+
+      val replacement = TestProbe("BlacklistedSlotReplacement")
+      val replacementAddress = new InetSocketAddress("198.51.100.41", 9043)
+      replacement.send(
+        controller,
+        Tcp.Connected(replacementAddress, settings.scorexSettings.network.bindAddress)
+      )
+      peerManagerProbe.expectMsgPF(1.second) {
+        case ConfirmConnection(connectionId, connectionRef) =>
+          connectionId.remoteAddress shouldBe replacementAddress
+          connectionRef shouldBe replacement.ref
+      }
+    }
+  }
   property("outgoing connection should bypass incoming limit check") {
     withFixture { f =>
       val (controller, peerManagerProbe, tcpManagerProbe) = f.createController(maxConnections = 30)

--- a/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
@@ -536,17 +536,16 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
       f.system.stop(terminatedConnection.ref)
       terminationProbe.expectTerminated(terminatedConnection.ref)
 
-      val replacement = TestProbe("TerminatedSlotReplacement")
       val replacementAddress = new InetSocketAddress("198.51.100.11", 9101)
       peerManagerProbe.awaitAssert({
+        val replacement = TestProbe()
         replacement.send(
           controller,
           Tcp.Connected(replacementAddress, settings.scorexSettings.network.bindAddress)
         )
         peerManagerProbe.expectMsgPF(200.millis) {
-          case ConfirmConnection(connectionId, connectionRef) =>
+          case ConfirmConnection(connectionId, _) =>
             connectionId.remoteAddress shouldBe replacementAddress
-            connectionRef shouldBe replacement.ref
         }
       }, 2.seconds, 50.millis)
     }
@@ -636,16 +635,27 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
   property("blacklisting should close pending incoming connections for the banned IP") {
     withFixture { f =>
       implicit val system = f.system
-      val (controller, peerManagerProbe, _) = f.createController(maxConnections = 10)
+      val maxConnections = 10
+      val (controller, peerManagerProbe, _) = f.createController(maxConnections)
+      val incomingLimit = Math.max(maxConnections / 2, maxConnections - NetworkController.OutgoingConnections)
+      incomingLimit shouldBe 5
+
       val firstAddress = new InetSocketAddress("192.0.2.40", 9040)
       val secondAddress = new InetSocketAddress("192.0.2.40", 9041)
       val unrelatedAddress = new InetSocketAddress("198.51.100.40", 9042)
-      val (firstConnection, _) =
+      val fillerAddresses = Seq(
+        new InetSocketAddress("198.51.100.41", 9043),
+        new InetSocketAddress("198.51.100.42", 9044)
+      )
+      val (firstConnection, firstConfirmation) =
         f.beginPendingIncomingConnection(controller, peerManagerProbe, firstAddress)
       val (secondConnection, _) =
         f.beginPendingIncomingConnection(controller, peerManagerProbe, secondAddress)
       val (unrelatedConnection, _) =
         f.beginPendingIncomingConnection(controller, peerManagerProbe, unrelatedAddress)
+      fillerAddresses.foreach { address =>
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, address)
+      }
 
       peerManagerProbe.send(controller, Blacklisted(firstAddress))
 
@@ -653,19 +663,41 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
       secondConnection.expectMsg(Tcp.Close)
       unrelatedConnection.expectNoMessage(200.millis)
 
-      val replacement = TestProbe("BlacklistedSlotReplacement")
-      val replacementAddress = new InetSocketAddress("198.51.100.41", 9043)
-      replacement.send(
+      peerManagerProbe.send(
         controller,
-        Tcp.Connected(replacementAddress, settings.scorexSettings.network.bindAddress)
+        ConnectionConfirmed(firstConfirmation.connectionId, firstConfirmation.handlerRef)
       )
-      peerManagerProbe.expectMsgPF(1.second) {
-        case ConfirmConnection(connectionId, connectionRef) =>
-          connectionId.remoteAddress shouldBe replacementAddress
-          connectionRef shouldBe replacement.ref
+      firstConnection.expectMsg(Tcp.Close)
+
+      val duplicate = TestProbe("BlacklistedUnrelatedDuplicate")
+      duplicate.send(
+        controller,
+        Tcp.Connected(unrelatedAddress, settings.scorexSettings.network.bindAddress)
+      )
+      duplicate.expectMsg(Tcp.Close)
+      peerManagerProbe.expectNoMessage(200.millis)
+
+      val replacementAddresses = Seq(
+        new InetSocketAddress("198.51.100.43", 9045),
+        new InetSocketAddress("198.51.100.44", 9046)
+      )
+      replacementAddresses.foreach { address =>
+        f.beginPendingIncomingConnection(controller, peerManagerProbe, address)
       }
+
+      val overflow = TestProbe("BlacklistedSlotOverflow")
+      overflow.send(
+        controller,
+        Tcp.Connected(
+          new InetSocketAddress("198.51.100.45", 9047),
+          settings.scorexSettings.network.bindAddress
+        )
+      )
+      overflow.expectMsg(Tcp.Close)
+      peerManagerProbe.expectNoMessage(200.millis)
     }
   }
+
   property("outgoing connection should bypass incoming limit check") {
     withFixture { f =>
       val (controller, peerManagerProbe, tcpManagerProbe) = f.createController(maxConnections = 30)

--- a/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/core/network/NetworkControllerSpec.scala
@@ -3,6 +3,7 @@ package scorex.core.network
 import akka.actor.ActorRef
 import akka.io.Tcp
 import akka.testkit.{TestActorRef, TestProbe}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.DisconnectedPeer
 import org.ergoplatform.network.message.MessageConstants.MessageCode
 import org.ergoplatform.network.peer.PeerInfo
 import org.ergoplatform.utils.ErgoCorePropertyTest
@@ -67,6 +68,33 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
       }
 
       remoteAddress
+    }
+
+    def beginPendingConnection(
+      controller: TestActorRef[NetworkController],
+      peerManagerProbe: TestProbe,
+      remoteAddress: InetSocketAddress,
+      localAddress: InetSocketAddress = settings.scorexSettings.network.bindAddress
+    ): (TestProbe, ConfirmConnection) = {
+      val connection = TestProbe("PendingConnection")
+      connection.send(controller, Tcp.Connected(remoteAddress, localAddress))
+      val request = peerManagerProbe.expectMsgType[ConfirmConnection]
+      request.handlerRef shouldBe connection.ref
+      request.connectionId.remoteAddress shouldBe remoteAddress
+      (connection, request)
+    }
+
+    def confirmConnection(
+      controller: TestActorRef[NetworkController],
+      peerManagerProbe: TestProbe,
+      connection: TestProbe,
+      request: ConfirmConnection
+    ): ActorRef = {
+      peerManagerProbe.send(controller, ConnectionConfirmed(request.connectionId, request.handlerRef))
+      val handler = connection.expectMsgType[Tcp.Register].handler
+      connection.expectMsg(Tcp.ResumeReading)
+      connection.expectMsgType[Tcp.Write]
+      handler
     }
 
     def establishOutgoingConnection(
@@ -268,6 +296,100 @@ class NetworkControllerSpec extends ErgoCorePropertyTest {
 
       connectionProbe.send(controller, Tcp.Connected(remoteAddress, localAddress))
       connectionProbe.expectMsg(Tcp.Close)
+    }
+  }
+
+  property("pending incoming confirmations should count toward the incoming limit") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManager, _) = f.createController(maxConnections = 10)
+      val pending = (1 to 5).map { i =>
+        f.beginPendingConnection(controller, peerManager, new InetSocketAddress(s"203.0.113.$i", 9000 + i))
+      }
+      // Confirmation transfers a slot; it does not free capacity for another socket.
+      val (first, request) = pending.head
+      f.confirmConnection(controller, peerManager, first, request)
+      val overflow = TestProbe()
+      overflow.send(controller, Tcp.Connected(new InetSocketAddress("198.51.100.1", 9999),
+        settings.scorexSettings.network.bindAddress))
+      overflow.expectMsg(Tcp.Close)
+      peerManager.expectNoMessage(200.millis)
+    }
+  }
+
+  property("denial should release exactly its pending slot despite stale replies") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManager, _) = f.createController(maxConnections = 4)
+      val address = new InetSocketAddress("203.0.113.10", 9010)
+      val (first, request) = f.beginPendingConnection(controller, peerManager, address)
+      f.beginPendingConnection(controller, peerManager, new InetSocketAddress("203.0.113.11", 9011))
+      peerManager.send(controller, ConnectionDenied(request.connectionId, request.handlerRef))
+      first.expectMsg(Tcp.Close)
+      val (replacement, replacementRequest) = f.beginPendingConnection(controller, peerManager, address)
+      peerManager.send(controller, ConnectionDenied(request.connectionId, request.handlerRef))
+      first.expectMsg(Tcp.Close)
+      peerManager.send(controller, ConnectionConfirmed(request.connectionId, request.handlerRef))
+      first.expectMsg(Tcp.Close)
+      val overflow = TestProbe()
+      overflow.send(controller, Tcp.Connected(new InetSocketAddress("198.51.100.2", 9998),
+        settings.scorexSettings.network.bindAddress))
+      overflow.expectMsg(Tcp.Close)
+      f.confirmConnection(controller, peerManager, replacement, replacementRequest)
+    }
+  }
+
+  property("raw actor termination should release its pending slot and reject late confirmation") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManager, _) = f.createController(maxConnections = 2)
+      val address = new InetSocketAddress("203.0.113.20", 9020)
+      val (first, request) = f.beginPendingConnection(controller, peerManager, address)
+      val watcher = TestProbe()
+      watcher.watch(first.ref)
+      f.system.stop(first.ref)
+      watcher.expectTerminated(first.ref)
+      // DeathWatch delivery is asynchronous; wait for the controller's watched
+      // raw actor to disappear before sending its delayed PeerManager reply.
+      val (replacement, next) = watcher.awaitAssert {
+        val replacement = TestProbe()
+        replacement.send(controller, Tcp.Connected(address, settings.scorexSettings.network.bindAddress))
+        val next = peerManager.expectMsgType[ConfirmConnection](200.millis)
+        (replacement, next)
+      }
+      peerManager.send(controller, ConnectionConfirmed(request.connectionId, request.handlerRef))
+      val handler = f.confirmConnection(controller, peerManager, replacement, next)
+      val events = TestProbe()
+      f.system.eventStream.subscribe(events.ref, classOf[DisconnectedPeer])
+      watcher.watch(handler)
+      f.system.stop(handler)
+      watcher.expectTerminated(handler)
+      events.expectMsgType[DisconnectedPeer].peer.connectionId.remoteAddress shouldBe address
+    }
+  }
+
+  property("confirming the same remote endpoint twice should preserve its first handler") {
+    withFixture { f =>
+      implicit val system = f.system
+      val (controller, peerManager, _) = f.createController(maxConnections = 4)
+      val address = new InetSocketAddress("203.0.113.30", 9030)
+      val (first, firstRequest) = f.beginPendingConnection(controller, peerManager, address,
+        new InetSocketAddress("192.0.2.1", 9030))
+      val (second, secondRequest) = f.beginPendingConnection(controller, peerManager, address,
+        new InetSocketAddress("192.0.2.2", 9030))
+      val handler = f.confirmConnection(controller, peerManager, first, firstRequest)
+      peerManager.send(controller, ConnectionConfirmed(secondRequest.connectionId, secondRequest.handlerRef))
+      second.expectMsg(Tcp.Close)
+      val events = TestProbe()
+      f.system.eventStream.subscribe(events.ref, classOf[DisconnectedPeer])
+      first.watch(handler)
+      // A close event sent by a non-pending actor must not remove the
+      // controller's watch on the established handler.
+      controller.tell(Tcp.PeerClosed, handler)
+      f.system.stop(handler)
+      first.expectTerminated(handler)
+      events.expectMsgType[DisconnectedPeer].peer.handlerRef shouldBe handler
+      f.beginPendingConnection(controller, peerManager, new InetSocketAddress("203.0.113.31", 9031))
     }
   }
 


### PR DESCRIPTION
Count raw inbound sockets awaiting `PeerManager` confirmation toward `incomingLimit`. Previously, a burst of `Tcp.Connected` events could all pass admission before the confirmation replies created established handlers.

## Focused release increment

The branch is rebuilt on `v6.0.6` at `8995ff243b140e7fe716bd3204423dd35690c2e4`. Review the [two-file correction](https://github.com/a-shannon/ergo/compare/8995ff243b140e7fe716bd3204423dd35690c2e4...810843cdf3ff51b0a1ff2eabb6d0b631ac93b43d).

The previous head `6924665a2ca45c2a90c3c7c808e221fd131add5e` remains the historical review reference. Its unrelated #2427 blacklist backport and pending-blacklist expansion have been removed. This PR no longer carries the shared blacklist changes also encountered in [#2449](https://github.com/ergoplatform/ergo/pull/2449) and [#2461](https://github.com/ergoplatform/ergo/pull/2461).

## September 12 review corrections

- Pending reservations are keyed by the raw connection `ActorRef`. Admission counts established incoming handlers plus pending sockets; confirmation transfers a reservation, so no second numeric limit check is needed.
- Denial or raw actor termination releases its reservation. A late confirmation must still own a pending reservation. Only actually pending actors are unwatched.
- Two sockets sharing a remote endpoint cannot overwrite the first established handler when their confirmations arrive. The listener can accept connections on different local interfaces, so the same remote endpoint does not imply the same TCP connection. Established handler termination retains its existing disconnect notification.
- `ConnectionClosed` keeps the release's logging behavior. Pending cleanup uses the raw actor lifecycle; the tests stop that actor instead of injecting a synthetic close event as proof of termination.
- Admission logging reports established count, pending count and limit. Blacklist admission remains with the existing `PeerManager` path.

## Validation

The controller suite passes 15 tests. The bounded network, peer and peers-API closure passes 25 tests across seven suites. The admission regression fails on the original release implementation. Separate single-fault mutations of the pending-membership and endpoint-uniqueness guards each fail their targeted race regression; restoring both guards passes all 15 controller tests. Independent source review is complete.

Local execution used JDK 8 and Scala 2.12.20. Current GitHub checks bind head `810843cdf3ff51b0a1ff2eabb6d0b631ac93b43d`; the [checks page](https://github.com/ergoplatform/ergo/pull/2432/checks) reports the live result.

## Integration

No prerequisite on #2449 or #2461 remains. [#2421](https://github.com/ergoplatform/ergo/pull/2421) independently corrects rejected-handshake cleanup in the same controller. Preserve both corrections and the union of their actor fixtures when integrating. The current merge/review plan is maintained in [#2533](https://github.com/ergoplatform/ergo/issues/2533).

All eight [CI jobs passed](https://github.com/ergoplatform/ergo/actions/runs/34720760986) on the current head. The [published composition with #2421](https://github.com/a-shannon/ergo/commit/cacb2dcb5d453e06200747c8e1612b3d7715a38b) passes all 18 controller cases; its [increment after this PR](https://github.com/a-shannon/ergo/compare/810843cdf3ff51b0a1ff2eabb6d0b631ac93b43d...cacb2dcb5d453e06200747c8e1612b3d7715a38b) preserves both corrections and their owned tests.
