### PR TITLE
Document interlinksProof in the PopowHeader OpenAPI schema

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -1585,6 +1585,7 @@ components:
       required:
         - header
         - interlinks
+        - interlinksProof
       properties:
         header:
           $ref: '#/components/schemas/BlockHeader'
@@ -1593,6 +1594,46 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ModifierId'
+        interlinksProof:
+          $ref: '#/components/schemas/BatchMerkleProof'
+
+    BatchMerkleProof:
+      type: object
+      description: Batch Merkle proof that the interlink vector corresponds to its header
+      required:
+        - indices
+        - proofs
+      properties:
+        indices:
+          description: Proven leaves, each with its index in the tree
+          type: array
+          items:
+            type: object
+            required:
+              - index
+              - digest
+            properties:
+              index:
+                description: Index of the leaf
+                type: integer
+              digest:
+                description: Base16-encoded hash of the leaf
+                type: string
+        proofs:
+          description: Hashes on the paths to the root, each with the side it is on
+          type: array
+          items:
+            type: object
+            required:
+              - digest
+              - side
+            properties:
+              digest:
+                description: Base16-encoded hash
+                type: string
+              side:
+                description: Side of the hash, 0 for left and 1 for right
+                type: integer
 
     NipopowProof:
       type: object


### PR DESCRIPTION
`PoPowHeader`'s encoder emits `interlinksProof` (`PoPowHeader.scala:126`) and its decoder requires it (`:134`), but the `PopowHeader` schema in `openapi.yaml:1583` listed only `header` and `interlinks`. The documented shape did not match the one the node actually serves.

Adds the field, plus a `BatchMerkleProof` schema matching what `batchMerkleProofEncoder` (`PoPowHeader.scala:81`) produces: `indices` as `{index, digest}` pairs and `proofs` as `{digest, side}` pairs.

Documentation only, no code paths touched. Noticed while reading #1384 — not a bounty claim, that work was @ApexTheory's in #1526.