### PR TITLE
Make ExtraIndexer checkpoints reorg-safe

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -4,18 +4,23 @@ import akka.actor.ActorContext
 import org.ergoplatform.consensus.ProgressInfo
 
 import java.io.File
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.charset.StandardCharsets
 import org.ergoplatform.mining.AutolykosPowScheme
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.{Header, PreGenesisHeader}
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ErgoNodeViewModifier, NonHeaderBlockSection}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.StartExtraIndexer
-import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{IndexedHeightKey, NewestVersion, NewestVersionBytes, SchemaVersionKey, getIndex}
+import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{GlobalBoxIndexKey, GlobalTxIndexKey, IndexedHeaderIdKey,
+  IndexedHeightKey, NewestVersion, NewestVersionBytes, RollbackToKey, SchemaVersionKey}
+import org.ergoplatform.nodeView.history.extra.{IndexedErgoBox, IndexedErgoTransaction, NumericBoxIndex, NumericTxIndex}
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.history.storage.modifierprocessors._
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{Algos, ErgoSettings}
 import org.ergoplatform.utils.LoggingUtil
 import org.ergoplatform.validation.RecoverableModifierError
-import scorex.util.{ModifierId, ScorexLogging, idToBytes}
+import scorex.db.ByteArrayWrapper
+import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 
 import scala.util.{Failure, Success, Try}
 
