### PR TITLE
Make 'transaction with too many inputs should be rejected' deterministic

### DIFF
--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {


### PR DESCRIPTION
Closes #2095.

## The flaky test

The unstable test is `property("transaction with too many inputs should be rejected")`, today in `ErgoNodeTransactionSpec` (it was in `ErgoTransactionSpec` when the issue was filed).

It calibrated a wall-clock budget on the machine running it:

```scala
val Timeout: Long = {
  val hf = Blake2b256
  (1 to 5000000).foreach(i => hf(s"$i-$i"))   // "just in case to heat up JVM"
  val t0 = System.currentTimeMillis()
  (1 to 250000).foreach(i => hf(s"$i"))
  System.currentTimeMillis() - t0
}
```

and then asserted `time0 <= Timeout` for the cost-limited validation and `time > Timeout` for the unlimited one.

The calibration window and the two measurement windows are three separate slices of wall time. On a contended CI runner they get different shares of the CPU, so either assertion can flip without anything being wrong with the node:

* calibration gets a full core, measurement gets preempted -> `time0 > Timeout` -> the first assertion fails;
* calibration gets preempted, measurement runs clean -> `time <= Timeout` -> the second assertion fails.

A GC pause landing in one window and not the others does the same thing.

## The fix

What actually protects the node from this transaction is the **block cost limit**, not the clock; the cost model exists precisely so that time does not have to be measured. So the assertions are now on cost, which is deterministic:

* with the default parameters the transaction is rejected, and the failure is `bsBlockTransactionsCost` — unchanged, this assertion was already there and was never the flaky one;
* with a cost limit high enough to let it through, validation succeeds and the cost it accumulates is **more than twice** the block limit. Measured today: block limit `1_000_000`, full cost `4_362_200`, a ratio of 4.4. The generator is called as `validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)`, and `boxesGenTemplate` is given `minInputs = maxInputs = 2000`, so the input count — and hence the cost — is fixed rather than sampled;
* and it is rejected by any limit below that cost, one unit below included.

The 5,000,000-hash warm-up and the 250,000-hash calibration are gone, which also takes several seconds off the suite. `BenchmarkUtil` and `Blake2b256` were used only here and their imports are removed.

## What is no longer asserted

The old test also implied "the rejection is fast because validation aborts as soon as the limit is passed, instead of validating all 2000 inputs". I did not try to replace that with a timing ratio between the two measurements: it would be less flaky than the absolute budget but still timing-based, and a single GC pause could still invert it. The cost assertions cover the property the node depends on — the transaction costs far more than a block may spend, and any limit below its cost rejects it.

Happy to add an instrumented check of the early abort if you would rather keep that guarantee explicitly covered; it needs a hook that does not exist today.

## Note on #2267

#2267 targets this issue but I don't think it can fix it: it edits `ergo-core/src/test/.../ErgoTransactionSpec.scala` — a file created in 2024, after the issue was filed — and swaps `.toEither.left.get` for a `Failure`/`Success` match on two fully deterministic tests. The timing-based property it does not touch is the unstable one.

`sbt "testOnly org.ergoplatform.modifiers.mempool.ErgoNodeTransactionSpec"` — 19 tests, green.