### PR TITLE
Resume missing-parent recovery for cached headers

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -267,6 +267,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     context.system.eventStream.subscribe(self, classOf[ChangedState])
     context.system.eventStream.subscribe(self, classOf[ModificationOutcome])
     context.system.eventStream.subscribe(self, classOf[DownloadRequest])
+    context.system.eventStream.subscribe(self, classOf[MissingParentHeaders])
     context.system.eventStream.subscribe(self, classOf[BlockAppliedTransactions])
     context.system.eventStream.subscribe(self, classOf[BlockSectionsProcessingCacheUpdate])
 
@@ -694,6 +695,28 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         }
       case _ =>
         log.warn("No peers available in requestDownload")
+    }
+  }
+
+  private def requestMissingParentHeaders(parentIds: Seq[ModifierId], historyReader: ErgoHistory): Unit = {
+    if (parentIds.nonEmpty) {
+      val olderPeers = HeadersDownloadFilter.filter(syncTracker.peersByStatus.getOrElse(Older, Seq.empty))
+      requestDownload(
+        maxModifiers = deliveryTracker.headersToDownload,
+        minHeadersPerBucket,
+        maxHeadersPerBucket
+      )(Option(olderPeers).filter(_.nonEmpty)) { howMany =>
+        val unknownParentIds = parentIds.distinct
+          .filter(parentId =>
+            deliveryTracker.status(parentId, Header.modifierTypeId, Seq(historyReader)) == ModifiersStatus.Unknown
+          )
+          .take(Math.min(howMany, MissingParentHeaders.MaxParentIds))
+        if (unknownParentIds.nonEmpty) {
+          Map(Header.modifierTypeId -> unknownParentIds)
+        } else {
+          Map.empty
+        }
+      }
     }
   }
 
@@ -1484,25 +1507,20 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     case SyntacticallySuccessfulModifier(modTypeId, modId) =>
       deliveryTracker.setHeld(modId, modTypeId)
 
+    case MissingParentHeaders(parentIds) =>
+      requestMissingParentHeaders(parentIds, historyReader)
+
     case RecoverableFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Setting recoverable failed modifier $modId as Unknown", e)
       e match {
-        case phError: ParentHeaderNotFoundError =>
-          // For missing parent header, request the parent header from peers if not already known
-          val parentId = phError.parentId
-          if (deliveryTracker.status(parentId, Header.modifierTypeId, Seq(historyReader)) == ModifiersStatus.Unknown) {
-            val olderPeers = syncTracker.peersByStatus.getOrElse(Older, Seq.empty)
-            if (olderPeers.nonEmpty) {
-              val randomPeer = olderPeers(scala.util.Random.nextInt(olderPeers.size))
-              requestBlockSection(Header.modifierTypeId, Seq(parentId), randomPeer)
-            } else {
-              logger.warn(s"No older peer available to download missing parent header $parentId for modifier $modId")
-            }
-          }
-          deliveryTracker.setUnknown(modId, modTypeId)
+        case error: ParentHeaderNotFoundError =>
+          // Unlike cached orphans, a modifier which reached this direct failure
+          // path is no longer retained, so it must become downloadable again.
+          self ! MissingParentHeaders(Seq(error.parentId))
         case _ =>
-          deliveryTracker.setUnknown(modId, modTypeId)
+          ()
       }
+      deliveryTracker.setUnknown(modId, modTypeId)
 
     case SyntacticallyFailedModification(modTypeId, modId, e) =>
       logger.debug(s"Invalidating syntactically failed modifier $modId", e)
@@ -1526,7 +1544,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         case _ =>
       }
 
-    case BlockSectionsProcessingCacheUpdate(headersCacheSize, blockSectionsCacheSize, cleared) =>
+    case BlockSectionsProcessingCacheUpdate(headersCacheSize, blockSectionsCacheSize, cleared, missingParentIds) =>
       val HeadersCacheSizeToDownloadMore = 3184
       val BlockSectionsCacheSizeToDownloadMore = 96
 
@@ -1541,6 +1559,9 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       // applied modifiers state was already changed at `SyntacticallySuccessfulModifier`
       val modTypeId = cleared._1
       cleared._2.foreach(mId => deliveryTracker.setUnknown(mId, modTypeId))
