### PR TITLE
Close state storage in the UTXO and digest state property tests

### DIFF
--- a/src/test/scala/org/ergoplatform/nodeView/state/DigestStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/DigestStateSpecification.scala
@@ -34,6 +34,8 @@ class DigestStateSpecification extends ErgoCorePropertyTest {
       val state = DigestState.create(None, None, dir2, settings)
       state.version shouldEqual fb.header.id
       state.rootDigest shouldEqual fb.header.stateRoot
+      state.close()
+      us.closeStorage()
     }
   }
 
@@ -69,6 +71,8 @@ class DigestStateSpecification extends ErgoCorePropertyTest {
 
       val ds = createDigestState(us.version, us.rootDigest)
       ds.applyModifier(block, None)(_ => ()) shouldBe 'success
+      ds.close()
+      us.closeStorage()
     }
   }
 
@@ -104,6 +108,9 @@ class DigestStateSpecification extends ErgoCorePropertyTest {
       ds3.stateContext.lastHeaders.size shouldEqual 0
 
       ds3.applyModifier(block, None)(_ => ()).get.rootDigest shouldBe ds2.rootDigest
+
+      ds.close()
+      us.closeStorage()
     }
   }
 
@@ -134,6 +141,9 @@ class DigestStateSpecification extends ErgoCorePropertyTest {
 
       val txs3 = IndexedSeq(txWithDataInputs, headTx, nextTx)
       ds.validateTransactions(txs3, digest2, proof2, emptyStateContext) shouldBe 'failure
+
+      ds.close()
+      us.closeStorage()
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -166,6 +166,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       bh.take(1000)._1.foreach { box =>
         us.boxById(box.id) shouldBe Some(box)
       }
+      us.closeStorage()
     }
   }
 
@@ -244,6 +245,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
 
       ADProofs.proofDigest(proof1) shouldBe ADProofs.proofDigest(proof2)
       digest1 shouldBe digest2
+      us.closeStorage()
     }
   }
 
@@ -271,6 +273,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       val correctTransactions = IndexedSeq(txWithDataInputs)
       val digest = us.proofsForTransactions(correctTransactions).get._2
       us.applyTransactions(correctTransactions, emptyModifierId, digest, emptyStateContext).get
+      us.closeStorage()
     }
   }
 
@@ -328,6 +331,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       // proof of non-existence
       val d2 = us.proofsForTransactions(txsNext).get._2
       us.applyTransactions(txsNext, emptyModifierId, d2, emptyStateContext) shouldBe 'success
+      us.closeStorage()
     }
   }
 
@@ -348,6 +352,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       val block = wBlock.copy(header = wBlock.header.copy(height = 1))
       val newSC = us.stateContext.appendFullBlock(block).get
       us.applyTransactions(txs, emptyModifierId, digest, newSC).get
+      us.closeStorage()
     }
   }
 
@@ -373,6 +378,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       val fb = new ErgoFullBlock(header, bt, genExtension(header, us.stateContext), None)
       val newSC = us.stateContext.appendFullBlock(fb).get
       us.applyTransactions(txs, emptyModifierId, digest, newSC).get
+      us.closeStorage()
     }
   }
 
@@ -413,6 +419,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
 
       // Fails on generating state root digest for the block
       us.proofsForTransactions(txs).isSuccess shouldBe false
+      us.closeStorage()
     }
   }
 
@@ -427,6 +434,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
       us.proofsForTransactions(txsFromHolder).isSuccess shouldBe true
       val d3 = us.rootDigest
       d1.sameElements(d3) shouldBe true
+      us.closeStorage()
     }
   }
 
@@ -446,6 +454,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
 
       val us = createUtxoState(bh, parameters)
       us.proofsForTransactions(txs).isSuccess shouldBe false
+      us.closeStorage()
     }
   }
 
@@ -456,6 +465,7 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
 
       val block = validFullBlock(parentOpt = None, us, bh)
       us.applyModifier(block, None)(_ => ()).get
+      us.closeStorage()
     }
   }
 


### PR DESCRIPTION
## The leak

Every `createUtxoState` opens a fresh LevelDB under a new temp dir. `ErgoState.closeStorage()` exists, but the only callers are in `ErgoNodeViewHolder` — **no test has ever closed one**. Measured on master, 40 calls in a loop:

```
leaked: base=148 after=472  delta=324  -> 8.1 fds per createUtxoState
closed: base=472 after=472  delta=0    -> 0   fds, calling us.closeStorage()
```

`UtxoStateSpecification` and `DigestStateSpecification` have 14 properties between them doing `forAll(boxesHolderGen)`, each opening a state per iteration at ScalaTest's default `minSuccessful = 10`. Nothing is released until the JVM exits.

## The effect

Peak open file descriptors while running just these two suites, sampled from `/proc/<pid>/fd` every 300ms:

| | peak fds |
|---|---|
| master | **2429** |
| this branch | **1019** |

A 58% drop from 20 added lines. For scale, the default limit on the container I measured this on is 4096 — two suites out of a ~740-test job were sitting at 59% of it.

I ran into this the hard way: a loop calling the `UtxoStateSpecification` property body 500 times died at roughly 450 with `java.nio.file.FileSystemException: ... Too many open files`.

## The change

`us.closeStorage()` at the end of each `forAll(boxesHolderGen)` body, plus `ds.close()` where the property also builds a `DigestState`. Nothing else. `DigestStateSpecification`'s `reopen` property already did exactly this — the convention existed, it just was not applied anywhere else.

Derived states share the parent's `store`, so one close per created store is enough and closing the original covers everything `applyModifier` / `rollbackTo` returned.

`testOnly ... UtxoStateSpecification ... DigestStateSpecification` — 27 tests, green.

## Two honest notes

**This may or may not fix the flaky CI.** `Run node tests` fails intermittently in exactly these two suites — a different one each time — with `IllegalArgumentException: requirement failed` during `forAll(boxesHolderGen)` evaluation. Descriptor exhaustion would explain the "different suite each run" pattern, and it would explain why neither suite reproduces alone. But I could not reproduce the failure locally (300 generator runs and 500 full property runs, clean), so **I am not claiming this is the cause.** The leak is worth fixing on its own terms.

**`closeStorage()` logs.** It does `log.warn("Closing state's store.")`, meant for node shutdown, so this adds ~140 WARN lines to the node test log. If that is unwelcome I am happy to switch to `us.store.close()`, or to move the log to debug in a separate commit — your call.
