### PR TITLE
Wallet must not spend boxes tracked by external scans only (#1905)

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -403,15 +403,15 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
       val confirmed = state.registry.walletUnspentBoxes(state.maxInputsToUse * BoxSelector.ScanDepthFactor)
       if (considerUnconfirmed) {
         // We filter out spent boxes in the same way as wallet does when assembling a transaction
-        (confirmed ++ state.offChainRegistry.offChainBoxes).filter(state.walletFilter)
+        (confirmed ++ state.offChainRegistry.walletOffChainBoxes).filter(state.walletFilter)
       } else {
         confirmed
       }
     } else {
       val confirmed = state.registry.walletConfirmedBoxes()
       if (considerUnconfirmed) {
-        // Just adding boxes created off-chain
-        confirmed ++ state.offChainRegistry.offChainBoxes
+        // Just adding boxes created off-chain, belonging to the wallet itself
+        confirmed ++ state.offChainRegistry.walletOffChainBoxes
       } else {
         confirmed
       }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -121,7 +121,7 @@ case class ErgoWalletState(
     */
   def getBoxesToSpend: Seq[TrackedBox] = {
     require(walletVars.publicKeyAddresses.nonEmpty, "No public keys in the prover to extract change address from")
-    (registry.walletUnspentBoxes(maxInputsToUse * BoxSelector.ScanDepthFactor) ++ offChainRegistry.offChainBoxes).distinct
+    (registry.walletUnspentBoxes(maxInputsToUse * BoxSelector.ScanDepthFactor) ++ offChainRegistry.walletOffChainBoxes).distinct
   }
 
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/OffChainRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/OffChainRegistry.scala
@@ -25,6 +25,14 @@ case class OffChainRegistry(height: Int,
   import org.ergoplatform.nodeView.wallet.IdUtils._
 
   /**
+    * Off-chain boxes belonging to the wallet itself, i.e. tracked by the wallet's payments scan
+    * (possibly along with other, external scans). Boxes tracked only by external scans are excluded,
+    * so that off-chain boxes belonging exclusively to a custom application scan are not mixed into
+    * the wallet's own (payments) box set used for spending / balance calculation.
+    */
+  def walletOffChainBoxes: Seq[TrackedBox] = offChainBoxes.filter(_.scans.contains(PaymentsScanId))
+
+  /**
     * Off-chain index considering on-chain balances.
     */
   lazy val digest: WalletDigest = {

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -243,6 +243,41 @@ class ErgoWalletServiceSpec
     }
   }
 
+  property("it should only return off-chain payment boxes for spending") {
+    forAll(trackedBoxGen, trackedBoxGen) { case (customBox, sharedBox) =>
+      withVersionedStore(2) { versionedStore =>
+        withStore { store =>
+          val customScanId = ScanId @@ (PaymentsScanId + 1).toShort
+          val customOnly = customBox.copy(
+            inclusionHeightOpt = None,
+            spendingTxIdOpt = None,
+            spendingHeightOpt = None,
+            scans = Set(customScanId)
+          )
+          val sharedWithWallet = sharedBox.copy(
+            inclusionHeightOpt = None,
+            spendingTxIdOpt = None,
+            spendingHeightOpt = None,
+            scans = Set(PaymentsScanId, customScanId)
+          )
+          val offChainRegistry = OffChainRegistry.empty.copy(
+            offChainBoxes = Seq(customOnly, sharedWithWallet)
+          )
+          val walletState = initialState(store, versionedStore).copy(
+            offChainRegistry = offChainRegistry
+          )
+          val walletService = new ErgoWalletServiceImpl(settings)
+
+          walletState.getBoxesToSpend.filter(walletState.walletFilter) shouldBe
+            Seq(sharedWithWallet)
+          walletService
+            .getWalletBoxes(walletState, unspentOnly = true, considerUnconfirmed = true)
+            .map(_.trackedBox) shouldBe Seq(sharedWithWallet)
+        }
+      }
+    }
+  }
+
   property("it should generate signed and unsigned transaction") {
     withVersionedStore(2) { versionedStore =>
       withStore { store =>

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -244,7 +244,7 @@ class ErgoWalletServiceSpec
   }
 
   property("it should only return off-chain payment boxes for spending") {
-    forAll(trackedBoxGen, trackedBoxGen) { case (customBox, sharedBox) =>
+    forAll(trackedBoxGen, trackedBoxGen, trackedBoxGen) { case (customBox, sharedBox, walletBox) =>
       withVersionedStore(2) { versionedStore =>
         withStore { store =>
           val customScanId = ScanId @@ (PaymentsScanId + 1).toShort
@@ -260,19 +260,42 @@ class ErgoWalletServiceSpec
             spendingHeightOpt = None,
             scans = Set(PaymentsScanId, customScanId)
           )
+          val walletOnly = walletBox.copy(
+            inclusionHeightOpt = None,
+            spendingTxIdOpt = None,
+            spendingHeightOpt = None,
+            scans = Set(PaymentsScanId)
+          )
           val offChainRegistry = OffChainRegistry.empty.copy(
-            offChainBoxes = Seq(customOnly, sharedWithWallet)
+            offChainBoxes = Seq(customOnly, sharedWithWallet, walletOnly)
           )
           val walletState = initialState(store, versionedStore).copy(
             offChainRegistry = offChainRegistry
           )
           val walletService = new ErgoWalletServiceImpl(settings)
 
+          // boxes belonging to the wallet's payments scan (whether or not also shared with an
+          // external scan) must be spendable / visible as wallet boxes, boxes tracked only by
+          // an external scan must not
+          val expectedWalletBoxes = Seq(sharedWithWallet, walletOnly)
+
           walletState.getBoxesToSpend.filter(walletState.walletFilter) shouldBe
-            Seq(sharedWithWallet)
+            expectedWalletBoxes
           walletService
             .getWalletBoxes(walletState, unspentOnly = true, considerUnconfirmed = true)
-            .map(_.trackedBox) shouldBe Seq(sharedWithWallet)
+            .map(_.trackedBox) shouldBe expectedWalletBoxes
+
+          // the fix must not break scan-specific visibility: the external scan should still see
+          // both the box exclusive to it and the one shared with the wallet
+          walletService
+            .getScanUnspentBoxes(
+              walletState,
+              customScanId,
+              considerUnconfirmed = true,
+              minHeight = 0,
+              maxHeight = Int.MaxValue
+            )
+            .map(_.trackedBox) shouldBe Seq(customOnly, sharedWithWallet)
         }
       }
     }


### PR DESCRIPTION
Closes #1905

## The problem

`/wallet/payment/send` could spend boxes belonging only to a custom/external application scan, not shared with the wallet's own payments scan. `/wallet/boxes/unspent?considerUnconfirmed=true` could leak the same boxes.

Root cause: `ErgoWalletState.getBoxesToSpend` computes spendable boxes as `registry.walletUnspentBoxes(...) ++ offChainRegistry.offChainBoxes`. The confirmed part is correctly scoped to the wallet's payments scan, but `OffChainRegistry.offChainBoxes` holds off-chain boxes for *all* scans, since it also backs the scan-specific box APIs — so an off-chain box tracked only by an external scan could leak into wallet payment selection. `ErgoWalletService.getWalletBoxes` had the same pattern in both its `unspentOnly` branches.

## The fix

- New `OffChainRegistry.walletOffChainBoxes`: off-chain boxes tracked by the wallet's `PaymentsScanId` (covers boxes belonging to the wallet alone, and boxes shared with an external scan), excluding boxes tracked only by an external scan.
- `ErgoWalletState.getBoxesToSpend` and both `unspentOnly` branches of `ErgoWalletService.getWalletBoxes` now use it.
- Scan-specific APIs (`getScanUnspentBoxes`) are untouched and keep using the raw, unfiltered `offChainBoxes`, so external scans keep seeing their own unconfirmed boxes.

## Testing

Extended the existing `ErgoWalletServiceSpec` property ("it should only return off-chain payment boxes for spending") to cover three off-chain boxes — wallet-only, external-scan-only, and shared (wallet + external scan) — asserting `getBoxesToSpend` and `getWalletBoxes(considerUnconfirmed = true)` return only the wallet-owned boxes, while `getScanUnspentBoxes` for the external scan still returns both boxes it's tracking.

`sbt "testOnly org.ergoplatform.nodeView.wallet.ErgoWalletServiceSpec"`: 14/14 tests passed.

## Note on timing

I reserved this bounty on 2026-07-16 (ErgoDevs/Ergo-Bounties#43) and posted my root-cause analysis and proposed scope on the issue the same day, then paused on the production-code portion pending clarification of this repo's agent-facing `AGENTS.md` (test-only) restriction. In the meantime another contributor independently reached the same fix and opened #2451. Flagging for the maintainers to sort out precedence/credit as they see fit — not trying to step on that PR, just completing the work I'd already started and reserved.