### PR TITLE
Log API queries at DEBUG level

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -30,6 +30,10 @@
         </encoder>
     </appender>
 
+    <!-- Uncomment to log every HTTP query served by the node: method, URI, status and duration.
+         Request and response bodies are not logged. -->
+    <!-- <logger name="org.ergoplatform.http.ErgoHttpService" level="DEBUG"/> -->
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>

--- a/src/main/scala/org/ergoplatform/http/ErgoHttpService.scala
+++ b/src/main/scala/org/ergoplatform/http/ErgoHttpService.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.directives.RouteDirectives
 import scorex.core.api.http.{ApiErrorHandler, ApiRejectionHandler, ApiRoute, CorsHandler}
 import akka.http.scaladsl.model.headers._
+import scorex.util.ScorexLogging
 
 import scala.collection.immutable
 
@@ -15,7 +16,7 @@ final case class ErgoHttpService(
   apiRoutes: Seq[ApiRoute],
   swaggerRoute: SwaggerRoute,
   panelRoute: NodePanelRoute
-)(implicit val system: ActorSystem) extends CorsHandler {
+)(implicit val system: ActorSystem) extends CorsHandler with ScorexLogging {
 
   def rejectionHandler: RejectionHandler = ApiRejectionHandler.rejectionHandler
 
@@ -36,15 +37,41 @@ final case class ErgoHttpService(
     super.respondWithHeaders(corsResponseHeaders)
   }
 
+  /**
+    * Logs every query served by the node's HTTP interface: method, relative URI (path and query
+    * string), response status and how long it took.
+    *
+    * Bodies are deliberately not logged, as requests carry secrets (a mnemonic on
+    * `/wallet/restore`, a password on `/wallet/unlock`, and so on) and responses can be large.
+    *
+    * Off by default, since the root logger is at INFO. To switch it on, add to `logback.xml`:
+    * {{{
+    *   <logger name="org.ergoplatform.http.ErgoHttpService" level="DEBUG"/>
+    * }}}
+    * When it is off, the message is never built: `log.debug` is a macro guarded by `isDebugEnabled`.
+    */
+  private val logQueries: Directive0 =
+    extractRequest.flatMap { request =>
+      val startTime = System.currentTimeMillis()
+      mapResponse { response =>
+        val elapsedMs = System.currentTimeMillis() - startTime
+        log.debug(s"${request.method.value} ${request.uri.toRelative} - " +
+          s"${response.status.intValue()} in $elapsedMs ms")
+        response
+      }
+    }
+
   val compositeRoute: Route =
-    handleRejections(rejectionHandler) {
-      handleExceptions(exceptionHandler) {
-        corsHandler {
-          apiR ~
-            apiSpecR ~
-            swaggerRoute.route ~
-            panelRoute.route ~
-            redirectToSwaggerR
+    logQueries {
+      handleRejections(rejectionHandler) {
+        handleExceptions(exceptionHandler) {
+          corsHandler {
+            apiR ~
+              apiSpecR ~
+              swaggerRoute.route ~
+              panelRoute.route ~
+              redirectToSwaggerR
+          }
         }
       }
     }

--- a/src/test/scala/org/ergoplatform/http/routes/ErgoHttpServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ErgoHttpServiceSpec.scala
@@ -1,0 +1,112 @@
+package org.ergoplatform.http.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
+import ch.qos.logback.core.read.ListAppender
+import org.ergoplatform.http.api.EmissionApiRoute
+import org.ergoplatform.http.{ErgoHttpService, NodePanelRoute, SwaggerRoute}
+import org.ergoplatform.utils.Stubs
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+class ErgoHttpServiceSpec extends AnyFlatSpec
+  with Matchers
+  with ScalatestRouteTest
+  with Stubs {
+
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+
+  private val restApiSettings = settings.scorexSettings.restApi
+
+  private val service = ErgoHttpService(
+    apiRoutes = Seq(EmissionApiRoute(settings)),
+    swaggerRoute = SwaggerRoute(restApiSettings, swaggerConfig = ""),
+    panelRoute = NodePanelRoute()
+  )
+
+  private val route: Route = service.compositeRoute
+
+  private val serviceLogger: LogbackLogger =
+    LoggerFactory.getLogger(classOf[ErgoHttpService]).asInstanceOf[LogbackLogger]
+
+  /** Runs `body` while capturing what the service logs at `level` */
+  private def capturingLogs[T](level: Level)(body: => T): (T, Seq[String]) = {
+    val appender = new ListAppender[ILoggingEvent]
+    appender.start()
+    val previousLevel = serviceLogger.getLevel
+    serviceLogger.setLevel(level)
+    serviceLogger.addAppender(appender)
+    try {
+      val result = body
+      (result, appender.list.asScala.map(_.getFormattedMessage).toList)
+    } finally {
+      serviceLogger.detachAppender(appender)
+      serviceLogger.setLevel(previousLevel)
+      appender.stop()
+    }
+  }
+
+  it should "log served queries at DEBUG level" in {
+    val (_, messages) = capturingLogs(Level.DEBUG) {
+      Get("/emission/at/100") ~> route ~> check {
+        status shouldBe StatusCodes.OK
+      }
+    }
+
+    val logged = messages.filter(_.startsWith("GET /emission/at/100"))
+    logged.size shouldBe 1
+    // method, uri, response status and elapsed time, and nothing else
+    logged.head should fullyMatch regex """GET /emission/at/100 - 200 in \d+ ms"""
+  }
+
+  it should "log the query string, and log unmatched paths with the status they were rejected with" in {
+    val (rejectedStatus, messages) = capturingLogs(Level.DEBUG) {
+      Get("/emission/at/100?foo=bar") ~> route ~> check {
+        status shouldBe StatusCodes.OK
+      }
+      Get("/no/such/route") ~> route ~> check {
+        status.isSuccess() shouldBe false
+        status.intValue()
+      }
+    }
+
+    messages.exists(_.startsWith("GET /emission/at/100?foo=bar - 200 in ")) shouldBe true
+    // rejections are turned into responses by the rejection handler, so they are logged too
+    messages.exists(_.startsWith(s"GET /no/such/route - $rejectedStatus in ")) shouldBe true
+  }
+
+  it should "log nothing when the logger is not at DEBUG level" in {
+    val (_, messages) = capturingLogs(Level.INFO) {
+      Get("/emission/at/100") ~> route ~> check {
+        status shouldBe StatusCodes.OK
+      }
+    }
+
+    messages shouldBe empty
+  }
+
+  it should "not change the response when logging is enabled" in {
+    val body = capturingLogs(Level.DEBUG) {
+      Get("/emission/at/100") ~> route ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String]
+      }
+    }._1
+
+    val bodyWithoutLogging = capturingLogs(Level.OFF) {
+      Get("/emission/at/100") ~> route ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String]
+      }
+    }._1
+
+    body shouldBe bodyWithoutLogging
+  }
+
+}


