### PR TITLE
Persist unconfirmed wallet transactions and restore them at start-up

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -29,6 +29,7 @@ import org.ergoplatform.modifiers.history.extension.Extension
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -87,10 +88,33 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         Escalate
     }
 
+  override def preStart(): Unit = {
+    super.preStart()
+    restoreUnconfirmedWalletTransactions()
+  }
+
   override def postStop(): Unit = {
     log.warn("Stopping ErgoNodeViewHolder")
     history().closeStorage()
     minimalState().closeStorage()
+  }
+
+  /**
+    * The memory pool is not persisted, so a restart drops every transaction which was waiting in it.
+    * The wallet does keep its own unconfirmed transactions, so ask it for them and put them back,
+    * instead of waiting for peers to gossip them again - which they may never do.
+    */
+  private def restoreUnconfirmedWalletTransactions(): Unit = {
+    implicit val ec: ExecutionContext = context.dispatcher
+    vault().unconfirmedTransactionsToRestore.onComplete {
+      case Success(txs) if txs.nonEmpty =>
+        log.info(s"Putting ${txs.size} unconfirmed wallet transaction(s) back into the memory pool")
+        txs.foreach(tx => self ! RestoredTransaction(UnconfirmedTransaction(tx, None)))
+      case Success(_) =>
+        log.debug("No unconfirmed wallet transactions to restore")
+      case Failure(t) =>
+        log.warn("Could not read unconfirmed wallet transactions to restore: ", t)
+    }
   }
 
   /**
@@ -658,6 +682,17 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       txModify(unconfirmedTx)
     case LocallyGeneratedTransaction(unconfirmedTx) =>
       sender() ! txModify(unconfirmedTx)
+    case RestoredTransaction(unconfirmedTx) =>
+      txModify(unconfirmedTx) match {
+        case _: ProcessingOutcome.Accepted =>
+          log.info(s"Unconfirmed wallet transaction ${unconfirmedTx.id} is back in the memory pool")
+        case outcome =>
+          // the transaction can not be brought back, e.g. it got on the blockchain while the node
+          // was down, or a conflicting one did. There is no point in keeping it for the next restart
+          log.info(s"Unconfirmed wallet transaction ${unconfirmedTx.id} was not accepted back " +
+            s"into the memory pool ($outcome), forgetting it")
+          vault().forgetUnconfirmedTransactions(Seq(unconfirmedTx.id))
+      }
     case RecheckedTransactions(unconfirmedTxs) =>
       val updatedPool = memoryPool().put(unconfirmedTxs)
       updateNodeView(updatedMempool = Some(updatedPool))
@@ -736,6 +771,12 @@ object ErgoNodeViewHolder {
       * Wrapper for transaction coming from P2P network
       */
     case class TransactionFromRemote(unconfirmedTx: UnconfirmedTransaction)
+
+    /**
+      * Wrapper for a wallet transaction which was unconfirmed when the node was stopped and is being
+      * put back into the memory pool now
+      */
+    case class RestoredTransaction(unconfirmedTx: UnconfirmedTransaction)
 
     /**
       * Wrapper for transactions which sit in mempool for long enough time, so `CleanWorker` is re-checking their

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWallet.scala
@@ -9,7 +9,7 @@ import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages._
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.wallet.boxes.{ReemissionData, ReplaceCompactCollectBoxSelector}
 import org.ergoplatform.core.VersionTag
-import scorex.util.ScorexLogging
+import scorex.util.{ModifierId, ScorexLogging}
 
 import scala.util.{Failure, Success, Try}
 
@@ -44,6 +44,14 @@ class ErgoWallet(historyReader: ErgoHistoryReader, settings: ErgoSettings, param
   def scanOffchain(txs: Seq[ErgoTransaction]): ErgoWallet = {
     txs.foreach(tx => scanOffchain(tx))
     this
+  }
+
+  /**
+    * Tell the wallet to stop keeping the given unconfirmed transactions across restarts, e.g.
+    * because the memory pool refused them when they were re-submitted.
+    */
+  def forgetUnconfirmedTransactions(ids: Seq[ModifierId]): Unit = {
+    walletActor ! ForgetUnconfirmedTransactions(ids)
   }
 
   def scanPersistent(modifier: BlockSection): ErgoWallet = {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -4,11 +4,14 @@ import akka.actor.SupervisorStrategy.{Restart, Stop}
 import akka.actor._
 import akka.pattern.StatusReply
 import org.ergoplatform.ErgoBox._
+import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, ChangedState}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.ErgoStateReader
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
+import org.ergoplatform.nodeView.wallet.persistence.WalletStorage
 import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.settings._
 import org.ergoplatform.wallet.Constants.ScanId
