### PR TITLE
Fix flaky UtxoStateNodesSyncSpec: compare best-chain headers, not every known header

### DIFF
--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -37,9 +37,16 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
       log.info(
         s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
       )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
     Await.result(result, 15.minutes)
   }


### PR DESCRIPTION
## The problem

The `Run it node tests` CI job has been red on `master` since 4a7dba0 (2026-07-08), so every pull request currently shows a failing check. The failing assertion is always the same:

```
- should Utxo state nodes synchronisation (5 blocks) *** FAILED ***
  List("a369836d…", "9b7eb811…", "a369836d…", "9b7eb811…", "a369836d…", "a369836d…")
    did not contain only ("a369836d…") (UtxoStateNodesSyncSpec.scala:42)
```

Four nodes are queried, but six ids come back: two of them know **two** headers at that height.

## Why it happens

`/blocks/at/{height}` returns *every* header id known at the given height, not only the one on the best chain. From the scaladoc of `HeadersProcessor.headerIdsAtHeight`:

> single id if no forks on this height
> multiple ids if there are forks at chosen height.
> **First id is always from the best headers chain.**

The spec mines with three generating nodes and then compares `headers.flatten`, i.e. the union of every header each node has seen at that height, orphaned ones included. The checked height is `initHeight + blocksQty - forkDepth` and `forkDepth == blocksQty`, so it is the *starting* height — exactly where competing blocks are most likely while several miners race from the genesis block.

The result is that the test fails whenever a short fork occurred and was correctly resolved, i.e. on a perfectly synchronised network.

The neighbouring integration specs already handle this correctly: `ForkResolutionSpec` compares `headerIdsByHeight(...).headOption` and `DeepRollBackSpec` uses `.head`.

## The fix

Compare the best-chain header of each node (the first returned id) instead of the flattened union, and assert explicitly that no node is missing a header at that height. This preserves the property the test is meant to verify — all nodes converge to the same chain — without failing on forks that were already resolved.

Test-only change, no production code touched.