### PR TITLE
Unite p2sAddress and p2shAddress routes (#2213)

### DIFF
--- a/src/main/scala/org/ergoplatform/http/api/ScriptApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/ScriptApiRoute.scala
@@ -70,37 +70,30 @@ case class ScriptApiRoute(readersHolder: ActorRef, ergoSettings: ErgoSettings)
     onSuccess((readersHolder ? GetReaders).mapTo[Readers].map(r => op(r)))(toRoute)
   }
 
-  // todo: unite p2sAddress and p2shAddress, https://github.com/ergoplatform/ergo/issues/2213
-  private def p2sAddressR: Route = (path("p2sAddress") & post & entity(as[CompileRequest])) { compileRequest =>
-    withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
-      onSuccess(addrsF) { addrs =>
-        val scriptVersion = Header.scriptFromBlockVersion(bv)
-        val treeVersion = compileRequest.treeVersion
-        VersionContext.withVersions(scriptVersion, treeVersion) {
-          compileSource(compileRequest.source, keysToEnv(addrs.map(_.pubkey)), treeVersion).map(Pay2SAddress.apply).fold(
-            e => BadRequest(e.getMessage),
-            address => ApiResponse(addressResponse(address))
-          )
+  /**
+    * Shared implementation behind `p2sAddressR` and `p2shAddressR`: compiles the submitted
+    * source against the requester's public keys and wraps the resulting `ErgoTree` with
+    * `wrapAddress`, differing only in whether the result is a P2S or P2SH address.
+    */
+  private def compiledAddressR(wrapAddress: ErgoTree => ErgoAddress): Route =
+    (post & entity(as[CompileRequest])) { compileRequest =>
+      withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
+        onSuccess(addrsF) { addrs =>
+          val scriptVersion = Header.scriptFromBlockVersion(bv)
+          val treeVersion = compileRequest.treeVersion
+          VersionContext.withVersions(scriptVersion, treeVersion) {
+            compileSource(compileRequest.source, keysToEnv(addrs.map(_.pubkey)), treeVersion).map(wrapAddress).fold(
+              e => BadRequest(e.getMessage),
+              address => ApiResponse(addressResponse(address))
+            )
+          }
         }
       }
     }
-  }
 
+  private def p2sAddressR: Route = path("p2sAddress") { compiledAddressR(Pay2SAddress.apply) }
 
-  private def p2shAddressR: Route = (path("p2shAddress") & post & entity(as[CompileRequest])) { compileRequest =>
-    withWalletAndStateOp(r => (r.w.publicKeys(0, loadMaxKeys), r.s.stateContext.blockVersion)) { case (addrsF, bv) =>
-      onSuccess(addrsF) { addrs =>
-        val scriptVersion = Header.scriptFromBlockVersion(bv)
-        val treeVersion = compileRequest.treeVersion
-        VersionContext.withVersions(scriptVersion, treeVersion) {
-          compileSource(compileRequest.source, keysToEnv(addrs.map(_.pubkey)), treeVersion).map(Pay2SHAddress.apply).fold(
-            e => BadRequest(e.getMessage),
-            address => ApiResponse(addressResponse(address))
-          )
-        }
-      }
-    }
-  }
+  private def p2shAddressR: Route = path("p2shAddress") { compiledAddressR(Pay2SHAddress.apply) }
 
 
   private def executeWithContextR: Route =


### PR DESCRIPTION
Closes #2213

## Summary

`ScriptApiRoute.p2sAddressR` and `p2shAddressR` were nearly identical, differing only in whether the compiled `ErgoTree` was wrapped with `Pay2SAddress.apply` or `Pay2SHAddress.apply`, per the repo's own `// todo: unite p2sAddress and p2shAddress` comment referencing this issue.

Extracted the shared logic into `compiledAddressR(wrapAddress: ErgoTree => ErgoAddress)`, and both routes now delegate to it:

```scala
private def p2sAddressR: Route = path("p2sAddress") { compiledAddressR(Pay2SAddress.apply) }
private def p2shAddressR: Route = path("p2shAddress") { compiledAddressR(Pay2SHAddress.apply) }
```

No behavior change: same request handling, validation, and response shape for both routes.

## Testing

`sbt "testOnly org.ergoplatform.http.routes.ScriptApiRouteSpec"` — 10/10 passed, run in an isolated Docker sandbox against upstream `master` (`4a7dba0`), including the two directly relevant cases:

```
[info] ScriptApiRouteSpec:
[info] - should execute script with context
[info] - should generate valid P2SAddress form source
[info] - should generate valid P2SHAddress form source
[info] - should get through address <-> ergoTree round-trip
[info] - should address <-> bytes roundtrip via addressToBytes
[info] - should generate addresses with different tree versions
[info] - should handle tree version 2 for P2SH address
[info] - should generate consistent addresses for same script and version
[info] - should generate different addresses for different tree versions
[info] - should handle P2SH with tree version 1 (should still use version 0)
[info] Tests: succeeded 10, failed 0, canceled 0, ignored 0, pending 0
```

## Note on prior attempt

An earlier PR for this issue (#2250) received a maintainer approval (@kushti) but was closed unmerged without comment, and no PR has been open against it since. Reserved via [ErgoDevs/Ergo-Bounties](https://github.com/ErgoDevs/Ergo-Bounties) before opening this.