+      // Cleanup and recovery are handled in one actor turn so an evicted parent
+      // cannot still look Received when the recovery request is filtered.
+      requestMissingParentHeaders(missingParentIds, historyReader)
       modifiersCacheSize = blockSectionsCacheSize
       if (downloadMore) {
         requestMoreModifiers(historyReader)

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -58,6 +58,16 @@ object ErgoNodeViewSynchronizerMessages {
 
     case object RollbackFailed extends NodeViewHolderEvent
 
+    /**
+     * Bounded recovery frontier for headers retained in the node-view cache
+     * while their direct parents are absent locally.
+     */
+    case class MissingParentHeaders(parentIds: Seq[ModifierId]) extends NodeViewHolderEvent
+
+    object MissingParentHeaders {
+      val MaxParentIds: Int = 400
+    }
+
     // hierarchy of events regarding modifiers application outcome
     trait ModificationOutcome extends NodeViewHolderEvent
 
@@ -145,10 +155,12 @@ object ErgoNodeViewSynchronizerMessages {
      * @param headersCacheSize       - headers cache size after processing
      * @param blockSectionsCacheSize - block sections cache size after processing
      * @param cleared                - blocks removed from cache being overfull
+     * @param missingParentIds       - missing header parents discovered after cleanup
      */
     case class BlockSectionsProcessingCacheUpdate(headersCacheSize: Int,
                                                   blockSectionsCacheSize: Int,
-                                                  cleared: (NetworkObjectTypeId.Value, Seq[ModifierId]))
+                                                  cleared: (NetworkObjectTypeId.Value, Seq[ModifierId]),
+                                                  missingParentIds: Seq[ModifierId] = Seq.empty)
 
     /**
      * Command to re-check mempool to clean transactions become invalid while sitting in the mempool up

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
@@ -44,6 +44,12 @@ class ErgoModifiersCache(override val maxSize: Int) extends ModifiersCache with 
     }
   }
 
+  /**
+    * Finds the lowest-height cached header whose applicability check currently
+    * fails with a [[RecoverableModifierError]].
+    *
+    * @return the header and its recoverable error, or `None` if no such header exists
+    */
   def findStuckHeader(history: ErgoHistory): Option[(Header, RecoverableModifierError)] = {
     cache.values
       .collect { case header: Header => header }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
@@ -4,12 +4,45 @@ import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistory
 import scorex.core.{LRUCache, ModifiersCache}
-import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.{MalformedModifierError, ParentHeaderNotFoundError}
 import scorex.util.ScorexLogging
 
+import scala.collection.mutable
 import scala.util.Failure
 
 class ErgoModifiersCache(override val maxSize: Int) extends ModifiersCache with LRUCache with ScorexLogging {
+
+  private val missingParentByChild = mutable.Map.empty[K, K]
+  private val childrenByMissingParent = mutable.LinkedHashMap.empty[K, mutable.LinkedHashSet[K]]
+  private val newMissingParents = mutable.LinkedHashSet.empty[K]
+  private val retryMissingParents = mutable.LinkedHashSet.empty[K]
+
+  override def put(key: K, value: V): Unit = {
+    val isNewHeader = !cache.contains(key) && value.isInstanceOf[Header]
+    super.put(key, value)
+    if (isNewHeader) {
+      // A parent already present in the cache is not an external recovery frontier.
+      newMissingParents -= key
+      retryMissingParents -= key
+    }
+  }
+
+  override def remove(key: K): Option[V] = {
+    val removed = super.remove(key)
+    removed.foreach {
+      case _: Header =>
+        forgetChild(key)
+        // If this header was shielding cached children, its removal exposes their
+        // parent frontier again. Selection later filters parents already in history.
+        childrenByMissingParent.get(key).filter(_.nonEmpty).foreach { _ =>
+          retryMissingParents -= key
+          newMissingParents += key
+        }
+      case _ =>
+        ()
+    }
+    removed
+  }
 
   override def findCandidateKey(history: ErgoHistory): Option[K] = {
     def tryToApply(k: K, v: BlockSection): Boolean = {
@@ -42,6 +75,97 @@ class ErgoModifiersCache(override val maxSize: Int) extends ModifiersCache with 
         }
       }.map(_._1)
     }
+  }
+
+  private def forgetChild(childId: K): Unit = {
+    missingParentByChild.remove(childId).foreach { parentId =>
+      childrenByMissingParent.get(parentId).foreach { childIds =>
+        childIds -= childId
+        if (childIds.isEmpty) {
+          childrenByMissingParent -= parentId
+          newMissingParents -= parentId
+          retryMissingParents -= parentId
+        }
+      }
+    }
+  }
+
+  private def registerMissingParent(childId: K, parentId: K): Unit = {
+    val wasTracked = childrenByMissingParent.contains(parentId)
+    if (!missingParentByChild.get(childId).contains(parentId)) {
+      forgetChild(childId)
+      missingParentByChild.put(childId, parentId)
+      childrenByMissingParent.getOrElseUpdate(parentId, mutable.LinkedHashSet.empty) += childId
+    }
+
+    if (cache.contains(parentId)) {
+      newMissingParents -= parentId
+      retryMissingParents -= parentId
+    } else if (!wasTracked || (!newMissingParents.contains(parentId) && !retryMissingParents.contains(parentId))) {
+      // A newly exposed frontier gets one turn before older retry candidates.
+      retryMissingParents -= parentId
+      newMissingParents += parentId
+    } else {
+      ()
+    }
+  }
+
+  /**
+    * Registers newly received orphan headers and returns a bounded, rotating
+    * page of parent ids absent from both history and this cache.
+    *
+    * Work is proportional to `candidates.size + limit`; the full cache is never
+    * scanned. Only one request frontier is kept for siblings sharing a parent.
+    */
+  def findMissingParentIds(history: ErgoHistory,
+                           candidates: Seq[Header],
+                           limit: Int): Seq[K] = {
+    require(limit > 0)
+
+    val inspectedCandidates = mutable.HashSet.empty[K]
+    candidates.foreach { header =>
+      if (inspectedCandidates.add(header.id)) {
+        if (cache.contains(header.id)) {
+          history.applicableTry(header) match {
+            case Failure(error: ParentHeaderNotFoundError) =>
+              registerMissingParent(header.id, error.parentId)
+            case _ =>
+              forgetChild(header.id)
+          }
+        } else {
+          forgetChild(header.id)
+        }
+      }
+    }
+
+    val selected = mutable.ArrayBuffer.empty[K]
+    val parentsToInspect = Math.min(newMissingParents.size + retryMissingParents.size, limit)
+    var inspectedParents = 0
+
+    while (selected.size < limit && inspectedParents < parentsToInspect &&
+      (newMissingParents.nonEmpty || retryMissingParents.nonEmpty)) {
+      val parentId = newMissingParents.headOption.getOrElse(retryMissingParents.head)
+      newMissingParents -= parentId
+      retryMissingParents -= parentId
+      inspectedParents += 1
+
+      childrenByMissingParent.get(parentId) match {
+        case Some(childIds) if childIds.nonEmpty && !cache.contains(parentId) && !history.contains(parentId) =>
+          selected += parentId
+          retryMissingParents += parentId
+        case Some(_) if cache.contains(parentId) =>
+          // Keep the relation dormant. Removing the cached parent re-enables it.
+          ()
+        case Some(_) =>
+          // The parent reached history; cached children will be consumed by the
+          // normal application loop and remove their registrations.
+          ()
+        case None =>
+          ()
+      }
+    }
+
+    selected.toVector
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoModifiersCache.scala
@@ -4,7 +4,7 @@ import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistory
 import scorex.core.{LRUCache, ModifiersCache}
-import org.ergoplatform.validation.MalformedModifierError
+import org.ergoplatform.validation.{MalformedModifierError, RecoverableModifierError}
 import scorex.util.ScorexLogging
 
 import scala.util.Failure
@@ -42,6 +42,22 @@ class ErgoModifiersCache(override val maxSize: Int) extends ModifiersCache with 
         }
       }.map(_._1)
     }
