### PR TITLE
Preserve prepared UTXO snapshot state on restart

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -575,6 +575,18 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       )
   }
 
+  private def isPreparedUtxoSnapshotState(state: State, history: ErgoHistory): Boolean = {
+    val snapshotHeight = history.minimalFullBlockHeight - 1
+    settings.nodeSettings.utxoSettings.utxoBootstrap &&
+      history.isUtxoSnapshotApplied &&
+      history.bestHeaderAtHeight(snapshotHeight).exists { header =>
+        ErgoNodeViewHolder.matchesPreparedUtxoSnapshotHeader(
+          state.version,
+          state.rootDigest,
+          header)
+      }
+  }
+
   private def restoreConsistentState(stateIn: State, history: ErgoHistory): Try[State] = {
     (stateIn.version, history.bestFullBlockOpt, stateIn) match {
       case (ErgoState.genesisStateVersion, None, _) =>
@@ -582,6 +594,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         Success(stateIn)
       case (stateId, Some(block), _) if stateId == block.id =>
         log.info(s"State and history have the same version ${encoder.encode(stateId)}, no recovery needed.")
+        Success(stateIn)
+      case (_, None, _: UtxoState) if isPreparedUtxoSnapshotState(stateIn, history) =>
+        log.info(s"Prepared UTXO snapshot state ${encoder.encode(stateIn.version)} restored before the first full block")
         Success(stateIn)
       case (_, None, _) =>
         log.info("State and history are inconsistent. History is empty on startup, rollback state to genesis.")
@@ -713,6 +728,13 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
 
 object ErgoNodeViewHolder {
+
+  private[nodeView] def matchesPreparedUtxoSnapshotHeader(
+      stateVersion: VersionTag,
+      stateRoot: Array[Byte],
+      header: Header): Boolean =
+    stateVersion == idToVersion(header.id) &&
+      java.util.Arrays.equals(stateRoot, header.stateRoot)
 
   object ReceivableMessages {
     // Tracking last modifier and header & block heights in time, being periodically checked for possible stuck

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -583,6 +583,18 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       )
   }
 
+  private def isPreparedUtxoSnapshotState(state: State, history: ErgoHistory): Boolean =
+    ErgoNodeViewHolder.isPreparedUtxoSnapshotState(
+      state.isInstanceOf[UtxoState],
+      settings.nodeSettings.utxoSettings.utxoBootstrap,
+      history.isUtxoSnapshotApplied,
+      state.version,
+      state.rootDigest,
+      {
+        val snapshotHeight = history.minimalFullBlockHeight - 1
+        history.bestHeaderAtHeight(snapshotHeight)
+      })
+
   private def restoreConsistentState(stateIn: State, history: ErgoHistory): Try[State] = {
     (stateIn.version, history.bestFullBlockOpt, stateIn) match {
       case (ErgoState.genesisStateVersion, None, _) =>
@@ -591,8 +603,12 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       case (stateId, Some(block), _) if stateId == block.id =>
         log.info(s"State and history have the same version ${encoder.encode(stateId)}, no recovery needed.")
         Success(stateIn)
+      case (_, None, _) if isPreparedUtxoSnapshotState(stateIn, history) =>
+        log.info(s"Prepared UTXO snapshot state ${encoder.encode(stateIn.version)} restored before the first full block")
+        Success(stateIn)
       case (_, None, _) =>
         log.info("State and history are inconsistent. History is empty on startup, rollback state to genesis.")
+        stateIn.closeStorage()
         Success(recreatedState())
       case (_, Some(bestFullBlock), _: DigestState) =>
         log.info(s"State and history are inconsistent. Going to switch state to version ${bestFullBlock.encodedId}")
@@ -721,6 +737,25 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
 
 object ErgoNodeViewHolder {
+
+  private[nodeView] def isPreparedUtxoSnapshotState(
+      stateIsUtxo: Boolean,
+      utxoBootstrap: => Boolean,
+      snapshotApplied: => Boolean,
+      stateVersion: VersionTag,
+      stateRoot: Array[Byte],
+      snapshotHeaderOpt: => Option[Header]): Boolean =
+    stateIsUtxo &&
+      utxoBootstrap &&
+      snapshotApplied &&
+      snapshotHeaderOpt.exists(matchesPreparedUtxoSnapshotHeader(stateVersion, stateRoot, _))
+
+  private def matchesPreparedUtxoSnapshotHeader(
+      stateVersion: VersionTag,
+      stateRoot: Array[Byte],
+      header: Header): Boolean =
+    stateVersion == idToVersion(header.id) &&
+      java.util.Arrays.equals(stateRoot, header.stateRoot)
 
   object ReceivableMessages {
     // Tracking last modifier and header & block heights in time, being periodically checked for possible stuck

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -573,6 +573,7 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
 
       val stateDir = new File(s"${nodeViewDir.getAbsolutePath}/state")
       fixture.deleteRecursive(stateDir)
+      stateDir.mkdirs() shouldBe true
       val persistedGenesis = ErgoState
         .generateGenesisUtxoState(stateDir, settings, Some(parameters))
         ._1

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.nodeView.viewholder
 
 import java.io.File
+import org.ergoplatform.core.idToVersion
 import org.ergoplatform.ErgoBoxCandidate
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.BlockTransactions
@@ -14,6 +15,7 @@ import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.settings.{Algos, ErgoSettings}
 import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestConfig, NodeViewTestOps, RandomWrapper, TestCase}
+import org.ergoplatform.utils.fixtures.NodeViewFixture
 import org.ergoplatform.validation.MalformedModifierError
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
@@ -635,6 +637,187 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
       property(s"${t.name} - $c") {
         t.run(parameters, c)
       }
+    }
+  }
+
+  property("preserve a prepared UTXO snapshot state across restart") {
+    val protoSettings = NodeViewTestConfig(StateType.Utxo, verifyTransactions = true, popowBootstrap = false)
+      .toSettings
+    val snapshotSettings = protoSettings.copy(
+      nodeSettings = protoSettings.nodeSettings.copy(
+        utxoSettings = protoSettings.nodeSettings.utxoSettings.copy(utxoBootstrap = true)
+      )
+    )
+
+    new NodeViewFixture(snapshotSettings, parameters).apply { fixture =>
+      import fixture._
+
+      val (sourceState, boxHolder) = createUtxoState(settings)
+      val snapshotBlock = validFullBlock(None, sourceState, boxHolder)
+      val sourceAtSnapshot = WrappedUtxoState(sourceState, boxHolder, settings)
+        .applyModifier(snapshotBlock)(_ => ())
+        .get
+      val nextBlock = validFullBlock(Some(snapshotBlock), sourceAtSnapshot)
+
+      applyHeader(snapshotBlock.header).get
+      getHistory.onUtxoSnapshotApplied(snapshotBlock.height)
+      stopNodeViewHolder()
+
+      val stateDir = new File(s"${nodeViewDir.getAbsolutePath}/state")
+      fixture.deleteRecursive(stateDir)
+      stateDir.mkdirs() shouldBe true
+      val persistedGenesis = ErgoState
+        .generateGenesisUtxoState(stateDir, settings, Some(parameters))
+        ._1
+      val persistedSnapshot = persistedGenesis
+        .applyModifier(snapshotBlock, None)(_ => ())
+        .get
+      persistedSnapshot.closeStorage()
+
+      startNodeViewHolder()
+
+      getRootHash shouldBe Algos.encode(snapshotBlock.header.stateRoot)
+      applyBlock(nextBlock) shouldBe 'success
+      getRootHash shouldBe Algos.encode(nextBlock.header.stateRoot)
+
+      sourceAtSnapshot.closeStorage()
+    }
+  }
+
+  property("reject a prepared UTXO snapshot state from a noncanonical fork on restart") {
+    val protoSettings = NodeViewTestConfig(StateType.Utxo, verifyTransactions = true, popowBootstrap = false)
+      .toSettings
+    val snapshotSettings = protoSettings.copy(
+      nodeSettings = protoSettings.nodeSettings.copy(
+        utxoSettings = protoSettings.nodeSettings.utxoSettings.copy(utxoBootstrap = true)
+      )
+    )
+
+    new NodeViewFixture(snapshotSettings, parameters).apply { fixture =>
+      import fixture._
+
+      val (sourceState, boxHolder) = createUtxoState(settings)
+      val transactions = validTransactionsFromBoxHolder(boxHolder, new RandomWrapper)._1
+      val firstTimestamp = System.currentTimeMillis()
+      val firstBlock = validFullBlock(None, sourceState, transactions, Some(firstTimestamp))
+      val secondBlock = validFullBlock(None, sourceState, transactions, Some(firstTimestamp + 1))
+      firstBlock.id should not be secondBlock.id
+      java.util.Arrays.equals(firstBlock.header.stateRoot, secondBlock.header.stateRoot) shouldBe true
+
+      applyHeader(firstBlock.header).get
+      applyHeader(secondBlock.header).get
+      val canonicalHeader = getHistory.bestHeaderAtHeight(firstBlock.height).get
+      val noncanonicalBlock = Seq(firstBlock, secondBlock).find(_.id != canonicalHeader.id).get
+      java.util.Arrays.equals(noncanonicalBlock.header.stateRoot, canonicalHeader.stateRoot) shouldBe true
+      getHistory.onUtxoSnapshotApplied(noncanonicalBlock.height)
+      stopNodeViewHolder()
+
+      val stateDir = new File(s"${nodeViewDir.getAbsolutePath}/state")
+      fixture.deleteRecursive(stateDir)
+      stateDir.mkdirs() shouldBe true
+      val persistedGenesis = ErgoState
+        .generateGenesisUtxoState(stateDir, settings, Some(parameters))
+        ._1
+      val persistedForkState = persistedGenesis
+        .applyModifier(noncanonicalBlock, None)(_ => ())
+        .get
+      persistedForkState.version shouldBe idToVersion(noncanonicalBlock.id)
+      persistedForkState.version should not be idToVersion(canonicalHeader.id)
+      java.util.Arrays.equals(persistedForkState.rootDigest, canonicalHeader.stateRoot) shouldBe true
+      persistedForkState.closeStorage()
+
+      startNodeViewHolder()
+
+      getRootHash shouldBe Algos.encode(settings.chainSettings.genesisStateDigest)
+
+      sourceState.closeStorage()
+    }
+  }
+
+  property("require every prepared UTXO snapshot trust signal") {
+    val (state, boxHolder) = createUtxoState(settings)
+
+    try {
+      val header = validFullBlock(None, state, boxHolder).header
+      val matchingVersion = idToVersion(header.id)
+      val mismatchedVersion = idToVersion(Header.GenesisParentId)
+      val mismatchedRoot = header.stateRoot.clone()
+      mismatchedRoot(0) = (mismatchedRoot(0) ^ 1).toByte
+
+      val cases = Seq(
+        ("all signals match", true, true, true, matchingVersion, header.stateRoot, Some(header), true),
+        ("state is not UTXO", false, true, true, matchingVersion, header.stateRoot, Some(header), false),
+        ("UTXO bootstrap disabled", true, false, true, matchingVersion, header.stateRoot, Some(header), false),
+        ("snapshot marker absent", true, true, false, matchingVersion, header.stateRoot, Some(header), false),
+        ("canonical header absent", true, true, true, matchingVersion, header.stateRoot, None, false),
+        ("state version mismatch", true, true, true, mismatchedVersion, header.stateRoot, Some(header), false),
+        ("state root mismatch", true, true, true, matchingVersion, mismatchedRoot, Some(header), false)
+      )
+
+      cases.foreach { case (clue, stateIsUtxo, utxoBootstrap, snapshotApplied, stateVersion, stateRoot, headerOpt, expected) =>
+        withClue(clue) {
+          ErgoNodeViewHolder.isPreparedUtxoSnapshotState(
+            stateIsUtxo,
+            utxoBootstrap,
+            snapshotApplied,
+            stateVersion,
+            stateRoot,
+            headerOpt) shouldBe expected
+        }
+      }
+
+      var utxoBootstrapRead = false
+      var snapshotMarkerRead = false
+      var snapshotHeaderRead = false
+      ErgoNodeViewHolder.isPreparedUtxoSnapshotState(
+        stateIsUtxo = false,
+        utxoBootstrap = {
+          utxoBootstrapRead = true
+          true
+        },
+        snapshotApplied = {
+          snapshotMarkerRead = true
+          true
+        },
+        stateVersion = matchingVersion,
+        stateRoot = header.stateRoot,
+        snapshotHeaderOpt = {
+          snapshotHeaderRead = true
+          Some(header)
+        }) shouldBe false
+      utxoBootstrapRead shouldBe false
+      snapshotMarkerRead shouldBe false
+      snapshotHeaderRead shouldBe false
+
+      ErgoNodeViewHolder.isPreparedUtxoSnapshotState(
+        stateIsUtxo = true,
+        utxoBootstrap = false,
+        snapshotApplied = {
+          snapshotMarkerRead = true
+          true
+        },
+        stateVersion = matchingVersion,
+        stateRoot = header.stateRoot,
+        snapshotHeaderOpt = {
+          snapshotHeaderRead = true
+          Some(header)
+        }) shouldBe false
+      snapshotMarkerRead shouldBe false
+      snapshotHeaderRead shouldBe false
+
+      ErgoNodeViewHolder.isPreparedUtxoSnapshotState(
+        stateIsUtxo = true,
+        utxoBootstrap = true,
+        snapshotApplied = false,
+        stateVersion = matchingVersion,
+        stateRoot = header.stateRoot,
+        snapshotHeaderOpt = {
+          snapshotHeaderRead = true
+          Some(header)
+        }) shouldBe false
+      snapshotHeaderRead shouldBe false
+    } finally {
+      state.closeStorage()
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -1,8 +1,10 @@
 package org.ergoplatform.nodeView.viewholder
 
 import java.io.File
+import org.ergoplatform.core.idToVersion
 import org.ergoplatform.ErgoBoxCandidate
 import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.UnconfirmedTransaction
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.state.StateType.Utxo
@@ -10,6 +12,7 @@ import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.settings.{Algos, ErgoSettings}
 import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestConfig, NodeViewTestOps, TestCase}
+import org.ergoplatform.utils.fixtures.NodeViewFixture
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.{ErgoNodeViewHolder, LocallyGeneratedModifier}
@@ -542,6 +545,77 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
       property(s"${t.name} - $c") {
         t.run(parameters, c)
       }
+    }
+  }
+
+  property("preserve a prepared UTXO snapshot state across restart") {
+    val protoSettings = NodeViewTestConfig(StateType.Utxo, verifyTransactions = true, popowBootstrap = false)
+      .toSettings
+    val snapshotSettings = protoSettings.copy(
+      nodeSettings = protoSettings.nodeSettings.copy(
+        utxoSettings = protoSettings.nodeSettings.utxoSettings.copy(utxoBootstrap = true)
+      )
+    )
+
+    new NodeViewFixture(snapshotSettings, parameters).apply { fixture =>
+      import fixture._
+
+      val (sourceState, boxHolder) = createUtxoState(settings)
+      val snapshotBlock = validFullBlock(None, sourceState, boxHolder)
+      val sourceAtSnapshot = WrappedUtxoState(sourceState, boxHolder, settings)
+        .applyModifier(snapshotBlock)(_ => ())
+        .get
+      val nextBlock = validFullBlock(Some(snapshotBlock), sourceAtSnapshot)
+
+      applyHeader(snapshotBlock.header).get
+      getHistory.onUtxoSnapshotApplied(snapshotBlock.height)
+      stopNodeViewHolder()
+
+      val stateDir = new File(s"${nodeViewDir.getAbsolutePath}/state")
+      fixture.deleteRecursive(stateDir)
+      val persistedGenesis = ErgoState
+        .generateGenesisUtxoState(stateDir, settings, Some(parameters))
+        ._1
+      val persistedSnapshot = persistedGenesis
+        .applyModifier(snapshotBlock, None)(_ => ())
+        .get
+      persistedSnapshot.closeStorage()
+
+      startNodeViewHolder()
+
+      getRootHash shouldBe Algos.encode(snapshotBlock.header.stateRoot)
+      applyBlock(nextBlock) shouldBe 'success
+      getRootHash shouldBe Algos.encode(nextBlock.header.stateRoot)
+
+      sourceAtSnapshot.closeStorage()
+    }
+  }
+
+  property("require the prepared UTXO snapshot state version and root to match its header") {
+    val (state, boxHolder) = createUtxoState(settings)
+
+    try {
+      val header = validFullBlock(None, state, boxHolder).header
+      val matchingVersion = idToVersion(header.id)
+      val mismatchedVersion = idToVersion(Header.GenesisParentId)
+      val mismatchedRoot = header.stateRoot.clone()
+      mismatchedRoot(0) = (mismatchedRoot(0) ^ 1).toByte
+
+      matchingVersion should not be mismatchedVersion
+      ErgoNodeViewHolder.matchesPreparedUtxoSnapshotHeader(
+        matchingVersion,
+        header.stateRoot,
+        header) shouldBe true
+      ErgoNodeViewHolder.matchesPreparedUtxoSnapshotHeader(
+        mismatchedVersion,
+        header.stateRoot,
+        header) shouldBe false
+      ErgoNodeViewHolder.matchesPreparedUtxoSnapshotHeader(
+        matchingVersion,
+        mismatchedRoot,
+        header) shouldBe false
+    } finally {
+      state.closeStorage()
     }
   }
 


### PR DESCRIPTION
## Summary

- preserve a persisted UTXO snapshot state when the node restarts before its first full block is available
- require UTXO state mode, snapshot bootstrap, the persisted applied marker, and exact version/root agreement with the canonical header at the snapshot height
- short-circuit history lookups when an earlier trust signal fails
- close a rejected state store before recreating genesis
- cover the successful restart through H + 1, rejection of a same-root noncanonical sibling, isolated trust-signal failures, and short-circuit behavior

## Rationale

Snapshot bootstrap persists the reconstructed state, records minimalFullBlockHeight = H + 1, and then installs the state in the in-memory node view. A restart between those last two steps reopens a valid state at H while bestFullBlockOpt is still empty. The previous startup path treated that combination as an empty history and recreated genesis even though history already recorded the snapshot as applied.

This change is limited to startup reconciliation. The persisted state is preserved only when every trust signal matches the canonical header at H. Any disabled, missing, mismatched, or noncanonical signal continues through the existing genesis-recovery path. There are no serialization or consensus-validation changes.

## Tests

- sbt "Test/testOnly org.ergoplatform.nodeView.viewholder.ErgoNodeViewHolderSpec -- -z prepared"
- sbt "Test/testOnly org.ergoplatform.nodeView.history.UtxoSetSnapshotProcessorSpecification"
- sbt compile