### PR TITLE
Require wallet-owned change addresses

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -4435,6 +4435,7 @@ paths:
       security:
         - ApiKeyAuth: [api_key]
       summary: Update address to be used to send change to
+      description: The wallet must be unlocked and the address must be owned by the wallet.
       operationId: walletUpdateChangeAddress
       tags:
         - wallet
@@ -4452,6 +4453,12 @@ paths:
       responses:
         '200':
           description: Change address updated successfully
+        '400':
+          description: Wallet is locked or the address is not owned by the wallet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
         default:
           description: Error
           content:

--- a/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/WalletApiRoute.scala
@@ -10,6 +10,7 @@ import org.ergoplatform.http.api.requests.HintExtractionRequest
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.wallet._
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.ChangeAddressValidationException
 import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.settings.{ErgoSettings, RESTApiSettings}
 import org.ergoplatform.wallet.Constants
@@ -464,8 +465,13 @@ case class WalletApiRoute(readersHolder: ActorRef,
   }
 
   def updateChangeAddressR: Route = (path("updateChangeAddress") & post & p2pkAddress) { p2pk =>
-    withWallet { w =>
+    withWalletOp { w =>
       w.updateChangeAddress(p2pk)
+        .map[Either[ChangeAddressValidationException, Unit]](Right(_))
+        .recover { case e: ChangeAddressValidationException => Left(e) }
+    } {
+      case Right(_) => ApiResponse(())
+      case Left(e) => BadRequest(e.getMessage)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -8,6 +8,7 @@ import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedMempool
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.ErgoStateReader
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.ChangeAddressValidationException
 import org.ergoplatform.nodeView.wallet.ErgoWalletServiceUtils.DeriveNextKeyResult
 import org.ergoplatform.sdk.wallet.secrets.DerivationPath
 import org.ergoplatform.settings._
@@ -408,12 +409,15 @@ class ErgoWalletActor(settings: ErgoSettings,
       }
 
     case UpdateChangeAddress(address) =>
-      state.storage.updateChangeAddress(address) match {
+      ergoWalletService.updateChangeAddress(state, address) match {
         case Success(_) =>
           sender() ! StatusReply.success(())
+        case Failure(t: ChangeAddressValidationException) =>
+          log.warn(t.getMessage)
+          sender() ! StatusReply.error(t)
         case Failure(t) =>
           log.error(s"Unable to update change address", t)
-          sender() ! StatusReply.error(s"Unable to update change address : ${t.getMessage}")
+          sender() ! StatusReply.error(t)
       }
 
     case RemoveScan(scanId) =>

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -96,6 +96,17 @@ trait ErgoWalletService {
   def lockWallet(state: ErgoWalletState): ErgoWalletState
 
   /**
+    * Update the address used for wallet change outputs.
+    * @param state current wallet state
+    * @param address new change address
+    * @return Success when the address was persisted
+    */
+  def updateChangeAddress(
+    state: ErgoWalletState,
+    address: P2PKAddress
+  ): Try[Unit]
+
+  /**
     * Close it, recursively delete registryFolder from filesystem if present and create new registry
     * @param state current wallet state
     * @param settings settings read from config file
@@ -265,6 +276,18 @@ trait ErgoWalletService {
 
 }
 
+object ErgoWalletService {
+
+  sealed abstract class ChangeAddressValidationException(message: String)
+    extends IllegalArgumentException(message)
+
+  final class WalletLockedForChangeAddress
+    extends ChangeAddressValidationException("Wallet is locked")
+
+  final class ChangeAddressNotOwned
+    extends ChangeAddressValidationException("Change address is not owned by the wallet")
+}
+
 class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends ErgoWalletService with ErgoWalletSupport with FileUtils {
 
 
@@ -374,6 +397,20 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
   override def lockWallet(state: ErgoWalletState): ErgoWalletState = {
     state.secretStorageOpt.foreach(_.lock())
     state.copy(walletVars = state.walletVars.resetProver())
+  }
+
+  override def updateChangeAddress(
+    state: ErgoWalletState,
+    address: P2PKAddress
+  ): Try[Unit] = {
+    state.walletVars.proverOpt match {
+      case None =>
+        Failure(new ErgoWalletService.WalletLockedForChangeAddress)
+      case Some(_) if !state.walletVars.ownsAddress(address) =>
+        Failure(new ErgoWalletService.ChangeAddressNotOwned)
+      case Some(_) =>
+        state.storage.updateChangeAddress(address)
+    }
   }
 
   override def recreateRegistry(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] = {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -83,9 +83,16 @@ case class ErgoWalletState(
 
   def getChangeAddress(addrEncoder: ErgoAddressEncoder): Option[P2PKAddress] = {
     walletVars.proverOpt.map { prover =>
-      storage.readChangeAddress.getOrElse {
-        log.debug("Change address not specified. Using root address from wallet.")
-        P2PKAddress(prover.hdPubKeys.head.key)(addrEncoder)
+      val rootAddress = P2PKAddress(prover.hdPubKeys.head.key)(addrEncoder)
+      storage.readChangeAddress match {
+        case Some(address) if walletVars.ownsAddress(address) =>
+          address
+        case Some(_) =>
+          log.warn("Ignoring persisted change address that is not owned by the wallet")
+          rootAddress
+        case None =>
+          log.debug("Change address not specified. Using root address from wallet.")
+          rootAddress
       }
     }
   }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletVars.scala
@@ -36,6 +36,13 @@ final case class WalletVars(proverOpt: Option[ErgoProvingInterpreter],
 
   val publicKeyAddresses: Seq[P2PKAddress] = stateCacheOpt.map(_.publicKeyAddresses).getOrElse(Seq.empty)
 
+  def ownsAddress(address: P2PKAddress): Boolean =
+    proverOpt.exists { prover =>
+      val tracked = trackedPubKeys.exists(_.key.value.equals(address.pubkey.value))
+      val signable = prover.secrets.exists(_.publicImage.equals(address.pubkey))
+      tracked && signable
+    }
+
   val trackedBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.trackedBytes).getOrElse(Seq.empty)
 
   val miningScriptsBytes: Seq[Array[Byte]] = stateCacheOpt.map(_.miningScriptsBytes).getOrElse(Seq.empty)

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -1,15 +1,28 @@
 package org.ergoplatform.http.routes
 
+import akka.actor.{Actor, Props}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{Route, ValidationRejection}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.pattern.StatusReply
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport
 import io.circe.syntax._
 import io.circe.{Decoder, Json}
 import org.ergoplatform.http.api.{ApiCodecs, ApiExtraCodecs, ApiRequestsCodecs, WalletApiRoute}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.nodeView.ErgoReadersHolder.GetReaders
+import org.ergoplatform.nodeView.wallet.ErgoWalletActorMessages.UpdateChangeAddress
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.{
+  ChangeAddressNotOwned,
+  ChangeAddressValidationException,
+  WalletLockedForChangeAddress
+}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequestEncoder, PaymentRequest, PaymentRequestEncoder, _}
-import org.ergoplatform.nodeView.wallet.{AugWalletTransaction, ErgoAddressJsonEncoder}
+import org.ergoplatform.nodeView.wallet.{
+  AugWalletTransaction,
+  ErgoAddressJsonEncoder,
+  ErgoWalletReader
+}
 import org.ergoplatform.settings.{Args, ErgoSettings, ErgoSettingsReader}
 import org.ergoplatform.utils.Stubs
 import org.ergoplatform.{ErgoAddress, Pay2SAddress}
@@ -61,6 +74,32 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Seq.empty,
     minerRewardDelay = 720
   )(settings.addressEncoder)
+
+  private val changeAddressBody = Json.obj(
+    "address" -> WalletActorStub.address.toString.asJson
+  )
+
+  private def changeAddressRoute(result: Either[Throwable, Unit]): Route = {
+    val walletActorRef = system.actorOf(Props(new Actor {
+      override def receive: Receive = {
+        case UpdateChangeAddress(_) =>
+          result match {
+            case Right(_) => sender() ! StatusReply.success(())
+            case Left(error) => sender() ! StatusReply.error(error)
+          }
+      }
+    }))
+    val walletReader = new ErgoWalletReader {
+      override val walletActor = walletActorRef
+    }
+    val readers = digestReaders.copy(w = walletReader)
+    val readersHolder = system.actorOf(Props(new Actor {
+      override def receive: Receive = {
+        case GetReaders => sender() ! readers
+      }
+    }))
+    Route.seal(WalletApiRoute(readersHolder, nodeViewRef, settings).route)
+  }
 
 
   it should "generate arbitrary transaction" in {
@@ -157,6 +196,36 @@ class WalletApiRouteSpec extends AnyFlatSpec
     Post(prefix + "/unlock", Json.obj("pass" -> "1234".asJson)) ~> route ~> check {
       status shouldBe StatusCodes.OK
     }
+  }
+
+  it should "return bad request for invalid change address updates" in {
+    val failures: Seq[ChangeAddressValidationException] = Seq(
+      new WalletLockedForChangeAddress,
+      new ChangeAddressNotOwned
+    )
+
+    failures.foreach { failure =>
+      Post(prefix + "/updateChangeAddress", changeAddressBody) ~>
+        changeAddressRoute(Left(failure)) ~> check {
+          status shouldBe StatusCodes.BadRequest
+          val detail = responseAs[Json].hcursor.downField("detail").as[String]
+          detail shouldBe Right(failure.getMessage)
+        }
+    }
+  }
+
+  it should "keep unexpected change address failures as internal errors" in {
+    Post(prefix + "/updateChangeAddress", changeAddressBody) ~>
+      changeAddressRoute(Left(new RuntimeException("storage failure"))) ~> check {
+        status shouldBe StatusCodes.InternalServerError
+      }
+  }
+
+  it should "accept a valid change address update" in {
+    Post(prefix + "/updateChangeAddress", changeAddressBody) ~>
+      changeAddressRoute(Right(())) ~> check {
+        status shouldBe StatusCodes.OK
+      }
   }
 
   it should "check wallet" in {

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -5,6 +5,10 @@ import org.ergoplatform._
 import org.ergoplatform.db.DBSpec
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.{
+  ChangeAddressNotOwned,
+  WalletLockedForChangeAddress
+}
 import org.ergoplatform.nodeView.wallet.WalletScanLogic.ScanResults
 import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, PaymentRequest}
@@ -28,10 +32,11 @@ import scorex.db.{LDBKVStore, LDBVersionedStore}
 import scorex.util.encode.Base16
 import sigma.Extensions.ArrayOps
 import sigma.ast.{ByteArrayConstant, EvaluatedValue, FalseLeaf, SType}
+import sigmastate.crypto.DLogProtocol.DLogProverInput
 import sigmastate.helpers.TestingHelpers.testBox
 
 import scala.collection.compat.immutable.ArraySeq
-import scala.util.Random
+import scala.util.{Random, Success}
 
 class ErgoWalletServiceSpec
   extends ErgoCorePropertyTest
@@ -324,6 +329,94 @@ class ErgoWalletServiceSpec
         finalUnlockedState.secretStorageOpt.get.isLocked shouldBe false
         finalUnlockedState.storage.readAllKeys().size shouldBe 1
         finalUnlockedState.walletVars.proverOpt shouldNot be(empty)
+      }
+    }
+  }
+
+  property("change address update should require an unlocked wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val ownedAddress = unlockedState.walletVars.publicKeyAddresses.head
+        val lockedState = walletService.lockWallet(unlockedState)
+
+        val result = walletService.updateChangeAddress(lockedState, ownedAddress)
+
+        result.isFailure shouldBe true
+        result.failed.get shouldBe a[WalletLockedForChangeAddress]
+        result.failed.get.getMessage should include("locked")
+        lockedState.storage.readChangeAddress shouldBe empty
+      }
+    }
+  }
+
+  property("change address update should reject an address not owned by the wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val unownedAddress = P2PKAddress(
+          DLogProverInput.random().publicImage
+        )(settings.addressEncoder)
+
+        val result = walletService.updateChangeAddress(unlockedState, unownedAddress)
+
+        result.isFailure shouldBe true
+        result.failed.get shouldBe a[ChangeAddressNotOwned]
+        result.failed.get.getMessage should include("not owned")
+        unlockedState.storage.readChangeAddress shouldBe empty
+      }
+    }
+  }
+
+  property("change address update should accept an address owned by an unlocked wallet") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val walletService = new ErgoWalletServiceImpl(settings)
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val ownedAddress = unlockedState.walletVars.publicKeyAddresses.head
+
+        walletService.updateChangeAddress(
+          unlockedState,
+          ownedAddress
+        ) shouldBe Success(())
+        unlockedState.storage.readChangeAddress shouldBe Some(ownedAddress)
+      }
+    }
+  }
+
+  property("change address lookup should ignore a persisted unowned address") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val unlockedState = processUnlock(
+          initialState(store, versionedStore),
+          masterKey,
+          usePreEip3Derivation = true
+        ).get
+        val unownedAddress = P2PKAddress(
+          DLogProverInput.random().publicImage
+        )(settings.addressEncoder)
+        val rootAddress = P2PKAddress(
+          unlockedState.walletVars.proverOpt.get.hdPubKeys.head.key
+        )(settings.addressEncoder)
+
+        unlockedState.storage.updateChangeAddress(unownedAddress).get
+
+        unlockedState.getChangeAddress(settings.addressEncoder) shouldBe Some(rootAddress)
+        unlockedState.storage.readChangeAddress shouldBe Some(unownedAddress)
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSpec.scala
@@ -3,6 +3,10 @@ package org.ergoplatform.nodeView.wallet
 import org.ergoplatform._
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnsignedErgoTransaction}
 import org.ergoplatform.nodeView.state.{ErgoStateContext, VotingData}
+import org.ergoplatform.nodeView.wallet.ErgoWalletService.{
+  ChangeAddressNotOwned,
+  WalletLockedForChangeAddress
+}
 import org.ergoplatform.nodeView.wallet.IdUtils._
 import org.ergoplatform.nodeView.wallet.persistence.{WalletDigest, WalletDigestSerializer}
 import org.ergoplatform.nodeView.wallet.requests.{AssetIssueRequest, BurnTokensRequest, ExternalSecret, PaymentRequest}
@@ -41,6 +45,38 @@ class ErgoWalletSpec extends ErgoCorePropertyTest with WalletTestOps with Eventu
       val wd0 = WalletDigest(1, 0, assets)
       val bs = WalletDigestSerializer.toBytes(wd0)
       WalletDigestSerializer.parseBytes(bs).walletAssetBalances shouldBe wd0.walletAssetBalances
+    }
+  }
+
+  property(
+    "change address updates enforce wallet ownership and lock state through the actor"
+  ) {
+    withFixture { implicit w =>
+      val addresses = getPublicKeys
+      val initialStatus = await(wallet.getWalletStatus)
+      val alternateOwnedAddress =
+        addresses.find(address => !initialStatus.changeAddress.contains(address)).get
+
+      await(wallet.updateChangeAddress(alternateOwnedAddress))
+      await(wallet.getWalletStatus).changeAddress shouldBe Some(alternateOwnedAddress)
+
+      val unownedAddress = P2PKAddress(
+        DLogProverInput.random().publicImage
+      )(settings.addressEncoder)
+      val unownedFailure = await(wallet.updateChangeAddress(unownedAddress).failed)
+      unownedFailure shouldBe a[ChangeAddressNotOwned]
+      unownedFailure.getMessage should include("not owned")
+      await(wallet.getWalletStatus).changeAddress shouldBe Some(alternateOwnedAddress)
+
+      wallet.lockWallet()
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 100.millis)
+      eventually {
+        await(wallet.getWalletStatus).unlocked shouldBe false
+      }
+
+      val lockedFailure = await(wallet.updateChangeAddress(alternateOwnedAddress).failed)
+      lockedFailure shouldBe a[WalletLockedForChangeAddress]
+      lockedFailure.getMessage should include("locked")
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletVarsSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletVarsSpec.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.nodeView.wallet
 
+import org.ergoplatform.P2PKAddress
+import org.ergoplatform.sdk.wallet.secrets.{DlogSecretKey, ExtendedSecretKey}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 
@@ -16,6 +18,37 @@ class WalletVarsSpec extends ErgoCorePropertyTest {
     wp.trackedBytes.length shouldBe 1
 
     defaultRootSecret.publicKey shouldBe wp.trackedPubKeys.head
+  }
+
+  property(".ownsAddress requires both tracking and an active signing key") {
+    val otherSecret = ExtendedSecretKey.deriveMasterKey(
+      Array.fill(32)(1: Byte),
+      usePre1627KeyDerivation = false
+    )
+    val otherAddress = P2PKAddress(otherSecret.publicKey.key)(settings.addressEncoder)
+    val rootProver = ErgoProvingInterpreter(defaultRootSecret, parameters)
+    val bothProver = ErgoProvingInterpreter(
+      IndexedSeq(defaultRootSecret, otherSecret),
+      parameters
+    )
+    val primitiveProver = ErgoProvingInterpreter(
+      IndexedSeq(defaultRootSecret, DlogSecretKey(otherSecret.privateInput)),
+      parameters
+    )
+    val rootCache = WalletCache(Seq(defaultRootSecret.publicKey), settings)
+    val bothCache = WalletCache(
+      Seq(defaultRootSecret.publicKey, otherSecret.publicKey),
+      settings
+    )
+
+    WalletVars(Some(rootProver), Seq.empty, Some(bothCache))
+      .ownsAddress(otherAddress) shouldBe false
+    WalletVars(Some(bothProver), Seq.empty, Some(rootCache))
+      .ownsAddress(otherAddress) shouldBe false
+    WalletVars(Some(bothProver), Seq.empty, Some(bothCache))
+      .ownsAddress(otherAddress) shouldBe true
+    WalletVars(Some(primitiveProver), Seq.empty, Some(bothCache))
+      .ownsAddress(otherAddress) shouldBe true
   }
 
 }


### PR DESCRIPTION
Reopens #2423 against `v6.0.6`. GitHub closed the original PR automatically when its `v6.0.4` base branch was deleted.

## Summary

- Require the wallet to be unlocked before updating its change address.
- Require the requested P2PK address to be both tracked by the wallet and signable by the active prover.
- Ignore a previously persisted unowned change address when resolving change outputs, falling back to the wallet root address.
- Return HTTP 400 for expected validation failures while preserving HTTP 500 for unexpected internal or storage failures.
- Document the endpoint contract in OpenAPI.

## Rationale

`/wallet/updateChangeAddress` currently persists any valid P2PK address, including one not controlled by the wallet, and accepts the update while the wallet is locked. The persisted value is later consumed when wallet transactions select their change output.

The update path now enforces the ownership boundary before persistence, and the read path revalidates legacy persisted values before transaction generation. Checking both tracked keys and active prover secrets also avoids assuming that every wallet signer is HD-derived.

## Validation

- `WalletApiRouteSpec`, `ErgoWalletServiceSpec`, `ErgoWalletSpec`, and `WalletVarsSpec`: 79/79 passed on `d5ef7d8da`.
- OpenAPI YAML parse and `git diff --check` passed.
- Independent review of the replayed `v6.0.6` diff found no blockers.

REST binding, API-key defaults, installer behavior, and release configuration are unchanged.