+  }
+
+  def findStuckHeader(history: ErgoHistory): Option[(Header, RecoverableModifierError)] = {
+    cache.values
+      .collect { case header: Header => header }
+      .toSeq
+      .sortBy(_.height)
+      .iterator
+      .flatMap { header =>
+        history.applicableTry(header) match {
+          case Failure(error: RecoverableModifierError) => Some(header -> error)
+          case _                                        => None
+        }
+      }
+      .toStream
+      .headOption
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -370,10 +370,20 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           applyFromCacheLoop(headersCache)
 
           val cleared = headersCache.cleanOverfull()
+
+          // Cached headers with missing parents do not reach pmodModify. Report a
+          // bounded, rotating page only after overfull entries have been evicted.
+          val parentIds = headersCache.findMissingParentIds(
+            history(),
+            sorted.collect { case header: Header => header },
+            limit = Math.min(mods.size, MissingParentHeaders.MaxParentIds)
+          )
+
           val upd = BlockSectionsProcessingCacheUpdate(
             headersCache.size,
             modifiersCache.size,
-            Header.modifierTypeId -> cleared.map(_.id)
+            Header.modifierTypeId -> cleared.map(_.id),
+            missingParentIds = parentIds
           )
           context.system.eventStream.publish(upd)
           log.debug(s"Cache size after: ${headersCache.size}")

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -361,6 +361,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
           applyFromCacheLoop(headersCache)
 
+          // Cached headers that fail applicability do not reach pmodModify.
+          // Report one recoverable failure so the synchronizer can mark the header
+          // as unknown and request a missing parent, if applicable.
           headersCache.findStuckHeader(history()).foreach { case (header, error) =>
             context.system.eventStream.publish(
               RecoverableFailedModification(header.modifierTypeId, header.id, error)

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -361,6 +361,12 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
           applyFromCacheLoop(headersCache)
 
+          headersCache.findStuckHeader(history()).foreach { case (header, error) =>
+            context.system.eventStream.publish(
+              RecoverableFailedModification(header.modifierTypeId, header.id, error)
+            )
+          }
+
           val cleared = headersCache.cleanOverfull()
           val upd = BlockSectionsProcessingCacheUpdate(
             headersCache.size,

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -21,7 +21,7 @@ import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.message._
 import org.ergoplatform.network.peer.PeerInfo
-import scorex.core.network.{ConnectedPeer, DeliveryTracker}
+import scorex.core.network.{ConnectedPeer, DeliveryTracker, SendToPeer}
 import scorex.util.bytesToId
 import org.ergoplatform.serialization.ErgoSerializer
 import org.scalatest.propspec.AnyPropSpec
@@ -59,6 +59,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
   private def withFixture2(testCode: Synchronizer2Fixture => Any): Unit = {
     val fixture = new Synchronizer2Fixture
+    try {
+      testCode(fixture)
+    }
+    finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  private def withFixture2(desiredModifierQueueSize: Int)(testCode: Synchronizer2Fixture => Any): Unit = {
+    val fixture = new Synchronizer2Fixture(desiredModifierQueueSize)
     try {
       testCode(fixture)
     }
@@ -173,12 +183,17 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val (synchronizer, nodeViewHolder, syncInfo, mod, tx, peer, pchProbe, ncProbe, eventListener, modSerializer, deliveryTracker) = nodeViewSynchronizer
   }
 
-  class Synchronizer2Fixture extends AkkaFixture {
+  class Synchronizer2Fixture(
+    desiredModifierQueueSize: Int = settings.scorexSettings.network.desiredInvObjects
+  ) extends AkkaFixture {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
-    val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
+    val deliveryTracker: DeliveryTracker = new DeliveryTracker(
+      settings.cacheSettings.network,
+      desiredModifierQueueSize
+    )
 
     // each test should always start with empty history
     deleteRecursive(ErgoHistory.historyDir(settings))
@@ -194,7 +209,17 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
         deliveryTracker)
     ))
 
-    val peerInfo = PeerInfo(defaultPeerSpec, System.currentTimeMillis())
+    val peerInfo = PeerInfo(
+      defaultPeerSpec.copy(features = Seq(
+        ModePeerFeature(
+          StateType.Utxo,
+          verifyingTransactions = true,
+          nipopowBootstrapped = None,
+          ModePeerFeature.AllBlocksKept
+        )
+      )),
+      System.currentTimeMillis()
+    )
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     val peer: ConnectedPeer = ConnectedPeer(
       connectionIdGen.sample.get,
@@ -267,10 +292,38 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       val modData = ModifiersData(Header.modifierTypeId, Map(olderChain.last.id -> olderChain.last.bytes))
       val modSpec = ModifiersSpec
       synchronizer ! Message(modSpec, Left(modSpec.toBytes(modData)), Some(peer))
+
       // desired state of submitting valid headers is Received
       eventually {
         deliveryTracker.status(olderChain.last.id, Header.modifierTypeId, Seq.empty) shouldBe Received
       }
+    }
+  }
+
+  property("NodeViewSynchronizer: missing-parent recovery retains the cached child delivery state") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val childId = bytesToId(scorex.utils.Random.randomBytes(32))
+      val missingParentId = bytesToId(scorex.utils.Random.randomBytes(32))
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(1))
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      deliveryTracker.setRequested(Header.modifierTypeId, childId, peer)(_ => Cancellable.alreadyCancelled)
+      deliveryTracker.setReceived(childId, Header.modifierTypeId, peer)
+      synchronizerMockRef ! MissingParentHeaders(Seq(missingParentId))
+
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val data = stn.message.data.get.asInstanceOf[InvData]
+            data.typeId == Header.modifierTypeId && data.ids == Seq(missingParentId)
+          case _ => false
+        }
+      }
+
+      deliveryTracker.status(childId, Header.modifierTypeId, Seq.empty) shouldBe Received
     }
   }
 
