### PR TITLE
Retry snapshot manifests with GetManifest

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -608,8 +608,14 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     }
   }
 
-  private def requestManifest(manifestId: ManifestId, peer: ConnectedPeer): Unit = {
-    deliveryTracker.setRequested(ManifestTypeId.value, ModifierId @@ Algos.encode(manifestId), peer) { deliveryCheck =>
+  private def requestManifest(manifestId: ManifestId,
+                              peer: ConnectedPeer,
+                              checksDone: Int = 0): Unit = {
+    deliveryTracker.setRequested(
+      ManifestTypeId.value,
+      ModifierId @@ Algos.encode(manifestId),
+      peer,
+      checksDone) { deliveryCheck =>
       context.system.scheduler.scheduleOnce(deliveryTimeout, self, deliveryCheck)
     }
     val msg = Message(GetManifestSpec, Right(manifestId), None)
@@ -1269,7 +1275,11 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
           val maxDeliveryChecks = networkSettings.maxDeliveryChecks
           if (checksDone < maxDeliveryChecks) {
-            if (modifierTypeId == UtxoSnapshotChunkTypeId.value) {
+            if (modifierTypeId == ManifestTypeId.value) {
+              log.info(s"Rescheduling request for UTXO set manifest $modifierId, peer $peer")
+              deliveryTracker.setUnknown(modifierId, modifierTypeId)
+              requestManifest(Digest32 @@ Algos.decode(modifierId).get, peer, checksDone)
+            } else if (modifierTypeId == UtxoSnapshotChunkTypeId.value) {
               // randomly choosing a peer to download UTXO set snapshot chunk
               val newPeerOpt = hr.randomPeerToDownloadChunks()
               log.info(s"Rescheduling request for UTXO set chunk $modifierId , new peer $newPeerOpt")

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.network
 import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
 import akka.testkit.TestProbe
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ManifestTypeId}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
@@ -18,10 +18,10 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
-import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
+import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, SendToNetwork}
 import org.ergoplatform.network.message._
 import org.ergoplatform.network.peer.PeerInfo
-import scorex.core.network.{ConnectedPeer, DeliveryTracker}
+import scorex.core.network.{ConnectedPeer, DeliveryTracker, SendToPeer}
 import scorex.util.bytesToId
 import org.ergoplatform.serialization.ErgoSerializer
 import org.scalatest.propspec.AnyPropSpec
@@ -741,6 +741,37 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       // After max attempts, non-header modifier should be set to Unknown (not Invalid)
       eventually {
         deliveryTracker.status(modifierId, nonHeaderTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should retry manifests with GetManifest") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val manifestBytes = scorex.utils.Random.randomBytes(32)
+      val manifestId = bytesToId(manifestBytes)
+      val checksBeforeTimeout = 2
+
+      synchronizerMockRef ! ChangedHistory(hhistory)
+      deliveryTracker.setRequested(
+        ManifestTypeId.value,
+        manifestId,
+        peer,
+        checksBeforeTimeout)(_ => Cancellable.alreadyCancelled)
+      synchronizerMockRef ! CheckDelivery(peer, ManifestTypeId.value, manifestId)
+
+      ncProbe.expectMsgType[PenalizePeer](3.seconds)
+      val retry = ncProbe.expectMsgType[SendToNetwork](3.seconds)
+      retry.message.spec shouldBe GetManifestSpec
+      retry.message.data.get.asInstanceOf[Array[Byte]].sameElements(manifestBytes) shouldBe true
+      retry.sendingStrategy shouldBe SendToPeer(peer)
+
+      eventually {
+        deliveryTracker
+          .getRequestedInfo(ManifestTypeId.value, manifestId)
+          .map(_.checks) shouldBe Some(checksBeforeTimeout + 1)
       }
     }
   }


### PR DESCRIPTION
## Summary

- Retry timed-out UTXO snapshot manifest requests with `GetManifestSpec`.
- Preserve the exact manifest ID and peer across the retry.
- Carry the delivery-attempt count into the replacement request.

## Root cause

`checkDelivery` special-cased snapshot chunks, but not snapshot manifests. A timed-out `ManifestTypeId` request therefore fell through to the generic block-section path, which sends `RequestModifierSpec` instead of the dedicated manifest request. That retry could not resume the manifest exchange and could delay or stall UTXO snapshot bootstrap.

The new regression test exercises the timeout path directly and verifies the message spec, manifest ID, peer, and updated attempt count.

No consensus rules, serialization formats, or configuration are changed.

## Validation

- `sbt "testOnly org.ergoplatform.network.ErgoNodeViewSynchronizerSpecification"` (26 tests)
- `sbt "testOnly scorex.core.network.DeliveryTrackerSpec org.ergoplatform.nodeView.history.UtxoSetSnapshotProcessorSpecification org.ergoplatform.network.RequestModifiersSpecification"` (4 tests)