@@ -18,8 +21,9 @@ import org.ergoplatform._
 import org.ergoplatform.core.VersionTag
 import org.ergoplatform.sdk.SecretString
 import org.ergoplatform.utils.ScorexEncoding
-import scorex.util.ScorexLogging
+import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 
+import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
@@ -76,7 +80,7 @@ class ErgoWalletActor(settings: ErgoSettings,
       val ws = settings.walletSettings
       // Try to read wallet from json file or test mnemonic provided in a config file
       val newState = ergoWalletService.readWallet(state, ws.testMnemonic.map(SecretString.create(_)), ws.testKeysQty, ws.secretStorage)
-      context.become(loadedWallet(newState))
+      context.become(loadedWallet(ergoWalletService.restoreOffChainState(newState)))
       unstashAll()
     case _ => // stashing all messages until wallet is setup
       stash()
@@ -223,13 +227,22 @@ class ErgoWalletActor(settings: ErgoSettings,
     /* SCAN COMMANDS */
     //scan mempool transaction
     case ScanOffChain(tx) =>
-      val dustLimit = settings.walletSettings.dustLimit
-      val newWalletBoxes = WalletScanLogic.extractWalletOutputs(tx, None, state.walletVars, dustLimit)
-      val inputs = WalletScanLogic.extractInputBoxes(tx)
-      val newState = state.copy(offChainRegistry =
-        state.offChainRegistry.updateOnTransaction(newWalletBoxes, inputs, state.walletVars.externalScans)
-      )
+      val (newState, walletAffected) = ergoWalletService.scanOffChainUpdate(state, tx)
+      if (walletAffected) {
+        // the transaction is kept until it gets on the blockchain, so that a restart in the meantime
+        // does not make the wallet consider its inputs spendable again
+        state.storage.addUnconfirmedTransaction(tx, state.fullHeight) match {
+          case Success(_) =>
+          case Failure(t) => log.error(s"Could not store unconfirmed transaction ${tx.id}: ", t)
+        }
+      }
       context.become(loadedWallet(newState))
+
+    case ReadUnconfirmedTransactions =>
+      sender() ! unconfirmedTransactionsToRestore(state)
+
+    case ForgetUnconfirmedTransactions(ids) =>
+      forgetUnconfirmedTransactions(state, ids)
 
     // rescan=true means we serve a user request for rescan from arbitrary height
     case ScanInThePast(blockHeight, rescan) =>
@@ -275,6 +288,7 @@ class ErgoWalletActor(settings: ErgoSettings,
               case Success(updatedState) =>
                 updatedState
             }
+          forgetConfirmedAndExpired(newState, newBlock)
           context.become(loadedWallet(newState))
         } else if (nextBlockHeight < newBlock.height) {
           log.warn(s"Wallet: skipped blocks found starting from $nextBlockHeight, going back to scan them")
@@ -489,6 +503,48 @@ class ErgoWalletActor(settings: ErgoSettings,
     sender() ! txsToSend
   }
 
+  /**
+    * Stored unconfirmed transactions worth putting back into the memory pool. Transactions which did
+    * not make it onto the blockchain for too long are dropped instead of being re-submitted forever.
+    */
+  private def unconfirmedTransactionsToRestore(state: ErgoWalletState): Seq[ErgoTransaction] = {
+    val (fresh, expired) = state.storage.readUnconfirmedTransactions().partition { case (_, seenAt) =>
+      state.fullHeight - seenAt <= WalletStorage.UnconfirmedTxLifetimeInBlocks
+    }
+    if (expired.nonEmpty) {
+      forgetUnconfirmedTransactions(state, expired.map(_._1.id))
+    }
+    ErgoWalletActor.orderByDependency(fresh.map(_._1))
+  }
+
+  /**
+    * Drop the transactions of a just applied block from the store, and give up on the ones which
+    * stayed unconfirmed for longer than [[WalletStorage.UnconfirmedTxLifetimeInBlocks]] blocks.
+    */
+  private def forgetConfirmedAndExpired(state: ErgoWalletState, block: ErgoFullBlock): Unit = {
+    val seenAtHeights = state.storage.unconfirmedTransactionHeights
+    if (seenAtHeights.nonEmpty) {
+      val confirmed = block.transactions.map(_.id).filter(seenAtHeights.contains)
+      val expired = seenAtHeights.collect {
+        case (id, seenAt) if block.height - seenAt > WalletStorage.UnconfirmedTxLifetimeInBlocks => id
+      }.toSeq
+      if (expired.nonEmpty) {
+        log.warn(s"Wallet gave up on ${expired.size} transaction(s) still unconfirmed at height ${block.height}")
+      }
+      val toForget = (confirmed ++ expired).distinct
+      if (toForget.nonEmpty) {
+        forgetUnconfirmedTransactions(state, toForget)
+      }
+    }
+  }
+
+  private def forgetUnconfirmedTransactions(state: ErgoWalletState, ids: Seq[ModifierId]): Unit = {
+    state.storage.removeUnconfirmedTransactions(ids) match {
+      case Success(_) =>
+      case Failure(t) => log.error("Could not forget unconfirmed transactions: ", t)
+    }
+  }
+
   override def receive: Receive = emptyWallet
 
   private def wrapLegalExc[T](e: Throwable): Failure[T] =
@@ -502,6 +558,42 @@ class ErgoWalletActor(settings: ErgoSettings,
 }
 
 object ErgoWalletActor extends ScorexLogging {
+
+  /**
+    * Order transactions so that a transaction spending an output of another one comes after it.
+    *
+    * Unconfirmed transactions do form such chains, and both consumers of this ordering need it: the
+    * off-chain registry only nets a spending out if it has seen the box being spent already, and the
+    * memory pool refuses a transaction whose inputs it does not know yet.
+    *
+    * Transactions with no producer among `txs` keep their relative order. A cycle is impossible
+    * between valid transactions, but should one be given, its members are appended unordered rather
+    * than dropped.
+    */
+  def orderByDependency(txs: Seq[ErgoTransaction]): Seq[ErgoTransaction] = {
+    val producerOf: Map[ModifierId, ModifierId] =
+      txs.flatMap(tx => tx.outputs.map(out => bytesToId(out.id) -> tx.id)).toMap
+
+    @tailrec
+    def loop(remaining: Seq[ErgoTransaction],
+             ordered: Set[ModifierId],
+             acc: Seq[ErgoTransaction]): Seq[ErgoTransaction] = {
+      if (remaining.isEmpty) {
+        acc
+      } else {
+        val (ready, blocked) = remaining.partition { tx =>
+          tx.inputs.forall(in => producerOf.get(bytesToId(in.boxId)).forall(ordered.contains))
+        }
+        if (ready.isEmpty) {
+          acc ++ blocked
+        } else {
+          loop(blocked, ordered ++ ready.map(_.id), acc ++ ready)
+        }
+      }
+    }
+
+    loop(txs, Set.empty, Seq.empty)
+  }
 
   /** Start actor and register its proper closing into coordinated shutdown */
   def apply(settings: ErgoSettings,

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActorMessages.scala
@@ -52,6 +52,21 @@ object ErgoWalletActorMessages {
   final case class ScanOnChain(block: ErgoFullBlock)
 
   /**
+   * Read wallet-related transactions which were not on the blockchain yet when the node was stopped,
+   * so that they can be put back into the memory pool. Answered with a `Seq[ErgoTransaction]`,
+   * ordered so that a transaction spending an output of another one comes after it.
+   */
+  final case object ReadUnconfirmedTransactions
+
+  /**
+   * Stop keeping the given unconfirmed transactions across restarts, e.g. because the memory pool
+   * refused them
+   *
+   * @param ids - identifiers of the transactions to forget
+   */
+  final case class ForgetUnconfirmedTransactions(ids: Seq[ModifierId])
+
+  /**
    * Rollback to previous version of the wallet, by throwing away effects of blocks after the version
    *
    * @param version

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletReader.scala
@@ -97,6 +97,14 @@ trait ErgoWalletReader extends NodeViewComponent {
   def transactionById(id: ModifierId): Future[Option[AugWalletTransaction]] =
     (walletActor ? GetTransaction(id)).mapTo[Option[AugWalletTransaction]]
 
+  /**
+    * Wallet-related transactions which were not on the blockchain yet when the node was stopped, so
+    * that they can be put back into the memory pool. Ordered so that a transaction spending an
+    * output of another one comes after it.
+    */
+  def unconfirmedTransactionsToRestore: Future[Seq[ErgoTransaction]] =
+    (walletActor ? ReadUnconfirmedTransactions).mapTo[Seq[ErgoTransaction]]
+
   def generateTransaction(requests: Seq[TransactionGenerationRequest],
                           inputsRaw: Seq[String] = Seq.empty,
                           dataInputsRaw: Seq[String] = Seq.empty): Future[Try[ErgoTransaction]] =

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -221,6 +221,21 @@ trait ErgoWalletService {
   def scanBlockUpdate(state: ErgoWalletState, block: ErgoFullBlock, dustLimit: Option[Long]): Try[ErgoWalletState]
 
   /**
+    * Update the off-chain part of the wallet with a transaction which is not on the blockchain yet.
+    *
+    * @return the updated state, and whether the transaction is of any interest to the wallet, that
+    *         is whether it pays the wallet or spends one of its boxes
+    */
+  def scanOffChainUpdate(state: ErgoWalletState, tx: ErgoTransaction): (ErgoWalletState, Boolean)
+
+  /**
+    * Rebuild the off-chain part of the wallet from the transactions which were unconfirmed when the
+    * node was stopped. Without it the wallet forgets that it already spent their inputs and can
+    * build a conflicting transaction spending the same boxes a second time.
+    */
+  def restoreOffChainState(state: ErgoWalletState): ErgoWalletState
+
+  /**
     * Sign a transaction
     */
   def signTransaction(proverOpt: Option[ErgoProvingInterpreter],
@@ -595,6 +610,33 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
         ergoSettings.walletSettings.walletProfile).map { case (reg, offReg, updatedOutputsFilter) =>
         state.copy(registry = reg, offChainRegistry = offReg, outputsFilter = Some(updatedOutputsFilter))
       }
+
+  override def scanOffChainUpdate(state: ErgoWalletState, tx: ErgoTransaction): (ErgoWalletState, Boolean) = {
+    val dustLimit = ergoSettings.walletSettings.dustLimit
+    val newWalletBoxes = WalletScanLogic.extractWalletOutputs(tx, None, state.walletVars, dustLimit)
+    val inputs = WalletScanLogic.extractInputBoxes(tx)
+
+    def spendsWalletBox: Boolean =
+      state.offChainRegistry.offChainBoxes.exists(box => inputs.contains(box.boxId)) ||
+        tx.inputs.exists(input => state.registry.getBox(input.boxId).isDefined)
+
+    val newState = state.copy(offChainRegistry =
+      state.offChainRegistry.updateOnTransaction(newWalletBoxes, inputs, state.walletVars.externalScans)
+    )
+    (newState, newWalletBoxes.nonEmpty || spendsWalletBox)
+  }
+
+  override def restoreOffChainState(state: ErgoWalletState): ErgoWalletState = {
+    val stored = state.storage.readUnconfirmedTransactions().map(_._1)
+    if (stored.isEmpty) {
+      state
+    } else {
+      log.info(s"Wallet is restoring ${stored.size} unconfirmed transaction(s) kept across restart")
+      ErgoWalletActor.orderByDependency(stored).foldLeft(state) { case (acc, tx) =>
+        scanOffChainUpdate(acc, tx)._1
+      }
+    }
+  }
 
   override def updateUtxoState(state: ErgoWalletState): ErgoWalletState = {
     (state.mempoolReaderOpt, state.stateReaderOpt) match {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.nodeView.wallet.persistence
 
 import com.google.common.primitives.{Ints, Shorts}
 import org.ergoplatform.P2PKAddress
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer}
 import org.ergoplatform.nodeView.state.{ErgoStateContext, ErgoStateContextSerializer}
 import org.ergoplatform.nodeView.wallet.scanning.{Scan, ScanRequest, ScanSerializer}
 import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DerivationPathSerializer, ExtendedPublicKey, ExtendedPublicKeySerializer}
@@ -9,7 +10,7 @@ import org.ergoplatform.settings.{Constants, ErgoSettings, Parameters}
 import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import scorex.crypto.hash.Blake2b256
 import scorex.db.{LDBFactory, LDBKVStore}
-import scorex.util.ScorexLogging
+import scorex.util.{ModifierId, ScorexLogging, idToBytes}
 import sigma.serialization.SigmaSerializer
 
 import java.io.File
@@ -24,6 +25,7 @@ import scala.util.{Failure, Success, Try}
   * * changed addresses
   * * ErgoStateContext (not version-agnostic, but state changes including rollbacks it is updated externally)
   * * external scans
+  * * wallet-related transactions which are not on the blockchain yet
   */
 final class WalletStorage(store: LDBKVStore, settings: ErgoSettings) extends ScorexLogging {
 
@@ -195,6 +197,76 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings) extends Sco
   }
 
   /**
+    * Heights at which wallet-related unconfirmed transactions stored in the database were first seen,
+    * by transaction identifier. Kept in memory so that applying a block does not need a database
+    * lookup per transaction of the block, and so that pruning does not need to read the whole bucket.
+    */
+  private var cachedUnconfirmedTxHeights: Option[Map[ModifierId, Int]] = None
+
+  /**
+    * @return heights at which stored unconfirmed transactions were first seen, by transaction id
+    */
+  def unconfirmedTransactionHeights: Map[ModifierId, Int] = cachedUnconfirmedTxHeights.getOrElse {
+    val heights = readUnconfirmedTransactions().map { case (tx, height) => tx.id -> height }.toMap
+    cachedUnconfirmedTxHeights = Some(heights)
+    heights
+  }
+
+  /**
+    * Store a wallet-related transaction which is not on the blockchain yet, so that it survives
+    * a node restart.
+    *
+    * A transaction already stored is left alone rather than re-dated: it is re-scanned every time it
+    * is put back into the memory pool, and refreshing its height there would push its expiry back on
+    * every restart, so a transaction which never confirms would be kept forever.
+    *
+    * @param tx           - unconfirmed transaction the wallet is interested in
+    * @param seenAtHeight - blockchain height at the moment the transaction was first seen
+    */
+  def addUnconfirmedTransaction(tx: ErgoTransaction, seenAtHeight: Int): Try[Unit] = {
+    if (unconfirmedTransactionHeights.contains(tx.id)) {
+      Success(())
+    } else {
+      store.insert(unconfirmedTxKey(tx.id), Ints.toByteArray(seenAtHeight) ++ tx.bytes).map { _ =>
+        cachedUnconfirmedTxHeights = Some(unconfirmedTransactionHeights.updated(tx.id, seenAtHeight))
+      }
+    }
+  }
+
+  /**
+    * Forget stored unconfirmed transactions, e.g. once they got on the blockchain. Identifiers of
+    * transactions which are not stored are ignored.
+    */
+  def removeUnconfirmedTransactions(ids: Seq[ModifierId]): Try[Unit] = {
+    val known = unconfirmedTransactionHeights
+    val toRemove = ids.filter(known.contains)
+    if (toRemove.isEmpty) {
+      Success(())
+    } else {
+      store.remove(toRemove.map(unconfirmedTxKey).toArray).map { _ =>
+        cachedUnconfirmedTxHeights = Some(known -- toRemove)
+      }
+    }
+  }
+
+  /**
+    * Read unconfirmed transactions stored, along with the height each of them was seen at.
+    * Records which can not be parsed are skipped, a corrupted record must not prevent the wallet
+    * from starting.
+    */
+  def readUnconfirmedTransactions(): Seq[(ErgoTransaction, Int)] = {
+    store.getRange(FirstUnconfirmedTxId, LastUnconfirmedTxId).flatMap { case (_, v) =>
+      ErgoTransactionSerializer.parseBytesTry(v.drop(java.lang.Integer.BYTES)) match {
+        case Success(tx) =>
+          Some(tx -> Ints.fromByteArray(v.take(java.lang.Integer.BYTES)))
+        case Failure(t) =>
+          log.error("Corrupted data when reading an unconfirmed transaction: ", t)
+          None
+      }
+    }
+  }
+
+  /**
     * Close wallet storage database
     */
   def close(): Unit = {
@@ -220,8 +292,15 @@ object WalletStorage {
     */
   val PublicKeyPrefixByte: Byte = 2: Byte
 
+  /**
+    * Secondary prefix byte for the bucket of wallet-related transactions which are not on the
+    * blockchain yet
+    */
+  val UnconfirmedTxPrefixByte: Byte = 3: Byte
+
   val ScanPrefixArray: Array[Byte] = Array(RangedKeyPrefix, ScanPrefixByte)
   val PublicKeyPrefixArray: Array[Byte] = Array(RangedKeyPrefix, PublicKeyPrefixByte)
+  val UnconfirmedTxPrefixArray: Array[Byte] = Array(RangedKeyPrefix, UnconfirmedTxPrefixByte)
 
   // scans key space to iterate over all of them
   val SmallestPossibleScanId: Array[Byte] = ScanPrefixArray ++ Shorts.toByteArray(0)
@@ -235,6 +314,20 @@ object WalletStorage {
   // public keys space to iterate over all of them
   val FirstPublicKeyId: Array[Byte] = PublicKeyPrefixArray ++ Array.fill(33)(0: Byte)
   val LastPublicKeyId: Array[Byte] = PublicKeyPrefixArray ++ Array.fill(33)(-1: Byte)
+
+  def unconfirmedTxKey(txId: ModifierId): Array[Byte] = UnconfirmedTxPrefixArray ++ idToBytes(txId)
+
+  // unconfirmed transactions space to iterate over all of them
+  val FirstUnconfirmedTxId: Array[Byte] = UnconfirmedTxPrefixArray ++ Array.fill(32)(0: Byte)
+  val LastUnconfirmedTxId: Array[Byte] = UnconfirmedTxPrefixArray ++ Array.fill(32)(-1: Byte)
+
+  /**
+    * For how many blocks a wallet-related unconfirmed transaction is kept in the database before
+    * being given up on. A transaction which did not get on the blockchain within this many blocks
+    * is most likely never going to, and re-submitting it forever would only keep the wallet from
+    * spending its inputs. Deliberately conservative (about two days at the target block rate).
+    */
+  val UnconfirmedTxLifetimeInBlocks: Int = 1440
 
   def noPrefixKey(keyString: String): Array[Byte] = Blake2b256.hash(keyString)
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -433,4 +433,120 @@ class ErgoWalletServiceSpec
     }
   }
 
+  /**
+    * An on-chain, unspent box of the wallet, and a transaction spending it which stays unconfirmed.
+    */
+  private def walletBoxAndSpendingTx(registry: WalletRegistry): (TrackedBox, ErgoTransaction) = {
+    val walletBox = TrackedBox(
+      creationTxId = modifierIdGen.sample.get,
+      creationOutIndex = 0,
+      inclusionHeightOpt = Some(100),
+      spendingTxIdOpt = None,
+      spendingHeightOpt = None,
+      box = testBox(1000000000L, pks.head.script, 100),
+      scans = Set(PaymentsScanId)
+    )
+    registry.updateOnBlock(
+      ScanResults(Seq(walletBox), ArraySeq.empty, ArraySeq.empty), modifierIdGen.sample.get, blockHeight = 100).get
+
+    val spendingTx = ErgoTransaction(
+      IndexedSeq(Input(walletBox.box.id, emptyProverResult)),
+      IndexedSeq(new ErgoBoxCandidate(walletBox.box.value, TrueTree, creationHeight = 100))
+    )
+    walletBox -> spendingTx
+  }
+
+  property("a box spent by an unconfirmed transaction is not offered for spending again") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val wState = initialState(store, versionedStore)
+        val (walletBox, spendingTx) = walletBoxAndSpendingTx(wState.registry)
+
+        val onChain = wState.copy(offChainRegistry = OffChainRegistry.init(wState.registry))
+        onChain.walletFilter(walletBox) shouldBe true
+
+        // the spending transaction pays a script the wallet does not track, so the only reason for
+        // the wallet to care about it is that it spends one of its boxes
+        val (offChain, walletAffected) = walletService.scanOffChainUpdate(onChain, spendingTx)
+        walletAffected shouldBe true
+        offChain.walletFilter(walletBox) shouldBe false
+      }
+    }
+  }
+
+  property("unconfirmed transactions are replayed on restart, so their inputs stay spent") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val wState = initialState(store, versionedStore)
+        val (walletBox, spendingTx) = walletBoxAndSpendingTx(wState.registry)
+
+        wState.storage.addUnconfirmedTransaction(spendingTx, seenAtHeight = 100).get
+
+        // a restart: the off-chain registry is rebuilt from the wallet registry alone, which still
+        // lists the box as unspent - the spending transaction never got onto the blockchain. Left
+        // like this the wallet would happily spend the box a second time (issue #1154)
+        val restarted = initialState(store, versionedStore)
+          .copy(offChainRegistry = OffChainRegistry.init(wState.registry))
+        restarted.walletFilter(walletBox) shouldBe true
+
+        walletService.restoreOffChainState(restarted).walletFilter(walletBox) shouldBe false
+      }
+    }
+  }
+
+  property("a restored unconfirmed transaction is dropped once it gets on the blockchain") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val wState = initialState(store, versionedStore)
+        val (_, spendingTx) = walletBoxAndSpendingTx(wState.registry)
+
+        wState.storage.addUnconfirmedTransaction(spendingTx, seenAtHeight = 100).get
+        wState.storage.unconfirmedTransactionHeights shouldBe Map(spendingTx.id -> 100)
+
+        wState.storage.removeUnconfirmedTransactions(Seq(spendingTx.id)).get
+        wState.storage.readUnconfirmedTransactions() shouldBe empty
+
+        // nothing left to replay, so the state comes back untouched
+        val restarted = initialState(store, versionedStore)
+        walletService.restoreOffChainState(restarted) shouldBe restarted
+      }
+    }
+  }
+
+  property("chained unconfirmed transactions are replayed parent first") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val wState = initialState(store, versionedStore)
+        val (walletBox, parentTx) = walletBoxAndSpendingTx(wState.registry)
+
+        // a child spending the output of the parent, stored - and hence read back - in the wrong order
+        val childTx = ErgoTransaction(
+          IndexedSeq(Input(parentTx.outputs.head.id, emptyProverResult)),
+          IndexedSeq(new ErgoBoxCandidate(parentTx.outputs.head.value, TrueTree, creationHeight = 100))
+        )
+        ErgoWalletActor.orderByDependency(Seq(childTx, parentTx)).map(_.id) shouldBe Seq(parentTx.id, childTx.id)
+
+        wState.storage.addUnconfirmedTransaction(childTx, seenAtHeight = 100).get
+        wState.storage.addUnconfirmedTransaction(parentTx, seenAtHeight = 100).get
+
+        val restarted = initialState(store, versionedStore)
+          .copy(offChainRegistry = OffChainRegistry.init(wState.registry))
+        walletService.restoreOffChainState(restarted).walletFilter(walletBox) shouldBe false
+      }
+    }
+  }
+
+  property("orderByDependency keeps independent transactions in order and tolerates cycles") {
+    forAll(Gen.nonEmptyListOf(validErgoTransactionGen)) { generated =>
+      // transactions generated independently spend boxes none of them creates
+      val txs = generated.map(_._2)
+      ErgoWalletActor.orderByDependency(txs).map(_.id) shouldBe txs.map(_.id)
+      ErgoWalletActor.orderByDependency(Seq.empty) shouldBe Seq.empty
+    }
+  }
+
 }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -95,6 +95,36 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
     }
   }
 
