### PR TITLE
Fix transaction proofs with duplicate witness ids

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
@@ -12,8 +12,8 @@ import org.ergoplatform.nodeView.mempool.TransactionMembershipProof
 import org.ergoplatform.settings.{Algos, Constants}
 import org.ergoplatform.modifiers.history.header.Header.Version
 import org.ergoplatform.serialization.ErgoSerializer
-import scorex.crypto.authds.LeafData
-import scorex.crypto.authds.merkle.{Leaf, MerkleProof, MerkleTree}
+import scorex.crypto.authds.{LeafData, Side}
+import scorex.crypto.authds.merkle.{InternalNode, Leaf, MerkleProof, MerkleTree, Node}
 import scorex.crypto.hash.Digest32
 import scorex.util.serialization.{Reader, Writer}
 import scorex.util.{ModifierId, bytesToId, idToBytes}
@@ -74,7 +74,18 @@ case class BlockTransactions(headerId: ModifierId,
     * @return Some(proof) or None (if transaction with given id is not in the block)
     */
   def proofFor(txId: Array[Byte]): Option[MerkleProof[Digest32]] =
-    merkleTree.proofByElement(Leaf[Digest32](LeafData @@ txId)(Algos.hash))
+    txIds.indexWhere(_.sameElements(txId)) match {
+      case -1 => None
+      case index =>
+        val leafCount = if (blockVersion == Header.InitialVersion) {
+          txIds.size.toLong
+        } else {
+          txIds.size.toLong + witnessIds.size.toLong
+        }
+        BlockTransactions
+          .proofByIndex(merkleTree, index, leafCount)
+          .filter(_.leafData.sameElements(txId))
+    }
 
   def proofFor(txId: ModifierId): Option[MerkleProof[Digest32]] = proofFor(scorex.util.idToBytes(txId))
 
@@ -99,6 +110,43 @@ case class BlockTransactions(headerId: ModifierId,
 object BlockTransactions extends ApiCodecs {
 
   val modifierTypeId: NetworkObjectTypeId.Value = BlockTransactionsTypeId.value
+
+  private def proofByIndex(tree: MerkleTree[Digest32],
+                           index: Int,
+                           leafCount: Long): Option[MerkleProof[Digest32]] = {
+    def paddedLength(length: Long, target: Long): Long =
+      if (length >= target) length else paddedLength(length * 2, target)
+
+    def loop(node: Node[Digest32],
+             leafIndex: Long,
+             subtreeLength: Long,
+             levels: List[(Digest32, Side)]): Option[MerkleProof[Digest32]] = node match {
+      case internal: InternalNode[Digest32] =>
+        val halfLength = subtreeLength / 2
+        if (leafIndex < halfLength) {
+          loop(
+            internal.left,
+            leafIndex,
+            halfLength,
+            (internal.right.hash, MerkleProof.LeftSide) :: levels
+          )
+        } else {
+          loop(
+            internal.right,
+            leafIndex - halfLength,
+            halfLength,
+            (internal.left.hash, MerkleProof.RightSide) :: levels
+          )
+        }
+      case leaf: Leaf[Digest32] if leafIndex == 0 && subtreeLength == 1 =>
+        Some(MerkleProof[Digest32](leaf.data, levels)(leaf.hf))
+      case _ =>
+        None
+    }
+
+    if (index < 0 || index.toLong >= leafCount) None
+    else loop(tree.topNode, index.toLong, paddedLength(2L, leafCount), Nil)
+  }
 
   // Used in the miner when a BlockTransaction instance is not generated yet (because a header is not known)
   def transactionsRoot(txs: Seq[ErgoTransaction], blockVersion: Version): Digest32 = {

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -58,5 +58,17 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
       }
     }
   }
+  property("Merkle proof returns the requested transaction when witness ids repeat") {
+    val txs = fixtureTransactions.take(3)
+    txs.map(_.id).distinct should have size 3
+    txs.map(_.witnessSerializedId.toSeq).distinct should have size 1
+
+    val blockTransactions = BlockTransactions(headerId, Header.HardeningVersion, txs)
+    val requestedTx = txs.head
+    val proof = blockTransactions.proofFor(requestedTx.id).get
+
+    BlockTransactions.proofValid(blockTransactions.digest, proof) shouldBe true
+    proof.leafData.sameElements(requestedTx.serializedId) shouldBe true
+  }
 
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -1,10 +1,27 @@
 package org.ergoplatform.modifiers.history
 
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.settings.Constants.TrueTree
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.{ErgoBoxCandidate, Input}
+import scorex.crypto.authds.ADKey
+import scorex.util.bytesToId
 
 class BlockTransactionsSpec extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoCoreTestConstants.emptyProverResult
   import org.ergoplatform.utils.generators.CoreObjectGenerators._
   import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators._
+
+  private val fixtureTransactions = (1 to 5).map { seed =>
+    ErgoTransaction(
+      IndexedSeq(Input(ADKey @@ Array.fill[Byte](32)(seed.toByte), emptyProverResult)),
+      IndexedSeq(new ErgoBoxCandidate(1000000L + seed, TrueTree, creationHeight = 0))
+    )
+  }
+
+  private val headerId = bytesToId(Array.fill[Byte](32)(0.toByte))
+  private val absentTxId = bytesToId(Array.fill[Byte](32)(Byte.MaxValue))
 
   property("Correct Merkle proofs are generated") {
     forAll(invalidBlockTransactionsGen, modifierIdGen){ case (bt, absentTx) =>
@@ -13,6 +30,32 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
 
       // no proof should be generated for a transaction which is not there
       bt.proofFor(absentTx).isDefined shouldBe false
+    }
+  }
+
+  property("Merkle proofs bind requested transaction ids across tree sizes") {
+    fixtureTransactions.map(_.id).distinct should have size 5
+    fixtureTransactions.map(_.witnessSerializedId.toSeq).distinct should have size 1
+
+    Seq(Header.InitialVersion, Header.HardeningVersion).foreach { blockVersion =>
+      (1 to fixtureTransactions.size).foreach { transactionCount =>
+        val txs = fixtureTransactions.take(transactionCount)
+        val blockTransactions = BlockTransactions(headerId, blockVersion, txs)
+
+        withClue(s"version=$blockVersion, transactionCount=$transactionCount: ") {
+          blockTransactions.digest.sameElements(
+            BlockTransactions.transactionsRoot(txs, blockVersion)
+          ) shouldBe true
+
+          blockTransactions.proofFor(absentTxId) shouldBe None
+
+          txs.foreach { tx =>
+            val proof = blockTransactions.proofFor(tx.id).get
+            proof.leafData.sameElements(tx.serializedId) shouldBe true
+            BlockTransactions.proofValid(blockTransactions.digest, proof) shouldBe true
+          }
+        }
+      }
     }
   }
 

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -71,5 +71,4 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
     BlockTransactions.proofValid(blockTransactions.digest, proof) shouldBe true
     proof.leafData.sameElements(requestedTx.serializedId) shouldBe true
   }
