### PR TITLE
Wallet must not spend boxes tracked by external scans only (#1905)

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -403,7 +403,7 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       val confirmed = state.registry.walletUnspentBoxes(state.maxInputsToUse * BoxSelector.ScanDepthFactor)
       if (considerUnconfirmed) {
         // We filter out spent boxes in the same way as wallet does when assembling a transaction
-        (confirmed ++ state.offChainRegistry.offChainBoxes).filter(state.walletFilter)
+        (confirmed ++ state.offChainRegistry.walletOffChainBoxes).filter(state.walletFilter)
       } else {
         confirmed
       }
@@ -411,7 +411,7 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       val confirmed = state.registry.walletConfirmedBoxes()
       if (considerUnconfirmed) {
         // Just adding boxes created off-chain
-        confirmed ++ state.offChainRegistry.offChainBoxes
+        confirmed ++ state.offChainRegistry.walletOffChainBoxes
       } else {
         confirmed
       }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -121,7 +121,7 @@ case class ErgoWalletState(
     */
   def getBoxesToSpend: Seq[TrackedBox] = {
     require(walletVars.publicKeyAddresses.nonEmpty, "No public keys in the prover to extract change address from")
-    (registry.walletUnspentBoxes(maxInputsToUse * BoxSelector.ScanDepthFactor) ++ offChainRegistry.offChainBoxes).distinct
+    (registry.walletUnspentBoxes(maxInputsToUse * BoxSelector.ScanDepthFactor) ++ offChainRegistry.walletOffChainBoxes).distinct
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/OffChainRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/OffChainRegistry.scala
@@ -39,6 +39,13 @@ case class OffChainRegistry(height: Int,
   }
 
   /**
+    * Off-chain boxes belonging to the wallet itself (i.e. tracked by the payments scan),
+    * excluding boxes tracked by external application scans only, which must not be
+    * spent by wallet transactions (see #1905).
+    */
+  def walletOffChainBoxes: Seq[TrackedBox] = offChainBoxes.filter(_.scans.contains(PaymentsScanId))
+
+  /**
     * Update on receiving new off-chain transaction.
     */
   def updateOnTransaction(newBoxes: Seq[TrackedBox],

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -433,4 +433,36 @@ class ErgoWalletServiceSpec
     }
   }
 
+
+  property("wallet-related APIs should not use boxes belonging to external scans only") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val customScanId = ScanId @@ 42.shortValue()
+        val emptyTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq())
+        val walletBox =
+          TrackedBox(emptyTx, creationOutIndex = 0, None, testBox(1000000000L, TrueTree, 0), Set(PaymentsScanId))
+        val customScanBox =
+          TrackedBox(emptyTx, creationOutIndex = 1, None, testBox(2000000000L, TrueTree, 0, boxIndex = 1), Set(customScanId))
+        val sharedBox =
+          TrackedBox(emptyTx, creationOutIndex = 2, None, testBox(3000000000L, TrueTree, 0, boxIndex = 2), Set(PaymentsScanId, customScanId))
+
+        val offChainRegistry =
+          OffChainRegistry.empty.copy(offChainBoxes = Seq(walletBox, customScanBox, sharedBox))
+        val walletState = initialState(store, versionedStore).copy(offChainRegistry = offChainRegistry)
+        val walletService = new ErgoWalletServiceImpl(settings)
+
+        // boxes the wallet can spend must not include boxes tracked by external scans only
+        walletState.getBoxesToSpend.map(_.boxId) should contain theSameElementsAs Seq(walletBox.boxId, sharedBox.boxId)
+
+        // /wallet/boxes/unspent with considerUnconfirmed must not return them either
+        val unspent = walletService.getWalletBoxes(walletState, unspentOnly = true, considerUnconfirmed = true)
+        unspent.map(_.trackedBox.boxId) should contain theSameElementsAs Seq(walletBox.boxId, sharedBox.boxId)
+
+        // while scan-related API still sees the box of the external scan
+        val scanBoxes = walletService.getScanUnspentBoxes(walletState, customScanId, considerUnconfirmed = true, 0, Int.MaxValue)
+        scanBoxes.map(_.trackedBox.boxId) should contain theSameElementsAs Seq(customScanBox.boxId, sharedBox.boxId)
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Closes #1905

## The problem

As reported in #1905, `/wallet/payment/send` could try to spend boxes belonging to a custom application scan not shared with the wallet, while `/wallet/boxes/unspent` (with default parameters) does not even return such boxes.

Cause: `ErgoWalletState.getBoxesToSpend` assembles spendable boxes as `registry.walletUnspentBoxes(...) ++ offChainRegistry.offChainBoxes`. The confirmed part is correctly limited to the wallet's payments scan, but `OffChainRegistry.offChainBoxes` holds the off-chain boxes of **all** scans (it also serves the scan APIs), including boxes tracked only by external application scans. So any unconfirmed box matching a custom scan became spendable by wallet transactions. The same leak affected `/wallet/boxes/unspent?considerUnconfirmed=true`.

## The fix

- New `OffChainRegistry.walletOffChainBoxes`: off-chain boxes tracked by the wallet's `PaymentsScanId` (which includes boxes of scans *shared* with the wallet, and excludes external-scan-only boxes).
- `ErgoWalletState.getBoxesToSpend` and `ErgoWalletService.getWalletBoxes` (both `unspentOnly` branches) now use it.
- Scan-related APIs (`getScanUnspentBoxes` etc.) keep using the unfiltered `offChainBoxes`, so external scans still see their unconfirmed boxes.

## Testing

New property in `ErgoWalletServiceSpec` with three off-chain boxes — wallet-only, external-scan-only, and shared (wallet + external scan): `getBoxesToSpend` and `getWalletBoxes(considerUnconfirmed = true)` must return the wallet and shared boxes but not the external-scan-only one, while `getScanUnspentBoxes` for the external scan still returns its two boxes.

The whole `ErgoWalletServiceSpec` suite passes locally.