+  property("keep an off-chain transaction so it can be put back into the memory pool after a restart") {
+    withFixture { implicit w =>
+      val addresses = getPublicKeys
+      addresses.length should be > 0
+      val genesisBlock = makeGenesisBlock(addresses.head.pubkey, randomNewAsset)
+      applyBlock(genesisBlock) shouldBe 'success //scan by wallet happens during apply
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.second, 300.millis)
+
+      await(wallet.unconfirmedTransactionsToRestore) shouldBe empty
+
+      val tx = eventually {
+        val snap = getConfirmedBalances
+        val req = Seq(PaymentRequest(addresses.head, snap.walletBalance / 2, Array.empty, Map.empty))
+        await(wallet.generateTransaction(req)).get
+      }
+      wallet.scanOffchain(tx)
+
+      // the memory pool is not persisted, so the wallet keeps its own unconfirmed transactions
+      eventually {
+        await(wallet.unconfirmedTransactionsToRestore).map(_.id) shouldBe Seq(tx.id)
+      }
+
+      // and stops keeping them once they are on the blockchain
+      applyBlock(makeNextBlock(getUtxoState, Seq(tx))) shouldBe 'success
+      eventually {
+        await(wallet.unconfirmedTransactionsToRestore) shouldBe empty
+      }
+    }
+  }
+
   property("Generate asset issuing transaction") {
     withFixture { implicit w =>
       val address = getPublicKeys.head

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
@@ -18,6 +18,8 @@ class WalletStorageSpec
     with DBSpec {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
   import org.ergoplatform.utils.generators.ErgoNodeWalletGenerators._
+  import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.validErgoTransactionGen
+  import org.ergoplatform.utils.generators.CoreObjectGenerators.modifierIdGen
   import org.ergoplatform.wallet.utils.WalletGenerators._
 
   it should "add and read derivation paths" in {
@@ -65,6 +67,45 @@ class WalletStorageSpec
         storageApps.map(_.scanId).foreach(storage.removeScan(_).get)
         storage.allScans.length shouldBe 0
       }
+    }
+  }
+
+  it should "add, read and forget unconfirmed transactions" in {
+    forAll(validErgoTransactionGen, extendedPubKeyListGen, externalScanReqGen) {
+      case ((_, tx), pubKeys, scanReq) =>
+        withStore { store =>
+          val storage = new WalletStorage(store, settings)
+          storage.readUnconfirmedTransactions() shouldBe empty
+          storage.unconfirmedTransactionHeights shouldBe empty
+
+          storage.addUnconfirmedTransaction(tx, 100).get
+          storage.readUnconfirmedTransactions().map { case (t, h) => t.id -> h } shouldBe Seq(tx.id -> 100)
+          storage.unconfirmedTransactionHeights shouldBe Map(tx.id -> 100)
+
+          // reading the database again is what happens on a node restart, and is the whole point
+          new WalletStorage(store, settings)
+            .readUnconfirmedTransactions().map { case (t, h) => t.id -> h } shouldBe Seq(tx.id -> 100)
+
+          // storing it again keeps the height it was first seen at, so that expiry is not pushed back
+          storage.addUnconfirmedTransaction(tx, 200).get
+          storage.unconfirmedTransactionHeights shouldBe Map(tx.id -> 100)
+
+          // the new bucket does not overlap with the ones already in this database
+          pubKeys.foreach(storage.addPublicKey(_).get)
+          storage.addScan(scanReq).get
+          storage.readAllKeys() should contain theSameElementsAs pubKeys.toSet
+          storage.allScans.length shouldBe 1
+          storage.readUnconfirmedTransactions().length shouldBe 1
+
+          // forgetting a transaction which is not there changes nothing
+          storage.removeUnconfirmedTransactions(Seq(modifierIdGen.sample.get)).get
+          storage.readUnconfirmedTransactions().length shouldBe 1
+
+          storage.removeUnconfirmedTransactions(Seq(tx.id)).get
+          storage.readUnconfirmedTransactions() shouldBe empty
+          storage.unconfirmedTransactionHeights shouldBe empty
+          new WalletStorage(store, settings).readUnconfirmedTransactions() shouldBe empty
+        }
     }
   }
 


### PR DESCRIPTION
Closes #1154.

## The problem

The memory pool is not persisted: `ErgoNodeViewHolder` builds it with `ErgoMemPool.empty(settings)` on both the genesis and the restore path, so a restart drops every transaction waiting in it. Peers may re-gossip them, but nothing guarantees that they will, or when.

What turns this from a nuisance into a correctness problem is the wallet side. `ErgoWalletState.walletFilter` decides whether an on-chain box may be spent by asking the off-chain registry:

```scala
val preStatus = if (trackedBox.chainStatus.onChain) {
  offChainRegistry.onChainBalances.exists(_.id == trackedBox.boxId)
} else { true }
```

and `OffChainRegistry.init` rebuilds `onChainBalances` from `walletRegistry.unspentBoxes(PaymentsScanId)` with `offChainBoxes = ArraySeq.empty`. The wallet registry still lists those boxes as unspent - the spending transaction never got onto the blockchain - so after a restart every box spent by a still-unconfirmed transaction is offered for spending again, and the wallet will build a conflicting transaction spending it. The memory pool cross-check in the same filter cannot save it, because the pool is empty too.

## The change

Wallet-related unconfirmed transactions are kept in `WalletStorage` and replayed at start-up.

**Where they are stored.** `WalletStorage`, not `WalletRegistry`: it is documented as holding *"version-agnostic wallet actor's mutable state (which is not a subject to rollbacks in case of forks)"*, which is what off-chain data is. New secondary prefix byte `3`, key `[0, 3] ++ txId`, value `height ++ txBytes`.

**Which ones.** `scanOffChainUpdate` now also reports whether the transaction is of any interest to the wallet: it either pays the wallet (`extractWalletOutputs` found something) or spends one of its boxes (`registry.getBox` on the inputs). Nothing else is stored, so the store does not turn into a copy of the memory pool.

**Start-up, wallet side.** `ErgoWalletService.restoreOffChainState` replays the stored transactions through the same off-chain scan, rebuilding `offChainRegistry` so the spent boxes stay spent. `updateOnTransaction` is idempotent, so a replayed transaction being scanned again later does no harm.

**Start-up, memory pool side.** `ErgoNodeViewHolder.preStart` asks the wallet for them and feeds them back through `txModify` as a new `RestoredTransaction` message. Accepted ones land in the pool and, via `SuccessfulTransaction`, get gossiped again. Anything the pool refuses - it got onto the blockchain while the node was down, or a conflicting transaction did - is dropped from the store, so the wallet self-heals instead of retrying forever.

**Ordering.** Unconfirmed transactions form chains, and both consumers need the parent first: the off-chain registry only nets a spending out if it has already seen the box being spent, and the pool refuses a transaction whose inputs it does not know. `ErgoWalletActor.orderByDependency` does that.

**Bounding the store.** Entries go away when their transaction appears in an applied block, and are given up on after `UnconfirmedTxLifetimeInBlocks = 1440` blocks (about two days). Re-storing a transaction keeps the height it was first seen at - otherwise the replay at every restart would push the expiry back forever. I kept the lifetime a constant rather than a config key to keep the diff small; happy to make it a setting if you prefer.

## Tests

- `WalletStorageSpec` - round trip through the database, the new bucket not colliding with the public keys and scans buckets, re-storing keeping the original height, forgetting an unknown id being a no-op.
- `ErgoWalletServiceSpec` - a box spent off-chain is filtered out; **after a simulated restart it is spendable again, and `restoreOffChainState` makes it unspendable** (that property is this issue, start to finish); chained transactions replayed parent first; `orderByDependency` leaving independent transactions alone.
- `ErgoWalletSpec` - end to end through the actor: a generated payment is kept after `scanOffchain`, comes back from `unconfirmedTransactionsToRestore`, and is forgotten once the block carrying it is applied.

Full suite green (`sbt test`, 751 tests, 0 failed).

## Notes for review

- `ErgoNodeViewHolder.preStart` uses an `ask` on the wallet actor. The wallet stashes messages until `ReadWallet` completes, so the reply arrives once it is loaded; a failure is logged and start-up carries on.
- Nothing changes for a node whose wallet has no unconfirmed transactions: `readUnconfirmedTransactions()` comes back empty and `restoreOffChainState` returns the state untouched.
- The rollback path still has the pre-existing gap of #1180 (the off-chain registry is not refreshed on rollback). This change does not make it worse, and once unconfirmed transactions are kept, refreshing on rollback could reuse the same replay.