### PR TITLE
Preserve snapshot chunk retry budget

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -616,10 +616,16 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     networkControllerRef ! SendToNetwork(msg, SendToPeer(peer))
   }
 
-  private def requestUtxoSetChunk(subtreeId: SubtreeId, peer: ConnectedPeer): Unit = {
+  private def requestUtxoSetChunk(subtreeId: SubtreeId,
+                                  peer: ConnectedPeer,
+                                  checksDone: Int = 0): Unit = {
     // as we download multiple chunks in parallel and they can be quite large, timeout increased
     val chunkDeliveryTimeout = 4 * deliveryTimeout
-    deliveryTracker.setRequested(UtxoSnapshotChunkTypeId.value, ModifierId @@ Algos.encode(subtreeId), peer) { deliveryCheck =>
+    deliveryTracker.setRequested(
+      UtxoSnapshotChunkTypeId.value,
+      ModifierId @@ Algos.encode(subtreeId),
+      peer,
+      checksDone) { deliveryCheck =>
       context.system.scheduler.scheduleOnce(chunkDeliveryTimeout, self, deliveryCheck)
     }
     val msg = Message(GetUtxoSnapshotChunkSpec, Right(subtreeId), None)
@@ -1275,7 +1281,11 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
               log.info(s"Rescheduling request for UTXO set chunk $modifierId , new peer $newPeerOpt")
               deliveryTracker.setUnknown(modifierId, modifierTypeId)
               newPeerOpt match {
-                case Some(newPeer) => requestUtxoSetChunk(Digest32 @@ Algos.decode(modifierId).get, newPeer)
+                case Some(newPeer) =>
+                  requestUtxoSetChunk(
+                    Digest32 @@ Algos.decode(modifierId).get,
+                    newPeer,
+                    checksDone)
                 case None => log.warn(s"No peer found to download UTXO set chunk $modifierId")
               }
              } else {

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -3,13 +3,13 @@ package org.ergoplatform.network
 import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
 import akka.testkit.TestProbe
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, UtxoSnapshotChunkTypeId}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
-import org.ergoplatform.nodeView.state.{StateType, UtxoState}
+import org.ergoplatform.nodeView.state.{SnapshotTestAccess, StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.validation.{ParentHeaderNotFoundError, RecoverableModifierError}
@@ -18,10 +18,10 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
-import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
+import scorex.core.network.NetworkController.ReceivableMessages.{PenalizePeer, SendToNetwork}
 import org.ergoplatform.network.message._
-import org.ergoplatform.network.peer.PeerInfo
-import scorex.core.network.{ConnectedPeer, DeliveryTracker}
+import org.ergoplatform.network.peer.{PeerInfo, PenaltyType}
+import scorex.core.network.{ConnectedPeer, DeliveryTracker, SendToPeer}
 import scorex.util.bytesToId
 import org.ergoplatform.serialization.ErgoSerializer
 import org.scalatest.propspec.AnyPropSpec
@@ -773,6 +773,56 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       eventually {
         deliveryTracker.status(modifierId, nonHeaderTypeId, Seq.empty) shouldBe Unknown
       }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should exhaust the snapshot chunk retry budget") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val boxes = boxesHolderGenOfSize(128).sample.get
+      val state = createUtxoState(boxes, parameters)
+      val snapshotHeight = 1
+      val manifestDepth = 2.toByte
+      val manifest = SnapshotTestAccess.dumpManifest(state, snapshotHeight, manifestDepth)
+      val plan = hhistory.registerManifestToDownload(manifest, snapshotHeight, Seq(peer))
+
+      val chunkBytes = plan.expectedChunkIds.head
+      val chunkId = bytesToId(chunkBytes)
+      val maxDeliveryChecks = settings.scorexSettings.network.maxDeliveryChecks
+      val checksBeforeTimeout = maxDeliveryChecks - 2
+
+      ncProbe.send(synchronizerMockRef, ChangedHistory(hhistory))
+      ncProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      deliveryTracker.setRequested(
+        UtxoSnapshotChunkTypeId.value,
+        chunkId,
+        peer,
+        checksBeforeTimeout)(_ => Cancellable.alreadyCancelled)
+
+      ncProbe.send(synchronizerMockRef, CheckDelivery(peer, UtxoSnapshotChunkTypeId.value, chunkId))
+      ncProbe.expectMsg(PenalizePeer(peer.connectionId.remoteAddress, PenaltyType.NonDeliveryPenalty))
+      ncProbe.expectMsgPF(3.seconds) {
+        case SendToNetwork(message, SendToPeer(selectedPeer)) if message.spec == GetUtxoSnapshotChunkSpec =>
+          selectedPeer shouldBe peer
+          message.data.get.asInstanceOf[Array[Byte]].sameElements(chunkBytes) shouldBe true
+      }
+
+      eventually {
+        val requestedInfo = deliveryTracker
+          .getRequestedInfo(UtxoSnapshotChunkTypeId.value, chunkId)
+          .get
+        requestedInfo.checks shouldBe checksBeforeTimeout + 1
+        requestedInfo.peer shouldBe peer
+      }
+
+      ncProbe.send(synchronizerMockRef, CheckDelivery(peer, UtxoSnapshotChunkTypeId.value, chunkId))
+      ncProbe.expectMsg(PenalizePeer(peer.connectionId.remoteAddress, PenaltyType.NonDeliveryPenalty))
+      eventually {
+        deliveryTracker.status(chunkId, UtxoSnapshotChunkTypeId.value, Seq.empty) shouldBe Unknown
+      }
+      ncProbe.expectNoMessage(1.second)
     }
   }
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -3,13 +3,13 @@ package org.ergoplatform.network
 import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
 import akka.testkit.TestProbe
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, UtxoSnapshotChunkTypeId}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
-import org.ergoplatform.nodeView.state.{StateType, UtxoState}
+import org.ergoplatform.nodeView.state.{SnapshotTestAccess, StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.validation.{ParentHeaderNotFoundError, RecoverableModifierError}
@@ -21,7 +21,7 @@ import scorex.core.network.ModifiersStatus.{Received, Requested, Unknown}
 import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.message._
 import org.ergoplatform.network.peer.PeerInfo
-import scorex.core.network.{ConnectedPeer, DeliveryTracker}
+import scorex.core.network.{ConnectedPeer, DeliveryTracker, SendToPeer}
 import scorex.util.bytesToId
 import org.ergoplatform.serialization.ErgoSerializer
 import org.scalatest.propspec.AnyPropSpec
@@ -741,6 +741,49 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       // After max attempts, non-header modifier should be set to Unknown (not Invalid)
       eventually {
         deliveryTracker.status(modifierId, nonHeaderTypeId, Seq.empty) shouldBe Unknown
+      }
+    }
+  }
+
+  property("NodeViewSynchronizer: checkDelivery should preserve snapshot chunk retry count") {
+    withFixture2 { ctx =>
+      import ctx._
+
+      val hhistory = ErgoHistory.readOrGenerate(settings)(null)
+      val boxes = boxesHolderGenOfSize(128).sample.get
+      val state = createUtxoState(boxes, parameters)
+      val snapshotHeight = 1
+      val manifestDepth = 2.toByte
+      val manifest = SnapshotTestAccess.dumpManifest(state, snapshotHeight, manifestDepth)
+      val plan = hhistory.registerManifestToDownload(manifest, snapshotHeight, Seq(peer))
+
+      val chunkBytes = plan.expectedChunkIds.head
+      val chunkId = bytesToId(chunkBytes)
+      val checksBeforeTimeout = settings.scorexSettings.network.maxDeliveryChecks - 2
+
+      ncProbe.send(synchronizerMockRef, ChangedHistory(hhistory))
+      ncProbe.send(synchronizerMockRef, ChangedMempool(ErgoMemPool.empty(settings)))
+      deliveryTracker.setRequested(
+        UtxoSnapshotChunkTypeId.value,
+        chunkId,
+        peer,
+        checksBeforeTimeout)(_ => Cancellable.alreadyCancelled)
+      ncProbe.send(synchronizerMockRef, CheckDelivery(peer, UtxoSnapshotChunkTypeId.value, chunkId))
+
+      ncProbe.fishForMessage(3.seconds) {
+        case SendToNetwork(message, SendToPeer(selectedPeer)) if message.spec == GetUtxoSnapshotChunkSpec =>
+          selectedPeer shouldBe peer
+          message.data.get.asInstanceOf[Array[Byte]].sameElements(chunkBytes) shouldBe true
+          true
+        case _ => false
+      }
+
+      eventually {
+        val requestedInfo = deliveryTracker
+          .getRequestedInfo(UtxoSnapshotChunkTypeId.value, chunkId)
+          .get
+        requestedInfo.checks shouldBe checksBeforeTimeout + 1
+        requestedInfo.peer shouldBe peer
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/state/SnapshotTestAccess.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/SnapshotTestAccess.scala
@@ -1,0 +1,16 @@
+package org.ergoplatform.nodeView.state
+
+import org.ergoplatform.serialization.ManifestSerializer
+import scorex.crypto.authds.avltree.batch.serialization.BatchAVLProverManifest
+import scorex.crypto.hash.Digest32
+
+object SnapshotTestAccess {
+  def dumpManifest(state: UtxoState,
+                   height: Int,
+                   manifestDepth: Byte): BatchAVLProverManifest[Digest32] = {
+    state.dumpSnapshot(height, state.rootDigest.dropRight(1), manifestDepth).get
+    val manifestId = state.snapshotsDb.readSnapshotsInfo.availableManifests(height)
+    val manifestBytes = state.snapshotsDb.readManifestBytes(manifestId).get
+    new ManifestSerializer(manifestDepth).parseBytes(manifestBytes)
+  }
+}


### PR DESCRIPTION
## Summary

- Preserve the accumulated delivery-check count when a timed-out UTXO snapshot chunk is requested from a replacement peer.
- Allow the configured `maxDeliveryChecks` budget to terminate repeated chunk retries.
- Add an actor-level regression test using a real chunk from a snapshot manifest, covering both the retry and terminal transitions.

## Root cause

`checkDelivery` incremented the stored attempt count, but `requestUtxoSetChunk` recreated the `DeliveryTracker` entry without passing that count. The default value of zero replaced the previous state on every retry, so the configured maximum could never be reached for snapshot chunks.

## Impact

When UTXO snapshot bootstrap is enabled, an unavailable or non-delivering chunk could be requested repeatedly instead of exhausting the configured retry budget. This could prolong or stall that bootstrap mode while producing repeated peer penalties, timers, logs, and network traffic.

This change does not affect consensus rules, transaction validity, serialization, or default configuration.

## Scope

The change enforces the existing retry budget. It does not alter snapshot-plan recovery after the budget is exhausted.

This is distinct from #2434, which corrects the request type used for snapshot manifest retries, and #2424, which restores wallet scanning after snapshot bootstrap. #2424 touches the same synchronizer and specification, so whichever change lands second may need a small rebase.

## Validation

- Regression witness on unpatched master: focused test `0/1` (`99` expected, `0` observed).
- Patched focused regression: `1/1`.
- Affected closure: `34/34` across the synchronizer, both delivery-tracker suites, snapshot processor, and modifier-request suite.