### PR DESCRIPTION
Closes #1909.

## Relation to #1911

@pragmaxim opened #1911 for this in 2022. @kushti's review question there was:

> Is the new dependency needed for purposes of this PR?

That PR needed `akka-slf4j` plus `akka.loglevel = "DEBUG"` in `application.conf` because it logged through `DebuggingDirectives.logRequest`, which goes via akka's `LoggingAdapter` and its event stream.

Both of those have since landed in master for other reasons — `build.sbt:332` and the `akka { ... }` block in `application.conf`. So the question is moot on the dependency side, but the mechanism is still worth avoiding: logging through the akka event stream means the verbosity of the node's HTTP log is coupled to akka's global log level, and turning it up brings along everything else akka has to say at DEBUG.

This PR logs through `ScorexLogging`, like the rest of the codebase, so nothing new is added to `build.sbt` and no global akka setting changes.

## The change

A single `Directive0` wrapping the composite route in `ErgoHttpService`:

```
GET /wallet/boxes/unspent?minInclusionHeight=100 - 200 in 7 ms
```

method, relative URI (path and query string), response status, elapsed time.

Notes on the choices:

* **It wraps the route outside `handleRejections`**, so rejected and failed requests are logged too, with the status they were finally answered with. Inside the rejection handler they would never reach `mapResponse`.
* **Bodies are not logged**, request or response. Requests to this API carry secrets — a mnemonic on `/wallet/restore`, a password on `/wallet/unlock`, a seed on `/wallet/init` — and responses can be large. Method, URI, status and duration are what makes API access diagnosable.
* **It costs nothing when disabled.** `ScorexLogging` extends `StrictLogging`, whose `log.debug` is a macro guarded by `isDebugEnabled`, so the interpolated string is not built unless the logger is actually at DEBUG.
* **It is off by default**, since the root logger in `logback.xml` is at `INFO`. A commented-out `<logger>` element is added there so the switch is discoverable:

```xml
<logger name="org.ergoplatform.http.ErgoHttpService" level="DEBUG"/>
```

That also means verbosity is per-logger and under the operator's control, rather than tied to akka's level.

## Tests

New `ErgoHttpServiceSpec` attaches a logback `ListAppender` to the service's logger and asserts on what is actually emitted:

* a served query is logged exactly once, matching `GET /emission/at/100 - 200 in <n> ms`;
* the query string is included, and an unmatched path is logged with the status the rejection handler answered with;
* nothing at all is logged when the logger is not at DEBUG;
* the response body is byte-identical with logging on and off.

`sbt "testOnly org.ergoplatform.http.routes.ErgoHttpServiceSpec"` — 4 tests, green.