### PR TITLE
Fix duplicate transaction ids in OrderedTxPool.updateFamily

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala
@@ -208,20 +208,28 @@ class OrderedTxPool(val orderedTransactions: TreeMap[WeightedTxId, UnconfirmedTr
       this
     } else {
 
-      val uniqueTxIds: Set[WeightedTxId] = tx.inputs.flatMap(input => this.outputs.get(input.boxId)).toSet
-      val parentTxs = uniqueTxIds.flatMap(wtx => this.orderedTransactions.get(wtx).map(ut => wtx -> ut))
+      val parentIds: Set[ModifierId] =
+        tx.inputs.flatMap(input => this.outputs.get(input.boxId).map(_.id)).toSet
 
-      parentTxs.foldLeft(this) { case (pool, (wtx, ut)) =>
-        val parent = ut.transaction
-        val newWtx = WeightedTxId(wtx.id, wtx.weight + weight, wtx.feePerFactor, wtx.created)
-        val newPool = new OrderedTxPool(
-          pool.orderedTransactions - wtx + (newWtx -> ut),
-          pool.transactionsRegistry.updated(parent.id, newWtx),
-          invalidatedTxIds,
-          parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)),
-          parent.inputs.foldLeft(pool.inputs)((newInputs, inp) => newInputs.updated(inp.boxId, newWtx))
-        )
-        newPool.updateFamily(parent, weight, startTime, depth + 1)
+      parentIds.foldLeft(this) { case (pool, parentId) =>
+        // resolve the parent's current key from the registry: an earlier iteration may have re-keyed
+        // it, so removing by a stale key would leave a duplicate (equality is id-only, ordering is by weight)
+        pool.transactionsRegistry.get(parentId) match {
+          case Some(curWtx) if pool.orderedTransactions.contains(curWtx) =>
+            val ut     = pool.orderedTransactions(curWtx)
+            val parent = ut.transaction
+            val newWtx = WeightedTxId(curWtx.id, curWtx.weight + weight, curWtx.feePerFactor, curWtx.created)
+            val newPool = new OrderedTxPool(
+              pool.orderedTransactions - curWtx + (newWtx -> ut),
+              pool.transactionsRegistry.updated(parent.id, newWtx),
+              invalidatedTxIds,
+              parent.outputs.foldLeft(pool.outputs)((newOutputs, box) => newOutputs.updated(box.id, newWtx)),
+              parent.inputs.foldLeft(pool.inputs)((newInputs, inp) => newInputs.updated(inp.boxId, newWtx))
+            )
+            newPool.updateFamily(parent, weight, startTime, depth + 1)
+          case _ =>
+            pool
+        }
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -832,6 +832,83 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     all.map(_.id).distinct.size shouldBe 1
   }
 
+  it should "not produce duplicate ids for a multi-diamond family put through the pool" in {
+    // A parent P, two children C1/C2 spending P, and X spending P plus both children. X's inputs are
+    // ordered children-first so updateFamily folds P last (small immutable Sets iterate in insertion
+    // order) — the case that triggers the stale-key duplicate on unfixed code. Run over two id sets.
+    val (us, bh) = createUtxoState(settings)
+    val genesis = validFullBlock(None, us, bh)
+    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
+
+    val feeProp = settings.chainSettings.monetary.feeProposition
+    val trueTree = TrueTree
+    val fee = 1000000L
+
+    // Build P -> {C1, C2} -> X (a double diamond) rooted at `srcBox`, put through the pool in
+    // dependency order, and return the resulting pool.
+    def buildFamilyPool(srcBox: org.ergoplatform.ErgoBox): OrderedTxPool = {
+      // P: fee output at index 0, then three true-script outputs at indices 1, 2, 3
+      val pTx = ErgoTransaction(
+        IndexedSeq(new Input(srcBox.id, emptyProverResult)),
+        IndexedSeq(
+          new ErgoBoxCandidate(fee, feeProp, creationHeight = 0),
+          new ErgoBoxCandidate(1000000L, trueTree, creationHeight = 0),
+          new ErgoBoxCandidate(1000000L, trueTree, creationHeight = 0),
+          new ErgoBoxCandidate(1000000L, trueTree, creationHeight = 0)
+        )
+      )
+      // C1 spends P's output #1
+      val c1Tx = ErgoTransaction(
+        IndexedSeq(new Input(pTx.outputs(1).id, emptyProverResult)),
+        IndexedSeq(
+          new ErgoBoxCandidate(fee, feeProp, creationHeight = 0),
+          new ErgoBoxCandidate(500000L, trueTree, creationHeight = 0)
+        )
+      )
+      // C2 spends P's output #2
+      val c2Tx = ErgoTransaction(
+        IndexedSeq(new Input(pTx.outputs(2).id, emptyProverResult)),
+        IndexedSeq(
+          new ErgoBoxCandidate(fee, feeProp, creationHeight = 0),
+          new ErgoBoxCandidate(500000L, trueTree, creationHeight = 0)
+        )
+      )
+      // X spends outputs of C1 and C2 first, then P's output #3; children-first/parent-last input
+      // order makes the family fold reach P after its children (see comment above).
+      val xTx = ErgoTransaction(
+        IndexedSeq(
+          new Input(c1Tx.outputs(1).id, emptyProverResult),
+          new Input(c2Tx.outputs(1).id, emptyProverResult),
+          new Input(pTx.outputs(3).id, emptyProverResult)
+        ),
+        IndexedSeq(new ErgoBoxCandidate(fee, feeProp, creationHeight = 0))
+      )
+
+      Seq(pTx, c1Tx, c2Tx, xTx).foldLeft(OrderedTxPool.empty(settings)) {
+        case (p, tx) => p.put(UnconfirmedTransaction(tx, None), tx.size)
+      }
+    }
+
+    // Two distinct source boxes -> two distinct tx-id sets, exercising the same fold-order path.
+    val srcBoxes = wus.takeBoxes(200).filter(_.ergoTree == trueTree).take(2)
+    srcBoxes.size shouldBe 2
+
+    srcBoxes.foreach { srcBox =>
+      val pool = buildFamilyPool(srcBox)
+
+      val ids = pool.orderedTransactions.values.map(_.id).toSeq
+      // no duplicate id in orderedTransactions and all four txs present
+      ids.size shouldBe 4
+      ids.distinct.size shouldBe ids.size
+      // registry and ordered map never diverge: every registry key resolves to the same present tx
+      pool.transactionsRegistry.forall { case (id, w) =>
+        pool.orderedTransactions.get(w).exists(_.transaction.id == id)
+      } shouldBe true
+      // and every id is retrievable through the registry path
+      ids.foreach(id => pool.get(id) shouldBe defined)
+    }
+  }
+
   it should "detect double spend after replace-by-fee replacement" in {
     val (us, bh) = createUtxoState(settings)
     val genesis = validFullBlock(None, us, bh)


### PR DESCRIPTION
## Problem
`OrderedTxPool` holds `transactionsRegistry` (id → `WeightedTxId`) and `orderedTransactions` (a `TreeMap` keyed and ordered by `(-weight, id)`) that must agree on each id's key. `WeightedTxId` equality is id-only, so a same-id key at a different weight is a *distinct* `TreeMap` entry.

`updateFamily` captures each parent's `WeightedTxId` once from the pre-fold snapshot, then re-keys with `orderedTransactions - staleWtx + (newWtx -> ut)`. On a reconvergent DAG — a transaction spending a parent `P` **plus** ≥2 of `P`'s other children — earlier fold iterations re-key `P` to a higher weight, so the later `- staleWtx` removes nothing and `+ newWtx` inserts a **second ordered entry for `P`'s id**. The registry then names one key while `orderedTransactions` holds two.

This is the *producer* of the duplicate ids observed after 6.0.3: `a21ece610` hardened only the removal-side (`remove`/`invalidate`) cleanup, which does not fire here because the registry key is present.

## Fix
Re-resolve each parent's current key from `transactionsRegistry` inside the fold, so the registry and the ordered map cannot diverge. This is a producer-only change; the 6.0.3 removal-side cleanup is left intact as a complement.

## Test
`ErgoMemPoolSpec` — *"not produce duplicate ids for a multi-diamond family put through the pool"*: starts from `OrderedTxPool.empty`, `put()`s `P`, `C1`, `C2` (each child spending `P`), then `put(X)` where `X` spends `C1`, `C2` and `P` with inputs ordered children-first so the fold reaches `P` last. It asserts no duplicate id in `orderedTransactions`, registry/ordered-map consistency, and `get(id)` resolution — over two distinct source boxes (two id sets), so it is not id-order-dependent. Reverting only the source change fails it deterministically.