-
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -58,6 +58,7 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
       }
     }
   }
+
   property("Merkle proof returns the requested transaction when witness ids repeat") {
     val txs = fixtureTransactions.take(3)
     txs.map(_.id).distinct should have size 3

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -1,10 +1,27 @@
 package org.ergoplatform.modifiers.history
 
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.settings.Constants.TrueTree
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.{ErgoBoxCandidate, Input}
+import scorex.crypto.authds.ADKey
+import scorex.util.bytesToId
 
 class BlockTransactionsSpec extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoCoreTestConstants.emptyProverResult
   import org.ergoplatform.utils.generators.CoreObjectGenerators._
   import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators._
+
+  private val fixtureTransactions = (1 to 5).map { seed =>
+    ErgoTransaction(
+      IndexedSeq(Input(ADKey @@ Array.fill[Byte](32)(seed.toByte), emptyProverResult)),
+      IndexedSeq(new ErgoBoxCandidate(1000000L + seed, TrueTree, creationHeight = 0))
+    )
+  }
+
+  private val headerId = bytesToId(Array.fill[Byte](32)(0.toByte))
+  private val absentTxId = bytesToId(Array.fill[Byte](32)(Byte.MaxValue))
 
   property("Correct Merkle proofs are generated") {
     forAll(invalidBlockTransactionsGen, modifierIdGen){ case (bt, absentTx) =>
@@ -16,4 +33,42 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
     }
   }
 
+  property("Merkle proofs bind requested transaction ids across tree sizes") {
+    fixtureTransactions.map(_.id).distinct should have size 5
+    fixtureTransactions.map(_.witnessSerializedId.toSeq).distinct should have size 1
+
+    Seq(Header.InitialVersion, Header.HardeningVersion).foreach { blockVersion =>
+      (1 to fixtureTransactions.size).foreach { transactionCount =>
+        val txs = fixtureTransactions.take(transactionCount)
+        val blockTransactions = BlockTransactions(headerId, blockVersion, txs)
+
+        withClue(s"version=$blockVersion, transactionCount=$transactionCount: ") {
+          blockTransactions.digest.sameElements(
+            BlockTransactions.transactionsRoot(txs, blockVersion)
+          ) shouldBe true
+
+          blockTransactions.proofFor(absentTxId) shouldBe None
+
+          txs.foreach { tx =>
+            val proof = blockTransactions.proofFor(tx.id).get
+            proof.leafData.sameElements(tx.serializedId) shouldBe true
+            BlockTransactions.proofValid(blockTransactions.digest, proof) shouldBe true
+          }
+        }
+      }
+    }
+  }
+
+  property("Merkle proof returns the requested transaction when witness ids repeat") {
+    val txs = fixtureTransactions.take(3)
+    txs.map(_.id).distinct should have size 3
+    txs.map(_.witnessSerializedId.toSeq).distinct should have size 1
+
+    val blockTransactions = BlockTransactions(headerId, Header.HardeningVersion, txs)
+    val requestedTx = txs.head
+    val proof = blockTransactions.proofFor(requestedTx.id).get
+
+    BlockTransactions.proofValid(blockTransactions.digest, proof) shouldBe true
+    proof.leafData.sameElements(requestedTx.serializedId) shouldBe true
+  }
 }

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -354,16 +354,22 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
 
     val ecb1 = getWorkMessage(minerRef, Seq(mandatoryTx1))
     ecb1.proofsForMandatoryTransactions.get.txProofs.length shouldBe 1