@@ -265,12 +270,113 @@ object ErgoHistory extends ScorexLogging {
     var db = HistoryStorage(ergoSettings)
 
     // ExtraIndexer db check
-    if(ergoSettings.nodeSettings.extraIndex) { // check db schema
-      val schemaVersion: Int = getIndex(SchemaVersionKey, db).getInt
-      if (schemaVersion != NewestVersion) {
-        if(getIndex(IndexedHeightKey, db).getInt > 0)
-          db = db.deleteExtraDB(ergoSettings) // older schema -> delete and reopen db
-        db.insertExtra(Array((SchemaVersionKey, NewestVersionBytes)), Array.empty) // update version key
+    if(ergoSettings.nodeSettings.extraIndex) { // check db schema and checkpoint provenance
+      def storedBytes(key: Array[Byte]): Option[Array[Byte]] = db.modifierBytesById(bytesToId(key))
+      def intValue(bytesOpt: Option[Array[Byte]]): Option[Int] = bytesOpt
+        .filter(_.length == Integer.BYTES)
+        .map(bytes => ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getInt)
+      def longValue(bytesOpt: Option[Array[Byte]]): Option[Long] = bytesOpt
+        .filter(_.length == java.lang.Long.BYTES)
+        .map(bytes => ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getLong)
+
+      val schemaVersionBytesOpt = storedBytes(SchemaVersionKey)
+      val indexedHeightBytesOpt = storedBytes(IndexedHeightKey)
+      val globalTxIndexBytesOpt = storedBytes(GlobalTxIndexKey)
+      val globalBoxIndexBytesOpt = storedBytes(GlobalBoxIndexKey)
+      val rollbackToBytesOpt = storedBytes(RollbackToKey)
+      val schemaVersionOpt = intValue(schemaVersionBytesOpt)
+      val indexedHeightOpt = intValue(indexedHeightBytesOpt)
+      val globalTxIndexOpt = longValue(globalTxIndexBytesOpt)
+      val globalBoxIndexOpt = longValue(globalBoxIndexBytesOpt)
+      val rollbackToOpt = intValue(rollbackToBytesOpt)
+      val indexedHeight = indexedHeightOpt.getOrElse(0)
+      val globalTxIndex = globalTxIndexOpt.getOrElse(0L)
+      val globalBoxIndex = globalBoxIndexOpt.getOrElse(0L)
+      val rollbackTo = rollbackToOpt.getOrElse(0)
+      val indexedHeaderIdBytesOpt = db.modifierBytesById(bytesToId(IndexedHeaderIdKey))
+      val indexedHeaderOpt = indexedHeaderIdBytesOpt
+        .filter(_.length == ErgoNodeViewModifier.ModifierIdSize)
+        .flatMap { idBytes =>
+        val id = bytesToId(idBytes)
+        val validityKey = ByteArrayWrapper(Algos.hash("validity".getBytes(StandardCharsets.UTF_8) ++ idToBytes(id)))
+        val isValid = db.getIndex(validityKey).exists(_.sameElements(Array(1.toByte)))
+        if (isValid) db.modifierById(id).collect {
+          case header: Header if header.height == indexedHeight && header.id == id => header
+        } else None
+      }
+      val terminalRowsMatchCheckpoint = indexedHeaderOpt.exists { header =>
+        if (globalTxIndex <= 0 || globalBoxIndex <= 0) {
+          false
+        } else {
+          db.modifierById(header.transactionsId).collect {
+            case transactions: BlockTransactions if transactions.headerId == header.id =>
+              val lastTx = transactions.txs.last
+              val lastTxIndex = globalTxIndex - 1
+              val firstTxBoxIndex = globalBoxIndex - lastTx.outputs.size
+              val expectedOutputNums = Array.tabulate(lastTx.outputs.size)(i => firstTxBoxIndex + i)
+              val expectedInputNumsOpt = if (header.height <= 1) {
+                Some(Array.fill[Long](lastTx.inputs.size)(0L))
+              } else {
+                val inputNums = lastTx.inputs.map { input =>
+                  val inputId = bytesToId(input.boxId)
+                  db.getExtraIndex(inputId).collect {
+                    case box: IndexedErgoBox
+                      if box.id == inputId && box.spendingTxIdOpt.contains(lastTx.id) &&
+                        box.spendingHeightOpt.contains(header.height) => box.globalIndex
+                  }
+                }
+                if (inputNums.forall(_.isDefined)) Some(inputNums.flatten.toArray) else None
+              }
+              val numericTxMatches = db.getExtraIndex(bytesToId(NumericTxIndex.indexToBytes(lastTxIndex))).exists {
+                case NumericTxIndex(index, id) => index == lastTxIndex && id == lastTx.id
+                case _ => false
+              }
+              val indexedTxMatches = db.getExtraIndex(lastTx.id).exists {
+                case tx: IndexedErgoTransaction =>
+                  tx.txid == lastTx.id && tx.globalIndex == lastTxIndex && tx.height == header.height &&
+                    tx.index == transactions.txs.size - 1 && tx.size == lastTx.size &&
+                    expectedInputNumsOpt.exists(expected => tx.inputNums.sameElements(expected)) &&
+                    tx.outputNums.sameElements(expectedOutputNums) && tx.dataInputs.sameElements(lastTx.dataInputs)
+                case _ => false
+              }
+              val outputRowsMatch = expectedOutputNums.zip(lastTx.outputs).forall { case (boxIndex, output) =>
+                val boxId = bytesToId(output.id)
+                val numericBoxMatches = db.getExtraIndex(bytesToId(NumericBoxIndex.indexToBytes(boxIndex))).exists {
+                  case NumericBoxIndex(index, id) => index == boxIndex && id == boxId
+                  case _ => false
+                }
+                val indexedBoxMatches = db.getExtraIndex(boxId).exists {
+                  case box: IndexedErgoBox =>
+                    box.globalIndex == boxIndex && box.inclusionHeight == header.height && box.id == boxId &&
+                      box.spendingTxIdOpt.isEmpty && box.spendingHeightOpt.isEmpty && box.spendingProofOpt.isEmpty
+                  case _ => false
+                }
+                numericBoxMatches && indexedBoxMatches
+              }
+              numericTxMatches && indexedTxMatches && outputRowsMatch
+          }.contains(true)
+        }
+      }
+      val numericValuesAreWellFormed = Seq(
+        indexedHeightBytesOpt.forall(_.length == Integer.BYTES),
+        globalTxIndexBytesOpt.forall(_.length == java.lang.Long.BYTES),
+        globalBoxIndexBytesOpt.forall(_.length == java.lang.Long.BYTES),
+        rollbackToBytesOpt.forall(_.length == Integer.BYTES)
+      ).forall(identity)
+      val valuesAreNonNegative = indexedHeight >= 0 && globalTxIndex >= 0 && globalBoxIndex >= 0 && rollbackTo >= 0
+      val emptyCheckpoint = indexedHeight == 0 && globalTxIndex == 0 && globalBoxIndex == 0 &&
+        rollbackTo == 0 && indexedHeaderIdBytesOpt.isEmpty
+      val nonEmptyCheckpoint = indexedHeight > 0 && Seq(indexedHeightOpt, globalTxIndexOpt, globalBoxIndexOpt, rollbackToOpt)
+        .forall(_.isDefined) && rollbackTo == 0 && terminalRowsMatchCheckpoint
+      val checkpointIsValid = schemaVersionOpt.contains(NewestVersion) && numericValuesAreWellFormed &&
+        valuesAreNonNegative && (emptyCheckpoint || nonEmptyCheckpoint)
+      if (!checkpointIsValid) {
+        val freshDb = db.deleteExtraDBTry(ergoSettings).get
+        freshDb.insertExtraTry(Array((SchemaVersionKey, NewestVersionBytes)), Array.empty).recoverWith { case error =>
+          Try(freshDb.close()).failed.foreach(error.addSuppressed)
+          Failure(error)
+        }.get
+        db = freshDb
       }
     }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -17,7 +17,6 @@ import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.history.storage.modifierprocessors.FullBlockProcessor
 import org.ergoplatform.settings.{Algos, CacheSettings, ChainSettings}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
-import scorex.db.ByteArrayWrapper
 import sigma.ast.ErgoTree
 import sigma.Extensions._
 import sigma.interpreter.ProverResult
@@ -75,9 +74,7 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
   protected def fullChainHeaderAtHeight(height: Int): Option[Header] = {
     _history.headerIdsAtHeight(height)
       .find { id =>
-        historyStorage.getIndex(FullBlockProcessor.chainStatusKey(id))
-          .map(ByteArrayWrapper.apply)
-          .contains(ByteArrayWrapper(FullBlockProcessor.BestChainMarker)) &&
+        FullBlockProcessor.isInBestFullChain(historyStorage, id) &&
           _history.isSemanticallyValid(id) == ModifierSemanticValidity.Valid
       }
       .flatMap(id => _history.typedModifierById[Header](id))
@@ -145,6 +142,13 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
     * Holds upcoming blocks to be indexed, and when empty, it is filled back from multiple threads
     */
   private val blockCache: concurrent.Map[Int, BlockTransactions] = new ConcurrentHashMap[Int, BlockTransactions]().asScala
+
+  private[extra] final def putBlockTransactionsInCache(
+    height: Int,
+    transactions: BlockTransactions
+  ): Unit =
+    blockCache.put(height, transactions)
+
   private var readingUpTo: Int = 0
 
   /**
@@ -168,7 +172,9 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
           blockNums.zip(blockNums.tail).map { range => // ranges of 250 blocks for each thread to read
             Future {
               (range._1 until range._2).foreach { blockNum =>
-                fullChainHeaderAtHeight(blockNum).flatMap(blockTransactionsForHeader).map(blockCache.put(blockNum, _))
+                fullChainHeaderAtHeight(blockNum)
+                  .flatMap(blockTransactionsForHeader)
+                  .map(putBlockTransactionsInCache(blockNum, _))
               }
             }
           }
@@ -176,7 +182,9 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
           val blockNums = height + 1 to readingUpTo
           Future {
             blockNums.foreach { blockNum =>
-              fullChainHeaderAtHeight(blockNum).flatMap(blockTransactionsForHeader).map(blockCache.put(blockNum, _))
+              fullChainHeaderAtHeight(blockNum)
+                .flatMap(blockTransactionsForHeader)
+                .map(putBlockTransactionsInCache(blockNum, _))
             }
           }
         }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -1,7 +1,8 @@
 package org.ergoplatform.nodeView.history.extra
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash}
-import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, GlobalConstants, Pay2SAddress}
+import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash, Timers}
+import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, ErgoApp, GlobalConstants, Pay2SAddress}
+import org.ergoplatform.consensus.ModifierSemanticValidity
 import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
@@ -13,8 +14,10 @@ import org.ergoplatform.nodeView.history.extra.IndexedContractTemplateSerializer
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
 import org.ergoplatform.nodeView.history.extra.IndexedTokenSerializer.uniqueId
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.history.storage.modifierprocessors.FullBlockProcessor
 import org.ergoplatform.settings.{Algos, CacheSettings, ChainSettings}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
+import scorex.db.ByteArrayWrapper
 import sigma.ast.ErgoTree
 import sigma.Extensions._
 import sigma.interpreter.ProverResult
@@ -27,19 +30,26 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.collection.concurrent
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
 
 /**
   * Base trait for extra indexer actor and its test.
   */
-trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
+trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
+
+  private case class RetryIndex(generation: Long)
+  private case object RetryIndexTimerKey
+  private case class RollbackToHeader(header: Header, resume: Boolean)
+  private var retryGeneration: Long = 0L
 
   private implicit val ec: ExecutionContextExecutor = context.dispatcher
 
   /**
     * Max buffer size (determined by config)
     */
-  protected val saveLimit: Int
+  protected def saveLimit: Int
 
   /**
     * Number of transaction/box numeric indexes object segments contain
@@ -62,16 +72,60 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
 
   protected def historyStorage: HistoryStorage = _history.historyStorage
 
+  protected def fullChainHeaderAtHeight(height: Int): Option[Header] = {
+    _history.headerIdsAtHeight(height)
+      .find { id =>
+        historyStorage.getIndex(FullBlockProcessor.chainStatusKey(id))
+          .map(ByteArrayWrapper.apply)
+          .contains(ByteArrayWrapper(FullBlockProcessor.BestChainMarker)) &&
+          _history.isSemanticallyValid(id) == ModifierSemanticValidity.Valid
+      }
+      .flatMap(id => _history.typedModifierById[Header](id))
+  }
+
+  protected def blockTransactionsForHeader(header: Header): Option[BlockTransactions] = {
+    history.typedModifierById[BlockTransactions](header.transactionsId).filter(_.headerId == header.id)
+  }
+
+  protected def retryDelay: FiniteDuration = 1.second
+
+  private def scheduleRetry(): Unit = {
+    if (!timers.isTimerActive(RetryIndexTimerKey)) {
+      retryGeneration += 1
+      timers.startSingleTimer(RetryIndexTimerKey, RetryIndex(retryGeneration), retryDelay)
+    }
+  }
+
+  private def cancelRetry(): Unit = {
+    retryGeneration += 1
+    timers.cancel(RetryIndexTimerKey)
+  }
+
+  protected def resetTransientState(): Unit = {
+    cancelRetry()
+    blockCache.clear()
+    readingUpTo = 0
+  }
+
   /**
    * Used in tests to indicate the indexer has caught up to the chain
    */
   protected def caughtUpHook(height: Int = 0): Unit = {}
 
+  protected def continueCatchUpAfterIndex(state: IndexerState): Boolean = true
+
+  protected def requestShutdown(): Unit = {
+    ErgoApp.shutdownSystem()(context.system)
+  }
+
+  protected def removeRollbackIndexes(ids: Array[ModifierId]): Try[Unit] =
+    historyStorage.removeExtraTry(ids)
+
   /**
    * Used in tests to get block for rollback, maybe orphan
    */
   protected def getLastTxForHeight(height: Int): ErgoTransaction = {
-    history.bestBlockTransactionsAt(height).get.txs.last
+    fullChainHeaderAtHeight(height).flatMap(blockTransactionsForHeader).get.txs.last
   }
 
   // fast access buffers
@@ -100,8 +154,11 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
     * @param height - blockheight to get transations from
     * @return transactions at height
     */
-  private def getBlockTransactionsAt(height: Int): Option[BlockTransactions] = {
-    blockCache.remove(height).orElse(history.bestBlockTransactionsAt(height)).map { txs =>
+  private def getBlockTransactionsAt(height: Int, header: Header): Option[BlockTransactions] = {
+    val cached = blockCache.remove(height)
+    val txsOpt = cached.filter(_.headerId == header.id).orElse(blockTransactionsForHeader(header))
+
+    txsOpt.map { txs =>
       if (height % 1000 == 0) blockCache.keySet.filter(_ < height).map(blockCache.remove)
       if (readingUpTo - height < 300 && chainHeight - height > 1000) {
         readingUpTo = math.min(height + 1001, chainHeight)
@@ -111,7 +168,7 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
           blockNums.zip(blockNums.tail).map { range => // ranges of 250 blocks for each thread to read
             Future {
               (range._1 until range._2).foreach { blockNum =>
-                history.bestBlockTransactionsAt(blockNum).map(blockCache.put(blockNum, _))
+                fullChainHeaderAtHeight(blockNum).flatMap(blockTransactionsForHeader).map(blockCache.put(blockNum, _))
               }
             }
           }
@@ -119,7 +176,7 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
           val blockNums = height + 1 to readingUpTo
           Future {
             blockNums.foreach { blockNum =>
-              history.bestBlockTransactionsAt(blockNum).map(blockCache.put(blockNum, _))
+              fullChainHeaderAtHeight(blockNum).flatMap(blockTransactionsForHeader).map(blockCache.put(blockNum, _))
             }
           }
         }
@@ -240,41 +297,41 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
   /**
     * Write buffered indexes to database and clear buffers.
     */
-  private def saveProgress(state: IndexerState): Unit = {
-
+  private def saveProgress(state: IndexerState): Try[Unit] = Try {
     val start: Long = System.currentTimeMillis
 
-    // perform segmentation on big addresses and save their internal segment buffer
     trees.values.foreach { tree =>
       tree.buffer.values.foreach(seg => segments.put(seg.id, seg))
       tree.splitToSegments.foreach(seg => segments.put(seg.id, seg))
     }
-
     templates.values.foreach { template =>
       template.buffer.values.foreach(seg => segments.put(seg.id, seg))
       template.splitToSegments.foreach(seg => segments.put(seg.id, seg))
     }
-
-    // perform segmentation on big tokens and save their internal segment buffer
     tokens.values.foreach { token =>
       token.buffer.values.foreach(seg => segments.put(seg.id, seg))
       token.splitToSegments.foreach(seg => segments.put(seg.id, seg))
     }
 
-    // insert modifiers and progress info to db
-    historyStorage.insertExtra(
+    val indexedHeaderEntry = state.indexedHeaderId.map { id =>
+      IndexedHeaderIdKey -> fastIdToBytes(id)
+    }.toArray
+    val objects = (general.iterator ++ boxes.valuesIterator ++ trees.valuesIterator ++
+      templates.valuesIterator ++ tokens.valuesIterator ++ segments.valuesIterator).toArray
+    historyStorage.insertExtraTry(
       Array(
         (IndexedHeightKey, ByteBuffer.allocate(4).putInt(state.indexedHeight).array),
         (GlobalTxIndexKey, ByteBuffer.allocate(8).putLong(state.globalTxIndex).array),
         (GlobalBoxIndexKey, ByteBuffer.allocate(8).putLong(state.globalBoxIndex).array),
         (RollbackToKey, ByteBuffer.allocate(4).putInt(state.rollbackTo).array)
-      ),
-      (((((general ++= boxes.values) ++= trees.values) ++= templates.values) ++= tokens.values) ++= segments.values).toArray
-    )
+      ) ++ indexedHeaderEntry,
+      objects
+    ).recoverWith { case error =>
+      historyStorage.invalidateExtraCache(objects.iterator.map(_.id).toSeq)
+      Failure(error)
+    }.get
 
     log.debug(s"Processed ${trees.size} ErgoTrees with ${boxes.size} boxes and inserted them to database in ${System.currentTimeMillis - start}ms")
-
-    // clear buffers for next batch
     general.clear()
     boxes.clear()
     trees.clear()
@@ -287,17 +344,18 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
     * Process a batch of BlockTransactions into memory and occasionally write them to database.
     *
     * @param state     - current indexer state
-    * @param headerOpt - header to index block transactions of (used after caught up with chain)
+    * @param header       - exact full-chain header to index
+    * @param targetHeight - full-chain height captured for this catch-up pass
     */
-  protected def index(state: IndexerState, headerOpt: Option[Header] = None): IndexerState = {
-    val btOpt = headerOpt.flatMap { header =>
-      history.typedModifierById[BlockTransactions](header.transactionsId)
-    }.orElse(getBlockTransactionsAt(state.indexedHeight))
-    val height = headerOpt.map(_.height).getOrElse(state.indexedHeight)
+  protected def index(state: IndexerState,
+                      header: Header,
+                      targetHeight: Int): Option[IndexerState] = {
+    val height = header.height
+    val btOpt = getBlockTransactionsAt(height, header)
 
     if (btOpt.isEmpty) {
       log.error(s"Could not read block $height / $chainHeight from database, waiting for new block until retrying")
-      return state.decrementIndexedHeight.copy(caughtUp = true)
+      return None
     }
 
     val txs: Seq[ErgoTransaction] = btOpt.get.txs
@@ -375,11 +433,10 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
 
     log.info(s"Buffered block $height / $chainHeight [txs: ${txs.length}, boxes: $boxCount] (buffer: $modCount / $saveLimit)")
 
-    val maxHeight = headerOpt.map(_.height).getOrElse(chainHeight)
-    newState.copy(
-      caughtUp = newState.indexedHeight == maxHeight,
-      indexedHeaderId = headerOpt.map(_.id).orElse(history.bestHeaderIdAtHeight(height))
-    )
+    Some(newState.copy(
+      caughtUp = newState.indexedHeight == targetHeight,
+      indexedHeaderId = Some(header.id)
+    ))
   }
 
   /**
@@ -388,15 +445,15 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
     * @param state  - current state of indexer
     * @param height - forking height (height of last common block)
     */
-  private def removeAfter(state: IndexerState, height: Int): IndexerState = {
+  private def removeAfter(state: IndexerState, targetHeader: Header): Try[IndexerState] = Try {
 
     var newState: IndexerState = state
+    val height = targetHeader.height
 
-    saveProgress(newState)
+    saveProgress(newState).get
     log.info(s"Rolling back indexes from ${state.indexedHeight} to $height")
 
-    try {
-      val lastTxToKeep: ErgoTransaction = getLastTxForHeight(height)
+      val lastTxToKeep: ErgoTransaction = blockTransactionsForHeader(targetHeader).get.txs.last
       val txTarget: Long = history.typedExtraIndexById[IndexedErgoTransaction](lastTxToKeep.id).get.globalIndex
       val boxTarget: Long = history.typedExtraIndexById[IndexedErgoBox](bytesToId(lastTxToKeep.outputs.last.id)).get.globalIndex
       val toRemove: ArrayBuffer[ModifierId] = ArrayBuffer.empty[ModifierId]
@@ -417,12 +474,12 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
           val template = history.typedExtraIndexById[IndexedContractTemplate](hashTreeTemplate(iEb.box.ergoTree)).get
           template.findAndModBox(iEb.globalIndex, history)
 
-          historyStorage.insertExtra(Array.empty, Array[ExtraIndex](iEb, address, template) ++ address.buffer.values ++ template.buffer.values)
+          historyStorage.insertExtraTry(Array.empty, Array[ExtraIndex](iEb, address, template) ++ address.buffer.values ++ template.buffer.values).get
 
           cfor(0)(_ < iEb.box.additionalTokens.length, _ + 1) { i =>
             history.typedExtraIndexById[IndexedToken](IndexedToken.fromBox(iEb, i).id).map { token =>
               token.findAndModBox(iEb.globalIndex, history)
-              historyStorage.insertExtra(Array.empty, Array[ExtraIndex](token) ++ token.buffer.values)
+              historyStorage.insertExtraTry(Array.empty, Array[ExtraIndex](token) ++ token.buffer.values).get
             }
           }
         }
@@ -460,61 +517,137 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
       newState = newState.incrementBoxIndex
 
       // Save changes
-      newState = newState.copy(
+      val completedState = newState.copy(
         indexedHeight = height,
         rollbackTo = 0,
-        caughtUp = state.caughtUp,
-        indexedHeaderId = history.bestHeaderIdAtHeight(height)
+        caughtUp = height == chainHeight && fullChainHeaderAtHeight(height).exists(_.id == targetHeader.id),
+        indexedHeaderId = Some(targetHeader.id)
       )
-      historyStorage.removeExtra(toRemove.toArray)
-      saveProgress(newState)
-    } catch {
-      case t: Throwable => log.error(s"removeAfter during rollback failed due to: ${t.getMessage}", t)
-    }
+      removeRollbackIndexes(toRemove.toArray).get
+      saveProgress(completedState).get
+      completedState
+  }
 
-    newState
+  private def indexedTipIsOnBestFullChain(state: IndexerState): Boolean = {
+    state.indexedHeight == 0 ||
+      (chainHeight >= state.indexedHeight &&
+        state.indexedHeaderId == fullChainHeaderAtHeight(state.indexedHeight).map(_.id))
+  }
+
+  private def reconcileIndexedTip(state: IndexerState): Boolean = {
+    val rollbackHeaderOpt = for {
+      indexedHeaderId <- state.indexedHeaderId
+      indexedHeader <- history.typedModifierById[Header](indexedHeaderId)
+      bestFullBlock <- history.bestFullBlockOpt
+      branchPointId <- history.chainToHeader(Some(indexedHeader), bestFullBlock.header)._1
+      branchHeader <- history.typedModifierById[Header](branchPointId)
+      if branchHeader.height < state.indexedHeight
+    } yield branchHeader
+
+    rollbackHeaderOpt.exists { branchHeader =>
+      beginRollback(state, branchHeader)
+      true
+    }
+  }
+
+  private def validatedRollbackHeader(state: IndexerState, branchPoint: ModifierId): Option[Header] = {
+    history.typedModifierById[Header](branchPoint).filter { header =>
+      header.height < state.indexedHeight &&
+        fullChainHeaderAtHeight(header.height).exists(_.id == header.id)
+    }
+  }
+
+  protected def beginRollback(state: IndexerState, targetHeader: Header, resume: Boolean = true): Unit = {
+    resetTransientState()
+    context.become(receive.orElse(loaded(state.copy(caughtUp = false, rollbackTo = targetHeader.height))))
+    self ! RollbackToHeader(targetHeader, resume)
+  }
+
+  private def persistBuffered(state: IndexerState): Boolean = {
+    saveProgress(state) match {
+      case Success(_) => true
+      case Failure(error) =>
+        log.error(s"Failed to persist extra indexes at height ${state.indexedHeight}; retrying", error)
+        scheduleRetry()
+        false
+    }
   }
 
   protected def loaded(state: IndexerState): Receive = {
 
     case Index() if !state.caughtUp && !state.rollbackInProgress =>
-      val nextHeaderOpt = history.bestHeaderAtHeight(state.indexedHeight + 1)
-      val extendsIndexedTip = nextHeaderOpt.forall { header =>
-        state.indexedHeight == 0 || state.indexedHeaderId.contains(header.parentId)
-      }
-      if (extendsIndexedTip) {
-        val newState = index(state.incrementIndexedHeight)
-        if (modCount >= saveLimit) saveProgress(newState)
-        context.become(receive.orElse(loaded(newState)))
-        self ! Index()
-      } else {
-        log.info("Deferring catch-up because the next header does not extend the indexed tip")
+      cancelRetry()
+      if (modCount < saveLimit || persistBuffered(state)) {
+        if (state.indexedHeight == chainHeight && indexedTipIsOnBestFullChain(state)) {
+          val newState = state.copy(caughtUp = true)
+          context.become(receive.orElse(loaded(newState)))
+          self ! Index()
+        } else {
+          val nextHeaderOpt = fullChainHeaderAtHeight(state.indexedHeight + 1)
+          val extendsIndexedTip = nextHeaderOpt.forall { header =>
+            state.indexedHeight == 0 || state.indexedHeaderId.contains(header.parentId)
+          }
+          if (extendsIndexedTip && nextHeaderOpt.isDefined) {
+            index(state.incrementIndexedHeight, nextHeaderOpt.get, chainHeight) match {
+              case Some(newState) =>
+                context.become(receive.orElse(loaded(newState)))
+                if (continueCatchUpAfterIndex(newState)) self ! Index()
+              case None =>
+                scheduleRetry()
+            }
+          } else if (!reconcileIndexedTip(state)) {
+            log.info("Deferring catch-up because the next full-chain header does not extend the indexed tip")
+            scheduleRetry()
+          }
+        }
       }
 
-    case Index() if state.caughtUp =>
-      if (modCount > 0) saveProgress(state)
-      blockCache.clear()
-      caughtUpHook()
-      log.info("Indexer caught up with chain")
+    case Index() if state.caughtUp && !state.rollbackInProgress && !indexedTipIsOnBestFullChain(state) =>
+      if (!reconcileIndexedTip(state)) {
+        val newState = state.copy(caughtUp = false)
+        context.become(receive.orElse(loaded(newState)))
+        scheduleRetry()
+      }
+
+    case Index() if state.caughtUp && !state.rollbackInProgress =>
+      cancelRetry()
+      if (modCount == 0 || persistBuffered(state)) {
+        blockCache.clear()
+        caughtUpHook()
+        log.info("Indexer caught up with chain")
+      }
+
+    case Index() if state.rollbackInProgress =>
 
     // after the indexer caught up with the chain, stay up to date
     case FullBlockApplied(header: Header) if state.caughtUp && !state.rollbackInProgress =>
-      val indexedTipStillBest = state.indexedHeight == 0 ||
-        (chainHeight >= state.indexedHeight && state.indexedHeaderId.exists { indexedHeaderId =>
-          history.bestHeaderIdAtHeight(state.indexedHeight).contains(indexedHeaderId)
-        })
+      val indexedTipStillBest = indexedTipIsOnBestFullChain(state)
       val isDirectSuccessor = header.height == state.indexedHeight + 1 &&
         (state.indexedHeight == 0 || state.indexedHeaderId.contains(header.parentId)) &&
-        history.bestHeaderIdAtHeight(header.height).contains(header.id)
+        fullChainHeaderAtHeight(header.height).exists(_.id == header.id)
 
       if (isDirectSuccessor) {
-        val newState: IndexerState = index(state.incrementIndexedHeight, Some(header))
-        saveProgress(newState)
-        context.become(receive.orElse(loaded(newState)))
-        caughtUpHook(header.height)
+        cancelRetry()
+        val targetHeight = chainHeight
+        index(state.incrementIndexedHeight, header, targetHeight) match {
+          case Some(newState) =>
+            context.become(receive.orElse(loaded(newState)))
+            if (newState.caughtUp) {
+              if (persistBuffered(newState)) caughtUpHook(header.height)
+            } else {
+              self ! Index()
+            }
+          case None =>
+            val newState = state.copy(caughtUp = false)
+            context.become(receive.orElse(loaded(newState)))
+            scheduleRetry()
+        }
       } else if (!indexedTipStillBest) {
-        log.info(s"Deferring block ${header.id} at height ${header.height} until rollback")
-        context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
+        log.info(s"Reconciling indexed tip before applying block ${header.id} at height ${header.height}")
+        if (!reconcileIndexedTip(state)) {
+          context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
+          scheduleRetry()
+        }
       } else if (header.height > state.indexedHeight + 1) {
         context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
         self ! Index()
@@ -522,40 +655,56 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
         log.warn(s"Skipping block ${header.id} applied at height ${header.height}, indexed height is ${state.indexedHeight}")
       }
 
+    case _: FullBlockApplied if !state.rollbackInProgress =>
+      scheduleRetry()
+
     case _: FullBlockApplied if state.rollbackInProgress => stash()
 
     case Rollback(branchPoint: ModifierId) =>
+      cancelRetry()
       if (state.rollbackInProgress) {
         log.warn(s"Rollback already in progress")
         stash()
+      } else if (indexedTipIsOnBestFullChain(state)) {
+        log.info(s"Ignoring rollback to $branchPoint because the indexed tip is already on the best full chain")
+        if (!state.caughtUp) self ! Index()
       } else {
-        history.heightOf(branchPoint) match {
-          case Some(branchHeight) =>
-            if (branchHeight < state.indexedHeight) {
-              context.become(receive.orElse(loaded(state.copy(rollbackTo = branchHeight))))
-              self ! RemoveAfter(branchHeight)
-            } else if (!state.caughtUp) {
-              blockCache.clear()
-              readingUpTo = 0
-              self ! Index()
-            }
-          case None =>
-            log.error(s"No rollback height found for $branchPoint")
-            val newState = state.copy(rollbackTo = 0)
+        validatedRollbackHeader(state, branchPoint) match {
+          case Some(header) => beginRollback(state, header)
+          case None if !reconcileIndexedTip(state) =>
+            log.info(s"Deferring rollback to $branchPoint until the indexed tip can be reconciled with the best full chain")
+            val newState = state.copy(caughtUp = false, rollbackTo = 0)
             context.become(receive.orElse(loaded(newState)))
-            unstashAll()
+            scheduleRetry()
+          case None =>
         }
       }
 
-    case RemoveAfter(branchHeight: Int) if state.rollbackInProgress =>
+    case RollbackToHeader(targetHeader, resume)
+      if state.rollbackInProgress && state.rollbackTo == targetHeader.height =>
       blockCache.clear()
       readingUpTo = 0
-      val newState = removeAfter(state, branchHeight)
-      context.become(receive.orElse(loaded(newState)))
-      if (!newState.caughtUp && !newState.rollbackInProgress) self ! Index()
-      caughtUpHook()
-      log.info(s"Successfully rolled back indexes to $branchHeight")
-      unstashAll()
+      removeAfter(state, targetHeader) match {
+        case Success(newState) =>
+          context.become(receive.orElse(loaded(newState)))
+          if (resume && !newState.caughtUp) self ! Index()
+          caughtUpHook()
+          log.info(s"Successfully rolled back indexes to ${targetHeader.height}")
+          unstashAll()
+        case Failure(error) =>
+          log.error(s"Failed to roll back extra indexes to ${targetHeader.height}; shutting down so startup can rebuild", error)
+          requestShutdown()
+      }
+
+    case RollbackToHeader(_, _) =>
+
+    case RetryIndex(generation) if generation == retryGeneration && !state.rollbackInProgress =>
+      self ! Index()
+
+    case RetryIndex(_) =>
+
+    case RemoveAfter(branchHeight) =>
+      log.warn(s"Ignoring unsupported direct extra-index rollback request to height $branchHeight")
 
     case GetSegmentThreshold =>
       sender ! segmentThreshold
@@ -678,13 +827,14 @@ object ExtraIndexer {
   /**
     * Current newest database schema version. Used to force extra database resync.
     */
-  val NewestVersion: Int = 6
+  val NewestVersion: Int = 7
   val NewestVersionBytes: Array[Byte] = ByteBuffer.allocate(4).putInt(NewestVersion).array
 
   val IndexedHeightKey: Array[Byte] = Algos.hash("indexed height")
   val GlobalTxIndexKey: Array[Byte] = Algos.hash("txns height")
   val GlobalBoxIndexKey: Array[Byte] = Algos.hash("boxes height")
   val RollbackToKey: Array[Byte] = Algos.hash("rollback to")
+  val IndexedHeaderIdKey: Array[Byte] = Algos.hash("indexed header id")
   val SchemaVersionKey: Array[Byte] = Algos.hash("schema version")
 
   def getIndex(key: Array[Byte], history: HistoryStorage): ByteBuffer =

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -81,7 +81,7 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
   }
 
   protected def blockTransactionsForHeader(header: Header): Option[BlockTransactions] = {
-    history.typedModifierById[BlockTransactions](header.transactionsId).filter(_.headerId == header.id)
+    history.typedModifierById[BlockTransactions](header.transactionsId)
   }
 
   protected def retryDelay: FiniteDuration = 1.second

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -1,7 +1,7 @@
 package org.ergoplatform.nodeView.history.extra
 
 import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash, Timers}
-import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, ErgoApp, GlobalConstants, Pay2SAddress}
+import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, GlobalConstants, Pay2SAddress}
 import org.ergoplatform.consensus.ModifierSemanticValidity
 import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
@@ -111,9 +111,7 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
 
   protected def continueCatchUpAfterIndex(state: IndexerState): Boolean = true
 
-  protected def requestShutdown(): Unit = {
-    ErgoApp.shutdownSystem()(context.system)
-  }
+  protected def stopIndexer(): Unit = context.stop(self)
 
   protected def removeRollbackIndexes(ids: Array[ModifierId]): Try[Unit] =
     historyStorage.removeExtraTry(ids)
@@ -700,8 +698,8 @@ trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
           log.info(s"Successfully rolled back indexes to ${targetHeader.height}")
           unstashAll()
         case Failure(error) =>
-          log.error(s"Failed to roll back extra indexes to ${targetHeader.height}; shutting down so startup can rebuild", error)
-          requestShutdown()
+          log.error(s"Failed to roll back extra indexes to ${targetHeader.height}; stopping extra indexer until node restart", error)
+          stopIndexer()
       }
 
     case RollbackToHeader(_, _) =>

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedContractTemplate.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedContractTemplate.scala
@@ -27,7 +27,7 @@ case class IndexedContractTemplate(templateHash: ModifierId,
     if (boxCount == 0)
       toRemove += templateHash
     else
-      history.historyStorage.insertExtra(Array.empty, Array(this))
+      history.historyStorage.insertExtraTry(Array.empty, Array(this)).get
 
     toRemove.toArray
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
@@ -88,7 +88,7 @@ case class IndexedErgoAddress(treeHash: ModifierId,
     if (txCount == 0 && boxCount == 0)
       toRemove += treeHash // all segments empty after rollback, delete parent
     else
-      history.historyStorage.insertExtra(Array.empty, Array(this)) // save the changes made to this address
+      history.historyStorage.insertExtraTry(Array.empty, Array(this)).get // save the changes made to this address
 
     toRemove.toArray
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
@@ -53,7 +53,7 @@ case class IndexedToken(tokenId: ModifierId,
       toRemove += id // all segments empty after rollback, delete parent
       log.info(s"Removing token $tokenId because no more boxes are associated with it")
     } else
-      history.historyStorage.insertExtra(Array.empty, Array(this)) // save the changes made to this address
+      history.historyStorage.insertExtraTry(Array.empty, Array(this)).get // save the changes made to this address
 
     toRemove.toArray
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexerState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexerState.scala
@@ -2,7 +2,9 @@ package org.ergoplatform.nodeView.history.extra
 
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer._
-import scorex.util.ModifierId
+import org.ergoplatform.modifiers.ErgoNodeViewModifier
+import org.ergoplatform.modifiers.history.header.Header
+import scorex.util.{ModifierId, bytesToId}
 
 /**
  * An immutable state for extra indexer
@@ -40,13 +42,19 @@ object IndexerState {
     val globalTxIndex = getIndex(GlobalTxIndexKey, history).getLong
     val globalBoxIndex = getIndex(GlobalBoxIndexKey, history).getLong
     val rollbackTo = getIndex(RollbackToKey, history).getInt
+    val indexedHeaderId = history.historyStorage
+      .modifierBytesById(bytesToId(IndexedHeaderIdKey))
+      .filter(_.length == ErgoNodeViewModifier.ModifierIdSize)
+      .map(bytesToId)
+      .filter(id => history.typedModifierById[Header](id).exists(_.height == indexedHeight))
     IndexerState(
       indexedHeight,
       globalTxIndex,
       globalBoxIndex,
       rollbackTo,
-      caughtUp = indexedHeight == history.fullBlockHeight,
-      indexedHeaderId = history.bestHeaderIdAtHeight(indexedHeight)
+      caughtUp = indexedHeight == history.fullBlockHeight &&
+        (indexedHeight == 0 || indexedHeaderId.isDefined),
+      indexedHeaderId = indexedHeaderId
     )
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
@@ -14,7 +14,8 @@ import scala.util.{Failure, Success, Try}
 import spire.syntax.all.cfor
 
 import java.io.File
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import scala.jdk.CollectionConverters.asScalaIteratorConverter
 
 /**
@@ -50,6 +51,20 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     Caffeine.newBuilder()
       .maximumSize(config.history.indexesCacheSize)
       .build[ByteArrayWrapper, Array[Byte]]
+
+  private val extraCacheLock = new ReentrantReadWriteLock()
+
+  private def withExtraCacheReadLock[A](body: => A): A = {
+    extraCacheLock.readLock().lock()
+    try body
+    finally extraCacheLock.readLock().unlock()
+  }
+
+  private def withExtraCacheWriteLock[A](body: => A): A = {
+    extraCacheLock.writeLock().lock()
+    try body
+    finally extraCacheLock.writeLock().unlock()
+  }
 
   private def cacheModifier(mod: BlockSection): Unit = mod.modifierTypeId match {
     case Header.modifierTypeId => headersCache.put(mod.id, mod)
@@ -89,7 +104,7 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
       }
     }
 
-  def getExtraIndex(id: ModifierId): Option[ExtraIndex] = {
+  def getExtraIndex(id: ModifierId): Option[ExtraIndex] = withExtraCacheReadLock {
     Option(extraCache.getIfPresent(id)) orElse extraStore.get(idToBytes(id)).flatMap { bytes =>
       ExtraIndexSerializer.parseBytesTry(bytes) match {
         case Success(pm) =>
@@ -150,16 +165,46 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
 
   def insertExtra(indexesToInsert: Array[(Array[Byte], Array[Byte])],
                   objectsToInsert: Array[ExtraIndex]): Unit = {
-    extraStore.insert(
-      objectsToInsert.map(mod => mod.serializedId),
-      objectsToInsert.map(mod => ExtraIndexSerializer.toBytes(mod))
-    )
-    cfor(0)(_ < indexesToInsert.length, _ + 1) { i => extraStore.insert(indexesToInsert(i)._1, indexesToInsert(i)._2)}
+    insertExtraTry(indexesToInsert, objectsToInsert).failed.foreach { error =>
+      log.error("Failed to insert extra indexes", error)
+    }
+  }
+
+  private[history] def invalidateExtraCache(ids: Iterable[ModifierId]): Unit = withExtraCacheWriteLock {
+    ids.foreach(extraCache.invalidate)
+  }
+
+  def insertExtraTry(indexesToInsert: Array[(Array[Byte], Array[Byte])],
+                     objectsToInsert: Array[ExtraIndex]): Try[Unit] = {
+    val objectIds = objectsToInsert.iterator.flatMap(obj => Try(obj.id).toOption).toArray
+    Try {
+      val keys = objectsToInsert.map(_.serializedId) ++ indexesToInsert.map(_._1)
+      val values = objectsToInsert.map(ExtraIndexSerializer.toBytes) ++ indexesToInsert.map(_._2)
+      keys -> values
+    }.flatMap { case (keys, values) =>
+      withExtraCacheWriteLock {
+        extraStore.insert(keys, values).map { _ =>
+          objectIds.foreach(extraCache.invalidate)
+        }
+      }
+    }.recoverWith { case error =>
+      invalidateExtraCache(objectIds)
+      Failure(error)
+    }
   }
 
   def removeExtra(indexesToRemove: Array[ModifierId]) : Unit = {
-    extraStore.remove(indexesToRemove.map(idToBytes))
-    cfor(0)(_ < indexesToRemove.length, _ + 1) { i => removeModifier(indexesToRemove(i)) }
+    removeExtraTry(indexesToRemove).failed.foreach { error =>
+      log.error("Failed to remove extra indexes", error)
+    }
+  }
+
+  def removeExtraTry(indexesToRemove: Array[ModifierId]): Try[Unit] = {
+    withExtraCacheWriteLock {
+      extraStore.remove(indexesToRemove.map(idToBytes)).map { _ =>
+        cfor(0)(_ < indexesToRemove.length, _ + 1) { i => removeModifier(indexesToRemove(i)) }
+      }
+    }
   }
 
   /**
@@ -205,26 +250,37 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     * Delete the extra index database and reopen it.
     *
     * @param ergoSettings - settings to use
-    * @return new HistoryStorage instance with empty extra database, or this instance in case of failure
+    * @return new HistoryStorage instance with an empty extra database
     */
-  def deleteExtraDB(ergoSettings: ErgoSettings): HistoryStorage = {
+  def deleteExtraDB(ergoSettings: ErgoSettings): HistoryStorage =
+    deleteExtraDBTry(ergoSettings).get
+
+  /**
+    * Delete the extra index database and reopen it, preserving deletion failures.
+    */
+  def deleteExtraDBTry(ergoSettings: ErgoSettings): Try[HistoryStorage] = {
     log.warn(s"Removing extra index database due to old schema.")
-    close()
-    // org.ergoplatform.wallet.utils.FileUtils
     val root = new File(s"${ergoSettings.directory}/history/extra")
-    if (root.exists()) {
-      Files.walk(root.toPath).iterator().asScala.toSeq.reverse.foreach(path => Try(Files.delete(path)))
-    }else {
-      log.error(s"Could not delete ${root.toString}")
-      return this
+    Try(close()).flatMap { _ =>
+      HistoryStorage.deleteRecursively(root.toPath, Files.delete)
+    }.map { _ =>
+      log.info(s"Deleted ${root.toString}")
+      HistoryStorage.apply(ergoSettings)
     }
-    log.info(s"Deleted ${root.toString}")
-    HistoryStorage.apply(ergoSettings)
   }
 
 }
 
 object HistoryStorage {
+  private[storage] def deleteRecursively(root: Path, deletePath: Path => Unit): Try[Unit] = Try {
+    if (Files.exists(root)) {
+      val paths = Files.walk(root)
+      try paths.iterator().asScala.toSeq.reverse.foreach(deletePath)
+      finally paths.close()
+    }
+    require(!Files.exists(root), s"Could not delete $root")
+  }
+
   def apply(ergoSettings: ErgoSettings): HistoryStorage = {
     val indexStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/index")
     val objectsStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/objects")

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -6,6 +6,7 @@ import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.settings.Algos
 import scorex.db.ByteArrayWrapper
 import scorex.util.{ModifierId, bytesToId, idToBytes}
@@ -24,9 +25,8 @@ trait FullBlockProcessor extends HeadersProcessor {
 
   private var nonBestChainsCache = FullBlockProcessor.emptyCache
 
-  def isInBestFullChain(id: ModifierId): Boolean = historyStorage.getIndex(chainStatusKey(id))
-    .map(ByteArrayWrapper.apply)
-    .contains(ByteArrayWrapper(FullBlockProcessor.BestChainMarker))
+  def isInBestFullChain(id: ModifierId): Boolean =
+    FullBlockProcessor.isInBestFullChain(historyStorage, id)
 
   /**
     * Id of header that contains transactions and proofs
@@ -287,5 +287,13 @@ object FullBlockProcessor {
 
   def chainStatusKey(id: ModifierId): ByteArrayWrapper =
     ByteArrayWrapper(Algos.hash("main_chain".getBytes(CharsetName) ++ idToBytes(id)))
+
+  private[history] def isInBestFullChain(
+    historyStorage: HistoryStorage,
+    id: ModifierId
+  ): Boolean =
+    historyStorage.getIndex(chainStatusKey(id))
+      .map(ByteArrayWrapper.apply)
+      .contains(ByteArrayWrapper(BestChainMarker))
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/VerifyNonADHistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/VerifyNonADHistorySpecification.scala
@@ -49,7 +49,7 @@ class VerifyNonADHistorySpecification extends ErgoCorePropertyTest {
   property("full chain status updating") {
 
     def isInBestChain(b: ErgoFullBlock, h: ErgoHistory): Boolean = {
-      h.asInstanceOf[FullBlockProcessor].isInBestFullChain(b.id)
+      FullBlockProcessor.isInBestFullChain(h.historyStorage, b.id)
     }
 
     var history = genHistory()

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ChainGenerator.scala
@@ -108,7 +108,9 @@ object ChainGenerator extends ErgoTestHelpers with Matchers {
       log.info(
         s"Block ${block.id} with ${block.transactions.size} transactions at height ${block.header.height} generated")
 
-      loop(state.applyModifier(block, None)(_ => ()).get, outToPassNext, Some(block.header), acc :+ block.id)(history)
+      val newState = state.applyModifier(block, None)(_ => ()).get
+      history.reportModifierIsValid(block).get
+      loop(newState, outToPassNext, Some(block.header), acc :+ block.id)(history)
     } else {
       acc
     }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -893,23 +893,28 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     indexer ! Reset()
   }
 
-  property("requests shutdown when final removal fails after partial rollback writes") {
-    indexer ! CreateDB(HEIGHT)
-    indexer ! Index()
+  property("requests only extra indexer stop when final removal fails after partial rollback writes") {
+    val failingIndexer = system.actorOf(Props.create(classOf[ExtraIndexerTestActor], this))
+    val lifecycleProbe = TestProbe()(system)
+    lifecycleProbe.watch(failingIndexer)
+
+    failingIndexer ! CreateDB(HEIGHT)
+    failingIndexer ! Index()
     awaitCondition(done)
     val spentInputId = bytesToId(fullChainTransactionsAt(HEIGHT).txs.flatMap(_.inputs).head.boxId)
     history.typedExtraIndexById[IndexedErgoBox](spentInputId).exists(_.isSpent) shouldBe true
 
     val probe = TestProbe()(system)
-    indexer ! FailNextRollbackRemoval(probe.ref)
+    failingIndexer ! FailNextRollbackRemoval(probe.ref)
     awaitCondition(created)
-    indexer ! ForceRollback(HEIGHT - 1)
+    failingIndexer ! ForceRollback(HEIGHT - 1)
 
-    probe.expectMsg("shutdown-requested")
+    probe.expectMsg("indexer-stop-requested")
+    lifecycleProbe.expectTerminated(failingIndexer)
+    system.whenTerminated.isCompleted shouldBe false
     ExtraIndexer.getIndex(ExtraIndexer.RollbackToKey, _history).getInt shouldBe HEIGHT - 1
     _history.historyStorage.invalidateExtraCache(Seq(spentInputId))
     history.typedExtraIndexById[IndexedErgoBox](spentInputId).exists(_.isSpent) shouldBe false
-    indexer ! Reset()
   }
 
   property("recovers a reloaded checkpoint without waiting for block or rollback events") {

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -1,8 +1,10 @@
 package org.ergoplatform.nodeView.history.extra
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{Actor, ActorIdentity, ActorRef, ActorSystem, Identify, Props}
+import akka.testkit.TestProbe
 import org.ergoplatform.ErgoAddressEncoder
 import org.ergoplatform.http.api.SortDirection
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{RemoteBlockApplied, Rollback}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.Index
@@ -10,13 +12,16 @@ import org.ergoplatform.nodeView.history.extra.IndexedContractTemplateSerializer
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
 import org.ergoplatform.nodeView.history.extra.SegmentSerializer.{boxSegmentId, txSegmentId}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, NetworkType}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import scorex.util.{ModifierId, bytesToId}
 import spire.implicits.cfor
 
 import java.util.concurrent.locks.{Condition, ReentrantLock}
+import java.nio.ByteBuffer
+import java.nio.file.Files
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.reflect.ClassTag
@@ -30,6 +35,14 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   case class ExtendDB(blockCount: Int)
   case class Reset()
   case class GenerateBetterChainTip()
+  case class CacheBlockTransactions(height: Int, transactions: BlockTransactions)
+  case class DeferNextHeaderOnce(height: Int)
+  case class DeferBlockTransactionsOnce(height: Int)
+  case class Reload()
+  case class ForceRollback(height: Int)
+  case class GetLoadedState()
+  case class FailNextRollbackRemoval(probe: ActorRef)
+  case class PauseBufferedCatchUpAt(height: Int, saveLimit: Int, probe: ActorRef)
 
   type ID_LL = mutable.HashMap[ModifierId,(Long,Long)]
 
@@ -42,6 +55,19 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
 
   var _history: ErgoHistory = _
   def history: ErgoHistoryReader = _history.getReader
+
+  def fullChainHeaderAt(height: Int): Header = {
+    val bestFullBlock = history.bestFullBlockOpt.get
+    history.headerChainBack(bestFullBlock.height - height + 1, bestFullBlock.header, _.height == height)
+      .headers
+      .find(_.height == height)
+      .get
+  }
+
+  def fullChainTransactionsAt(height: Int): BlockTransactions = {
+    val header = fullChainHeaderAt(height)
+    history.typedModifierById[BlockTransactions](header.transactionsId).get
+  }
 
   val lock: ReentrantLock = new ReentrantLock()
   val done: Condition = lock.newCondition()
@@ -64,8 +90,8 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     val templates: ID_LL = mutable.HashMap[ModifierId, (Long, Long)]()
     val indexedTokens: ID_LL = mutable.HashMap[ModifierId, (Long, Long)]()
     cfor(1)(_ <= limit, _ + 1) { i =>
-      val header = history.headerIdsAtHeight(i).last
-      val block = history.getFullBlock(history.typedModifierById[Header](header).get)
+      val header = fullChainHeaderAt(i)
+      val block = history.getFullBlock(header)
       block.get.transactions.foreach { tx =>
         txsIndexed += 1
         if (i != 1) {
@@ -174,9 +200,8 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
       val (addresses, templates, indexedTokens, txsIndexed, boxesIndexed) = manualIndex(n)
 
       // perform rollback
-      indexer ! Rollback(history.bestHeaderIdAtHeight(n).get)
-      lock.lock()
-      done.await()
+      indexer ! ForceRollback(n)
+      awaitCondition(done)
       state = IndexerState.fromHistory(_history)
 
       // address balances
@@ -220,8 +245,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
       println(s"Generate to $n")
       indexer ! CreateDB(n)
       indexer ! Index()
-      lock.lock()
-      done.await()
+      awaitCondition(done)
 
       val (addresses, _, _, _, _) = manualIndex(n)
 
@@ -274,11 +298,438 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     indexer ! Reset()
   }
 
+  property("catches up past a direct block event when history is already ahead") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+
+    indexer ! ExtendDB(HEIGHT + 2)
+    awaitCondition(created)
+    val firstHeader = fullChainHeaderAt(HEIGHT + 1)
+    indexer ! RemoteBlockApplied(firstHeader, history.getFullBlock(firstHeader).get.transactions.map(_.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 2
+      state.indexedHeaderId shouldBe Some(fullChainHeaderAt(HEIGHT + 2).id)
+    }
+    indexer ! Reset()
+  }
+
+  property("restores the exact persisted indexed header after the best header changes") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+
+    val persistedState = IndexerState.fromHistory(_history)
+    persistedState.indexedHeaderId shouldBe history.bestHeaderIdAtHeight(HEIGHT)
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! CreateDB(HEIGHT + 1)
+    awaitCondition(created)
+    history.bestHeaderIdAtHeight(HEIGHT) should not be persistedState.indexedHeaderId
+
+    IndexerState.fromHistory(_history).indexedHeaderId shouldBe persistedState.indexedHeaderId
+    indexer ! Reset()
+  }
+
+  property("rebuilds legacy, malformed, and interrupted checkpoints") {
+    def intBytes(value: Int): Array[Byte] = ByteBuffer.allocate(4).putInt(value).array
+    def longBytes(value: Long): Array[Byte] = ByteBuffer.allocate(8).putLong(value).array
+    val schema = ExtraIndexer.SchemaVersionKey -> intBytes(ExtraIndexer.NewestVersion)
+    val emptyMetadata = Array(
+      ExtraIndexer.IndexedHeightKey -> intBytes(0),
+      ExtraIndexer.GlobalTxIndexKey -> longBytes(0),
+      ExtraIndexer.GlobalBoxIndexKey -> longBytes(0),
+      ExtraIndexer.RollbackToKey -> intBytes(0)
+    )
+    val invalidCheckpoints = Seq[(String, Array[(Array[Byte], Array[Byte])])](
+      "legacy non-empty" -> Array(
+        ExtraIndexer.SchemaVersionKey -> intBytes(6),
+        ExtraIndexer.IndexedHeightKey -> intBytes(1),
+        ExtraIndexer.GlobalTxIndexKey -> longBytes(0),
+        ExtraIndexer.GlobalBoxIndexKey -> longBytes(0),
+        ExtraIndexer.RollbackToKey -> intBytes(0)
+      ),
+      "legacy height zero with stale counters" -> Array(
+        ExtraIndexer.SchemaVersionKey -> intBytes(6),
+        ExtraIndexer.IndexedHeightKey -> intBytes(0),
+        ExtraIndexer.GlobalTxIndexKey -> longBytes(7),
+        ExtraIndexer.GlobalBoxIndexKey -> longBytes(9),
+        ExtraIndexer.RollbackToKey -> intBytes(0)
+      ),
+      "missing header id" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> intBytes(1))),
+      "short header id" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> intBytes(1)) ++
+        Array(ExtraIndexer.IndexedHeaderIdKey -> Array[Byte](1, 2, 3))),
+      "unknown header id" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> intBytes(1)) ++
+        Array(ExtraIndexer.IndexedHeaderIdKey -> Array.fill[Byte](32)(1))),
+      "interrupted rollback" -> (Array(schema) ++ emptyMetadata.updated(3, ExtraIndexer.RollbackToKey -> intBytes(1))),
+      "short indexed height" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> Array[Byte](1))),
+      "long transaction index" -> (Array(schema) ++ emptyMetadata.updated(1, ExtraIndexer.GlobalTxIndexKey -> Array.fill[Byte](9)(1))),
+      "short box index" -> (Array(schema) ++ emptyMetadata.updated(2, ExtraIndexer.GlobalBoxIndexKey -> Array[Byte](1))),
+      "short rollback target" -> (Array(schema) ++ emptyMetadata.updated(3, ExtraIndexer.RollbackToKey -> Array[Byte](1))),
+      "current schema height zero with stale transaction counter" ->
+        (Array(schema) ++ emptyMetadata.updated(1, ExtraIndexer.GlobalTxIndexKey -> longBytes(1))),
+      "current schema height zero with stale box counter" ->
+        (Array(schema) ++ emptyMetadata.updated(2, ExtraIndexer.GlobalBoxIndexKey -> longBytes(1))),
+      "negative box index" -> (Array(schema) ++ emptyMetadata.updated(2, ExtraIndexer.GlobalBoxIndexKey -> longBytes(-1)))
+    )
+
+    invalidCheckpoints.foreach { case (name, entries) =>
+      val dbDir = Files.createTempDirectory("extra-indexer-checkpoint").toFile
+      val dbSettings = initSettings.copy(
+        directory = dbDir.getAbsolutePath,
+        nodeSettings = initSettings.nodeSettings.copy(extraIndex = true)
+      )
+      val db = HistoryStorage(dbSettings)
+      db.insertExtraTry(entries, Array.empty).get
+      db.close()
+
+      val probe = TestProbe()(system)
+      system.actorOf(Props(new Actor {
+        override def preStart(): Unit = {
+          val reloaded = ErgoHistory.readOrGenerate(dbSettings)(context)
+          probe.ref ! ((
+            ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, reloaded).getInt,
+            ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, reloaded).getLong,
+            ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, reloaded).getLong,
+            ExtraIndexer.getIndex(ExtraIndexer.RollbackToKey, reloaded).getInt,
+            reloaded.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+          ))
+          reloaded.closeStorage()
+          context.stop(self)
+        }
+
+        override def receive: Receive = Actor.emptyBehavior
+      }))
+      withClue(name) {
+        probe.expectMsg((0, 0L, 0L, 0, None))
+      }
+    }
+  }
+
+  property("preserves a valid non-empty checkpoint across storage reopen") {
+    val dbDir = Files.createTempDirectory("extra-indexer-valid-checkpoint").toFile
+    val dbSettings = initSettings.copy(
+      directory = dbDir.getAbsolutePath,
+      networkType = NetworkType.TestNet,
+      nodeSettings = initSettings.nodeSettings.copy(extraIndex = true, headerChainDiff = 5000)
+    )
+    val generationSettings = dbSettings.copy(
+      nodeSettings = dbSettings.nodeSettings.copy(extraIndex = false)
+    )
+    val probe = TestProbe()(system)
+    system.actorOf(Props(new Actor {
+      override def preStart(): Unit = {
+        val generatedHistory = ErgoHistory.readOrGenerate(generationSettings)(context)
+        ChainGenerator.generate(1, dbDir, generatedHistory, None)
+        generatedHistory.closeStorage()
+
+        val indexedHistory = ErgoHistory.readOrGenerate(dbSettings)(context)
+        val header = indexedHistory.bestFullBlockOpt.get.header
+        val blockTransactions = indexedHistory.typedModifierById[BlockTransactions](header.transactionsId).get
+        val txCount = blockTransactions.txs.size.toLong
+        val boxCount = blockTransactions.txs.map(_.outputs.size.toLong).sum
+        val lastTx = blockTransactions.txs.last
+        val lastTxIndex = txCount - 1
+        val lastBoxIndex = boxCount - 1
+        val outputIndexes = Array.tabulate(lastTx.outputs.size) { i =>
+          boxCount - lastTx.outputs.size.toLong + i.toLong
+        }
+        val indexedTx = IndexedErgoTransaction.fromTx(
+          lastTx,
+          blockTransactions.txs.size - 1,
+          header.height,
+          lastTxIndex,
+          Array.fill(lastTx.inputs.size)(0L),
+          outputIndexes
+        )
+        val indexedBoxes = lastTx.outputs.zip(outputIndexes).map { case (output, outputIndex) =>
+          new IndexedErgoBox(
+            header.height,
+            None,
+            None,
+            None,
+            output,
+            outputIndex
+          )
+        }.toArray
+        val numericBoxes = indexedBoxes.map(box => NumericBoxIndex(box.globalIndex, box.id))
+        val lastBox = indexedBoxes.last
+        val numericTx = NumericTxIndex(lastTxIndex, lastTx.id)
+        val numericBox = numericBoxes.last
+        val checkpointMetadata = Array(
+          ExtraIndexer.SchemaVersionKey -> ByteBuffer.allocate(4).putInt(ExtraIndexer.NewestVersion).array,
+          ExtraIndexer.IndexedHeightKey -> ByteBuffer.allocate(4).putInt(header.height).array,
+          ExtraIndexer.GlobalTxIndexKey -> ByteBuffer.allocate(8).putLong(txCount).array,
+          ExtraIndexer.GlobalBoxIndexKey -> ByteBuffer.allocate(8).putLong(boxCount).array,
+          ExtraIndexer.RollbackToKey -> ByteBuffer.allocate(4).putInt(0).array,
+          ExtraIndexer.IndexedHeaderIdKey -> ExtraIndexer.fastIdToBytes(header.id)
+        )
+        val checkpointObjects = Array[ExtraIndex](numericTx, indexedTx) ++ numericBoxes ++ indexedBoxes
+        indexedHistory.historyStorage.insertExtraTry(
+          checkpointMetadata,
+          checkpointObjects
+        ).get
+        indexedHistory.closeStorage()
+
+        val reloaded = ErgoHistory.readOrGenerate(dbSettings)(context)
+        val state = IndexerState.fromHistory(reloaded)
+        val terminalRowsPreserved =
+          reloaded.typedExtraIndexById[NumericTxIndex](numericTx.id).contains(numericTx) &&
+            reloaded.typedExtraIndexById[IndexedErgoTransaction](indexedTx.id).exists { tx =>
+              tx.txid == indexedTx.txid && tx.globalIndex == indexedTx.globalIndex &&
+                tx.height == indexedTx.height && tx.outputNums.sameElements(indexedTx.outputNums)
+            } &&
+            reloaded.typedExtraIndexById[NumericBoxIndex](numericBox.id).contains(numericBox) &&
+            reloaded.typedExtraIndexById[IndexedErgoBox](lastBox.id).exists(_.globalIndex == lastBoxIndex)
+        probe.ref ! state
+        probe.ref ! terminalRowsPreserved
+        reloaded.closeStorage()
+
+        val interrupted = HistoryStorage(dbSettings)
+        interrupted.insertExtraTry(
+          Array(ExtraIndexer.RollbackToKey -> ByteBuffer.allocate(4).putInt(header.height).array),
+          Array.empty
+        ).get
+        interrupted.close()
+
+        val rebuiltAfterInterruptedRollback = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterInterruptedRollback).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterInterruptedRollback).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterInterruptedRollback).getLong,
+          rebuiltAfterInterruptedRollback.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterInterruptedRollback.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterInterruptedRollback.closeStorage()
+
+        val wrongSchema = HistoryStorage(dbSettings)
+        wrongSchema.insertExtraTry(
+          Array(ExtraIndexer.SchemaVersionKey -> ByteBuffer.allocate(4).putInt(ExtraIndexer.NewestVersion - 1).array),
+          Array.empty
+        ).get
+        wrongSchema.close()
+
+        val rebuiltAfterSchemaMismatch = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterSchemaMismatch).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterSchemaMismatch).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterSchemaMismatch).getLong,
+          rebuiltAfterSchemaMismatch.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterSchemaMismatch.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterSchemaMismatch.closeStorage()
+
+        val malformed = HistoryStorage(dbSettings)
+        val malformedTx = indexedTx.copy(outputNums = indexedTx.outputNums ++ Array(lastBoxIndex))
+        malformed.insertExtraTry(Array.empty, Array(malformedTx)).get
+        malformed.close()
+
+        val rebuiltAfterMalformedTx = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterMalformedTx).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterMalformedTx).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterMalformedTx).getLong,
+          rebuiltAfterMalformedTx.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterMalformedTx.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterMalformedTx.closeStorage()
+
+        val malformedInputs = HistoryStorage(dbSettings)
+        val malformedInputTx = indexedTx.copy(inputNums = indexedTx.inputNums.map(_ + 1L))
+        malformedInputs.insertExtraTry(Array.empty, Array(malformedInputTx)).get
+        malformedInputs.close()
+
+        val rebuiltAfterMalformedInputs = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterMalformedInputs).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterMalformedInputs).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterMalformedInputs).getLong,
+          rebuiltAfterMalformedInputs.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterMalformedInputs.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterMalformedInputs.closeStorage()
+
+        val malformedSpentOutput = HistoryStorage(dbSettings)
+        val spentTerminalBox = new IndexedErgoBox(
+          header.height,
+          Some(lastTx.id),
+          Some(header.height + 1),
+          None,
+          lastTx.outputs.last,
+          lastBoxIndex
+        )
+        malformedSpentOutput.insertExtraTry(Array.empty, Array(spentTerminalBox)).get
+        malformedSpentOutput.close()
+
+        val rebuiltAfterSpentOutput = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterSpentOutput).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterSpentOutput).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterSpentOutput).getLong,
+          rebuiltAfterSpentOutput.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterSpentOutput.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterSpentOutput.closeStorage()
+
+        val corrupted = HistoryStorage(dbSettings)
+        corrupted.removeExtraTry(Array(numericBox.id)).get
+        corrupted.close()
+
+        val rebuilt = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuilt).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuilt).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuilt).getLong,
+          rebuilt.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuilt.closeStorage()
+
+        val invalidatedHeaderHistory = ErgoHistory.readOrGenerate(dbSettings)(context)
+        invalidatedHeaderHistory.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        invalidatedHeaderHistory.historyStorage.insert(
+          Array(invalidatedHeaderHistory.validityKey(header.id) -> Array(0.toByte)),
+          org.ergoplatform.modifiers.BlockSection.emptyArray
+        ).get
+        invalidatedHeaderHistory.closeStorage()
+
+        val rebuiltAfterInvalidatedHeader = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterInvalidatedHeader).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterInvalidatedHeader).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterInvalidatedHeader).getLong,
+          rebuiltAfterInvalidatedHeader.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterInvalidatedHeader.closeStorage()
+        context.stop(self)
+      }
+
+      override def receive: Receive = Actor.emptyBehavior
+    }))
+    val preserved = probe.expectMsgType[IndexerState]
+    preserved.indexedHeight shouldBe 1
+    preserved.indexedHeaderId should not be empty
+    preserved.globalTxIndex should be > 0L
+    preserved.globalBoxIndex should be > 0L
+    probe.expectMsg(true)
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+  }
+
+  property("binds cached transactions to the selected header") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+    val originalTransactions = history.bestBlockTransactionsAt(HEIGHT).get
+    val staleTransactions = originalTransactions.copy(
+      txs = history.bestBlockTransactionsAt(HEIGHT - 1).get.txs
+    )
+
+    indexer ! ForceRollback(HEIGHT - 1)
+    awaitCondition(done)
+    val branchState = IndexerState.fromHistory(_history)
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! CreateDB(HEIGHT + 1)
+    awaitCondition(created)
+    val selectedTransactions = history.bestBlockTransactionsAt(HEIGHT).get
+    selectedTransactions.headerId should not be originalTransactions.headerId
+    selectedTransactions.txs.head.id should not be staleTransactions.txs.head.id
+
+    indexer ! CacheBlockTransactions(HEIGHT, staleTransactions)
+    awaitCondition(created)
+    indexer ! Index()
+    awaitCondition(done)
+
+    NumericTxIndex.getTxByNumber(history, branchState.globalTxIndex).map(_.id) shouldBe
+      Some(selectedTransactions.txs.head.id)
+    indexer ! Reset()
+  }
+
+  property("retries catch-up after a transient non-extending header") {
+    indexer ! CreateDB(HEIGHT)
+    awaitCondition(created)
+    indexer ! DeferNextHeaderOnce(2)
+    awaitCondition(created)
+    indexer ! Index()
+
+    org.ergoplatform.utils.untilTimeout(3.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT
+      state.indexedHeaderId shouldBe history.bestHeaderIdAtHeight(HEIGHT)
+    }
+    indexer ! Reset()
+  }
+
+  property("retries catch-up when the selected block transactions are temporarily unavailable") {
+    indexer ! CreateDB(HEIGHT)
+    awaitCondition(created)
+    indexer ! DeferBlockTransactionsOnce(2)
+    awaitCondition(created)
+    indexer ! Index()
+
+    org.ergoplatform.utils.untilTimeout(3.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT
+      state.indexedHeaderId shouldBe Some(fullChainHeaderAt(HEIGHT).id)
+    }
+    indexer ! Reset()
+  }
+
+  property("the production actor starts catch-up from the event stream") {
+    val dbDir = Files.createTempDirectory("extra-indexer-production-start").toFile
+    val dbSettings = initSettings.copy(
+      directory = dbDir.getAbsolutePath,
+      networkType = NetworkType.TestNet,
+      nodeSettings = initSettings.nodeSettings.copy(extraIndex = true, headerChainDiff = 5000)
+    )
+    val setupProbe = TestProbe()(system)
+    system.actorOf(Props(new Actor {
+      override def preStart(): Unit = {
+        val generatedHistory = ErgoHistory.readOrGenerate(dbSettings)(context)
+        ChainGenerator.generate(5, dbDir, generatedHistory, None)
+        setupProbe.ref ! generatedHistory
+        context.stop(self)
+      }
+
+      override def receive: Receive = Actor.emptyBehavior
+    }))
+    val history = setupProbe.expectMsgType[ErgoHistory](30.seconds)
+    IndexerState.fromHistory(history).indexedHeight shouldBe 0
+
+    val productionIndexer = system.actorOf(Props(new ExtraIndexer(
+      dbSettings.cacheSettings,
+      dbSettings.chainSettings.addressEncoder
+    )))
+    val probe = TestProbe()(system)
+    probe.send(productionIndexer, Identify("started"))
+    probe.expectMsg(ActorIdentity("started", Some(productionIndexer)))
+    system.eventStream.publish(ExtraIndexer.ReceivableMessages.StartExtraIndexer(history))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(history)
+      state.indexedHeight shouldBe history.fullBlockHeight
+      state.indexedHeaderId shouldBe Some(history.bestFullBlockOpt.get.header.id)
+    }
+
+    probe.watch(productionIndexer)
+    system.stop(productionIndexer)
+    probe.expectTerminated(productionIndexer)
+    history.closeStorage()
+  }
+
   property("transactions") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val state = IndexerState.fromHistory(_history)
     cfor(0)(_ < state.globalTxIndex, _ + 1) { n =>
       val id = history.typedExtraIndexById[NumericTxIndex](bytesToId(NumericTxIndex.indexToBytes(n)))
@@ -291,8 +742,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("boxes") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val state = IndexerState.fromHistory(_history)
     cfor(0)(_ < state.globalBoxIndex, _ + 1) { n =>
       val id = history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(n)))
@@ -305,8 +755,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("addresses") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val (addresses, _, _, _, _) = manualIndex(HEIGHT)
     checkAddresses(addresses) shouldBe 0
     indexer ! Reset()
@@ -315,8 +764,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("templates") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val (_, templates, _, _, _) = manualIndex(HEIGHT)
     checkTemplates(templates) shouldBe 0
     indexer ! Reset()
@@ -325,8 +773,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("tokens") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val (_, _, indexedTokens, _, _) = manualIndex(HEIGHT)
     checkTokens(indexedTokens) shouldBe 0
     indexer ! Reset()
@@ -352,26 +799,168 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     rollbackWithPattern("G-5;G-15;R-5;G-20;G-25;R-15;G-30;R-10;G-50;R-25")
   }
 
-  property("indexes replacement blocks after rolling back an orphan block") {
+  property("uses the production rollback point when the indexed tip becomes invalid") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
     awaitCondition(done)
+    val originalTipId = IndexerState.fromHistory(_history).indexedHeaderId.get
+
     indexer ! GenerateBetterChainTip()
-    lock.lock()
-    created.await()
-    val newBestHeaderOpt = history.typedModifierById[Header](history.headerIdsAtHeight(history.fullBlockHeight).last)
-    indexer ! RemoteBlockApplied(newBestHeaderOpt.get, Seq.empty) // will be ignored
-    indexer ! CreateDB(HEIGHT + 1)
-    lock.lock()
-    created.await()
+    awaitCondition(created)
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+    val branchPoint = fullChainHeaderAt(HEIGHT - 1)
+    val replacementHeader = fullChainHeaderAt(HEIGHT)
+    val replacementTip = fullChainHeaderAt(HEIGHT + 1)
+
+    _history.historyStorage.insert(
+      Array(_history.validityKey(originalTipId) -> Array(0.toByte)),
+      org.ergoplatform.modifiers.BlockSection.emptyArray
+    ).get
+    val eventProbe = TestProbe()(system)
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementHeader,
+      history.getFullBlock(replacementHeader).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementTip,
+      history.getFullBlock(replacementTip).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, Rollback(branchPoint.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.indexedHeaderId shouldBe Some(replacementTip.id)
+    }
+    indexer ! Reset()
+  }
+
+  property("persists buffered catch-up rows before processing a reorg") {
+    indexer ! CreateDB(HEIGHT)
+    awaitCondition(created)
+    val pauseProbe = TestProbe()(system)
+    pauseProbe.send(indexer, PauseBufferedCatchUpAt(HEIGHT, Int.MaxValue, pauseProbe.ref))
+    pauseProbe.expectMsg("configured")
     indexer ! Index()
-    lock.lock()
-    done.await()
-    indexer ! Rollback(history.bestHeaderIdAtHeight(HEIGHT).get)
-    lock.lock()
-    done.await()
-    val (_, _, indexedTokens, _, _) = manualIndex(HEIGHT)
+
+    val bufferedState = pauseProbe.expectMsgType[IndexerState](10.seconds)
+    bufferedState.indexedHeight shouldBe HEIGHT
+    IndexerState.fromHistory(_history).indexedHeight shouldBe 0
+    val originalTipId = bufferedState.indexedHeaderId.get
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+    val branchPoint = fullChainHeaderAt(HEIGHT - 1)
+    val replacementHeader = fullChainHeaderAt(HEIGHT)
+    val replacementTip = fullChainHeaderAt(HEIGHT + 1)
+    replacementHeader.id should not be originalTipId
+
+    val eventProbe = TestProbe()(system)
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementHeader,
+      history.getFullBlock(replacementHeader).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementTip,
+      history.getFullBlock(replacementTip).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, Rollback(branchPoint.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.indexedHeaderId shouldBe Some(replacementTip.id)
+    }
+
+    val expectedTransactions = (1 to HEIGHT + 1).flatMap(fullChainTransactionsAt(_).txs)
+    val expectedBoxes = expectedTransactions.flatMap(_.outputs)
+    val state = IndexerState.fromHistory(_history)
+    state.globalTxIndex shouldBe expectedTransactions.size
+    state.globalBoxIndex shouldBe expectedBoxes.size
+    expectedTransactions.zipWithIndex.foreach { case (tx, index) =>
+      NumericTxIndex.getTxByNumber(history, index).map(_.id) shouldBe Some(tx.id)
+    }
+    expectedBoxes.zipWithIndex.foreach { case (box, index) =>
+      NumericBoxIndex.getBoxByNumber(history, index).map(_.id) shouldBe Some(bytesToId(box.id))
+    }
+    val (addresses, templates, indexedTokens, _, _) = manualIndex(HEIGHT + 1)
+    checkAddresses(addresses) shouldBe 0
+    checkTemplates(templates) shouldBe 0
     checkTokens(indexedTokens) shouldBe 0
+    indexer ! Reset()
+  }
+
+  property("requests shutdown when final removal fails after partial rollback writes") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+    val spentInputId = bytesToId(fullChainTransactionsAt(HEIGHT).txs.flatMap(_.inputs).head.boxId)
+    history.typedExtraIndexById[IndexedErgoBox](spentInputId).exists(_.isSpent) shouldBe true
+
+    val probe = TestProbe()(system)
+    indexer ! FailNextRollbackRemoval(probe.ref)
+    awaitCondition(created)
+    indexer ! ForceRollback(HEIGHT - 1)
+
+    probe.expectMsg("shutdown-requested")
+    ExtraIndexer.getIndex(ExtraIndexer.RollbackToKey, _history).getInt shouldBe HEIGHT - 1
+    _history.historyStorage.invalidateExtraCache(Seq(spentInputId))
+    history.typedExtraIndexById[IndexedErgoBox](spentInputId).exists(_.isSpent) shouldBe false
+    indexer ! Reset()
+  }
+
+  property("recovers a reloaded checkpoint without waiting for block or rollback events") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+    val originalTipId = IndexerState.fromHistory(_history).indexedHeaderId
+    val branchPointId = fullChainHeaderAt(HEIGHT - 1).id
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+
+    val replacementHeader = fullChainHeaderAt(HEIGHT)
+    val replacementChild = fullChainHeaderAt(HEIGHT + 1)
+    replacementHeader.id should not be originalTipId.get
+
+    indexer ! Reload()
+    awaitCondition(created)
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.indexedHeaderId shouldBe Some(replacementChild.id)
+    }
+
+    val expectedTransactions = (1 to HEIGHT + 1).flatMap(fullChainTransactionsAt(_).txs)
+    val expectedBoxes = expectedTransactions.flatMap(_.outputs)
+    val state = IndexerState.fromHistory(_history)
+    state.globalTxIndex shouldBe expectedTransactions.size
+    state.globalBoxIndex shouldBe expectedBoxes.size
+    expectedTransactions.zipWithIndex.foreach { case (tx, index) =>
+      NumericTxIndex.getTxByNumber(history, index).map(_.id) shouldBe Some(tx.id)
+    }
+    expectedBoxes.zipWithIndex.foreach { case (box, index) =>
+      NumericBoxIndex.getBoxByNumber(history, index).map(_.id) shouldBe Some(bytesToId(box.id))
+    }
+
+    val (addresses, templates, indexedTokens, _, _) = manualIndex(HEIGHT + 1)
+    checkAddresses(addresses) shouldBe 0
+    checkTemplates(templates) shouldBe 0
+    checkTokens(indexedTokens) shouldBe 0
+
+    val probe = TestProbe()(system)
+    probe.send(indexer, Rollback(branchPointId))
+    probe.send(indexer, GetLoadedState())
+    val stateAfterLateRollback = probe.expectMsgType[IndexerState]
+    stateAfterLateRollback.indexedHeight shouldBe HEIGHT + 1
+    stateAfterLateRollback.indexedHeaderId shouldBe Some(replacementChild.id)
+    IndexerState.fromHistory(_history) shouldBe stateAfterLateRollback
     indexer ! Reset()
   }
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
@@ -90,9 +90,10 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
       Failure(new IllegalStateException("injected final rollback removal failure"))
     } else super.removeRollbackIndexes(ids)
 
-  override protected def requestShutdown(): Unit = {
-    rollbackFailureProbeOpt.foreach(_ ! "shutdown-requested")
+  override protected def stopIndexer(): Unit = {
+    rollbackFailureProbeOpt.foreach(_ ! "indexer-stop-requested")
     rollbackFailureProbeOpt = None
+    super.stopIndexer()
   }
 
   override protected def fullChainHeaderAtHeight(height: Int): Option[Header] = {

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
@@ -1,18 +1,21 @@
 package org.ergoplatform.nodeView.history.extra
 
+import akka.actor.ActorRef
 import org.ergoplatform._
 import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.SortingOption
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.settings._
 import org.ergoplatform.wallet.utils.FileUtils
-import scorex.util.ModifierId
+import scorex.util.{ModifierId, bytesToId}
 
 import java.io.File
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Try}
 
 class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexerBase with FileUtils {
 
@@ -21,7 +24,19 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
     case test.ExtendDB(blockCount: Int) => extendDB(blockCount)
     case test.Reset() => reset()
     case test.GenerateBetterChainTip() => GenerateBetterChainTip()
+    case test.CacheBlockTransactions(height, transactions) => cacheBlockTransactions(height, transactions)
+    case test.DeferNextHeaderOnce(height) => deferNextHeaderOnce(height)
+    case test.DeferBlockTransactionsOnce(height) => deferBlockTransactionsOnce(height)
+    case test.Reload() => reload()
+    case test.FailNextRollbackRemoval(probe) => failNextRollbackRemoval(probe)
+    case test.PauseBufferedCatchUpAt(height, limit, probe) => pauseBufferedCatchUpAt(height, limit, probe)
   }
+
+  override protected def loaded(state: IndexerState): Receive = ({
+    case test.ForceRollback(height) =>
+      beginRollback(state, fullChainHeaderAtHeight(height).get, resume = false)
+    case test.GetLoadedState() => sender ! state
+  }: Receive).orElse(super.loaded(state))
 
   override def caughtUpHook(height: Int = 0): Unit = {
     if(height > 0 && height < chainHeight) return
@@ -31,16 +46,18 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
   }
 
   override def getLastTxForHeight(height: Int): ErgoTransaction = {
-    val header = history.headerIdsAtHeight(height).last
-    val block = history.getFullBlock(history.typedModifierById[Header](header).get)
+    val header = fullChainHeaderAtHeight(height).get
+    val block = history.getFullBlock(header)
     block.get.transactions.last
   }
 
   type ID_LL = mutable.HashMap[ModifierId,(Long,Long)]
 
-  override protected val saveLimit: Int = 1 // save every block
+  private var configuredSaveLimit: Int = 1
+  override protected def saveLimit: Int = configuredSaveLimit
   override protected implicit val segmentThreshold: Int = 8 // split to smaller segments
   override protected implicit val addressEncoder: ErgoAddressEncoder = test.initSettings.chainSettings.addressEncoder
+  override protected val retryDelay = 50.millis
 
   val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true,
     -1, UtxoSettings(utxoBootstrap = false, 0, 2), NipopowSettings(nipopowBootstrap = false, 1), mining = false,
@@ -51,6 +68,51 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
 
   private var dir: File = _
   private var stateOpt: Option[UtxoState] = None
+  private var deferredHeaderHeightOpt: Option[Int] = None
+  private var deferredTransactionsHeightOpt: Option[Int] = None
+  private var rollbackFailureProbeOpt: Option[ActorRef] = None
+  private var failRollbackRemoval: Boolean = false
+  private var pauseCatchUpAtHeightOpt: Option[Int] = None
+  private var catchUpPauseProbeOpt: Option[ActorRef] = None
+
+  override protected def continueCatchUpAfterIndex(state: IndexerState): Boolean = {
+    if (pauseCatchUpAtHeightOpt.contains(state.indexedHeight)) {
+      pauseCatchUpAtHeightOpt = None
+      catchUpPauseProbeOpt.foreach(_ ! state)
+      catchUpPauseProbeOpt = None
+      false
+    } else true
+  }
+
+  override protected def removeRollbackIndexes(ids: Array[ModifierId]): Try[Unit] =
+    if (failRollbackRemoval) {
+      failRollbackRemoval = false
+      Failure(new IllegalStateException("injected final rollback removal failure"))
+    } else super.removeRollbackIndexes(ids)
+
+  override protected def requestShutdown(): Unit = {
+    rollbackFailureProbeOpt.foreach(_ ! "shutdown-requested")
+    rollbackFailureProbeOpt = None
+  }
+
+  override protected def fullChainHeaderAtHeight(height: Int): Option[Header] = {
+    val headerOpt = super.fullChainHeaderAtHeight(height)
+    if (deferredHeaderHeightOpt.contains(height)) {
+      deferredHeaderHeightOpt = None
+      headerOpt.map(_.copy(parentId = bytesToId(Array.fill(32)(0x7f.toByte))))
+    } else {
+      headerOpt
+    }
+  }
+
+  override protected def blockTransactionsForHeader(header: Header): Option[BlockTransactions] = {
+    if (deferredTransactionsHeightOpt.contains(header.height)) {
+      deferredTransactionsHeightOpt = None
+      None
+    } else {
+      super.blockTransactionsForHeader(header)
+    }
+  }
 
   def createDB(blockCount: Int): Unit = {
     if(stateOpt.isEmpty) {
@@ -80,13 +142,22 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
   }
 
   def reset(): Unit = {
+    resetTransientState()
     stateOpt = None
     test._history = null
     general.clear()
     boxes.clear()
     trees.clear()
+    templates.clear()
     tokens.clear()
     segments.clear()
+    deferredHeaderHeightOpt = None
+    deferredTransactionsHeightOpt = None
+    rollbackFailureProbeOpt = None
+    failRollbackRemoval = false
+    configuredSaveLimit = 1
+    pauseCatchUpAtHeightOpt = None
+    catchUpPauseProbeOpt = None
     context.become(receive.orElse(loaded(IndexerState(0, 0, 0, 0, caughtUp = false))))
   }
 
@@ -96,6 +167,56 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
     test.lock.lock()
     test.created.signal()
     test.lock.unlock()
+  }
+
+  private def cacheBlockTransactions(height: Int, transactions: BlockTransactions): Unit = {
+    val cacheAccessor = getClass.getMethods
+      .find(_.getName.endsWith("$$blockCache"))
+      .getOrElse(throw new IllegalStateException("ExtraIndexer block cache accessor not found"))
+    val cache = cacheAccessor.invoke(this)
+      .asInstanceOf[scala.collection.concurrent.Map[Int, BlockTransactions]]
+    cache.put(height, transactions)
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def deferNextHeaderOnce(height: Int): Unit = {
+    deferredHeaderHeightOpt = Some(height)
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def deferBlockTransactionsOnce(height: Int): Unit = {
+    deferredTransactionsHeightOpt = Some(height)
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def reload(): Unit = {
+    resetTransientState()
+    context.become(receive.orElse(loaded(IndexerState.fromHistory(_history))))
+    self ! ExtraIndexer.ReceivableMessages.Index()
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def failNextRollbackRemoval(probe: ActorRef): Unit = {
+    rollbackFailureProbeOpt = Some(probe)
+    failRollbackRemoval = true
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def pauseBufferedCatchUpAt(height: Int, limit: Int, probe: ActorRef): Unit = {
+    configuredSaveLimit = limit
+    pauseCatchUpAtHeightOpt = Some(height)
+    catchUpPauseProbeOpt = Some(probe)
+    probe ! "configured"
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
@@ -170,12 +170,7 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
   }
 
   private def cacheBlockTransactions(height: Int, transactions: BlockTransactions): Unit = {
-    val cacheAccessor = getClass.getMethods
-      .find(_.getName.endsWith("$$blockCache"))
-      .getOrElse(throw new IllegalStateException("ExtraIndexer block cache accessor not found"))
-    val cache = cacheAccessor.invoke(this)
-      .asInstanceOf[scala.collection.concurrent.Map[Int, BlockTransactions]]
-    cache.put(height, transactions)
+    putBlockTransactionsInCache(height, transactions)
     test.lock.lock()
     test.created.signal()
     test.lock.unlock()

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryStorageSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryStorageSpec.scala
@@ -4,11 +4,20 @@ import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.ADProofs
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
+import org.ergoplatform.nodeView.history.extra.{ExtraIndex, IndexedErgoBox}
 import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalacheck.Gen
-import scorex.db.ByteArrayWrapper
+import scorex.db.{ByteArrayWrapper, LDBFactory, LDBKVStore}
 import scorex.util.{ModifierId, idToBytes}
+
+import java.io.IOException
+import java.nio.file.Files
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import org.iq80.leveldb.Options
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Try
 
 class HistoryStorageSpec extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
@@ -38,6 +47,102 @@ class HistoryStorageSpec extends ErgoCorePropertyTest {
     headers.forall(h => !db.get(h.id).exists(_.nonEmpty)) shouldBe true
     modifiers.forall(m => !db.get(m.id).exists(_.nonEmpty)) shouldBe true
     indexes.forall(i => !db.getIndex(i._1).exists(_.nonEmpty)) shouldBe true
+  }
+
+  property("recursive extra index deletion propagates a file failure") {
+    val root = Files.createTempDirectory("extra-index-delete-failure")
+    val sentinel = Files.createFile(root.resolve("sentinel"))
+
+    val result = HistoryStorage.deleteRecursively(root, path => {
+      if (path == sentinel) throw new IOException("injected deletion failure")
+      Files.delete(path)
+    })
+
+    result shouldBe 'failure
+    Files.exists(sentinel) shouldBe true
+    Files.delete(sentinel)
+    Files.delete(root)
+  }
+
+  property("extra serialization failure invalidates mutated cached objects") {
+    import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.ergoBoxGenNoProp
+
+    val indexedBox = new IndexedErgoBox(1, None, None, None, ergoBoxGenNoProp.sample.get, 0L)
+    db.insertExtraTry(Array.empty, Array(indexedBox)).get
+    val cachedBox = db.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox]
+    cachedBox.spendingHeightOpt = Some(2)
+    val unsupported = new ExtraIndex {
+      override def serializedId: Array[Byte] = Array.fill[Byte](32)(0x55.toByte)
+    }
+
+    db.insertExtraTry(Array.empty, Array[ExtraIndex](cachedBox, unsupported)) shouldBe 'failure
+    db.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe None
+    db.insertExtraTry(Array.empty, Array(cachedBox)).get
+    db.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe Some(2)
+  }
+
+  property("an in-flight cache miss cannot restore stale data after a successful write") {
+    import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.ergoBoxGenNoProp
+
+    implicit val executionContext: ExecutionContext = ExecutionContext.global
+    val root = Files.createTempDirectory("extra-index-cache-race")
+    val oldValueRead = new CountDownLatch(1)
+    val resumeOldRead = new CountDownLatch(1)
+    val writerStarted = new CountDownLatch(1)
+    val writeCommitted = new CountDownLatch(1)
+    @volatile var pauseNextRead = false
+    @volatile var observeWrite = false
+
+    val options = new Options().createIfMissing(true)
+    val indexStore = LDBFactory.createKvDb(root.resolve("index").toString)
+    val objectsStore = LDBFactory.createKvDb(root.resolve("objects").toString)
+    val rawExtraDb = LDBFactory.factory.open(root.resolve("extra").toFile, options)
+    val extraStore = new LDBKVStore(rawExtraDb) {
+      override def get(key: Array[Byte]): Option[Array[Byte]] = {
+        val value = super.get(key)
+        if (pauseNextRead) {
+          pauseNextRead = false
+          oldValueRead.countDown()
+          require(resumeOldRead.await(5, TimeUnit.SECONDS), "timed out waiting to resume cache-miss read")
+        }
+        value
+      }
+
+      override def update(toInsertKeys: Array[Array[Byte]],
+                          toInsertValues: Array[Array[Byte]],
+                          toRemove: Array[Array[Byte]]): Try[Unit] = {
+        val result = super.update(toInsertKeys, toInsertValues, toRemove)
+        if (observeWrite && result.isSuccess) writeCommitted.countDown()
+        result
+      }
+    }
+    val concurrentStorage = new HistoryStorage(indexStore, objectsStore, extraStore, settings.cacheSettings)
+
+    try {
+      val indexedBox = new IndexedErgoBox(1, None, None, None, ergoBoxGenNoProp.sample.get, 0L)
+      concurrentStorage.insertExtraTry(Array.empty, Array(indexedBox)).get
+      pauseNextRead = true
+      val staleRead = Future(concurrentStorage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox])
+      oldValueRead.await(5, TimeUnit.SECONDS) shouldBe true
+
+      indexedBox.spendingHeightOpt = Some(2)
+      observeWrite = true
+      val write = Future {
+        writerStarted.countDown()
+        concurrentStorage.insertExtraTry(Array.empty, Array(indexedBox)).get
+      }
+      writerStarted.await(5, TimeUnit.SECONDS) shouldBe true
+      val committedWhileReadWasPaused = writeCommitted.await(200, TimeUnit.MILLISECONDS)
+      resumeOldRead.countDown()
+
+      Await.result(staleRead, 5.seconds).spendingHeightOpt shouldBe None
+      Await.result(write, 5.seconds)
+      committedWhileReadWasPaused shouldBe false
+      concurrentStorage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe Some(2)
+    } finally {
+      resumeOldRead.countDown()
+      concurrentStorage.close()
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

- Persist the exact full-chain header represented by each ExtraIndexer checkpoint and rebuild legacy, malformed, or interrupted checkpoints under schema 7.
- Write forward index rows and checkpoint metadata in one LevelDB batch, bind cached transaction sections to their selected header, and serialize extra-cache misses with writes.
- Retry transient catch-up gaps, reconcile restart/reorg ordering against the valid full-block chain, and fail closed when a multi-step rollback cannot be persisted safely.

## Why

#2442 made the running indexer track an exact header, but restart still reconstructed that identity from the current best header at the stored height. During a fork, the persisted rows could represent branch A while the reloaded state claimed branch B. Replacement block events could then be applied over the wrong rows before the delayed rollback notification.

This change persists provenance instead of inferring it, validates checkpoint shape and terminal mappings on startup, and drives recovery from the current valid full-block chain. Missing block sections and transient header/full-block disagreement are deferred and retried rather than being recorded as caught up.

## Validation

- `ExtraIndexerSpecification`: 23/23
- `HistoryStorageSpec`: 4/4
- `LDBKVStoreSpec`: 3/3

The regressions cover restart onto a competing branch, replacement events before rollback, buffered catch-up followed by reorg, missing transaction sections, malformed/interrupted checkpoints, rollback write failure, cache write failures and retries, an in-flight cache-miss/write race, and production actor startup through the event stream.

## Operational notes

- Existing non-empty schema-6 extra indexes rebuild once under schema 7.
- Forward rows and checkpoint metadata are committed atomically. Rollback remains multi-batch: a durable rollback marker is written first, and a later write failure stops only the ExtraIndexer actor. The node keeps running, and startup validation rebuilds the optional index on the next node restart.
- This affects the optional derived extra index only. It does not change consensus validation, UTXO state, P2P serialization, or API schemas.