@@ -554,42 +607,28 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should request parent header") {
+  property("NodeViewSynchronizer: missing-parent recovery caps and deduplicates parent requests") {
     withFixture2 { ctx =>
       import ctx._
 
       val hhistory = ErgoHistory.readOrGenerate(settings)(null)
-      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
-      baseChain.headers.foreach(hhistory.append)
-
-      val parentHeader = baseChain.last
-      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
-
-      // Set up sync tracker with an older peer
-      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(childHeader.height))
-
-      // Send ChangedHistory to set up historyReader in the synchronizer
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(1))
       synchronizerMockRef ! ChangedHistory(hhistory)
 
-      // Use a random parent ID that is NOT in the history so the synchronizer will request it
-      val unknownParentId = bytesToId(scorex.utils.Random.randomBytes(32))
-      val modifierId = childHeader.id
-      val error = new ParentHeaderNotFoundError(unknownParentId, modifierId, Header.modifierTypeId)
-      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+      val parentIds = (0 to MissingParentHeaders.MaxParentIds)
+        .map(_ => bytesToId(scorex.utils.Random.randomBytes(32)))
+      synchronizerMockRef ! MissingParentHeaders(parentIds ++ parentIds.take(10))
 
-      // Should request the parent header from the older peer
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
             val invData = stn.message.data.get.asInstanceOf[InvData]
-            invData.typeId == Header.modifierTypeId && invData.ids.contains(unknownParentId)
+            invData.typeId == Header.modifierTypeId &&
+              invData.ids.size == MissingParentHeaders.MaxParentIds &&
+              invData.ids.distinct.size == invData.ids.size &&
+              invData.ids.forall(parentIds.contains)
           case _ => false
         }
-      }
-
-      // The modifier should be set to Unknown
-      eventually {
-        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
       }
     }
   }
@@ -616,68 +655,184 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should not request if parent already known") {
+  property("NodeViewSynchronizer: missing-parent recovery respects available header request capacity") {
+    withFixture2(desiredModifierQueueSize = 2) { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(1))
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      val initialHeaderCapacity = deliveryTracker.headersToDownload
+      val alreadyRequested = (1 until initialHeaderCapacity)
+        .map(i => bytesToId(Array.fill(32)(i.toByte)))
+      alreadyRequested.foreach { headerId =>
+        deliveryTracker.setRequested(Header.modifierTypeId, headerId, peer)(_ => Cancellable.alreadyCancelled)
+      }
+      deliveryTracker.headersToDownload shouldBe 1
+
+      val parentIds = Seq(101, 102).map(i => bytesToId(Array.fill(32)(i.toByte)))
+      synchronizerMockRef ! MissingParentHeaders(parentIds)
+
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val data = stn.message.data.get.asInstanceOf[InvData]
+            data.typeId == Header.modifierTypeId &&
+              data.ids.size == 1 &&
+              data.ids.forall(parentIds.contains)
+          case _ => false
+        }
+      }
+      deliveryTracker.headersToDownload shouldBe 0
+    }
+  }
+
+  property("NodeViewSynchronizer: cache cleanup releases an evicted parent before requesting it again") {
     withFixture2 { ctx =>
       import ctx._
 
       val hhistory = ErgoHistory.readOrGenerate(settings)(null)
-      val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
-      baseChain.headers.foreach(hhistory.append)
-
-      val parentHeader = baseChain.last
-      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
-
-      // Set up sync tracker with an older peer
-      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(childHeader.height))
-
-      // Send ChangedHistory to set up historyReader in the synchronizer
+      val missingParentId = bytesToId(Array.fill(32)(103.toByte))
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(1))
       synchronizerMockRef ! ChangedHistory(hhistory)
 
-      // Parent header IS in history, so no request should be made
-      val parentId = parentHeader.id
-      val modifierId = childHeader.id
-      val error = new ParentHeaderNotFoundError(parentId, modifierId, Header.modifierTypeId)
-      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+      deliveryTracker.setRequested(Header.modifierTypeId, missingParentId, peer)(_ => Cancellable.alreadyCancelled)
+      deliveryTracker.setReceived(missingParentId, Header.modifierTypeId, peer)
+      deliveryTracker.status(missingParentId, Header.modifierTypeId, Seq.empty) shouldBe Received
 
-      // Should NOT request the parent header since it's already in history
-      ncProbe.expectNoMessage(1.second)
+      synchronizerMockRef ! BlockSectionsProcessingCacheUpdate(
+        headersCacheSize = 1,
+        blockSectionsCacheSize = 0,
+        cleared = Header.modifierTypeId -> Seq(missingParentId),
+        missingParentIds = Seq(missingParentId)
+      )
 
-      // The modifier should still be set to Unknown
-      eventually {
-        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val data = stn.message.data.get.asInstanceOf[InvData]
+            data.typeId == Header.modifierTypeId && data.ids == Seq(missingParentId)
+          case _ => false
+        }
       }
     }
   }
 