+    ecb1.proofsForMandatoryTransactions.get.txProofs.head.proof.leafData
+      .sameElements(mandatoryTx1.serializedId) shouldBe true
     ecb1.proofsForMandatoryTransactions.get.check() shouldBe true
 
     val ecb2 = getWorkMessage(minerRef, Seq(mandatoryTx2))
     ecb2.msg.sameElements(ecb1.msg) shouldBe false
     ecb2.proofsForMandatoryTransactions.get.txProofs.length shouldBe 1
+    ecb2.proofsForMandatoryTransactions.get.txProofs.head.proof.leafData
+      .sameElements(mandatoryTx2.serializedId) shouldBe true
     ecb2.proofsForMandatoryTransactions.get.check() shouldBe true
 
     val ecb3 = getWorkMessage(minerRef, Seq.empty)
     ecb3.msg.sameElements(ecb2.msg) shouldBe true
     ecb3.proofsForMandatoryTransactions.get.txProofs.length shouldBe 1
+    ecb3.proofsForMandatoryTransactions.get.txProofs.head.proof.leafData
+      .sameElements(mandatoryTx2.serializedId) shouldBe true
     ecb3.proofsForMandatoryTransactions.get.check() shouldBe true
 
     system.terminate()


### PR DESCRIPTION
## Summary

- return transaction membership proofs for the requested transaction when witness ids repeat
- traverse the existing Merkle tree with its real ordered leaf count instead of scrypto's deduplicated map length
- cover duplicate witnesses, padding boundaries, absent ids, and the mandatory-mining consumer

## Root cause

For block versions after v1, `BlockTransactions` commits to `txIds ++ witnessIds`.
The scrypto tree keeps every leaf in `topNode`, but its hash-to-index map collapses
duplicate leaf hashes. `proofByElement` then traverses the real tree using the map's
smaller size, so it can return a proof for another leaf that still validates against
the transaction root.

This change locates the requested transaction in `txIds` and traverses the existing
tree with `n` leaves for v1 or `2n` leaves for later versions. It also fails closed if
the traversal does not terminate at the requested leaf.

## Compatibility

The ordered leaves, Merkle-tree construction, transaction root, block serialization,
JSON schema, and consensus bytes are unchanged. Only membership-proof selection is
corrected. The transaction lookup is intentionally tx-only and uses a bounded linear
scan followed by logarithmic tree traversal.

The generic duplicate-leaf fix is already merged in scrypto #5. This `v6.0.6` branch
still resolves scrypto 3.0.0, so the node-local fix remains necessary here.

## Validation

- regression reproduced on the current `v6.0.6` base: the test-only `BlockTransactionsSpec` run passed 1 test and failed the 2 new proof-identity cases
- `sbt "ergoCore/Test/testOnly org.ergoplatform.modifiers.history.BlockTransactionsSpec"` — 3 passed
- `sbt "ergoCore/Test/testOnly org.ergoplatform.serialization.SerializationCoreTests -- -z BlockTransactions"` — 1 passed
- `sbt "Test/testOnly org.ergoplatform.mining.ErgoMinerSpec"` — 5 passed
- `sbt "Test/testOnly org.ergoplatform.http.routes.BlocksApiRouteSpec"` — 10 passed
- GitHub CI — 8/8 jobs passed on `202f762cb38b6ac56c6cc9afdb9bf51aa5208dca`
- independent review of the exact 3-file patch — no findings

## Related work

Fixes #2463.

- #2373 fixes candidate caching by miner public key; it does not change transaction-proof lookup.
- #2348 touches `BlockTransactions` serializer parsing only; it does not change membership-proof selection.
- ergoplatform/scrypto#5 is the merged generic-library fix; this PR covers the dependency version used by the release branch.