### PR TITLE
Prevent duplicate IDs in OrderedTxPool

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -41,6 +41,32 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
 
   private val mempoolCapacity = settings.nodeSettings.mempoolCapacity
 
+  private def withoutTransaction(id: ModifierId): TreeMap[WeightedTxId, UnconfirmedTransaction] = {
+    // Keep healthy mutations logarithmic; scan by ID only after cardinality diverges.
+    transactionsRegistry.get(id) match {
+      case Some(wtx) if orderedTransactions.size == transactionsRegistry.size &&
+        orderedTransactions.contains(wtx) =>
+        orderedTransactions - wtx
+      case None if orderedTransactions.size == transactionsRegistry.size =>
+        orderedTransactions
+      case _ =>
+        orderedTransactions.filter { case (wtx, utx) => wtx.id != id && utx.id != id }
+    }
+  }
+
+  private def hasUnregisteredTransaction(id: ModifierId): Boolean =
+    orderedTransactions.size != transactionsRegistry.size &&
+      orderedTransactions.valuesIterator.exists(_.id == id)
+
+  private def currentTransaction(id: ModifierId): Option[(WeightedTxId, UnconfirmedTransaction)] =
+    transactionsRegistry.get(id)
+      .flatMap(wtx => orderedTransactions.get(wtx).filter(_.id == id).map(wtx -> _))
+      .orElse {
+        orderedTransactions.iterator.collectFirst {
+          case (wtx, utx) if wtx.id == id && utx.id == id => wtx -> utx
+        }
+      }
+
   def size: Int = orderedTransactions.size
 
   def get(id: ModifierId): Option[UnconfirmedTransaction] = {
@@ -69,17 +95,18 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
 
     val newPool = transactionsRegistry.get(tx.id) match {
       case Some(wtx) =>
+        val currentWtx = currentTransaction(tx.id).map(_._1).getOrElse(wtx)
         new OrderedTxPool(
-          orderedTransactions.updated(wtx, unconfirmedTx),
-          transactionsRegistry,
+          withoutTransaction(tx.id).updated(currentWtx, unconfirmedTx),
+          transactionsRegistry.updated(tx.id, currentWtx),
           invalidatedTxIds,
-          outputs,
-          inputs
+          outputs ++ tx.outputs.map(_.id -> currentWtx),
+          inputs ++ tx.inputs.map(_.boxId -> currentWtx)
         )
       case None =>
         val wtx = weighted(tx, feeFactor)
         new OrderedTxPool(
-          orderedTransactions.updated(wtx, unconfirmedTx),
+          withoutTransaction(tx.id).updated(wtx, unconfirmedTx),
           transactionsRegistry.updated(wtx.id, wtx),
           invalidatedTxIds,
           outputs ++ tx.outputs.map(_.id -> wtx),
@@ -107,7 +134,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
     transactionsRegistry.get(tx.id) match {
       case Some(wtx) if orderedTransactions.contains(wtx) =>
         new OrderedTxPool(
-          orderedTransactions - wtx,
+          withoutTransaction(tx.id),
           transactionsRegistry - tx.id,
           invalidatedTxIds,
           outputs -- tx.outputs.map(_.id),
@@ -116,7 +143,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
       case Some(_) =>
         if (orderedTransactions.valuesIterator.exists(_.id == tx.id)) {
           new OrderedTxPool(
-            orderedTransactions.filter(_._2.id != tx.id),
+            withoutTransaction(tx.id),
             transactionsRegistry - tx.id,
             invalidatedTxIds,
             outputs -- tx.outputs.map(_.id),
@@ -126,7 +153,17 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
           this
         }
       case None =>
-        this
+        if (hasUnregisteredTransaction(tx.id)) {
+          new OrderedTxPool(
+            withoutTransaction(tx.id),
+            transactionsRegistry,
+            invalidatedTxIds,
+            outputs -- tx.outputs.map(_.id),
+            inputs -- tx.inputs.map(_.boxId)
+          )
+        } else {
+          this
+        }
     }
   }
 
@@ -140,7 +177,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
     transactionsRegistry.get(tx.id) match {
       case Some(wtx) if orderedTransactions.contains(wtx) =>
         new OrderedTxPool(
-          orderedTransactions - wtx,
+          withoutTransaction(tx.id),
           transactionsRegistry - tx.id,
           invalidatedTxIds.put(tx.id),
           outputs -- tx.outputs.map(_.id),
@@ -149,7 +186,7 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
       case Some(_) =>
         if (orderedTransactions.valuesIterator.exists(utx => utx.id == tx.id)) {
           new OrderedTxPool(
-            orderedTransactions.filter(_._2.id != tx.id),
+            withoutTransaction(tx.id),
             transactionsRegistry - tx.id,
             invalidatedTxIds.put(tx.id),
             outputs -- tx.outputs.map(_.id),
@@ -159,7 +196,17 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
           new OrderedTxPool(orderedTransactions, transactionsRegistry, invalidatedTxIds.put(tx.id), outputs, inputs)
         }
       case None =>
-        new OrderedTxPool(orderedTransactions, transactionsRegistry, invalidatedTxIds.put(tx.id), outputs, inputs)
+        if (hasUnregisteredTransaction(tx.id)) {
+          new OrderedTxPool(
+            withoutTransaction(tx.id),
+            transactionsRegistry,
+            invalidatedTxIds.put(tx.id),
+            outputs -- tx.outputs.map(_.id),
+            inputs -- tx.inputs.map(_.boxId)
+          )
+        } else {
+          new OrderedTxPool(orderedTransactions, transactionsRegistry, invalidatedTxIds.put(tx.id), outputs, inputs)
+        }
     }
   }
 
@@ -211,17 +258,22 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
       val uniqueTxIds: Set[WeightedTxId] = tx.inputs.flatMap(input => this.outputs.get(input.boxId)).toSet
       val parentTxs = uniqueTxIds.flatMap(wtx => this.orderedTransactions.get(wtx).map(ut => wtx -> ut))
 
-      parentTxs.foldLeft(this) { case (pool, (wtx, ut)) =>
-        val parent = ut.transaction
-        val newWtx = WeightedTxId(wtx.id, wtx.weight + weight, wtx.feePerFactor, wtx.created)
-        val newPool = new OrderedTxPool(
-          pool.orderedTransactions - wtx + (newWtx -> ut),
-          pool.transactionsRegistry.updated(parent.id, newWtx),
-          invalidatedTxIds,
-          parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)),
-          parent.inputs.foldLeft(pool.inputs)((newInputs, inp) => newInputs.updated(inp.boxId, newWtx))
-        )
-        newPool.updateFamily(parent, weight, startTime, depth + 1)
+      parentTxs.foldLeft(this) { case (pool, (snapshotWtx, _)) =>
+        pool.currentTransaction(snapshotWtx.id) match {
+          case Some((wtx, ut)) =>
+            val parent = ut.transaction
+            val newWtx = WeightedTxId(wtx.id, wtx.weight + weight, wtx.feePerFactor, wtx.created)
+            val newPool = new OrderedTxPool(
+              pool.withoutTransaction(parent.id).updated(newWtx, ut),
+              pool.transactionsRegistry.updated(parent.id, newWtx),
+              pool.invalidatedTxIds,
+              parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)),
+              parent.inputs.foldLeft(pool.inputs)((newInputs, inp) => newInputs.updated(inp.boxId, newWtx))
+            )
+            newPool.updateFamily(parent, weight, startTime, depth + 1)
+          case None =>
+            pool
+        }
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/OrderedTxPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/OrderedTxPoolSpec.scala
@@ -1,0 +1,259 @@
+package org.ergoplatform.nodeView.mempool
+
+import org.ergoplatform.ErgoBox.BoxId
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.ErgoTestHelpers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.crypto.authds.ADKey
+import scorex.util.ModifierId
+
+class OrderedTxPoolSpec extends AnyFlatSpec with Matchers with ErgoTestHelpers {
+  import org.ergoplatform.utils.ErgoCoreTestConstants.emptyProverResult
+  import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+
+  private final class ReconvergentFixture(
+    val a: ErgoTransaction,
+    val b: ErgoTransaction,
+    val c: ErgoTransaction,
+    val d: ErgoTransaction,
+    val beforeD: ErgoMemPool,
+    val parentOrder: Seq[ModifierId]
+  )
+
+  private def deterministicRootId(nonce: Int): BoxId = {
+    val bytes = Array.fill[Byte](32)(0)
+    bytes(28) = (nonce >>> 24).toByte
+    bytes(29) = (nonce >>> 16).toByte
+    bytes(30) = (nonce >>> 8).toByte
+    bytes(31) = nonce.toByte
+    ADKey @@ bytes
+  }
+
+  private def outputCandidates(plainCount: Int, plainValue: Long = 4000000L) = {
+    val feeProposition = settings.chainSettings.monetary.feeProposition
+    IndexedSeq.fill(plainCount)(new org.ergoplatform.ErgoBoxCandidate(plainValue, TrueTree, 0)) :+
+      new org.ergoplatform.ErgoBoxCandidate(1000000L, feeProposition, 0)
+  }
+
+  private def buildReconvergentFixture(nonce: Int): ReconvergentFixture = {
+    val a = ErgoTransaction(
+      IndexedSeq(new org.ergoplatform.Input(deterministicRootId(nonce), emptyProverResult)),
+      outputCandidates(3)
+    )
+    val b = ErgoTransaction(
+      IndexedSeq(new org.ergoplatform.Input(a.outputs(0).id, emptyProverResult)),
+      outputCandidates(1, 3000000L)
+    )
+    val c = ErgoTransaction(
+      IndexedSeq(new org.ergoplatform.Input(a.outputs(1).id, emptyProverResult)),
+      outputCandidates(1, 3000000L)
+    )
+    val d = ErgoTransaction(
+      IndexedSeq(
+        new org.ergoplatform.Input(b.outputs(0).id, emptyProverResult),
+        new org.ergoplatform.Input(c.outputs(0).id, emptyProverResult),
+        new org.ergoplatform.Input(a.outputs(2).id, emptyProverResult)
+      ),
+      outputCandidates(1, 9000000L)
+    )
+
+    val beforeD = Seq(a, b, c).foldLeft(ErgoMemPool.empty(settings)) {
+      case (pool, tx) => pool.put(UnconfirmedTransaction(tx, None))
+    }
+    val uniqueParentKeys = d.inputs.flatMap(input => beforeD.pool.outputs.get(input.boxId)).toSet
+    val parentOrder = uniqueParentKeys
+      .flatMap { wtx =>
+        beforeD.pool.orderedTransactions.get(wtx).map(unconfirmed => wtx -> unconfirmed)
+      }
+      .toSeq
+      .map(_._1.id)
+
+    new ReconvergentFixture(a, b, c, d, beforeD, parentOrder)
+  }
+
+  private def fixtureWithSharedAncestorLast(): ReconvergentFixture = {
+    val fixture = (0 until 4096)
+      .iterator
+      .map(buildReconvergentFixture)
+      .find { candidate =>
+        candidate.parentOrder.lastOption.contains(candidate.a.id) &&
+          candidate.parentOrder.take(2).toSet == Set(candidate.b.id, candidate.c.id)
+      }
+    fixture.getOrElse(fail("No deterministic reconvergent fixture found"))
+  }
+
+  private def orderedIds(pool: OrderedTxPool): Vector[ModifierId] =
+    pool.orderedTransactions.valuesIterator.map(_.id).toVector
+
+  private def assertConsistent(pool: OrderedTxPool, expectedIds: Set[ModifierId]): Unit = {
+    val ids = orderedIds(pool)
+    ids.toSet shouldBe expectedIds
+    ids.distinct.size shouldBe ids.size
+    pool.orderedTransactions.size shouldBe expectedIds.size
+    pool.transactionsRegistry.keySet shouldBe expectedIds
+    pool.transactionsRegistry.foreach { case (id, key) =>
+      pool.orderedTransactions.get(key).map(_.id) shouldBe Some(id)
+    }
+    val transactions = pool.orderedTransactions.valuesIterator.map(_.transaction).toVector
+    val expectedOutputIds = transactions.flatMap(_.outputs.map(_.id)).toSet
+    val expectedInputIds = transactions.flatMap(_.inputs.map(_.boxId)).toSet
+    pool.outputs.keySet shouldBe expectedOutputIds
+    pool.inputs.keySet shouldBe expectedInputIds
+    pool.orderedTransactions.foreach { case (key, unconfirmed) =>
+      unconfirmed.transaction.outputs.foreach { output =>
+        pool.outputs.get(output.id) shouldBe Some(key)
+      }
+      unconfirmed.transaction.inputs.foreach { input =>
+        pool.inputs.get(input.boxId) shouldBe Some(key)
+      }
+    }
+    pool.outputs.valuesIterator.foreach { key =>
+      pool.orderedTransactions.contains(key) shouldBe true
+    }
+    pool.inputs.valuesIterator.foreach { key =>
+      pool.orderedTransactions.contains(key) shouldBe true
+    }
+  }
+
+  private def withDuplicate(pool: OrderedTxPool, tx: ErgoTransaction): OrderedTxPool = {
+    val registeredKey = pool.transactionsRegistry(tx.id)
+    val unconfirmed = pool.orderedTransactions(registeredKey)
+    val duplicateKey = registeredKey.copy(weight = registeredKey.weight + 1L)
+
+    new OrderedTxPool(
+      pool.orderedTransactions.updated(duplicateKey, unconfirmed),
+      pool.transactionsRegistry,
+      pool.invalidatedTxIds,
+      pool.outputs,
+      pool.inputs
+    )(settings)
+  }
+
+  private def withoutRegistry(pool: OrderedTxPool, tx: ErgoTransaction): OrderedTxPool = {
+    new OrderedTxPool(
+      pool.orderedTransactions,
+      pool.transactionsRegistry - tx.id,
+      pool.invalidatedTxIds,
+      pool.outputs,
+      pool.inputs
+    )(settings)
+  }
+
+  it should "keep indexes consistent when a transaction closes a reconvergent family" in {
+    val fixture = fixtureWithSharedAncestorLast()
+    val beforeIds = Set(fixture.a.id, fixture.b.id, fixture.c.id)
+    val beforeWeights = beforeIds.map { id =>
+      id -> fixture.beforeD.pool.transactionsRegistry(id).weight
+    }.toMap
+
+    fixture.parentOrder.last shouldBe fixture.a.id
+    fixture.parentOrder.take(2).toSet shouldBe Set(fixture.b.id, fixture.c.id)
+    fixture.d.inputs.map(_.boxId).distinct.size shouldBe fixture.d.inputs.size
+    assertConsistent(fixture.beforeD.pool, beforeIds)
+
+    val afterD = fixture.beforeD.put(UnconfirmedTransaction(fixture.d, None))
+    val expectedIds = beforeIds + fixture.d.id
+    val duplicateCounts = orderedIds(afterD.pool).groupBy(identity).mapValues(_.size)
+    val orderedKeys = afterD.pool.orderedTransactions.keysIterator
+      .map(key => key.id -> key.weight)
+      .toVector
+
+    withClue(s"ordered keys=$orderedKeys, duplicate counts=$duplicateCounts") {
+      assertConsistent(afterD.pool, expectedIds)
+      val afterWeights = afterD.pool.transactionsRegistry.mapValues(_.weight)
+      val dWeight = afterWeights(fixture.d.id)
+      dWeight should be > (0L)
+      afterWeights(fixture.b.id) shouldBe beforeWeights(fixture.b.id) + dWeight
+      afterWeights(fixture.c.id) shouldBe beforeWeights(fixture.c.id) + dWeight
+      afterWeights(fixture.a.id) shouldBe beforeWeights(fixture.a.id) + 3L * dWeight
+    }
+  }
+
+
+  it should "heal a duplicated ancestor while propagating a new child" in {
+    val fixture = fixtureWithSharedAncestorLast()
+    val before = fixture.beforeD.pool
+    val ancestorWeight = before.transactionsRegistry(fixture.a.id).weight
+    val corrupted = withDuplicate(before, fixture.a)
+
+    orderedIds(corrupted).count(_ == fixture.a.id) shouldBe 2
+    val healed = corrupted.put(UnconfirmedTransaction(fixture.d, None), fixture.d.size)
+
+    assertConsistent(
+      healed,
+      Set(fixture.a.id, fixture.b.id, fixture.c.id, fixture.d.id)
+    )
+    val dWeight = healed.transactionsRegistry(fixture.d.id).weight
+    healed.transactionsRegistry(fixture.a.id).weight shouldBe ancestorWeight + 3L * dWeight
+  }
+  it should "self-heal duplicate keys without propagating family weight twice" in {
+    val fixture = fixtureWithSharedAncestorLast()
+    val before = fixture.beforeD.pool
+    val originalKey = before.transactionsRegistry(fixture.b.id)
+    val ancestorWeight = before.transactionsRegistry(fixture.a.id).weight
+    val corrupted = withDuplicate(before, fixture.b)
+
+    orderedIds(corrupted).count(_ == fixture.b.id) shouldBe 2
+    val healed = corrupted.put(UnconfirmedTransaction(fixture.b, None), fixture.b.size)
+
+    assertConsistent(healed, Set(fixture.a.id, fixture.b.id, fixture.c.id))
+    val healedKeys = healed.orderedTransactions.keysIterator
+      .filter(_.id == fixture.b.id)
+      .toVector
+    healedKeys.map(_.weight) shouldBe Vector(originalKey.weight)
+    healedKeys.map(_.created) shouldBe Vector(originalKey.created)
+    healed.transactionsRegistry(fixture.a.id).weight shouldBe ancestorWeight
+  }
+
+  it should "purge duplicate keys and subtract family weight once on removal" in {
+    val fixture = fixtureWithSharedAncestorLast()
+    val before = fixture.beforeD.pool
+    val ancestorWeight = before.transactionsRegistry(fixture.a.id).weight
+    val childWeight = before.transactionsRegistry(fixture.b.id).weight
+    val siblingWeight = before.transactionsRegistry(fixture.c.id).weight
+    val corrupted = withDuplicate(before, fixture.b)
+
+    orderedIds(corrupted).count(_ == fixture.b.id) shouldBe 2
+    val removed = corrupted.remove(fixture.b)
+
+    assertConsistent(removed, Set(fixture.a.id, fixture.c.id))
+    removed.transactionsRegistry(fixture.a.id).weight shouldBe ancestorWeight - childWeight
+    removed.transactionsRegistry(fixture.c.id).weight shouldBe siblingWeight
+  }
+
+  it should "purge duplicate keys and subtract family weight once on invalidation" in {
+    val fixture = fixtureWithSharedAncestorLast()
+    val before = fixture.beforeD.pool
+    val ancestorWeight = before.transactionsRegistry(fixture.a.id).weight
+    val childWeight = before.transactionsRegistry(fixture.b.id).weight
+    val siblingWeight = before.transactionsRegistry(fixture.c.id).weight
+    val corrupted = withDuplicate(before, fixture.b)
+
+    orderedIds(corrupted).count(_ == fixture.b.id) shouldBe 2
+    val invalidated = corrupted.invalidate(UnconfirmedTransaction(fixture.b, None))
+
+    assertConsistent(invalidated, Set(fixture.a.id, fixture.c.id))
+    invalidated.transactionsRegistry(fixture.a.id).weight shouldBe ancestorWeight - childWeight
+    invalidated.transactionsRegistry(fixture.c.id).weight shouldBe siblingWeight
+    invalidated.isInvalidated(fixture.b.id) shouldBe true
+  }
+
+  it should "purge unregistered orphan keys on removal and invalidation" in {
+    val fixture = fixtureWithSharedAncestorLast()
+    val before = fixture.beforeD.pool
+    val orphaned = withoutRegistry(before, fixture.b)
+    val expectedIds = Set(fixture.a.id, fixture.c.id)
+
+    orphaned.transactionsRegistry should not contain fixture.b.id
+    orderedIds(orphaned).count(_ == fixture.b.id) shouldBe 1
+
+    val removed = orphaned.remove(fixture.b)
+    assertConsistent(removed, expectedIds)
+
+    val invalidated = orphaned.invalidate(UnconfirmedTransaction(fixture.b, None))
+    assertConsistent(invalidated, expectedIds)
+    invalidated.isInvalidated(fixture.b.id) shouldBe true
+  }
+}


### PR DESCRIPTION
## Summary

- resolve each snapshotted parent ID from the current `foldLeft` accumulator before reweighting it
- purge same-ID ordered keys when a cardinality mismatch shows that the pool is already inconsistent
- clean registry-absent ordered orphans through `remove` and `invalidate`
- preserve the existing per-dependency-path family-weight semantics

## Root cause

`updateFamily` snapshots `(WeightedTxId, transaction)` pairs from the pre-fold pool. In a reconvergent dependency graph, an earlier recursive branch can rekey a shared ancestor before a later branch processes its captured key. The later removal then targets a stale `(-weight, id)` TreeMap position and removes nothing, while insertion adds another key for the same transaction ID.

`WeightedTxId.equals` and `hashCode` are ID-only, but TreeMap key identity follows its `(-weight, id)` ordering, so both weights can coexist. The registry points to only one copy.

## Deterministic regression

The new test inserts this valid unconfirmed dependency graph through normal `ErgoMemPool.put` calls:

- A creates three outputs
- B spends one A output
- C spends another A output
- D spends outputs from B, C, and the third A output

With the direct-parent iteration order B, C, A, the unpatched code produces five ordered entries for four transaction IDs and stores A at two weights. The test also locks the current path semantics: D contributes once to A through B, once through C, and once directly.

Additional cases cover:

- re-putting a duplicated transaction without propagating family weight twice
- adding a child while an ancestor is already duplicated
- removing or invalidating all live-registry duplicate keys with one family subtraction
- removing and invalidating an ordered orphan whose registry entry is already absent
- exact registry, input-index, and output-index consistency

The healthy path still removes the registered TreeMap key in logarithmic time. Same-ID scans are limited to states where ordered/registry cardinality has already diverged.

## Tests

```text
sbt "testOnly org.ergoplatform.nodeView.mempool.OrderedTxPoolSpec"
# 6 passed

sbt "testOnly org.ergoplatform.nodeView.mempool.ErgoMemPoolSpec org.ergoplatform.local.MempoolAuditorSpec"
# 29 passed
```