### PR TITLE
Caught-up fix

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -524,6 +524,13 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
 
     case _: FullBlockApplied if state.rollbackInProgress => stash()
 
+    // Resume catch-up when a block is applied while the indexer is behind.
+    // Without this the indexer can stall after logging "Deferring catch-up",
+    // because no Index() message is scheduled and further FullBlockApplied events
+    // are dropped while caughtUp = false.
+    case _: FullBlockApplied if !state.caughtUp && !state.rollbackInProgress =>
+      self ! Index()
+
     case Rollback(branchPoint: ModifierId) =>
       if (state.rollbackInProgress) {
         log.warn(s"Rollback already in progress")

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -30,6 +30,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   case class ExtendDB(blockCount: Int)
   case class Reset()
   case class GenerateBetterChainTip()
+  case class SetCaughtUp(caughtUp: Boolean)
 
   type ID_LL = mutable.HashMap[ModifierId,(Long,Long)]
 
@@ -372,6 +373,31 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     done.await()
     val (_, _, indexedTokens, _, _) = manualIndex(HEIGHT)
     checkTokens(indexedTokens) shouldBe 0
+    indexer ! Reset()
+  }
+
+  property("resumes catch-up from a deferred state on FullBlockApplied") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+    val nextHeader = history.typedModifierById[Header](history.bestHeaderIdAtHeight(HEIGHT + 1).get).get
+
+    // Simulate the state after a headers-only fork briefly became the best chain
+    // and then lost: caughtUp=false, but the indexed tip is still on the main chain.
+    indexer ! SetCaughtUp(caughtUp = false)
+
+    // Without the FullBlockApplied handler for !caughtUp, this event would be
+    // dropped and the indexer would stay stalled.
+    indexer ! RemoteBlockApplied(nextHeader, history.getFullBlock(nextHeader).get.transactions.map(_.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.caughtUp shouldBe true
+    }
     indexer ! Reset()
   }
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
@@ -23,6 +23,12 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
     case test.GenerateBetterChainTip() => GenerateBetterChainTip()
   }
 
+  override protected def loaded(state: IndexerState): Receive = {
+    case test.SetCaughtUp(caughtUp: Boolean) =>
+      context.become(receive.orElse(loaded(state.copy(caughtUp = caughtUp))))
+    case x => super.loaded(state)(x)
+  }
+
   override def caughtUpHook(height: Int = 0): Unit = {
     if(height > 0 && height < chainHeight) return
     test.lock.lock()


### PR DESCRIPTION
Fix ExtraIndexer stalling after "Deferring catch-up": add a FullBlockApplied handler for the !caughtUp state that reschedules Index(), so the indexer resumes catch-up when the chain heals instead of waiting for a Rollback. Includes a regression test that fails without the fix.