-  property("NodeViewSynchronizer: RecoverableFailedModification with ParentHeaderNotFoundError should warn when no older peers") {
+  property("NodeViewSynchronizer: missing-parent recovery filters known and requested parents") {
     withFixture2 { ctx =>
       import ctx._
 
       val hhistory = ErgoHistory.readOrGenerate(settings)(null)
       val baseChain = genHeaderChain(_.size > 4, None, hhistory.difficultyCalculator, None, false)
       baseChain.headers.foreach(hhistory.append)
-
-      val parentHeader = baseChain.last
-      val childHeader = genHeaderChain(_.size > 2, Some(parentHeader), hhistory.difficultyCalculator, None, false).last
-
-      // NO older peers set up - only the original peer as Younger
-      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Younger, Some(childHeader.height))
-
-      // Send ChangedHistory to set up historyReader in the synchronizer
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(baseChain.last.height + 1))
       synchronizerMockRef ! ChangedHistory(hhistory)
 
-      // Use a random parent ID that is NOT in the history
+      val knownParentId = baseChain.last.id
+      val requestedParentId = bytesToId(scorex.utils.Random.randomBytes(32))
       val unknownParentId = bytesToId(scorex.utils.Random.randomBytes(32))
-      val modifierId = childHeader.id
-      val error = new ParentHeaderNotFoundError(unknownParentId, modifierId, Header.modifierTypeId)
-      synchronizerMockRef ! RecoverableFailedModification(Header.modifierTypeId, modifierId, error)
+      deliveryTracker.setRequested(Header.modifierTypeId, requestedParentId, peer)(_ => Cancellable.alreadyCancelled)
+      synchronizerMockRef ! MissingParentHeaders(Seq(knownParentId, requestedParentId, unknownParentId))
 
-      // Should NOT send any network request since no older peers available
-      ncProbe.expectNoMessage(1.second)
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val invData = stn.message.data.get.asInstanceOf[InvData]
+            invData.typeId == Header.modifierTypeId && invData.ids == Seq(unknownParentId)
+          case _ => false
+        }
+      }
+    }
+  }
 
