### PR TITLE
Refresh expired mining candidates on request

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -199,7 +199,15 @@ class CandidateGenerator(
     case gen @ GenerateCandidate(txsToInclude, reply, forced, optPk) =>
       val senderOpt = if (reply) Some(sender()) else None
       val effectiveMinerPk = optPk.getOrElse(minerPk)
-      if (!forced && cachedFor(state.cachedCandidate, txsToInclude, effectiveMinerPk)) {
+      if (
+        !forced &&
+        cachedFor(state.cachedCandidate, txsToInclude, effectiveMinerPk) &&
+        !hasCandidateExpired(
+          state.cachedCandidate,
+          state.solvedBlock,
+          candidateGenInterval
+        )
+      ) {
         senderOpt.foreach(_ ! StatusReply.success(state.cachedCandidate.get))
       } else {
         val start = System.currentTimeMillis()

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -331,6 +331,117 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
+  it should "refresh an expired candidate after an earlier mempool change" in new TestKit(
+    ActorSystem()
+  ) {
+    val testProbe = new TestProbe(system)
+    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+
+    val regenerationInterval = 5.seconds
+    val testDir =
+      s"${defaultSettings.directory}-expired-cache-${System.currentTimeMillis()}"
+    val testSettings = ErgoSettingsReader.read()
+      .copy(
+        nodeSettings = defaultSettings.nodeSettings
+          .copy(blockCandidateGenerationInterval = regenerationInterval),
+        chainSettings = defaultSettings.chainSettings.copy(blockInterval = 1.seconds),
+        directory = testDir
+      )
+
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(testSettings)
+    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+    val candidateGenerator: ActorRef = CandidateGenerator(
+      defaultMinerSecret.publicImage,
+      readersHolderRef,
+      viewHolderRef,
+      testSettings
+    )
+
+    val powScheme = testSettings.chainSettings.powScheme
+
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val initialCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+    val initialBlock = powScheme
+      .proveCandidate(initialCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
+      .get
+    candidateGenerator.tell(initialBlock.header.powSolution, testProbe.ref)
+
+    var ackSeen     = false
+    var appliedSeen = false
+    testProbe.fishForMessage(blockValidationDelay) {
+      case StatusReply.Success(()) =>
+        ackSeen = true
+        ackSeen && appliedSeen
+      case FullBlockApplied(header) if header.id == initialBlock.header.id =>
+        appliedSeen = true
+        ackSeen && appliedSeen
+      case _ => false
+    }
+
+    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val prop = DLogProverInput(
+      BigIntegers.fromUnsignedByteArray("expired-cache-test".getBytes())
+    ).publicImage
+    val rewardBox = readers.h.bestFullBlockOpt.get.transactions.last.outputs.last
+    val unsignedTx = new UnsignedErgoTransaction(
+      IndexedSeq(Input(rewardBox.id, emptyProverResult)),
+      IndexedSeq(),
+      IndexedSeq(
+        new ErgoBoxCandidate(
+          rewardBox.value,
+          ErgoTree.fromSigmaBoolean(prop),
+          readers.s.stateContext.currentHeight
+        )
+      )
+    )
+    val tx = ErgoTransaction(
+      defaultProver
+        .sign(unsignedTx, IndexedSeq(rewardBox), IndexedSeq(), readers.s.stateContext)
+        .get
+    )
+
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = true),
+      testProbe.ref
+    )
+    val freshCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+
+    val poolWithTx = ErgoMemPool.empty(testSettings).put(UnconfirmedTransaction(tx, None))
+    candidateGenerator.tell(ChangedMempool(poolWithTx), testProbe.ref)
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val unexpiredCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+    unexpiredCandidate.candidateBlock shouldBe freshCandidate.candidateBlock
+    unexpiredCandidate.candidateBlock.transactions.map(_.id) should not contain tx.id
+
+    val remainingMillis = regenerationInterval.toMillis -
+      (System.currentTimeMillis() - freshCandidate.candidateBlock.timestamp) + 200
+    remainingMillis should be > 200L
+    testProbe.expectNoMessage(remainingMillis.millis)
+
+    candidateGenerator.tell(
+      GenerateCandidate(Seq.empty, reply = true, forced = false),
+      testProbe.ref
+    )
+    val regeneratedCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
+    }
+
+    regeneratedCandidate.candidateBlock.transactions.map(_.id) should contain(tx.id)
+    system.terminate()
+  }
+
   it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
@@ -831,17 +942,17 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithLongCache: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            .copy(blockCandidateGenerationInterval = 1.minute),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithLongCache)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -849,10 +960,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        settingsWithShortRegeneration
+        settingsWithLongCache
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    val powScheme = settingsWithLongCache.chainSettings.powScheme
 
     // First mine a block to establish chain (needed for avg mining time calculation)
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)


### PR DESCRIPTION
Reopens #2443 against `v6.0.7`. GitHub closed the original PR automatically when its `v6.0.4` base branch was deleted.

## Problem

Candidate expiry is checked while handling `ChangedMempool`, but a mempool change can arrive before `blockCandidateGenerationInterval` elapses. In that case the reader is updated without regenerating. If the pool then stays unchanged, later non-forced mining requests can keep returning the expired candidate because the cache-hit path does not check its age.

This can leave transactions already present in the node's mempool out of successive mining jobs beyond the configured refresh interval.

## Fix

- Require a compatible cached candidate to still be unexpired before serving it.
- Regenerate through the existing slow path on the first non-forced poll after expiry.
- Preserve solved-block handling and the existing previous-candidate fallback.
- Add an actor regression for the change-before-expiry event ordering.
- Keep the existing forced-cache test independent of expiration.

## Validation

- `CandidateGeneratorSpec`: 20/20 passed.
- `MiningApiRouteSpec`: 10/10 passed.
- `ErgoMinerSpec`: 5/5 passed.
- `git diff --check` passed on `b8eb8f402`.
- Independent review of the `v6.0.7` replay found no blocker or duplicate implementation.

## Scope

This patch does not change mempool ordering or candidate transaction-selection policy. It complements the regeneration work in #1363, #1412, #2164, and #2231 by enforcing candidate lifetime when a later non-forced request reads the cache.