### PR TITLE
Fix for lastHeaders in upcoming state context , miner not stuck on divergence in block pre-validation and validation

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/nodeView/state/ErgoStateContext.scala
@@ -41,6 +41,11 @@ case class UpcomingStateContext(override val lastHeaders: Seq[Header],
   extends ErgoStateContext(lastHeaders, lastExtensionOpt, genesisStateDigest, currentParameters,
                             validationSettings, votingData)(chainSettings) {
 
+  if (lastHeaders.size > Constants.LastHeadersInContext - 1) {
+    log.error(s"UpcomingStateContext created with ${lastHeaders.size} last headers, " +
+              s"expected at most ${Constants.LastHeadersInContext - 1}")
+  }
+
   override def sigmaPreHeader: sigma.PreHeader = PreHeader.toSigma(predictedHeader)
 
   override def sigmaLastHeaders: Coll[sigma.Header] = {
@@ -129,8 +134,15 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
     val (calculatedParams, updated) =
       currentParameters.update(height, forkVote, ArraySeq.unsafeWrapArray(votingData.epochVotes), proposedUpdate, votingSettings)
     val calculatedValidationSettings = validationSettings.updated(updated)
-    UpcomingStateContext(lastHeaders, lastExtensionOpt, upcomingHeader, genesisStateDigest, calculatedParams,
-                          calculatedValidationSettings, votingData)
+    UpcomingStateContext(
+      lastHeaders.take(Constants.LastHeadersInContext - 1),
+      lastExtensionOpt,
+      upcomingHeader,
+      genesisStateDigest,
+      calculatedParams,
+      calculatedValidationSettings,
+      votingData
+    )
   }
 
   /**
@@ -149,8 +161,15 @@ class ErgoStateContext(val lastHeaders: Seq[Header],
     val (calculatedParams, updated) =
       currentParameters.update(height, forkVote = false, ArraySeq.unsafeWrapArray(votingData.epochVotes), proposedUpdate, votingSettings)
     val calculatedValidationSettings = validationSettings.updated(updated)
-    UpcomingStateContext(lastHeaders, lastExtensionOpt, upcomingHeader, genesisStateDigest, calculatedParams,
-      calculatedValidationSettings, votingData)
+    UpcomingStateContext(
+      lastHeaders.take(Constants.LastHeadersInContext - 1),
+      lastExtensionOpt,
+      upcomingHeader,
+      genesisStateDigest,
+      calculatedParams,
+      calculatedValidationSettings,
+      votingData
+    )
   }
 
   protected def checkForkVote(height: Height): Unit = {

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -84,6 +84,24 @@ class CandidateGenerator(
     sectionsToApply.foreach(viewHolderRef ! LocallyGeneratedModifier(_))
   }
 
+  /**
+    * Reaction on invalidation of the block solved by us (e.g. due to a transaction which became
+    * invalid after the block candidate was generated): drop the solved block along with cached
+    * candidates. Mining will resume on the next external request, which will generate a fresh
+    * candidate because the cached one was dropped.
+    */
+  private def onSolvedBlockFailed(state: CandidateGeneratorState, modId: ModifierId, error: Throwable): Unit = {
+    state.solvedBlock.filter(_.toSeq.exists(_.id == modId)).foreach { block =>
+      log.warn(
+        s"Locally mined block ${block.id} invalidated by the node view holder, resuming mining",
+        error
+      )
+      context.become(
+        initialized(state.copy(cachedCandidate = None, cachedPreviousCandidate = None, solvedBlock = None))
+      )
+    }
+  }
+
   override def receive: Receive = {
 
     // first we need to get Readers to have some initial state to work with
@@ -114,6 +132,8 @@ class CandidateGenerator(
       context.system.eventStream
         .subscribe(self, classOf[FullBlockApplied])
       context.system.eventStream.subscribe(self, classOf[NodeViewChange])
+      context.system.eventStream.subscribe(self, classOf[SemanticallyFailedModification])
+      context.system.eventStream.subscribe(self, classOf[SyntacticallyFailedModification])
     case Readers(_, _, _, _) =>
       log.error("Invalid readers state, mining is possible in UTXO mode only")
     case m =>
@@ -164,6 +184,17 @@ class CandidateGenerator(
       } else {
         context.become(initialized(stateWithAppliedTxs))
       }
+
+    /*
+     * If a block solved by us was invalidated by the node view holder, we need to drop it along
+     * with cached candidates, as otherwise mining would stall (new solutions are rejected with
+     * "Block already solved" and candidate regeneration is paused while solvedBlock is set).
+     */
+    case SemanticallyFailedModification(_, modId, error) =>
+      onSolvedBlockFailed(state, modId, error)
+
+    case SyntacticallyFailedModification(_, modId, error) =>
+      onSolvedBlockFailed(state, modId, error)
 
     case gen @ GenerateCandidate(txsToInclude, reply, forced, optPk) =>
       val senderOpt = if (reply) Some(sender()) else None

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -22,7 +22,7 @@ import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, NetworkType, S
 import org.ergoplatform.utils.ScorexEncoding
 import org.ergoplatform.validation.{MalformedModifierError, RecoverableModifierError}
 import org.ergoplatform.wallet.utils.FileUtils
-import scorex.util.{ModifierId, ScorexLogging, bytesToId}
+import scorex.util.{ModifierId, ScorexLogging}
 import spire.syntax.all.cfor
 
 import java.io.File

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -4,24 +4,25 @@ import akka.actor.SupervisorStrategy.Escalate
 import akka.actor.{Actor, ActorRef, ActorSystem, OneForOneStrategy, Props}
 import org.ergoplatform.{CriticalSystemException, ErgoApp}
 import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.core._
 import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.history.{ADProofs, HistoryModifierSerializer}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
+import org.ergoplatform.modifiers.transaction.TooHighCostError
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NetworkObjectTypeId, TransactionsCarryingBlockSection}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.{BlockAppliedTransactions, CurrentView, DownloadRequest}
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages._
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.wallet.ErgoWallet
-import org.ergoplatform.wallet.utils.FileUtils
 import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, NetworkType, ScorexSettings}
-import org.ergoplatform.core._
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
-import org.ergoplatform.nodeView.ErgoNodeViewHolder.{BlockAppliedTransactions, CurrentView, DownloadRequest}
-import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages._
-import org.ergoplatform.modifiers.history.{ADProofs, HistoryModifierSerializer}
 import org.ergoplatform.utils.ScorexEncoding
-import org.ergoplatform.validation.RecoverableModifierError
-import scorex.util.{ModifierId, ScorexLogging}
+import org.ergoplatform.validation.{MalformedModifierError, RecoverableModifierError}
+import org.ergoplatform.wallet.utils.FileUtils
+import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import spire.syntax.all.cfor
 
 import java.io.File
@@ -252,6 +253,12 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
               log.warn(s"Invalid modifier! Typeid: ${modToApply.modifierTypeId} id: ${modToApply.id} ", e)
               history.reportModifierIsInvalid(modToApply, progressInfo).map { case (newHis, newProgressInfo) =>
                 context.system.eventStream.publish(SemanticallyFailedModification(modToApply.modifierTypeId, modToApply.id, e))
+                ErgoNodeViewHolder.extractFailedTxId(e).foreach { txId =>
+                  log.warn(s"Removing transaction $txId which caused the block validation failure from the mempool")
+                  val updatedPool = memoryPool().invalidate(txId)
+                  updateNodeView(updatedMempool = Some(updatedPool))
+                  context.system.eventStream.publish(FailedOnRecheckTransaction(txId, new Exception("Became invalid")))
+                }
                 UpdateInformation(newHis, updateInfo.state, Some(modToApply), Some(newProgressInfo), updateInfo.suffix)
               }
           }
@@ -761,6 +768,24 @@ object ErgoNodeViewHolder {
   case class DownloadRequest(modifiersToFetch: Map[NetworkObjectTypeId.Value, Seq[ModifierId]]) extends NodeViewHolderEvent
 
   case class CurrentView[State](history: ErgoHistory, state: State, vault: ErgoWallet, pool: ErgoMemPool)
+
+  /**
+    * Extract id of a transaction which caused block validation failure, walking the cause chain.
+    * Transaction-level validation errors are reported as [[MalformedModifierError]] tagged with
+    * the transaction id, or as [[TooHighCostError]] carrying the transaction itself.
+    */
+  @tailrec
+  def extractFailedTxId(error: Throwable): Option[ModifierId] = error match {
+    case null =>
+      None
+    case mme: MalformedModifierError
+        if mme.modifierTypeId == ErgoTransaction.modifierTypeId =>
+      Some(mme.modifierId)
+    case TooHighCostError(tx, _) =>
+      Some(tx.id)
+    case other =>
+      extractFailedTxId(other.getCause)
+  }
 
   /**
     * Checks whether chain got stuck by comparing timestamp of bestFullBlock or last time a modifier was applied to history.

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -7,23 +7,24 @@ import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, FullBlockApplied, LocalBlockApplied}
-
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool, FullBlockApplied, LocalBlockApplied, SemanticallyFailedModification}
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{EliminateTransactions, LocallyGeneratedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
-import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
+import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedModifier}
 import org.ergoplatform.settings.NetworkType.DevNet60
 import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.utils.generators.ValidBlocksGenerators.{createUtxoState, validFullBlock, validTransactionsFromBoxHolder}
 import org.ergoplatform.utils.generators.ChainGenerator.{applyChain, genHeaderChain}
 import org.ergoplatform.utils.{HistoryTestHelpers, RandomWrapper}
+import org.ergoplatform.validation.MalformedModifierError
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
@@ -83,6 +84,70 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
+    system.terminate()
+  }
+
+  it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
+    ActorSystem()
+  ) {
+    val replyProbe = new TestProbe(system)
+    // fake node view holder: solved block is never applied, so solvedBlock stays set
+    val viewHolderProbe = new TestProbe(system)
+
+    // real readers holder over real node view holder, needed for candidate generation
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
+
+    val candidateGenerator: ActorRef =
+      CandidateGenerator(
+        defaultMinerSecret.publicImage,
+        readersHolderRef,
+        viewHolderProbe.ref,
+        defaultSettings
+      )
+
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
+    val block = replyProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        defaultSettings.chainSettings.powScheme
+          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
+          .get
+    }
+
+    candidateGenerator.tell(block.header.powSolution, replyProbe.ref)
+    replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
+
+    // block sections were sent to the (fake) node view holder
+    viewHolderProbe.expectMsg(LocallyGeneratedModifier(block.header))
+    block.mandatoryBlockSections.foreach { section =>
+      viewHolderProbe.expectMsg(LocallyGeneratedModifier(section))
+    }
+
+    // mining is stalled: new solutions are rejected while solvedBlock is set
+    candidateGenerator.tell(block.header.powSolution, replyProbe.ref)
+    replyProbe.expectMsgPF(blockValidationDelay) {
+      case r: StatusReply[_] if r.isError =>
+    }
+
+    // node view holder invalidates the block (e.g. a transaction became invalid)
+    val failedTxId = block.blockTransactions.txs.head.id
+    val error =
+      new MalformedModifierError("tx failed", failedTxId, ErgoTransaction.modifierTypeId)
+    system.eventStream.publish(
+      SemanticallyFailedModification(BlockTransactions.modifierTypeId, block.blockTransactions.id, error)
+    )
+
+    // mining resumes: a new candidate is generated and new solutions are accepted again
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
+    val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) =>
+        defaultSettings.chainSettings.powScheme
+          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
+          .get
+    }
+    candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
+    replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
+
     system.terminate()
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateContextSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/ErgoStateContextSpec.scala
@@ -4,6 +4,7 @@ import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.settings.Constants
+import org.ergoplatform.settings.ErgoValidationSettingsUpdate
 import org.ergoplatform.settings.Parameters._
 import org.ergoplatform.utils.ErgoCorePropertyTest
 
@@ -140,6 +141,52 @@ class ErgoStateContextSpec extends ErgoCorePropertyTest {
     // positive control - the unmutated block still validates, so the failures above
     // are attributable to the mutations rather than the fixture
     sc.appendFullBlock(fb) shouldBe 'success
+  }
+
+  property("upcoming() exposes the same previous headers as full-block validation context") {
+    val chain = genChain(Constants.LastHeadersInContext + 1)
+    val parentChain = chain.init
+    val nextBlock = chain.last
+    val sc = parentChain.foldLeft[ErgoStateContext](emptyStateContext) { (acc, fb) =>
+      acc.appendFullBlock(fb).get
+    }
+
+    val upcomingContext = sc.upcoming(
+      nextBlock.header.minerPk,
+      nextBlock.header.timestamp,
+      nextBlock.header.nBits,
+      nextBlock.header.votes,
+      ErgoValidationSettingsUpdate.empty,
+      nextBlock.header.version
+    )
+
+    val validationContext = sc.appendFullBlock(nextBlock).get
+
+    upcomingContext.sigmaLastHeaders.size shouldBe Constants.LastHeadersInContext - 1
+    validationContext.sigmaLastHeaders.size shouldBe Constants.LastHeadersInContext - 1
+
+    val upcomingIds = upcomingContext.sigmaLastHeaders.toArray.map(_.id)
+    val validationIds = validationContext.sigmaLastHeaders.toArray.map(_.id)
+    upcomingIds.zip(validationIds).foreach { case (a, b) =>
+      a.toArray shouldEqual b.toArray
+    }
+  }
+
+  property("simplifiedUpcoming() exposes the same previous headers as full-block validation context") {
+    val chain = genChain(Constants.LastHeadersInContext + 1)
+    val parentChain = chain.init
+    val nextBlock = chain.last
+    val sc = parentChain.foldLeft[ErgoStateContext](emptyStateContext) { (acc, fb) =>
+      acc.appendFullBlock(fb).get
+    }
+
+    val upcomingContext = sc.simplifiedUpcoming()
+    val validationContext = sc.appendFullBlock(nextBlock).get
+
+    upcomingContext.sigmaLastHeaders.size shouldBe validationContext.sigmaLastHeaders.size
+    upcomingContext.sigmaLastHeaders.toArray.map(_.id)
+      .zip(validationContext.sigmaLastHeaders.toArray.map(_.id))
+      .foreach { case (a, b) => a.toArray shouldEqual b.toArray }
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -12,9 +12,10 @@ import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransact
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.modifiers.transaction.TooHighCostError
 import org.ergoplatform.core.idToVersion
+import org.ergoplatform.nodeView.ErgoNodeViewHolder
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.settings.Constants.FalseTree
-import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.boxesHolderGen
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
 import org.ergoplatform.utils.{ErgoCorePropertyTest, RandomWrapper}
 import org.scalatest.OptionValues
 import scorex.crypto.authds.ADKey
@@ -555,6 +556,31 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
   }
 
 
+
+  property("applyTransactions() - failing transaction id is tagged in the validation error") {
+    val (us, bh) = createUtxoState(settings)
+    val wus = WrappedUtxoState(us, bh, settings)
+
+    // Apply a valid genesis block so transaction validation is enabled (height > checkpoint).
+    val genesis = validFullBlock(parentOpt = None, wus)
+    val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
+
+    // Build a valid transaction spending one of the post-genesis boxes,
+    // then corrupt its output value to be negative.
+    val box = wusAfterGenesis.takeBoxes(1).head
+    val validTx = validTransactionFromBoxes(IndexedSeq(box), new RandomWrapper)
+    val invalidOutputs = validTx.outputCandidates.map { out =>
+      new ErgoBoxCandidate(-1, out.ergoTree, out.creationHeight, out.additionalTokens, out.additionalRegisters)
+    }
+    val invalidTx = validTx.copy(outputCandidates = invalidOutputs)
+
+    val error = wusAfterGenesis
+      .applyTransactions(Seq(invalidTx), invalidTx.id, wusAfterGenesis.rootDigest, wusAfterGenesis.stateContext)
+      .failed
+      .get
+
+    ErgoNodeViewHolder.extractFailedTxId(error) shouldBe Some(invalidTx.id)
+  }
 
   private def genExtension(header: Header, sc: ErgoStateContext): Extension = {
     nipopowAlgos.interlinksToExtension(nipopowAlgos.updateInterlinks(sc.lastHeaderOpt, sc.lastExtensionOpt)).toExtension(header.id)

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -3,6 +3,7 @@ package org.ergoplatform.nodeView.viewholder
 import java.io.File
 import org.ergoplatform.ErgoBoxCandidate
 import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
@@ -618,11 +619,11 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
         new MalformedModifierError("tx failed", tx.id, ErgoTransaction.modifierTypeId)
       ErgoNodeViewHolder.extractFailedTxId(txError) shouldBe Some(tx.id)
 
-      // block-level error with zero-filled modifier id should be ignored
+      // block-level error with non-transaction modifier id should be ignored
       val blockError = new MalformedModifierError(
         "block failed",
         bytesToId(Array.fill(32)(0.toByte)),
-        ErgoTransaction.modifierTypeId
+        BlockTransactions.modifierTypeId
       )
       ErgoNodeViewHolder.extractFailedTxId(blockError) shouldBe None
 

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -3,13 +3,17 @@ package org.ergoplatform.nodeView.viewholder
 import java.io.File
 import org.ergoplatform.ErgoBoxCandidate
 import org.ergoplatform.modifiers.ErgoFullBlock
-import org.ergoplatform.modifiers.mempool.UnconfirmedTransaction
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.history.popow.NipopowAlgos
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
+import org.ergoplatform.modifiers.transaction.TooHighCostError
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
 import org.ergoplatform.nodeView.state.StateType.Utxo
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.settings.{Algos, ErgoSettings}
-import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestConfig, NodeViewTestOps, TestCase}
+import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestConfig, NodeViewTestOps, RandomWrapper, TestCase}
+import org.ergoplatform.validation.MalformedModifierError
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages._
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.{ErgoNodeViewHolder, LocallyGeneratedModifier}
@@ -525,6 +529,56 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     }
   }
 
+  private val t20 = TestCase("SemanticallyFailedModification carries failing transaction id") { fixture =>
+    import fixture._
+
+    val (us, bh) = createUtxoState(fixture.settings)
+    val wus = WrappedUtxoState(us, bh, fixture.settings)
+
+    val genesis = validFullBlock(None, wus)
+
+    // Apply genesis through the standard NVH route first, so the next block can reference it.
+    applyBlock(genesis) shouldBe 'success
+    val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
+
+    val box = wusAfterGenesis.takeBoxes(1).head
+    val validTx = validTransactionFromBoxes(IndexedSeq(box), new RandomWrapper)
+    val invalidOutputs = validTx.outputCandidates.map { out =>
+      new ErgoBoxCandidate(-1, out.ergoTree, out.creationHeight, out.additionalTokens, out.additionalRegisters)
+    }
+    val invalidTx = validTx.copy(outputCandidates = invalidOutputs)
+
+    val (adProofBytes, adDigest) = wusAfterGenesis.proofsForTransactions(Seq(invalidTx)).get
+    val time = genesis.header.timestamp + 1
+    val parentOpt = Some(genesis.header)
+    val parentExtensionOpt = wusAfterGenesis.stateContext.lastExtensionOpt
+    val nipopowAlgos = new NipopowAlgos(settings.chainSettings)
+    val extension = parameters.toExtensionCandidate ++
+      nipopowAlgos.interlinksToExtension(nipopowAlgos.updateInterlinks(parentOpt, parentExtensionOpt))
+
+    val invalidBlock = settings.chainSettings.powScheme.proveBlock(
+      parentOpt,
+      Header.InitialVersion,
+      settings.chainSettings.initialNBits,
+      adDigest,
+      adProofBytes,
+      Seq(invalidTx),
+      time,
+      extension,
+      Array.fill(3)(0: Byte),
+      defaultMinerSecretNumber
+    ).get
+
+    subscribeEvents(classOf[SemanticallyFailedModification])
+
+    if (verifyTransactions) {
+      applyBlock(invalidBlock) shouldBe 'success
+
+      val semFailed = expectMsgType[SemanticallyFailedModification]
+      ErgoNodeViewHolder.extractFailedTxId(semFailed.error) shouldBe Some(invalidTx.id)
+    }
+  }
+
   val cases: List[TestCase] = List(t0, t1, t2, t3, t3a, t4, t5, t6, t7, t8, t9)
 
   NodeViewTestConfig.allConfigs.foreach { c =>
@@ -535,7 +589,7 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     }
   }
 
-  val verifyingTxCases: List[TestCase] = List(t10, t11, t12, t13)
+  val verifyingTxCases: List[TestCase] = List(t10, t11, t12, t13, t20)
 
   NodeViewTestConfig.verifyTxConfigs.foreach { c =>
     verifyingTxCases.foreach { t =>
@@ -554,6 +608,37 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
   genesisIdTestCases.foreach { t =>
     property(t.name) {
       t.run(parameters, NodeViewTestConfig(StateType.Digest, verifyTransactions = true, popowBootstrap = true))
+    }
+  }
+
+  property("extractFailedTxId should extract failing transaction id from validation error shapes") {
+    forAll(invalidErgoTransactionGen) { tx =>
+      // transaction-level error tagged with the transaction id
+      val txError =
+        new MalformedModifierError("tx failed", tx.id, ErgoTransaction.modifierTypeId)
+      ErgoNodeViewHolder.extractFailedTxId(txError) shouldBe Some(tx.id)
+
+      // block-level error with zero-filled modifier id should be ignored
+      val blockError = new MalformedModifierError(
+        "block failed",
+        bytesToId(Array.fill(32)(0.toByte)),
+        ErgoTransaction.modifierTypeId
+      )
+      ErgoNodeViewHolder.extractFailedTxId(blockError) shouldBe None
+
+      // header-level error should be ignored
+      val headerError = new MalformedModifierError("header failed", tx.id, Header.modifierTypeId)
+      ErgoNodeViewHolder.extractFailedTxId(headerError) shouldBe None
+
+      // too high cost error carries the transaction itself
+      ErgoNodeViewHolder.extractFailedTxId(TooHighCostError(tx, Some(1000))) shouldBe Some(tx.id)
+
+      // errors wrapped into other exceptions are found via the cause chain
+      val wrapped = new Exception("wrapper", new RuntimeException(txError))
+      ErgoNodeViewHolder.extractFailedTxId(wrapped) shouldBe Some(tx.id)
+
+      // unrelated exception
+      ErgoNodeViewHolder.extractFailedTxId(new Exception("unrelated")) shouldBe None
     }
   }
 


### PR DESCRIPTION
This PR fixes two mining-related issues. 

First, it prevents the node from stalling after a locally mined block is semantically or syntactically rejected by clearing `solvedBlock` and cached candidates, allowing the miner to resume work instead of rejecting new solutions with “Block already solved.”

 Second, it resolves a divergence between candidate construction and full-block validation: `UpcomingStateContext` (used by `createCandidate`, `/transactions/check`, and mempool validation) was exposing 10 previous headers while full-block validation only exposed 9, so a script reading `CONTEXT.headers(9)` could pass candidate validation and then fail block validation with `ArrayIndexOutOfBoundsException`. The fix trims `lastHeaders` to `Constants.LastHeadersInContext - 1` in `upcoming()` and `simplifiedUpcoming()`, adds a defensive size check in `UpcomingStateContext`, and includes equivalence tests verifying that both upcoming contexts expose the same headers as the post-`appendFullBlock` validation context.