-      // The modifier should still be set to Unknown
+  property("NodeViewSynchronizer: direct missing-parent failure requests the parent and releases the uncached child") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val childId = bytesToId(scorex.utils.Random.randomBytes(32))
+      val missingParentId = bytesToId(scorex.utils.Random.randomBytes(32))
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Older, Some(1))
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      deliveryTracker.setRequested(Header.modifierTypeId, childId, peer)(_ => Cancellable.alreadyCancelled)
+      deliveryTracker.setReceived(childId, Header.modifierTypeId, peer)
+      synchronizerMockRef ! RecoverableFailedModification(
+        Header.modifierTypeId,
+        childId,
+        new ParentHeaderNotFoundError(missingParentId, childId, Header.modifierTypeId)
+      )
+
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val data = stn.message.data.get.asInstanceOf[InvData]
+            data.typeId == Header.modifierTypeId && data.ids == Seq(missingParentId)
+          case _ => false
+        }
+      }
       eventually {
-        deliveryTracker.status(modifierId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+        deliveryTracker.status(childId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: missing-parent recovery sends nothing without an older peer") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Younger, Some(1))
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      val unknownParentId = bytesToId(scorex.utils.Random.randomBytes(32))
+      synchronizerMockRef ! MissingParentHeaders(Seq(unknownParentId))
+
+      ncProbe.expectNoMessage(1.second)
+    }
+  }
+
+  property("NodeViewSynchronizer: missing-parent recovery uses only peers with complete header history") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      synchronizerMockRef ! ChangedMempool(ErgoMemPool.empty(settings))
+      synchronizerMockRef ! ChangedHistory(hhistory)
+
+      def withMode(peer: ConnectedPeer, nipopowBootstrapped: Option[Int]): ConnectedPeer =
+        peer.copy(peerInfo = peer.peerInfo.map { info =>
+          info.copy(peerSpec = info.peerSpec.copy(features = Seq(
+            ModePeerFeature(StateType.Utxo, verifyingTransactions = true, nipopowBootstrapped, ModePeerFeature.AllBlocksKept)
+          )))
+        })
+
+      val nipopowPeer = withMode(peer, Some(ModePeerFeature.NiPoPoWDefaultFlag))
+      syncTracker.updateStatus(nipopowPeer, org.ergoplatform.consensus.Older, Some(1))
+      syncTracker.peersByStatus(org.ergoplatform.consensus.Older) should contain only nipopowPeer
+      deliveryTracker.headersToDownload should be > 0
+
+      val unavailableParentId = bytesToId(Array.fill(32)(104.toByte))
+      synchronizerMockRef ! MissingParentHeaders(Seq(unavailableParentId))
+      ncProbe.expectNoMessage(1.second)
+      deliveryTracker.status(unavailableParentId, Header.modifierTypeId, Seq.empty) shouldBe Unknown
+
+      @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+      val fullHistoryPeer = withMode(peer.copy(connectionId = connectionIdGen.sample.get), None)
+      val missingParentId = bytesToId(Array.fill(32)(105.toByte))
+      syncTracker.updateStatus(fullHistoryPeer, org.ergoplatform.consensus.Older, Some(1))
+      synchronizerMockRef ! MissingParentHeaders(Seq(missingParentId))
+
+      ncProbe.fishForMessage(3 seconds) { case m =>
+        m match {
+          case stn: SendToNetwork if stn.message.spec.messageCode == RequestModifierSpec.messageCode =>
+            val data = stn.message.data.get.asInstanceOf[InvData]
+            data.typeId == Header.modifierTypeId &&
+              data.ids == Seq(missingParentId) &&
+              stn.sendingStrategy == SendToPeer(fullHistoryPeer)
+          case _ => false
+        }
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -17,7 +17,7 @@ import org.ergoplatform.wallet.utils.FileUtils
 import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
-import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
+import scorex.core.network.ModifiersStatus.{Requested, Unknown}
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.message._
 import org.ergoplatform.network.peer.PeerInfo
@@ -227,7 +227,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  property("NodeViewSynchronizer: receiving valid header") {
+  property("NodeViewSynchronizer: receiving an orphan header returns it to Unknown for parent recovery") {
     withFixture { ctx =>
       import ctx._
       deliveryTracker.reset()
@@ -236,9 +236,8 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       val modData = ModifiersData(Header.modifierTypeId, Map(olderChain.last.id -> olderChain.last.bytes))
       val modSpec = ModifiersSpec
       synchronizer ! Message(modSpec, Left(modSpec.toBytes(modData)), Some(peer))
-      // desired state of submitting valid headers is Received
       eventually {
-        deliveryTracker.status(olderChain.last.id, Header.modifierTypeId, Seq.empty) shouldBe Received
+        deliveryTracker.status(olderChain.last.id, Header.modifierTypeId, Seq.empty) shouldBe Unknown
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -6,8 +6,9 @@ import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
-import org.ergoplatform.nodeView.mempool.ErgoMemPool
+import org.ergoplatform.nodeView.mempool.{ErgoMemPool, ErgoMemPoolReader}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
@@ -67,7 +68,27 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  class NodeViewHolderMock extends ErgoNodeViewHolder[UtxoState](settings)
+  private def isolatedNodeSettings(prototype: ErgoSettings): ErgoSettings = {
+    val directory = createTempDir
+    prototype.copy(directory = directory.getAbsolutePath,
+      walletSettings = prototype.walletSettings.copy(secretStorage =
+        prototype.walletSettings.secretStorage.copy(
+          secretDir = new java.io.File(directory, "keystore").getAbsolutePath)))
+  }
+
+  class NodeViewHolderMock(nodeSettings: ErgoSettings) extends ErgoNodeViewHolder[UtxoState](nodeSettings)
+
+  class InjectedReadersNodeViewHolder(nodeSettings: ErgoSettings,
+                                     injectedHistory: ErgoHistoryReader,
+                                     injectedMempool: ErgoMemPoolReader) extends NodeViewHolderMock(nodeSettings) {
+    // This fixture owns its history and mempool; startup replies must use those same readers.
+    override protected def getNodeViewChanges: Receive = {
+      case request: GetNodeViewChanges =>
+        if (request.history) sender() ! ChangedHistory(injectedHistory)
+        super.getNodeViewChanges(request.copy(history = false, mempool = false))
+        if (request.mempool) sender() ! ChangedMempool(injectedMempool)
+    }
+  }
 
   class SynchronizerMock(networkControllerRef: ActorRef,
                          viewHolderRef: ActorRef,
@@ -129,7 +150,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val h = localHistoryGen.sample.get
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     val s = localStateGen.sample.get
-    val settings = ErgoSettingsReader.read()
+    val settings = isolatedNodeSettings(ErgoSettingsReader.read())
     val pool = ErgoMemPool.empty(settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
@@ -138,9 +159,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new InjectedReadersNodeViewHolder(settings, h, pool)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -174,15 +193,14 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   }
 
   class Synchronizer2Fixture extends AkkaFixture {
+    val settings: ErgoSettings = isolatedNodeSettings(org.ergoplatform.utils.ErgoNodeTestConstants.settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock(settings)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -509,6 +527,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - unknown peer") {
     withFixture { ctx =>
       import ctx._
+
+      // Replay a late startup request before observing the peer response. The fixture's
+      // injected history and mempool must not be replaced by the holder's empty readers.
+      val startupReaders = TestProbe("StartupReaders")
+      startupReaders.send(nodeViewHolder,
+        GetNodeViewChanges(history = true, state = false, vault = false, mempool = true))
+      val changedHistory = startupReaders.expectMsgType[ChangedHistory](3.seconds)
+      val changedMempool = startupReaders.expectMsgType[ChangedMempool](3.seconds)
+      synchronizer ! changedHistory
+      synchronizer ! changedMempool
 
       val sync = ErgoSyncInfoV2(Seq(altchain.last))
 

--- a/src/test/scala/org/ergoplatform/nodeView/ErgoModifiersCacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/ErgoModifiersCacheSpec.scala
@@ -5,6 +5,7 @@ import org.ergoplatform.modifiers.history.{ADProofs, BlockTransactions}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.validation.{ParentHeaderNotFoundError, RecoverableModifierError}
 import org.scalatest.OptionValues
 import scorex.crypto.hash.Blake2b256
 import scorex.util.{ModifierId, bytesToId}
@@ -117,6 +118,181 @@ class ErgoModifiersCacheSpec extends ErgoCorePropertyTest with OptionValues {
       }
     }
     applyLoop()
+  }
+
+  property("stuck-header recovery rotates across independent missing parents") {
+    val modifiersCache = new ErgoModifiersCache(25)
+    val history = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+
+    val firstBranch = genChain(2, history)
+    val secondBranch = (1 to 10).iterator
+      .map(_ => genChain(2, history))
+      .find(_.head.header.id != firstBranch.head.header.id)
+      .value
+    val orphanHeaders = Seq(firstBranch.last.header, secondBranch.last.header)
+
+    orphanHeaders.foreach(header => modifiersCache.put(header.id, header))
+
+    val expectedParents = orphanHeaders.map(_.parentId).toSet
+    val samePage = modifiersCache.findMissingParentIds(history, orphanHeaders, limit = orphanHeaders.size)
+    samePage.toSet shouldBe expectedParents
+
+    val firstReported = modifiersCache.findMissingParentIds(history, Seq.empty, limit = 1).head
+    val secondReported = modifiersCache.findMissingParentIds(history, Seq.empty, limit = 1).head
+
+    firstReported should not be secondReported
+    Set(firstReported, secondReported) shouldBe expectedParents
+  }
+
+  property("a newly discovered missing parent is not starved by a previously reported parent") {
+    val modifiersCache = new ErgoModifiersCache(25)
+    val history = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+    val firstBranch = genChain(2, history)
+    val secondBranch = (1 to 10).iterator
+      .map(_ => genChain(2, history))
+      .find(_.head.header.id != firstBranch.head.header.id)
+      .value
+    val firstOrphan = firstBranch.last.header
+    val secondOrphan = secondBranch.last.header
+
+    modifiersCache.put(firstOrphan.id, firstOrphan)
+    modifiersCache.findMissingParentIds(history, Seq(firstOrphan), limit = 1) shouldBe
+      Seq(firstOrphan.parentId)
+
+    modifiersCache.put(secondOrphan.id, secondOrphan)
+    modifiersCache.findMissingParentIds(history, Seq(secondOrphan), limit = 1) shouldBe
+      Seq(secondOrphan.parentId)
+  }
+
+  property("stuck-header recovery reports only the external frontier of a cached chain") {
+    val modifiersCache = new ErgoModifiersCache(25)
+    val history = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+    val chain = genChain(3, history)
+    val frontier = chain(1).header
+    val descendant = chain(2).header
+
+    Seq(frontier, descendant).foreach(header => modifiersCache.put(header.id, header))
+
+    val reported = modifiersCache.findMissingParentIds(history, Seq(frontier, descendant), limit = 25)
+    reported shouldBe Seq(chain.head.header.id)
+  }
+
+  property("stuck-header recovery reports one representative per missing parent") {
+    val modifiersCache = new ErgoModifiersCache(25)
+    val history = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+    val parent = genChain(1, history).head.header
+    val firstChild = nextHeader(
+      Some(parent),
+      history.difficultyCalculator,
+      tsOpt = Some(parent.timestamp + 1),
+      useRealTs = false
+    )
+    val secondChild = nextHeader(
+      Some(parent),
+      history.difficultyCalculator,
+      tsOpt = Some(parent.timestamp + 2),
+      useRealTs = false
+    )
+
+    Seq(firstChild, secondChild).foreach(header => modifiersCache.put(header.id, header))
+
+    val reported = modifiersCache.findMissingParentIds(history, Seq(firstChild, secondChild), limit = 25)
+    reported shouldBe Seq(parent.id)
+  }
+
+  property("stuck-header recovery excludes non-parent recoverable errors") {
+    val modifiersCache = new ErgoModifiersCache(25)
+    val emptyHistory = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+    val parent = genChain(1, emptyHistory).head.header
+    val history = emptyHistory.append(parent).get._1
+    val futureHeader = nextHeader(
+      Some(parent),
+      history.difficultyCalculator,
+      tsOpt = Some(System.currentTimeMillis() + 60L * 60L * 1000L),
+      useRealTs = true
+    )
+    val failure = history.applicableTry(futureHeader).failed.toOption.value
+
+    failure.isInstanceOf[RecoverableModifierError] shouldBe true
+    failure.isInstanceOf[ParentHeaderNotFoundError] shouldBe false
+    modifiersCache.put(futureHeader.id, futureHeader)
+
+    modifiersCache.findMissingParentIds(history, Seq(futureHeader), limit = 25) shouldBe empty
+  }
+
+  property("missing-parent recovery suppresses cached parents and restores evicted frontiers") {
+    val modifiersCache = new ErgoModifiersCache(25)
+    val history = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+    val chain = genChain(2, history)
+    val parent = chain.head.header
+    val child = chain.last.header
+
+    modifiersCache.put(child.id, child)
+    modifiersCache.findMissingParentIds(history, Seq(child), limit = 25) shouldBe Seq(parent.id)
+
+    modifiersCache.put(parent.id, parent)
+    modifiersCache.findMissingParentIds(history, Seq.empty, limit = 25) shouldBe empty
+
+    modifiersCache.remove(parent.id).value shouldBe parent
+    modifiersCache.findMissingParentIds(history, Seq.empty, limit = 25) shouldBe Seq(parent.id)
+
+    modifiersCache.remove(child.id).value shouldBe child
+    modifiersCache.findMissingParentIds(history, Seq.empty, limit = 25) shouldBe empty
+  }
+
+  property("missing-parent recovery excludes headers removed by overfull cleanup") {
+    val modifiersCache = new ErgoModifiersCache(1)
+    val history = generateHistory(
+      verifyTransactions = true,
+      StateType.Utxo,
+      PoPoWBootstrap = false,
+      BlocksToKeep
+    )
+    val firstBranch = genChain(2, history)
+    val secondBranch = (1 to 10).iterator
+      .map(_ => genChain(2, history))
+      .find(_.head.header.id != firstBranch.head.header.id)
+      .value
+    val firstOrphan = firstBranch.last.header
+    val secondOrphan = secondBranch.last.header
+
+    modifiersCache.put(firstOrphan.id, firstOrphan)
+    modifiersCache.findMissingParentIds(history, Seq(firstOrphan), limit = 1) shouldBe Seq(firstOrphan.parentId)
+    modifiersCache.put(secondOrphan.id, secondOrphan)
+
+    modifiersCache.cleanOverfull() should contain only firstOrphan
+    modifiersCache.findMissingParentIds(history, Seq(firstOrphan, secondOrphan), limit = 25) shouldBe
+      Seq(secondOrphan.parentId)
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -81,7 +81,7 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     getBestHeaderOpt shouldBe Some(block.header)
   }
 
-  private val t3a = TestCase("do not apply block headers in invalid order") { fixture =>
+  private val t3a = TestCase("apply a cached child after its missing parent arrives") { fixture =>
     import fixture._
     val (us, bh) = createUtxoState(fixture.settings)
     val parentBlock = validFullBlock(None, us, bh)
@@ -90,20 +90,21 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     getBestHeaderOpt shouldBe None
     getHistoryHeight shouldBe EmptyHistoryHeight
 
+    subscribeEvents(classOf[BlockSectionsProcessingCacheUpdate])
     subscribeEvents(classOf[SyntacticallySuccessfulModifier])
 
-    //sending child header without parent header
+    // Send the child first and verify that recovery identifies its exact missing parent.
     nodeViewHolderRef ! ModifiersFromRemote(List(block.header))
-    expectNoMsg()
+    expectMsgType[BlockSectionsProcessingCacheUpdate].missingParentIds shouldBe Seq(parentBlock.header.id)
 
-    // sende correct header sequence
+    // Sending the parent once must apply both the parent and the already cached child.
     nodeViewHolderRef ! ModifiersFromRemote(List(parentBlock.header))
-    expectMsgType[SyntacticallySuccessfulModifier]
-
-    nodeViewHolderRef ! ModifiersFromRemote(List(block.header))
-    expectMsgType[SyntacticallySuccessfulModifier]
+    expectMsgType[SyntacticallySuccessfulModifier].modifierId shouldBe parentBlock.header.id
+    expectMsgType[SyntacticallySuccessfulModifier].modifierId shouldBe block.header.id
 
     getHistoryHeight shouldBe 2
+    getHeightOf(block.header.id) shouldBe Some(2)
+    getBestHeaderOpt shouldBe Some(block.header)
   }
 
   private val t4 = TestCase("apply valid block as genesis") { fixture =>

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -19,6 +19,7 @@ import org.ergoplatform.wallet.utils.FileUtils
 import scorex.crypto.authds.{ADKey, SerializedAdProof}
 import scorex.util.{ModifierId, bytesToId}
 import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.validation.ParentHeaderNotFoundError
 
 class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps with FileUtils {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
@@ -76,7 +77,7 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     getBestHeaderOpt shouldBe Some(block.header)
   }
 
-  private val t3a = TestCase("do not apply block headers in invalid order") { fixture =>
+  private val t3a = TestCase("apply a cached child after its missing parent arrives") { fixture =>
     import fixture._
     val (us, bh) = createUtxoState(fixture.settings)
     val parentBlock = validFullBlock(None, us, bh)
@@ -85,20 +86,24 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     getBestHeaderOpt shouldBe None
     getHistoryHeight shouldBe EmptyHistoryHeight
 
+    subscribeEvents(classOf[RecoverableFailedModification])
     subscribeEvents(classOf[SyntacticallySuccessfulModifier])
 
-    //sending child header without parent header
+    // Send the child first and verify that recovery identifies its exact missing parent.
     nodeViewHolderRef ! ModifiersFromRemote(List(block.header))
-    expectNoMsg()
+    val failed = expectMsgType[RecoverableFailedModification]
+    failed.modifierId shouldBe block.header.id
+    failed.error shouldBe a[ParentHeaderNotFoundError]
+    failed.error.asInstanceOf[ParentHeaderNotFoundError].parentId shouldBe parentBlock.header.id
 
-    // sende correct header sequence
+    // Sending the parent once must apply both the parent and the already cached child.
     nodeViewHolderRef ! ModifiersFromRemote(List(parentBlock.header))
-    expectMsgType[SyntacticallySuccessfulModifier]
-
-    nodeViewHolderRef ! ModifiersFromRemote(List(block.header))
-    expectMsgType[SyntacticallySuccessfulModifier]
+    expectMsgType[SyntacticallySuccessfulModifier].modifierId shouldBe parentBlock.header.id
+    expectMsgType[SyntacticallySuccessfulModifier].modifierId shouldBe block.header.id
 
     getHistoryHeight shouldBe 2
+    getHeightOf(block.header.id) shouldBe Some(2)
+    getBestHeaderOpt shouldBe Some(block.header)
   }
 
   private val t4 = TestCase("apply valid block as genesis") { fixture =>


### PR DESCRIPTION
## Summary

- Track the external missing-parent frontier of orphan headers retained in the node-view cache.
- Request missing parents through a bounded and fair new/retry queue without making cached children downloadable again.
- Apply cache eviction and parent recovery in one synchronizer event, respect the header download budget, and use only peers with complete header history.
- Preserve the direct recoverable-failure path for uncached headers.

## Root cause

Headers received above `history.headersHeight + 1` are cached. A cached orphan cannot be selected by `applyFromCacheLoop`, so it never reaches the normal recoverable-failure path that requests its missing parent. Synchronization can therefore stop making progress while the child remains in cache.

## Behaviour

`ErgoModifiersCache` now maintains an incremental child-to-missing-parent index. It reports only parents absent from both history and the cache, deduplicates siblings, prioritizes newly exposed frontiers, and rotates retries within a 400-ID bound.

`ErgoNodeViewHolder` reports the post-cleanup frontier together with `BlockSectionsProcessingCacheUpdate`. The synchronizer first releases evicted delivery entries, then requests still-unknown parents using `headersToDownload` and `HeadersDownloadFilter`. The cached child remains `Received`; once its parent arrives, the normal cache loop applies both without downloading the child again.

PR #2312 provided the broad original diagnosis. This PR isolates the cached-header recovery invariant on current `master`.

## Review increments and shared support

Current head: `c261bb188ea7782c8092494c67889e1e960c4c21`, targeting master `5528ef569a41ebccbc8658212e6ee3c97d990b96`. The [original production and regression increment](https://github.com/a-shannon/ergo/compare/5528ef569a41ebccbc8658212e6ee3c97d990b96...f0d6eb1fd88aa84b8b8d90c0eec0aec065e42da9) retains its scope.

Review [#2535](https://github.com/ergoplatform/ergo/pull/2535)'s [shared synchronizer fixture increment](https://github.com/a-shannon/ergo/compare/c313356950fe69ef406c2ee031204079a05ea7d7...76e5ec4bfc377334fdced4bd60a61df06e6b4cb6) first. This head reuses that exact commit, `76e5ec4bfc377334fdced4bd60a61df06e6b4cb6`. Its [one-file consumer composition](https://github.com/a-shannon/ergo/compare/f0d6eb1fd88aa84b8b8d90c0eec0aec065e42da9...c261bb188ea7782c8092494c67889e1e960c4c21) isolates fixture directories and keeps startup history/mempool replies bound to the injected readers. The conflict resolution retains this PR's custom queue size and delivery tracker, together with every missing-parent assertion and deadline. This shared test support adds no production prerequisite between the two PRs.

## Regression evidence

The new tests were observed failing before their corresponding fixes for:

- starvation of a newly discovered parent behind an older retry;
- requests exceeding the remaining header queue capacity;
- an evicted parent still appearing `Received` when recovery was evaluated;
- selection of a NiPoPoW-bootstrapped peer without complete header history.

All now pass, including the child-before-parent holder matrix across all six node-view configurations.

## Validation

- Normal compilation and the final composition passed 47/47 focused tests: `ErgoModifiersCacheSpec` + `ErgoNodeViewSynchronizerSpecification` 41/41, plus the cached-child holder matrix 6/6.
- The earlier missing-parent synchronizer slice passed 7/7; its assertions and deadlines remain intact.
- Independent review of the shared fixture and final conflict resolution found no blockers.

[Current-head CI](https://github.com/ergoplatform/ergo/actions/runs/34730861379) passed all eight jobs, including node and integration tests.

## Scope

This changes synchronization liveness and the internal node-view/synchronizer event payload. It does not change consensus validation, serialized network messages, persisted data, configuration, or transaction handling.
