### PR TITLE
Enforce the global modifier download limit

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -77,6 +77,8 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private var syncInfoV2CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV2)] = Option.empty
 
+  private var lastRequestedDownloadTypeId: Option[NetworkObjectTypeId.Value] = None
+
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 
   protected val deliveryTimeout: FiniteDuration = networkSettings.deliveryTimeout
@@ -650,6 +652,45 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       }
   }
 
+  private def limitFetchedModifiers(fetched: Map[NetworkObjectTypeId.Value, Seq[ModifierId]],
+                                    limit: Int,
+                                    afterTypeId: Option[NetworkObjectTypeId.Value])
+  : (Map[NetworkObjectTypeId.Value, Seq[ModifierId]], Option[NetworkObjectTypeId.Value]) = {
+    @tailrec
+    def takeRound(remaining: Vector[(NetworkObjectTypeId.Value, Seq[ModifierId])],
+                  slotsLeft: Int,
+                  selected: Map[NetworkObjectTypeId.Value, Vector[ModifierId]],
+                  lastSelectedTypeId: Option[NetworkObjectTypeId.Value])
+    : (Map[NetworkObjectTypeId.Value, Seq[ModifierId]], Option[NetworkObjectTypeId.Value]) = {
+      if (slotsLeft <= 0 || remaining.isEmpty) {
+        selected.map { case (typeId, modifierIds) => typeId -> modifierIds } -> lastSelectedTypeId
+      } else {
+        val roundSize = Math.min(slotsLeft, remaining.size)
+        val (round, untouched) = remaining.splitAt(roundSize)
+        val updatedSelected = round.foldLeft(selected) { case (acc, (typeId, modifierIds)) =>
+          acc.updated(typeId, acc.getOrElse(typeId, Vector.empty) :+ modifierIds.head)
+        }
+        val nextRound = round.flatMap { case (typeId, modifierIds) =>
+          val tail = modifierIds.tail
+          if (tail.nonEmpty) Some(typeId -> tail) else None
+        } ++ untouched
+        takeRound(nextRound, slotsLeft - roundSize, updatedSelected, round.lastOption.map(_._1))
+      }
+    }
+
+    val sortedCandidates = fetched.toVector
+      .filter(_._2.nonEmpty)
+      .sortBy { case (typeId, _) => typeId.toInt & 0xff }
+    val candidates = afterTypeId.flatMap { previousTypeId =>
+      val previousId = previousTypeId.toInt & 0xff
+      sortedCandidates.indexWhere { case (typeId, _) => (typeId.toInt & 0xff) > previousId } match {
+        case -1 => None
+        case nextTypeIndex => Some(sortedCandidates.drop(nextTypeIndex) ++ sortedCandidates.take(nextTypeIndex))
+      }
+    }.getOrElse(sortedCandidates)
+    takeRound(candidates, limit, Map.empty, None)
+  }
+
   /**
     * Modifier download method that is given min/max constraints for modifiers to download from peers.
     * It sends requests for modifiers to given peers in optimally sized batches.
@@ -667,7 +708,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       case Some(peers) if peers.nonEmpty =>
         val peersCount = peers.size
         val maxElementsToFetch = Math.min(maxModifiers, peersCount * maxModifiersPerBucket)
-        val fetched = if (maxElementsToFetch <= 0) {
+        val fetched: Map[NetworkObjectTypeId.Value, Seq[ModifierId]] = if (maxElementsToFetch <= 0) {
           Map.empty
         } else {
           fetchMax(maxElementsToFetch)
@@ -677,7 +718,14 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
           // to start downloading UTXO set snapshots
           requestSnapshotsInfo()
         } else {
-          val modifiersByBucket = ElementPartitioner.distribute(peers, minModifiersPerBucket, fetched)
+          val hasNonHeaderCandidates = fetched.keys.exists(_ != Header.modifierTypeId)
+          val rotateAfter = if (hasNonHeaderCandidates) lastRequestedDownloadTypeId else None
+          val (limitedFetched, lastSelectedTypeId) =
+            limitFetchedModifiers(fetched, maxElementsToFetch, rotateAfter)
+          if (hasNonHeaderCandidates) {
+            lastSelectedTypeId.foreach(typeId => lastRequestedDownloadTypeId = Some(typeId))
+          }
+          val modifiersByBucket = ElementPartitioner.distribute(peers, minModifiersPerBucket, limitedFetched)
           // collect and log useful downloading progress information, don't worry it does not run frequently
           modifiersByBucket.headOption.foreach { _ =>
             modifiersByBucket

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -3,13 +3,13 @@ package org.ergoplatform.network
 import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
 import akka.testkit.TestProbe
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NetworkObjectTypeId, SnapshotsInfoTypeId}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
-import org.ergoplatform.nodeView.state.{StateType, UtxoState}
+import org.ergoplatform.nodeView.state.{StateType, UtxoState, UtxoStateReader}
 import org.ergoplatform.sanity.ErgoSanity._
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.validation.{ParentHeaderNotFoundError, RecoverableModifierError}
@@ -22,7 +22,7 @@ import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.message._
 import org.ergoplatform.network.peer.PeerInfo
 import scorex.core.network.{ConnectedPeer, DeliveryTracker}
-import scorex.util.bytesToId
+import scorex.util.{ModifierId, bytesToId}
 import org.ergoplatform.serialization.ErgoSerializer
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -45,6 +45,10 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   import org.ergoplatform.utils.generators.ValidBlocksGenerators._
   import org.ergoplatform.utils.generators.ChainGenerator._
   import org.ergoplatform.utils.HistoryTestHelpers._
+
+  private case class RequestDownloadForTest(maxModifiers: Int,
+                                            peers: Seq[ConnectedPeer],
+                                            fetched: Map[NetworkObjectTypeId.Value, Seq[ModifierId]])
 
   // ToDo: factor this out of here and NVHTests?
   private def withFixture(testCode: SynchronizerFixture => Any): Unit = {
@@ -81,7 +85,18 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     syncInfoSpec,
     settings,
     syncTracker,
-    deliveryTracker)(ec)
+    deliveryTracker)(ec) {
+
+    override def initialized(hr: ErgoHistory,
+                             mp: ErgoMemPool,
+                             usr: Option[UtxoStateReader],
+                             blockAppliedTxsCache: FixedSizeApproximateCacheQueue): PartialFunction[Any, Unit] = ({
+      case RequestDownloadForTest(maxModifiers, peers, fetched) =>
+        requestDownload(maxModifiers, minModifiersPerBucket = 1, maxModifiersPerBucket = 12)(Some(peers)) { _ =>
+          fetched
+        }
+    }: PartialFunction[Any, Unit]) orElse super.initialized(hr, mp, usr, blockAppliedTxsCache)
+  }
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(2.seconds, 100.millis)
   val history = generateHistory(verifyTransactions = true, StateType.Utxo, PoPoWBootstrap = false, blocksToKeep = -1)
@@ -201,6 +216,137 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       pchProbe.ref,
       Some(peerInfo)
     )
+  }
+
+  private def fetchedBlockSections(headers: Seq[Header]): Map[NetworkObjectTypeId.Value, Seq[ModifierId]] = {
+    headers
+      .flatMap(_.sectionIds)
+      .foldLeft(Map.empty[NetworkObjectTypeId.Value, Seq[ModifierId]]) {
+        case (sections, (typeId, modifierId)) =>
+          sections.updated(typeId, sections.getOrElse(typeId, Seq.empty) :+ modifierId)
+      }
+  }
+
+  private def requestedModifiers(probe: TestProbe, expectedMessages: Int): Seq[InvData] = {
+    val requests = probe.receiveN(expectedMessages, 3.seconds).map {
+      case message: SendToNetwork if message.message.spec.messageCode == RequestModifierSpec.messageCode =>
+        message.message.data.get.asInstanceOf[InvData]
+      case message =>
+        fail(s"Expected a modifier request, got $message")
+    }
+    probe.expectNoMessage(200.millis)
+    requests
+  }
+
+  property("NodeViewSynchronizer: modifier download budget should be shared across types") {
+    withFixture2 { ctx =>
+      import ctx._
+      val controlProbe = TestProbe("DownloadBudgetControlProbe")
+      val fetched = fetchedBlockSections(localChain.take(2).headers)
+      fetched.size shouldBe 3
+      fetched.values.foreach(_.size shouldBe 2)
+
+      controlProbe.send(synchronizerMockRef, ChangedHistory(history))
+      controlProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      controlProbe.send(synchronizerMockRef, RequestDownloadForTest(2, Seq(peer), fetched))
+
+      val requests = requestedModifiers(ncProbe, expectedMessages = 2)
+      requests.flatMap(_.ids).size shouldBe 2
+    }
+  }
+
+  property("NodeViewSynchronizer: modifier download budget should be shared fairly") {
+    withFixture2 { ctx =>
+      import ctx._
+      val controlProbe = TestProbe("FairDownloadBudgetControlProbe")
+      val fetched = fetchedBlockSections(localChain.take(2).headers)
+
+      controlProbe.send(synchronizerMockRef, ChangedHistory(history))
+      controlProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      controlProbe.send(synchronizerMockRef, RequestDownloadForTest(4, Seq(peer), fetched))
+
+      val requests = requestedModifiers(ncProbe, expectedMessages = 3)
+      val requestedByType = requests.map(request => request.typeId -> request.ids).toMap
+      val requestCounts = requestedByType.values.map(_.size).toSeq
+      val firstType = fetched.keys.minBy(_.toInt & 0xff)
+      requests.flatMap(_.ids).size shouldBe 4
+      requestedByType.keySet shouldBe fetched.keySet
+      requestCounts.max - requestCounts.min should be <= 1
+      requestedByType(firstType) shouldBe fetched(firstType).take(2)
+      requestedByType.foreach { case (typeId, modifierIds) =>
+        modifierIds shouldBe fetched(typeId).take(modifierIds.size)
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: one-slot modifier budget should rotate across calls") {
+    withFixture2 { ctx =>
+      import ctx._
+      val controlProbe = TestProbe("RotatingDownloadBudgetControlProbe")
+      val fetched = fetchedBlockSections(localChain.take(2).headers)
+      val expectedTypes = fetched.keys.toSeq.sortBy(_.toInt & 0xff)
+
+      controlProbe.send(synchronizerMockRef, ChangedHistory(history))
+      controlProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      val requestedTypes = expectedTypes.map { _ =>
+        controlProbe.send(synchronizerMockRef, RequestDownloadForTest(1, Seq(peer), fetched))
+        requestedModifiers(ncProbe, expectedMessages = 1).head.typeId
+      }
+
+      requestedTypes shouldBe expectedTypes
+    }
+  }
+
+  property("NodeViewSynchronizer: snapshot-info sentinel should bypass the modifier cap") {
+    withFixture2 { ctx =>
+      import ctx._
+      val controlProbe = TestProbe("SnapshotSentinelControlProbe")
+      val secondPeerHandler = TestProbe("SnapshotSentinelSecondPeerHandler")
+      var secondConnectionId = connectionIdGen.sample.get
+      while (secondConnectionId.remoteAddress == peer.connectionId.remoteAddress) {
+        secondConnectionId = connectionIdGen.sample.get
+      }
+      val secondPeer = ConnectedPeer(
+        secondConnectionId,
+        secondPeerHandler.ref,
+        Some(PeerInfo(defaultPeerSpec.copy(nodeName = "snapshot-sentinel-peer"), System.currentTimeMillis()))
+      )
+
+      syncTracker.updateStatus(peer, org.ergoplatform.consensus.Unknown, None)
+      syncTracker.updateStatus(secondPeer, org.ergoplatform.consensus.Unknown, None)
+      controlProbe.send(synchronizerMockRef, ChangedHistory(history))
+      controlProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      controlProbe.send(
+        synchronizerMockRef,
+        RequestDownloadForTest(1, Seq(peer, secondPeer), Map(SnapshotsInfoTypeId.value -> Seq.empty))
+      )
+
+      ncProbe.fishForMessage(3.seconds) {
+        case message: SendToNetwork => message.message.spec.messageCode == GetSnapshotsInfoSpec.messageCode
+        case _ => false
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: modifier download cap should preserve single-type ordering and zero budget") {
+    withFixture2 { ctx =>
+      import ctx._
+      val controlProbe = TestProbe("SingleTypeDownloadBudgetControlProbe")
+      val allSections = fetchedBlockSections(localChain.take(3).headers)
+      val (typeId, modifierIds) = allSections.head
+      val fetched = Map(typeId -> modifierIds)
+
+      controlProbe.send(synchronizerMockRef, ChangedHistory(history))
+      controlProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      controlProbe.send(synchronizerMockRef, RequestDownloadForTest(0, Seq(peer), fetched))
+      ncProbe.expectNoMessage(200.millis)
+
+      controlProbe.send(synchronizerMockRef, RequestDownloadForTest(2, Seq(peer), fetched))
+      val requests = requestedModifiers(ncProbe, expectedMessages = 1)
+      requests should have size 1
+      requests.head.typeId shouldBe typeId
+      requests.head.ids shouldBe modifierIds.take(2)
+    }
   }
 
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - younger peer") {


### PR DESCRIPTION
## Summary

- enforce the remaining modifier download capacity across all returned types
- rotate fair selection across types while preserving per-type order
- keep the snapshot-info bootstrap trigger unchanged

## Root cause

`requestDownload` passed one total remaining capacity to callbacks that may
return up to that many IDs for each modifier type. The combined request could
therefore exceed the delivery tracker's remaining capacity by the number of
returned types.

## Impact

During block synchronization, the node could create more outstanding section
requests, delivery timers, and network traffic than configured.

## Validation

- actor-level coverage for the total cap, fairness within and across calls,
  per-type ordering, zero capacity, and the snapshot-info sentinel
- `ErgoNodeViewSynchronizerSpecification`: 30 of 30 passed
- `ElementPartitionerSpecification` and `VerifyNonADHistorySpecification`: 16
  of 16 passed

## Related work

This is independent from #2434 and #2405, which modify different paths in the
same synchronizer.
