### PR TITLE
Block candidate generation improvements

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -105,7 +105,8 @@ class CandidateGenerator(
             h,
             s,
             m,
-            avgGenTime = 1000.millis
+            avgGenTime = 1000.millis,
+            lastAppliedBlockTxs = None
           )
         )
       )
@@ -147,18 +148,21 @@ class CandidateGenerator(
      * When new block is applied, either one mined by us or received from peers isn't equal to our candidate's parent,
      * we need to generate new candidate and possibly also discard existing solution if it is also behind
      */
-    case FullBlockApplied(header) =>
+    case applied: FullBlockApplied =>
+      val header = applied.header
       log.info(
         s"Preparing new candidate on getting new block at ${header.height}"
       )
+      val stateWithAppliedTxs =
+        state.copy(lastAppliedBlockTxs = Some(header.id -> applied.txIds.toSet))
       if (needNewCandidate(state.cachedCandidate, header)) {
         if (needNewSolution(state.solvedBlock, header.id))
-          context.become(initialized(state.copy(cachedCandidate = None, cachedPreviousCandidate = None, solvedBlock = None)))
+          context.become(initialized(stateWithAppliedTxs.copy(cachedCandidate = None, cachedPreviousCandidate = None, solvedBlock = None)))
         else
-          context.become(initialized(state.copy(cachedCandidate = None, cachedPreviousCandidate = None)))
+          context.become(initialized(stateWithAppliedTxs.copy(cachedCandidate = None, cachedPreviousCandidate = None)))
         self ! GenerateCandidate(txsToInclude = Seq.empty, reply = false, forced = false)
       } else {
-        context.become(initialized(state))
+        context.become(initialized(stateWithAppliedTxs))
       }
 
     case gen @ GenerateCandidate(txsToInclude, reply, forced, optPk) =>
@@ -174,6 +178,7 @@ class CandidateGenerator(
           state.mpr,
           effectiveMinerPk,
           txsToInclude,
+          state.lastAppliedBlockTxs,
           ergoSettings
         ) match {
           case Some(Failure(ex)) =>
@@ -280,7 +285,8 @@ object CandidateGenerator extends ScorexLogging {
     hr: ErgoHistoryReader,
     sr: UtxoStateReader,
     mpr: ErgoMemPoolReader,
-    avgGenTime: FiniteDuration // approximation of average block generation time for more efficient retries
+    avgGenTime: FiniteDuration, // approximation of average block generation time for more efficient retries
+    lastAppliedBlockTxs: Option[(ModifierId, Set[ModifierId])] // header id and tx ids of the last applied block
   )
 
   def apply(
@@ -388,6 +394,38 @@ object CandidateGenerator extends ScorexLogging {
     tx.inputs.forall(inp => s.boxById(inp.boxId).isDefined)
 
   /**
+    * Checks that the best full block in the history corresponds to the state.
+    * Evaluated via live history storage reads, so re-checking it after candidate assembly
+    * detects a block applied concurrently with the assembly.
+    */
+  def isChainSynced(
+    bestFullBlockIdOpt: Option[ModifierId],
+    stateContext: ErgoStateContext
+  ): Boolean =
+    bestFullBlockIdOpt == stateContext.lastHeaderOpt.map(_.id)
+
+  /**
+    * Filters out from `poolTxs` transactions included into the last applied block
+    * (`lastAppliedBlockTxs`), if the block is still the best full block (`bestFullBlockIdOpt`).
+    * Such transactions are removed from the mempool by the node view holder itself on block
+    * application, so there is no need to validate them during candidate assembly (which logs
+    * misleading double-spending messages) nor to eliminate them via EliminateTransactions.
+    */
+  def excludeAppliedTxs(
+    poolTxs: Seq[UnconfirmedTransaction],
+    lastAppliedBlockTxs: Option[(ModifierId, Set[ModifierId])],
+    bestFullBlockIdOpt: Option[ModifierId]
+  ): Seq[UnconfirmedTransaction] = {
+    lastAppliedBlockTxs match {
+      case Some((appliedHeaderId, appliedTxIds))
+          if appliedTxIds.nonEmpty && bestFullBlockIdOpt.contains(appliedHeaderId) =>
+        poolTxs.filterNot(tx => appliedTxIds.contains(tx.id))
+      case _ =>
+        poolTxs
+    }
+  }
+
+  /**
     * @return None if chain is not synced or Some of attempt to create candidate
     */
   def generateCandidate(
@@ -396,6 +434,7 @@ object CandidateGenerator extends ScorexLogging {
     m: ErgoMemPoolReader,
     pk: ProveDlog,
     txsToInclude: Seq[ErgoTransaction],
+    lastAppliedBlockTxs: Option[(ModifierId, Set[ModifierId])],
     ergoSettings: ErgoSettings
   ): Option[Try[(Candidate, EliminateTransactions)]] = {
     // mandatory transactions to include into next block taken from the previous candidate
@@ -406,14 +445,16 @@ object CandidateGenerator extends ScorexLogging {
 
     val stateContext = s.stateContext
 
-    //only transactions valid from against the current utxo state we take from the mem pool
-    lazy val poolTransactions = m.getAllPrioritized
+    //only transactions valid from against the current utxo state we take from the mem pool,
+    //skipping transactions already included into the last applied block
+    lazy val poolTransactions =
+      excludeAppliedTxs(m.getAllPrioritized, lastAppliedBlockTxs, h.bestFullBlockOpt.map(_.id))
 
     lazy val emissionTxOpt =
       CandidateGenerator.collectEmission(s, pk, stateContext)
 
     def chainSynced =
-      h.bestFullBlockOpt.map(_.id) == stateContext.lastHeaderOpt.map(_.id)
+      isChainSynced(h.bestFullBlockOpt.map(_.id), stateContext)
 
     def hasAnyMemPoolOrMinerTx =
       poolTransactions.nonEmpty || unspentTxsToInclude.nonEmpty || emissionTxOpt.nonEmpty
@@ -436,18 +477,25 @@ object CandidateGenerator extends ScorexLogging {
       } else {
         ergoSettings.votingTargets.desiredUpdate
       }
-      Some(
-        createCandidate(
-          pk,
-          h,
-          desiredUpdate,
-          s,
-          poolTransactions,
-          emissionTxOpt,
-          unspentTxsToInclude,
-          ergoSettings
-        )
+      val candidateAttempt = createCandidate(
+        pk,
+        h,
+        desiredUpdate,
+        s,
+        poolTransactions,
+        emissionTxOpt,
+        unspentTxsToInclude,
+        ergoSettings
       )
+      if (!chainSynced) {
+        log.debug(
+          "Discarding block candidate as a new block was applied during its assembly, " +
+          "a new candidate will be generated on FullBlockApplied"
+        )
+        None
+      } else {
+        Some(candidateAttempt)
+      }
     }
   }
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1429,7 +1429,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       }
 
     // Locally mined block applied - skip broadcast (already done via NewBlockMined)
-    case LocalBlockApplied(header) =>
+    case LocalBlockApplied(header, _) =>
       log.debug(
         s"Local block applied at height ${header.height}, " +
         s"header id: ${header.encodedId}, skipping broadcast"
@@ -1440,7 +1440,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       processFirstTxProcessingCacheRecord() // resume cache processing
 
     // Peer-received block applied - broadcast to our peers
-    case RemoteBlockApplied(header) =>
+    case RemoteBlockApplied(header, _) =>
       if (header.isNew(2.hours)) {
         broadcastModifierInv(Header.modifierTypeId, header.id)
         header.sectionIds.foreach { case (mtId, id) =>

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -105,9 +105,11 @@ object ErgoNodeViewSynchronizerMessages {
       * Use LocalBlockApplied or RemoteBlockApplied for specific cases.
       *
       * @param header - full block's header
+      * @param txIds  - ids of transactions included into the full block applied
       */
     sealed trait FullBlockApplied extends ModificationOutcome {
       def header: Header
+      def txIds: Seq[ModifierId]
     }
 
     object FullBlockApplied {
@@ -119,13 +121,13 @@ object ErgoNodeViewSynchronizerMessages {
       * The block was already broadcast via NewBlockMined, so no additional
       * inv broadcast is needed.
       */
-    case class LocalBlockApplied(header: Header) extends FullBlockApplied
+    case class LocalBlockApplied(header: Header, txIds: Seq[ModifierId]) extends FullBlockApplied
 
     /**
       * Signal sent when a peer-received full block is applied to state.
       * An inv broadcast should be sent to propagate the block to our peers.
       */
-    case class RemoteBlockApplied(header: Header) extends FullBlockApplied
+    case class RemoteBlockApplied(header: Header, txIds: Seq[ModifierId]) extends FullBlockApplied
 
     /**
       * Signal sent by CandidateGenerator when a new block is mined locally.

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -237,11 +237,12 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
             case Success(stateAfterApply) =>
               history.reportModifierIsValid(modToApply).map { newHis =>
                 if (modToApply.modifierTypeId == ErgoFullBlock.modifierTypeId) {
-                  val header = modToApply.asInstanceOf[ErgoFullBlock].header
+                  val fullBlock = modToApply.asInstanceOf[ErgoFullBlock]
+                  val txIds = fullBlock.blockTransactions.transactions.map(_.id)
                   val event = if (local) {
-                    LocalBlockApplied(header)
+                    LocalBlockApplied(fullBlock.header, txIds)
                   } else {
-                    RemoteBlockApplied(header)
+                    RemoteBlockApplied(fullBlock.header, txIds)
                   }
                   context.system.eventStream.publish(event)
                 }

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -1,12 +1,14 @@
 package org.ergoplatform.mining
 
 import org.ergoplatform.ErgoTreePredef
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.state.ErgoStateContext
 import org.ergoplatform.settings.MonetarySettings
 import org.ergoplatform.utils.{BoxUtils, ErgoCorePropertyTest, RandomWrapper}
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.scalacheck.Gen
+import scorex.util.{ModifierId, bytesToId}
 import sigma.data.ProveDlog
 
 import scala.concurrent.duration._
@@ -278,6 +280,142 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
         defaultMinerPk
       )
     }
+  }
+
+  property("stale emission tx is invalidated when its box was spent by concurrently applied block") {
+    val us0 = createUtxoState(settings)._1
+    us0.emissionBoxOpt should not be None
+    val emissionTx =
+      CandidateGenerator.collectEmission(us0, defaultMinerPk, emptyStateContext).toSeq.head
+
+    val appliedBlock = validFullBlock(None, us0, Seq(emissionTx))
+    val us1          = us0.applyModifier(appliedBlock, None)(_ => ()).get
+
+    val h = appliedBlock.header
+    val upcomingContext = us1.stateContext.upcoming(
+      h.minerPk,
+      h.timestamp,
+      h.nBits,
+      h.votes,
+      emptyVSUpdate,
+      h.version
+    )
+
+    val (collected, invalid) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      parameters.maxBlockCost,
+      parameters.maxBlockSize,
+      us1,
+      upcomingContext,
+      Seq(emissionTx)
+    )
+
+    collected shouldBe empty
+    invalid shouldBe Seq(emissionTx.id)
+  }
+
+  property("mempool transactions spent by applied block are invalidated at next candidate assembly") {
+    val bh       = boxesHolderGen.sample.get
+    val rnd      = new RandomWrapper
+    val us0      = createUtxoState(bh, parameters)
+    val minValue = BoxUtils.sufficientAmount(parameters)
+    val inputs   = bh.boxes.values.toIndexedSeq.filter(_.value >= minValue * 2).takeRight(10)
+    val mempoolTxs =
+      inputs.map(i => validTransactionFromBoxes(IndexedSeq(i), rnd, issueNew = false, feeProp))
+
+    val appliedBlock = validFullBlock(None, us0, mempoolTxs)
+    val us1          = us0.applyModifier(appliedBlock, None)(_ => ()).get
+
+    val h = appliedBlock.header
+    val upcomingContext = us1.stateContext.upcoming(
+      h.minerPk,
+      h.timestamp,
+      h.nBits,
+      h.votes,
+      emptyVSUpdate,
+      h.version
+    )
+
+    val (collected, invalid) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      parameters.maxBlockCost,
+      parameters.maxBlockSize,
+      us1,
+      upcomingContext,
+      mempoolTxs
+    )
+
+    collected shouldBe empty
+    invalid should contain theSameElementsAs mempoolTxs.map(_.id)
+  }
+
+  property("zero-fee transactions are collected without creating fee transaction") {
+    val bh       = boxesHolderGen.sample.get
+    val rnd      = new RandomWrapper
+    val us       = createUtxoState(bh, parameters)
+    val minValue = BoxUtils.sufficientAmount(parameters)
+    val inputs   = bh.boxes.values.toIndexedSeq.filter(_.value >= minValue * 2).takeRight(5)
+    val zeroFeeTxs = inputs.map(i => validTransactionFromBoxes(IndexedSeq(i), rnd, issueNew = false))
+
+    val h = validFullBlock(None, us, bh, rnd).header
+    val upcomingContext = us.stateContext.upcoming(
+      h.minerPk,
+      h.timestamp,
+      h.nBits,
+      h.votes,
+      emptyVSUpdate,
+      h.version
+    )
+
+    val (collected, invalid) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      parameters.maxBlockCost,
+      parameters.maxBlockSize,
+      us,
+      upcomingContext,
+      zeroFeeTxs
+    )
+
+    invalid shouldBe empty
+    collected should contain theSameElementsAs zeroFeeTxs
+  }
+
+  property("excludeAppliedTxs filters transactions of the applied best block only") {
+    val now = System.currentTimeMillis()
+    def utx(t: ErgoTransaction): UnconfirmedTransaction =
+      new UnconfirmedTransaction(t, None, now, now, None, None)
+
+    val tx1 = validErgoTransactionGen.sample.get._2
+    val tx2 = validErgoTransactionGen.sample.get._2
+    val tx3 = validErgoTransactionGen.sample.get._2
+    val pool = Seq(utx(tx1), utx(tx2), utx(tx3))
+    val appliedId = bytesToId(Array.fill(32)(11.toByte))
+    val otherId = bytesToId(Array.fill(32)(22.toByte))
+
+    CandidateGenerator.excludeAppliedTxs(
+      pool,
+      Some(appliedId -> Set(tx1.id, tx3.id)),
+      Some(appliedId)
+    ).map(_.id) shouldBe Seq(tx2.id)
+
+    CandidateGenerator.excludeAppliedTxs(
+      pool,
+      Some(appliedId -> Set(tx1.id, tx3.id)),
+      Some(otherId)
+    ).map(_.id) shouldBe Seq(tx1.id, tx2.id, tx3.id)
+
+    CandidateGenerator.excludeAppliedTxs(pool, None, Some(appliedId)) shouldBe pool
+
+    CandidateGenerator.excludeAppliedTxs(
+      pool,
+      Some(appliedId -> Set.empty[ModifierId]),
+      Some(appliedId)
+    ) shouldBe pool
+  }
+
+  property("isChainSynced compares best full block id with state context last header id") {
+    CandidateGenerator.isChainSynced(None, emptyStateContext) shouldBe true
+    CandidateGenerator.isChainSynced(Some(bytesToId(Array.fill(32)(33.toByte))), emptyStateContext) shouldBe false
   }
 
   property("it should calculate average block mining time from creation timestamps") {

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -356,6 +356,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     val minValue = BoxUtils.sufficientAmount(parameters)
     val inputs   = bh.boxes.values.toIndexedSeq.filter(_.value >= minValue * 2).takeRight(5)
     val zeroFeeTxs = inputs.map(i => validTransactionFromBoxes(IndexedSeq(i), rnd, issueNew = false))
+    zeroFeeTxs should not be empty
 
     val h = validFullBlock(None, us, bh, rnd).header
     val upcomingContext = us.stateContext.upcoming(

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.mining
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
@@ -9,15 +9,21 @@ import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.FullBlockApplied
-import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.LocallyGeneratedTransaction
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, FullBlockApplied, LocalBlockApplied}
+
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{EliminateTransactions, LocallyGeneratedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
-import org.ergoplatform.nodeView.history.ErgoHistoryReader
+import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
+import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
 import org.ergoplatform.settings.NetworkType.DevNet60
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.ErgoTestHelpers
+import org.ergoplatform.utils.generators.ValidBlocksGenerators.{createUtxoState, validFullBlock, validTransactionsFromBoxHolder}
+import org.ergoplatform.utils.generators.ChainGenerator.{applyChain, genHeaderChain}
+import org.ergoplatform.utils.{HistoryTestHelpers, RandomWrapper}
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
@@ -1147,6 +1153,153 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case FullBlockApplied(header) if header.id != solvedBlock.header.parentId => true
       case _ => false
     }
+
+    system.terminate()
+  }
+
+  private class FixedReadersHolder(readers: Readers) extends Actor {
+    override def receive: Receive = {
+      case GetReaders => sender() ! readers
+    }
+  }
+
+  private def walletStub(implicit system: ActorSystem): ErgoWalletReader = new ErgoWalletReader {
+    val walletActor: ActorRef = system.deadLetters
+  }
+
+  private def testSettings(directory: String): ErgoSettings = {
+    defaultSettings.copy(
+      directory = directory,
+      nodeSettings = defaultSettings.nodeSettings.copy(
+        blockCandidateGenerationInterval = 1.second
+      )
+    )
+  }
+
+  private def historyWithBestFullBlock(blocks: Seq[ErgoFullBlock]): ErgoHistory = {
+    val h0 = HistoryTestHelpers.generateHistory(
+      verifyTransactions = true,
+      stateType = StateType.Utxo,
+      PoPoWBootstrap = false,
+      blocksToKeep = 100
+    )
+    val h1 = applyChain(h0, blocks)
+    val extraHeaders = genHeaderChain(2, h1, diffBitsOpt = None, useRealTs = false)
+    extraHeaders.headers.drop(h1.headersHeight).foldLeft(h1) { case (h, header) =>
+      h.append(header).get._1
+    }
+  }
+
+  it should "exclude applied transactions from stale mempool and not eliminate them" in new TestKit(
+    ActorSystem()
+  ) {
+
+    val testDir = s"${defaultSettings.directory}-a1-stale-${System.currentTimeMillis()}"
+    val settings = testSettings(testDir)
+    val viewHolderProbe = TestProbe()
+    val senderProbe = TestProbe()
+
+    val (us0, bh0) = createUtxoState(settings)
+    val rnd = new RandomWrapper
+
+    val (txs1, bh1) = validTransactionsFromBoxHolder(bh0, rnd)
+    txs1 should not be empty
+    val block1 = validFullBlock(None, us0, txs1)
+    val us1 = us0.applyModifier(block1, None)(_ => ()).get
+
+    val (txs2, _) = validTransactionsFromBoxHolder(bh1, rnd)
+    txs2 should not be empty
+    val tx = txs2.head
+    val block2 = validFullBlock(Some(block1), us1, txs2)
+    val us2 = us1.applyModifier(block2, None)(_ => ()).get
+
+    val history0 = HistoryTestHelpers.generateHistory(
+      verifyTransactions = true,
+      stateType = StateType.Utxo,
+      PoPoWBootstrap = false,
+      blocksToKeep = 100
+    )
+    val history2 = applyChain(history0, Seq(block1, block2))
+
+    val wallet = walletStub
+    val emptyMempool = ErgoMemPool.empty(settings)
+    val readers = Readers(history2, us2, emptyMempool, wallet)
+
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
+    val candidateGenerator = CandidateGenerator(
+      defaultMinerSecret.publicImage,
+      readersHolderRef,
+      viewHolderProbe.ref,
+      settings
+    )
+
+    // let the actor initialize and generate an initial candidate with the empty mempool
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), senderProbe.ref)
+    senderProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(_: Candidate) => ()
+    }
+
+    candidateGenerator ! LocalBlockApplied(block2.header, Seq(tx.id))
+
+    val staleMempool = ErgoMemPool.empty(settings).put(Seq(UnconfirmedTransaction(tx, None)))
+    staleMempool.getAllPrioritized.map(_.id) should contain(tx.id)
+    candidateGenerator ! ChangedMempool(staleMempool)
+
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), senderProbe.ref)
+
+    val candidate = senderProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+
+    candidate.candidateBlock.transactions should not be empty
+    candidate.candidateBlock.transactions.map(_.id) should not contain tx.id
+
+    val eliminatedIds = viewHolderProbe.receiveWhile(500.millis) {
+      case e: EliminateTransactions => e
+    }.flatMap(_.ids)
+    eliminatedIds should not contain tx.id
+
+    system.terminate()
+  }
+
+  it should "discard candidate when history and state are out of sync" in new TestKit(
+    ActorSystem()
+  ) {
+
+    val testDir = s"${defaultSettings.directory}-b1-sync-${System.currentTimeMillis()}"
+    val settings = testSettings(testDir)
+    val viewHolderProbe = TestProbe()
+    val senderProbe = TestProbe()
+
+    val (us0, bh0) = createUtxoState(settings)
+    val rnd = new RandomWrapper
+    val (txs1, bh1) = validTransactionsFromBoxHolder(bh0, rnd)
+    txs1 should not be empty
+
+    val block1 = validFullBlock(None, us0, txs1)
+    val us1 = us0.applyModifier(block1, None)(_ => ()).get
+    val history1 = historyWithBestFullBlock(Seq(block1))
+
+    val (txs2, _) = validTransactionsFromBoxHolder(bh1, rnd)
+    txs2 should not be empty
+    val block2 = validFullBlock(Some(block1), us1, txs2)
+    val us2 = us1.applyModifier(block2, None)(_ => ()).get
+
+    val mempool = ErgoMemPool.empty(settings)
+    val wallet = walletStub
+    val readers = Readers(history1, us2, mempool, wallet)
+
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
+    val candidateGenerator = CandidateGenerator(
+      defaultMinerSecret.publicImage,
+      readersHolderRef,
+      viewHolderProbe.ref,
+      settings
+    )
+
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), senderProbe.ref)
+    senderProbe.expectNoMessage(2.seconds)
+    viewHolderProbe.expectNoMessage(500.millis)
 
     system.terminate()
   }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -972,7 +972,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       }
 
       // Second: LocalBlockApplied for same header should NOT send additional invs
-      synchronizerMockRef ! LocalBlockApplied(newBlock.header)
+      synchronizerMockRef ! LocalBlockApplied(newBlock.header, newBlock.transactions.map(_.id))
 
       // Should receive no additional InvSpec messages
       ncProbe.expectNoMessage(1.second)
@@ -1008,7 +1008,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       }
 
       // LocalBlockApplied for same block should NOT broadcast again
-      synchronizerMockRef ! LocalBlockApplied(newBlock.header)
+      synchronizerMockRef ! LocalBlockApplied(newBlock.header, newBlock.transactions.map(_.id))
 
       // Should receive no additional InvSpec messages
       ncProbe.expectNoMessage(1.second)
@@ -1032,7 +1032,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       val newBlock = statefulyValidFullBlock(wus)
 
       // Send RemoteBlockApplied to synchronizer
-      synchronizerMockRef ! RemoteBlockApplied(newBlock.header)
+      synchronizerMockRef ! RemoteBlockApplied(newBlock.header, newBlock.transactions.map(_.id))
 
       // Expect 4 inv messages (1 header + 3 sections)
       val invMessages = (0 until 4).map { _ =>
@@ -1114,12 +1114,12 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
       val newBlock = statefulyValidFullBlock(wus)
 
       // Send LocalBlockApplied - should not broadcast but should perform cleanup
-      synchronizerMockRef ! LocalBlockApplied(newBlock.header)
+      synchronizerMockRef ! LocalBlockApplied(newBlock.header, newBlock.transactions.map(_.id))
       ncProbe.expectNoMessage(500.millis)
 
       // Send RemoteBlockApplied - should broadcast (different block)
       val newBlock2 = statefulyValidFullBlock(wus)
-      synchronizerMockRef ! RemoteBlockApplied(newBlock2.header)
+      synchronizerMockRef ! RemoteBlockApplied(newBlock2.header, newBlock2.transactions.map(_.id))
 
       // Expect 4 inv messages (1 header + 3 sections)
       val invMessages = (0 until 4).map { _ =>

--- a/src/test/scala/org/ergoplatform/nodeView/NodeViewSynchronizerTests.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/NodeViewSynchronizerTests.scala
@@ -105,7 +105,7 @@ trait NodeViewSynchronizerTests[ST <: ErgoState[ST]] extends AnyPropSpec
   property("NodeViewSynchronizer: SemanticallySuccessfulModifier") {
     withFixture { ctx =>
       import ctx._
-      node ! RemoteBlockApplied(mod.asInstanceOf[Header]) //todo: fix
+      node ! RemoteBlockApplied(mod.asInstanceOf[Header], Seq.empty) //todo: fix
       ncProbe.fishForMessage(3 seconds) { case m => m.isInstanceOf[SendToNetwork] }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -328,7 +328,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     lock.lock()
     created.await()
     val newBestHeaderOpt = history.typedModifierById[Header](history.headerIdsAtHeight(history.fullBlockHeight).last)
-    indexer ! RemoteBlockApplied(newBestHeaderOpt.get) // will be ignored
+    indexer ! RemoteBlockApplied(newBestHeaderOpt.get, Seq.empty) // will be ignored
     indexer ! CreateDB(HEIGHT + 1)
     lock.lock()
     created.await()


### PR DESCRIPTION
In this PR: 
* transaction ids from the block applied are used in candidate generation to filter out quickly transactions which can be in the mempool yet 
* extra check that blockchain is synced after candidate generation (and discarding candidate if blockchain is not synced, then a new candidate will be generated quickly on new FullBlockApplied signal)