### PR TITLE
Handle fragmented and coalesced handshakes

### DIFF
--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -13,11 +13,13 @@ import org.ergoplatform.network.message.MessageSerializer
 import org.ergoplatform.network.peer.{PeerInfo, PenaltyType}
 import org.ergoplatform.settings.ScorexSettings
 import scorex.util.ScorexLogging
+import scorex.util.serialization.VLQByteBufferReader
 
+import java.nio.{BufferUnderflowException, ByteBuffer}
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 class PeerConnectionHandler(scorexSettings: ScorexSettings,
                             networkControllerRef: ActorRef,
@@ -91,15 +93,38 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
 
   private def receiveAndHandleHandshake(handler: Handshake => Unit): Receive = {
     case Received(data) =>
-      HandshakeSerializer.parseBytesTry(data.toArray) match {
+      val candidate = chunksBuffer ++ data
+      val reader = new VLQByteBufferReader(
+        ByteBuffer.wrap(candidate.take(HandshakeSerializer.maxHandshakeSize).toArray)
+      ) {
+        override def getBytes(size: Int): Array[Byte] = {
+          if (size > remaining) {
+            throw new BufferUnderflowException()
+          }
+          super.getBytes(size)
+        }
+      }
+
+      Try(HandshakeSerializer.parse(reader)) match {
         case Success(handshake) =>
+          chunksBuffer = candidate.drop(reader.position)
           if (handshake.peerSpec.protocolVersion < Eip37ForkVersion) {
             // peers not suporting EIP-37 hard-fork are stuck on another chain
             log.info(s"Peer of version < 4.0.100 sent handshake $handshake")
             banPeer()
           } else {
             handler(handshake)
+            processRemoteData()
           }
+
+        case Failure(t) if candidate.length >= HandshakeSerializer.maxHandshakeSize =>
+          log.info(s"Handshake from $connectionId reached the size limit", t)
+          context become closing
+          self ! CloseConnection
+
+        case Failure(_: BufferUnderflowException) =>
+          chunksBuffer = candidate
+          connection ! ResumeReading
 
         case Failure(t) =>
           log.info(s"Error during parsing a handshake: ${t.getMessage}", t)
@@ -124,6 +149,9 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
       remoteInterface orElse
       closeCommands orElse
       reportStrangeInput
+
+  private def closing: Receive =
+    closeCommands orElse reportStrangeInput
 
   private def closeCommands: Receive = {
     case CloseConnection =>
@@ -192,32 +220,31 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
     case Received(data) =>
 
       chunksBuffer ++= data
-
-      @tailrec
-      def process(): Unit = {
-        messageSerializer.deserialize(chunksBuffer, selfPeer) match {
-          case Success(Some(message)) =>
-            log.debug("Received message " + message.spec + " from " + connectionId)
-            networkControllerRef ! message
-            chunksBuffer = chunksBuffer.drop(message.messageLength)
-            process()
-          case Success(None) =>
-          case Failure(e) =>
-            e match {
-              //peer is doing bad things, ban it
-              case MaliciousBehaviorException(msg) =>
-                log.warn(s"Banning peer for malicious behaviour($msg): ${connectionId.toString}")
-                //peer will be added to the blacklist and the network controller will send CloseConnection
-                networkControllerRef ! PenalizePeer(connectionId.remoteAddress, PenaltyType.PermanentPenalty)
-              //non-malicious corruptions
-              case _ =>
-                log.info(s"Corrupted data from ${connectionId.toString}: ${e.getMessage}")
-            }
-        }
-      }
-
-      process()
+      processRemoteData()
       connection ! ResumeReading
+  }
+
+  @tailrec
+  private def processRemoteData(): Unit = {
+    messageSerializer.deserialize(chunksBuffer, selfPeer) match {
+      case Success(Some(message)) =>
+        log.debug("Received message " + message.spec + " from " + connectionId)
+        networkControllerRef ! message
+        chunksBuffer = chunksBuffer.drop(message.messageLength)
+        processRemoteData()
+      case Success(None) =>
+      case Failure(e) =>
+        e match {
+          //peer is doing bad things, ban it
+          case MaliciousBehaviorException(msg) =>
+            log.warn(s"Banning peer for malicious behaviour($msg): ${connectionId.toString}")
+            //peer will be added to the blacklist and the network controller will send CloseConnection
+            networkControllerRef ! PenalizePeer(connectionId.remoteAddress, PenaltyType.PermanentPenalty)
+          //non-malicious corruptions
+          case _ =>
+            log.info(s"Corrupted data from ${connectionId.toString}: ${e.getMessage}")
+        }
+    }
   }
 
   private def reportStrangeInput: Receive = {

--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -18,11 +18,13 @@ import scorex.core.app.ScorexContext
 import scorex.core.network.NetworkController.ReceivableMessages.{Handshaked, PenalizePeer}
 import scorex.core.network.PeerConnectionHandler.ReceivableMessages
 import scorex.util.ScorexLogging
+import scorex.util.serialization.VLQByteBufferReader
 
+import java.nio.{BufferUnderflowException, ByteBuffer}
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 class PeerConnectionHandler(scorexSettings: ScorexSettings,
                             networkControllerRef: ActorRef,
@@ -99,15 +101,38 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
 
   private def receiveAndHandleHandshake(handler: Handshake => Unit): Receive = {
     case Received(data) =>
-      HandshakeSerializer.parseBytesTry(data.toArray) match {
+      val candidate = chunksBuffer ++ data
+      val reader = new VLQByteBufferReader(
+        ByteBuffer.wrap(candidate.take(HandshakeSerializer.maxHandshakeSize).toArray)
+      ) {
+        override def getBytes(size: Int): Array[Byte] = {
+          if (size > remaining) {
+            throw new BufferUnderflowException()
+          }
+          super.getBytes(size)
+        }
+      }
+
+      Try(HandshakeSerializer.parse(reader)) match {
         case Success(handshake) =>
+          chunksBuffer = candidate.drop(reader.position)
           if (handshake.peerSpec.protocolVersion < Eip37ForkVersion) {
             // peers not suporting EIP-37 hard-fork are stuck on another chain
             log.info(s"Peer of version < 4.0.100 sent handshake $handshake")
             banPeer()
           } else {
             handler(handshake)
+            processRemoteData()
           }
+
+        case Failure(t) if candidate.length >= HandshakeSerializer.maxHandshakeSize =>
+          log.info(s"Handshake from $connectionId reached the size limit", t)
+          context become closing
+          self ! CloseConnection
+
+        case Failure(_: BufferUnderflowException) =>
+          chunksBuffer = candidate
+          connection ! ResumeReading
 
         case Failure(t) =>
           log.info(s"Error during parsing a handshake: ${t.getMessage}", t)
@@ -132,6 +157,9 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
       remoteInterface orElse
       closeCommands orElse
       reportStrangeInput
+
+  private def closing: Receive =
+    closeCommands orElse reportStrangeInput
 
   private def closeCommands: Receive = {
     case CloseConnection =>
@@ -203,32 +231,31 @@ class PeerConnectionHandler(scorexSettings: ScorexSettings,
     case Received(data) =>
 
       chunksBuffer ++= data
+      processRemoteData()
+      connection ! ResumeReading
+  }
 
-      @tailrec
-      def process(): Unit = {
-        messageSerializer.deserialize(chunksBuffer, selfPeer) match {
-          case Success(Some(message)) =>
-            log.debug("Received message " + message.spec + " from " + connectionId)
-            networkControllerRef ! message
-            chunksBuffer = chunksBuffer.drop(message.messageLength)
-            process()
-          case Success(None) =>
-          case Failure(e) =>
-            e match {
-              //peer is doing bad things, ban it
-              case MaliciousBehaviorException(msg) =>
-                log.warn(s"Banning peer for malicious behaviour($msg): ${connectionId.toString}")
-                //peer will be added to the blacklist and the network controller will send CloseConnection
-                networkControllerRef ! PenalizePeer(connectionId.remoteAddress, PenaltyType.PermanentPenalty)
-              //non-malicious corruptions
-              case _ =>
-                log.info(s"Corrupted data from ${connectionId.toString}: ${e.getMessage}")
-            }
+  @tailrec
+  private def processRemoteData(): Unit = {
+    messageSerializer.deserialize(chunksBuffer, selfPeer) match {
+      case Success(Some(message)) =>
+        log.debug("Received message " + message.spec + " from " + connectionId)
+        networkControllerRef ! message
+        chunksBuffer = chunksBuffer.drop(message.messageLength)
+        processRemoteData()
+      case Success(None) =>
+      case Failure(e) =>
+        e match {
+          //peer is doing bad things, ban it
+          case MaliciousBehaviorException(msg) =>
+            log.warn(s"Banning peer for malicious behaviour($msg): ${connectionId.toString}")
+            //peer will be added to the blacklist and the network controller will send CloseConnection
+            networkControllerRef ! PenalizePeer(connectionId.remoteAddress, PenaltyType.PermanentPenalty)
+          //non-malicious corruptions
+          case _ =>
+            log.info(s"Corrupted data from ${connectionId.toString}: ${e.getMessage}")
         }
       }
-
-      process()
-      connection ! ResumeReading
   }
 
   private def reportStrangeInput: Receive = {

--- a/src/test/scala/scorex/core/network/PeerConnectionHandlerHandshakeSpecification.scala
+++ b/src/test/scala/scorex/core/network/PeerConnectionHandlerHandshakeSpecification.scala
@@ -1,0 +1,191 @@
+package scorex.core.network
+
+import akka.io.Tcp
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import org.ergoplatform.network.{Handshake, HandshakeSerializer}
+import org.ergoplatform.network.message.{
+  GetPeersSpec,
+  Message,
+  MessageSerializer,
+  UtxoSnapshotChunkSpec
+}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.core.app.ScorexContext
+import scorex.testkit.utils.AkkaFixture
+
+import java.net.InetSocketAddress
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class PeerConnectionHandlerHandshakeSpecification extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+
+  property("accept a valid handshake split across TCP chunks") {
+    val fixture = new AkkaFixture
+    try {
+      implicit val system = fixture.system
+      implicit val ec = system.dispatcher
+      val connection = TestProbe("connection")
+      val controller = TestProbe("controller")
+      val localAddress = new InetSocketAddress("127.0.0.1", 9053)
+      val remoteAddress = new InetSocketAddress("127.0.0.1", 9054)
+      val description = ConnectionDescription(
+        connection.ref,
+        ConnectionId(remoteAddress, localAddress, Incoming),
+        Some(localAddress),
+        Seq.empty
+      )
+      val handler = system.actorOf(
+        PeerConnectionHandlerRef.props(
+          settings.scorexSettings,
+          controller.ref,
+          ScorexContext(Seq.empty, None, None),
+          description
+        )
+      )
+      val bytes =
+        HandshakeSerializer.toBytes(Handshake(defaultPeerSpec, System.currentTimeMillis()))
+      val splitAt = bytes.length / 2
+
+      connection.send(handler, Tcp.Received(ByteString(bytes.take(splitAt))))
+      connection.send(handler, Tcp.Received(ByteString(bytes.drop(splitAt))))
+
+      controller.expectMsgType[NetworkController.ReceivableMessages.Handshaked](2.seconds)
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  property("preserve a framed message coalesced with the handshake") {
+    val fixture = new AkkaFixture
+    try {
+      implicit val system = fixture.system
+      implicit val ec = system.dispatcher
+      val connection = TestProbe("connection")
+      val controller = TestProbe("controller")
+      val localAddress = new InetSocketAddress("127.0.0.1", 9063)
+      val remoteAddress = new InetSocketAddress("127.0.0.1", 9064)
+      val description = ConnectionDescription(
+        connection.ref,
+        ConnectionId(remoteAddress, localAddress, Incoming),
+        Some(localAddress),
+        Seq.empty
+      )
+      val scorexContext = ScorexContext(Seq(GetPeersSpec), None, None)
+      val handler = system.actorOf(
+        PeerConnectionHandlerRef.props(
+          settings.scorexSettings,
+          controller.ref,
+          scorexContext,
+          description
+        )
+      )
+      val baseHandshake =
+        HandshakeSerializer.toBytes(Handshake(defaultPeerSpec, System.currentTimeMillis()))
+      val handshake = ByteString(baseHandshake.dropRight(1)) ++
+        ByteString(Array[Byte](1, 127, 3, 1, 2, 3))
+      val framedMessage =
+        new MessageSerializer(Seq(GetPeersSpec), settings.scorexSettings.network.magicBytes)
+          .serialize(Message(GetPeersSpec, Right(()), None))
+
+      connection.send(handler, Tcp.Received(handshake ++ framedMessage))
+
+      controller.expectMsgType[NetworkController.ReceivableMessages.Handshaked](2.seconds)
+      val received = controller.expectMsgType[Message[_]](2.seconds)
+      received.spec shouldBe GetPeersSpec
+      controller.expectNoMessage(200.millis)
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  property("apply the handshake size limit only to the handshake prefix") {
+    val fixture = new AkkaFixture
+    try {
+      implicit val system = fixture.system
+      implicit val ec = system.dispatcher
+      val connection = TestProbe("connection")
+      val controller = TestProbe("controller")
+      val localAddress = new InetSocketAddress("127.0.0.1", 9073)
+      val remoteAddress = new InetSocketAddress("127.0.0.1", 9074)
+      val description = ConnectionDescription(
+        connection.ref,
+        ConnectionId(remoteAddress, localAddress, Incoming),
+        Some(localAddress),
+        Seq.empty
+      )
+      val scorexContext = ScorexContext(Seq(UtxoSnapshotChunkSpec), None, None)
+      val handler = system.actorOf(
+        PeerConnectionHandlerRef.props(
+          settings.scorexSettings,
+          controller.ref,
+          scorexContext,
+          description
+        )
+      )
+      val handshake =
+        HandshakeSerializer.toBytes(Handshake(defaultPeerSpec, System.currentTimeMillis()))
+      val framedMessage = new MessageSerializer(
+        Seq(UtxoSnapshotChunkSpec),
+        settings.scorexSettings.network.magicBytes
+      ).serialize(Message(UtxoSnapshotChunkSpec, Right(Array.fill[Byte](9000)(1)), None))
+
+      (handshake.length + framedMessage.length) should be > HandshakeSerializer.maxHandshakeSize
+      connection.send(handler, Tcp.Received(ByteString(handshake) ++ framedMessage))
+
+      controller.expectMsgType[NetworkController.ReceivableMessages.Handshaked](2.seconds)
+      val received = controller.expectMsgType[Message[_]](2.seconds)
+      received.spec shouldBe UtxoSnapshotChunkSpec
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+
+  property("close when an incomplete handshake reaches the size limit") {
+    val fixture = new AkkaFixture
+    try {
+      implicit val system = fixture.system
+      implicit val ec = system.dispatcher
+      val connection = TestProbe("connection")
+      val controller = TestProbe("controller")
+      val localAddress = new InetSocketAddress("127.0.0.1", 9083)
+      val remoteAddress = new InetSocketAddress("127.0.0.1", 9084)
+      val description = ConnectionDescription(
+        connection.ref,
+        ConnectionId(remoteAddress, localAddress, Incoming),
+        Some(localAddress),
+        Seq.empty
+      )
+      val handler = system.actorOf(
+        PeerConnectionHandlerRef.props(
+          settings.scorexSettings,
+          controller.ref,
+          ScorexContext(Seq.empty, None, None),
+          description
+        )
+      )
+
+      connection.expectMsgType[Tcp.Register]
+      connection.expectMsg(Tcp.ResumeReading)
+      connection.expectMsgType[Tcp.Write]
+      val header = ByteString(
+        Array[Byte](0, 1, 'a'.toByte, 4, 0, 100, 0, 0, 1, 127, 0xa0.toByte, 0x3f)
+      )
+      val incompleteHandshake =
+        header ++ ByteString(
+          Array.fill[Byte](HandshakeSerializer.maxHandshakeSize - header.length)(0)
+        )
+
+      connection.send(handler, Tcp.Received(incompleteHandshake))
+      val validHandshake =
+        HandshakeSerializer.toBytes(Handshake(defaultPeerSpec, System.currentTimeMillis()))
+      connection.send(handler, Tcp.Received(ByteString(validHandshake)))
+
+      connection.expectMsg(Tcp.Abort)
+      controller.expectNoMessage(200.millis)
+    } finally {
+      Await.result(fixture.system.terminate(), Duration.Inf)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- buffer inbound handshake bytes across TCP reads;
- preserve and process bytes coalesced after the handshake;
- keep the 8096-byte limit scoped to the handshake prefix;
- close terminally when an incomplete handshake reaches that limit.

## Root cause

PeerConnectionHandler parsed each Tcp.Received payload as one complete handshake. TCP provides an ordered byte stream, so one handshake may be split across reads or share a read with the first framed message.

A split handshake was therefore treated as incomplete without retaining its bytes. A coalesced first message was left unprocessed, and a valid short handshake followed by a large frame could be rejected because the handshake size check saw the whole TCP payload.

## Implementation

The handler now parses a bounded view of the accumulated handshake prefix with a position-aware reader. On success, the reader position defines the exact wire boundary and the existing framed-message loop processes the suffix synchronously after the peer enters the working state.

Underflow below the limit retains the prefix and resumes reading. Any parse failure at the limit moves the actor into its closing behavior before CloseConnection is queued, so already queued TCP input cannot reopen the handshake transition.

No wire format, protocol version, peer identity, penalty policy, or consensus rule changes.

## Tests

The actor-level regression suite covers:

- a valid handshake split across two TCP reads;
- a handshake containing an unknown feature followed by a framed GetPeers message, delivered exactly once;
- a valid handshake plus a 9000-byte framed payload whose total TCP payload is above the handshake limit;
- an incomplete handshake at the exact limit, immediately followed by another handshake, which must still abort without reaching Handshaked.

Current-master validation:

- RED baseline: 0/4 regression tests passed;
- GREEN candidate: 4/4 regression tests passed;
- affected handler, controller, serializer, and peer closure: 25/25 passed;
- ergoCore handshake and peer serializer closure: 2/2 passed;
- independent review: no critical or important findings.

Current master already contains #2426's independent outbound-buffer bound; this rebuild preserves it unchanged.