### PR TITLE
Continue candidate assembly after limit overflow

### DIFF
--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -25,6 +25,7 @@ import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
 import scorex.crypto.hash.Digest32
+import scorex.db.ByteArrayWrapper
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging}
 import sigma.ast.syntax.ErgoBoxRType
@@ -960,21 +961,34 @@ object CandidateGenerator extends ScorexLogging {
               mempoolTxs: Iterable[ErgoTransaction],
               acc: Seq[CostedTransaction],
               lastFeeTx: Option[CostedTransaction],
-              invalidTxs: Seq[ModifierId]
+              invalidTxs: Seq[ModifierId],
+              deferredOutputs: Set[ByteArrayWrapper]
             ): (Seq[ErgoTransaction], Seq[ModifierId]) = {
       // transactions from mempool and fee txs from the previous step
       val currentCosted = acc ++ lastFeeTx
       def current: Seq[ErgoTransaction] = currentCosted.map(_._1)
 
-      val stateWithTxs = us.withTransactions(current)
+      lazy val stateWithTxs = us.withTransactions(current)
 
       mempoolTxs.headOption match {
         case Some(tx) =>
-          if (!inputsNotSpent(tx, stateWithTxs) || doublespend(current, tx)) {
-            //mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
-            //do these checks before validating the scripts to save time
-            log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
-            loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
+          val dependsOnDeferredOutput = deferredOutputs.nonEmpty && (
+            tx.inputs.exists(input => deferredOutputs.contains(ByteArrayWrapper(input.boxId))) ||
+            tx.dataInputs.exists(input => deferredOutputs.contains(ByteArrayWrapper(input.boxId)))
+          )
+          lazy val deferredWithTxOutputs =
+            deferredOutputs ++ tx.outputs.iterator.map(box => ByteArrayWrapper(box.id))
+
+          if (dependsOnDeferredOutput) {
+            log.debug(s"Deferring transaction ${tx.id} with a capacity-deferred ancestor")
+            loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs, deferredWithTxOutputs)
+          } else if (doublespend(current, tx)) {
+            // Do this check before validating the scripts to save time.
+            log.debug(s"Transaction ${tx.id} double-spending selected candidate inputs")
+            loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id, deferredOutputs)
+          } else if (!inputsNotSpent(tx, stateWithTxs)) {
+            log.debug(s"Transaction ${tx.id} spending non-existing inputs")
+            loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id, deferredOutputs)
           } else {
             // check validity and calculate transaction cost
             stateWithTxs.validateWithCost(
@@ -996,11 +1010,10 @@ object CandidateGenerator extends ScorexLogging {
                       case Success(cost) =>
                         val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
                         if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                          loop(mempoolTxs.tail, newTxs, Some(feeTx -> cost), invalidTxs)
+                          loop(mempoolTxs.tail, newTxs, Some(feeTx -> cost), invalidTxs, deferredOutputs)
                         } else {
-                          log.debug(s"Finishing block assembly on limits overflow, " +
-                                    s"cost is ${currentCosted.map(_._2).sum}, cost limit: $maxBlockCost")
-                          current -> invalidTxs
+                          log.debug(s"Deferring transaction ${tx.id} on candidate limits overflow")
+                          loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs, deferredWithTxOutputs)
                         }
                       case Failure(e) =>
                         log.warn(
@@ -1013,14 +1026,15 @@ object CandidateGenerator extends ScorexLogging {
                     log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
                     val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
                     if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                      loop(mempoolTxs.tail, blockTxs, lastFeeTx, invalidTxs)
+                      loop(mempoolTxs.tail, blockTxs, lastFeeTx, invalidTxs, deferredOutputs)
                     } else {
-                      current -> invalidTxs
+                      log.debug(s"Deferring transaction ${tx.id} on candidate limits overflow")
+                      loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs, deferredWithTxOutputs)
                     }
                 }
               case Failure(e) =>
                 log.info(s"Not included transaction ${tx.id} due to ${e.getMessage}: ", e)
-                loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
+                loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id, deferredOutputs)
             }
           }
         case None => // mempool is empty
@@ -1028,7 +1042,7 @@ object CandidateGenerator extends ScorexLogging {
       }
     }
 
-    val res = loop(transactions, Seq.empty, None, Seq.empty)
+    val res = loop(transactions, Seq.empty, None, Seq.empty, Set.empty)
     log.debug(
       s"Collected ${res._1.length} transactions for block #$currentHeight, " +
         s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -199,6 +199,281 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
 
   }
 
+  property("a transaction exceeding candidate size should not starve later transactions") {
+    val bh       = boxesHolderGen.sample.get
+    val rnd      = new RandomWrapper(Some(0))
+    val us       = createUtxoState(bh, parameters)
+    val minValue = BoxUtils.sufficientAmount(parameters)
+    val inputs   = bh.boxes.values.toIndexedSeq.filter(_.value >= minValue * 2).takeRight(21)
+
+    inputs.size shouldBe 21
+
+    val largeTx = validTransactionFromBoxes(
+      inputs.take(20),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+    val smallTx = validTransactionFromBoxes(
+      IndexedSeq(inputs.last),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+
+    val h = validFullBlock(None, us, bh, rnd).header
+    val upcomingContext = us.stateContext.upcoming(
+      h.minerPk,
+      h.timestamp,
+      h.nBits,
+      h.votes,
+      emptyVSUpdate,
+      h.version
+    )
+
+    val largeFeeTx = CandidateGenerator
+      .collectFees(us.stateContext.currentHeight, Seq(largeTx), defaultMinerPk, upcomingContext)
+      .get
+    val smallFeeTx = CandidateGenerator
+      .collectFees(us.stateContext.currentHeight, Seq(smallTx), defaultMinerPk, upcomingContext)
+      .get
+    val maxSize = smallTx.size + smallFeeTx.size + 1
+
+    largeTx.size + largeFeeTx.size should be >= maxSize
+
+    val (selected, eliminated) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      Int.MaxValue,
+      maxSize,
+      us,
+      upcomingContext,
+      Seq(largeTx, smallTx)
+    )
+
+    selected.map(_.id) should contain(smallTx.id)
+    selected.map(_.id) should not contain largeTx.id
+    selected.map(_.size).sum should be < maxSize
+    eliminated shouldBe empty
+
+    val (atSizeLimit, eliminatedAtSizeLimit) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      Int.MaxValue,
+      smallTx.size + smallFeeTx.size,
+      us,
+      upcomingContext,
+      Seq(smallTx)
+    )
+    atSizeLimit shouldBe empty
+    eliminatedAtSizeLimit shouldBe empty
+  }
+
+  property("a transaction exceeding candidate cost should not starve later transactions") {
+    val bh       = boxesHolderGen.sample.get
+    val rnd      = new RandomWrapper(Some(2))
+    val us       = createUtxoState(bh, parameters)
+    val minValue = BoxUtils.sufficientAmount(parameters)
+    val inputs   = bh.boxes.values.toIndexedSeq.filter(_.value >= minValue * 2).takeRight(31)
+
+    inputs.size shouldBe 31
+
+    val accepted = validTransactionFromBoxes(
+      inputs.take(20),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+    val expensive = validTransactionFromBoxes(
+      inputs.slice(20, 30),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+    val small = validTransactionFromBoxes(
+      IndexedSeq(inputs.last),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+
+    val h = validFullBlock(None, us, bh, rnd).header
+    val upcomingContext = us.stateContext.upcoming(
+      h.minerPk,
+      h.timestamp,
+      h.nBits,
+      h.votes,
+      emptyVSUpdate,
+      h.version
+    )
+
+    def transactionCost(tx: ErgoTransaction): Int =
+      us.validateWithCost(tx, upcomingContext, Int.MaxValue, Some(verifier)).get
+
+    def candidateCost(txs: Seq[ErgoTransaction]): Int = {
+      val newBoxes = txs.flatMap(_.outputs)
+      val feeTx = CandidateGenerator
+        .collectFees(us.stateContext.currentHeight, txs, defaultMinerPk, upcomingContext)
+        .get
+      val boxesToSpend = feeTx.inputs.flatMap(input =>
+        newBoxes.find(box => java.util.Arrays.equals(box.id, input.boxId))
+      )
+      val feeCost = feeTx
+        .statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier)
+        .get
+      txs.map(transactionCost).sum + feeCost
+    }
+
+    val acceptedAndSmallCost     = candidateCost(Seq(accepted, small))
+    val acceptedAndExpensiveCost = candidateCost(Seq(accepted, expensive))
+    val maxCost                  = acceptedAndSmallCost + 1
+
+    transactionCost(expensive) should be < maxCost
+    acceptedAndExpensiveCost should be >= maxCost
+
+    val (selected, eliminated) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      maxCost,
+      Int.MaxValue,
+      us,
+      upcomingContext,
+      Seq(accepted, expensive, small)
+    )
+
+    selected.map(_.id) should contain allOf (accepted.id, small.id)
+    selected.map(_.id) should not contain expensive.id
+    val newBoxes = selected.flatMap(_.outputs)
+    val selectedCost = selected.map { tx =>
+      us.validateWithCost(tx, upcomingContext, Int.MaxValue, Some(verifier)).getOrElse {
+        val boxesToSpend = tx.inputs.map(input =>
+          newBoxes.find(box => java.util.Arrays.equals(box.id, input.boxId)).get
+        )
+        tx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier).get
+      }
+    }.sum
+    selectedCost should be < maxCost
+    eliminated shouldBe empty
+
+    val (atCostLimit, eliminatedAtCostLimit) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      acceptedAndSmallCost,
+      Int.MaxValue,
+      us,
+      upcomingContext,
+      Seq(accepted, small)
+    )
+    atCostLimit.map(_.id) should contain(accepted.id)
+    atCostLimit.map(_.id) should not contain small.id
+    eliminatedAtCostLimit shouldBe empty
+  }
+
+  property("descendants of a capacity-deferred transaction should remain in the mempool") {
+    val bh       = boxesHolderGen.sample.get
+    val rnd      = new RandomWrapper(Some(1))
+    val us       = createUtxoState(bh, parameters)
+    val minValue = BoxUtils.sufficientAmount(parameters)
+    val inputs   = bh.boxes.values.toIndexedSeq.filter(_.value >= minValue * 2).takeRight(22)
+
+    inputs.size shouldBe 22
+
+    val parent = validTransactionFromBoxes(
+      inputs.take(20),
+      rnd,
+      issueNew = false
+    )
+    val accepted = validTransactionFromBoxes(
+      IndexedSeq(inputs(20)),
+      rnd,
+      issueNew = false
+    )
+    val dataDependent = validTransactionFromBoxes(
+      IndexedSeq(inputs(20)),
+      rnd,
+      issueNew = false,
+      stateCtxOpt = Some(us.stateContext),
+      dataBoxes = IndexedSeq(parent.outputs.head)
+    )
+    val child = validTransactionFromBoxes(
+      IndexedSeq(dataDependent.outputs.head),
+      rnd,
+      issueNew = false,
+      stateCtxOpt = Some(us.stateContext)
+    )
+    val grandchild = validTransactionFromBoxes(
+      IndexedSeq(child.outputs.head),
+      rnd,
+      issueNew = false,
+      stateCtxOpt = Some(us.stateContext)
+    )
+    val conflicting = validTransactionFromBoxes(
+      IndexedSeq(inputs(20)),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+    val independent = validTransactionFromBoxes(
+      IndexedSeq(inputs.last),
+      rnd,
+      issueNew = false,
+      outputsProposition = feeProp
+    )
+
+    val h = validFullBlock(None, us, bh, rnd).header
+    val upcomingContext = us.stateContext.upcoming(
+      h.minerPk,
+      h.timestamp,
+      h.nBits,
+      h.votes,
+      emptyVSUpdate,
+      h.version
+    )
+
+    val independentFeeTx = CandidateGenerator
+      .collectFees(
+        us.stateContext.currentHeight,
+        Seq(accepted, independent),
+        defaultMinerPk,
+        upcomingContext
+      )
+      .get
+    val maxSize = accepted.size + independent.size + independentFeeTx.size + 1
+
+    accepted.size + parent.size should be >= maxSize
+
+    val (familySelected, familyEliminated) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      Int.MaxValue,
+      Int.MaxValue,
+      us,
+      upcomingContext,
+      Seq(parent, dataDependent, child, grandchild)
+    )
+    familySelected.map(_.id) should contain allOf (
+      parent.id,
+      dataDependent.id,
+      child.id,
+      grandchild.id
+    )
+    familyEliminated shouldBe empty
+
+    val (selected, eliminated) = CandidateGenerator.collectTxs(
+      defaultMinerPk,
+      Int.MaxValue,
+      maxSize,
+      us,
+      upcomingContext,
+      Seq(accepted, parent, dataDependent, child, grandchild, conflicting, independent)
+    )
+
+    selected.map(_.id) should contain allOf (accepted.id, independent.id)
+    selected.map(_.id) should contain noneOf (
+      parent.id,
+      dataDependent.id,
+      child.id,
+      grandchild.id
+    )
+    selected.map(_.size).sum should be < maxSize
+    eliminated shouldBe Seq(conflicting.id)
+  }
+
   property("should not be able to spend recent fee boxes") {
 
     val delta          = 1


### PR DESCRIPTION
Reopens #2444 against `v6.0.7`. GitHub closed the original PR automatically when its `v6.0.4` base branch was deleted.

## Invariant

A valid transaction that cannot fit the current candidate must not prevent later independent transactions from being considered, or cause its later dependents to be eliminated from the mempool.

## Root cause

`CandidateGenerator.collectTxs` returned immediately when adding a valid transaction plus the updated fee transaction exceeded the candidate cost or size limit. Because the mempool sequence is priority-ordered rather than size-packed, one non-fitting transaction could starve every later transaction.

Simply continuing is unsafe: a later transaction spending or reading the omitted transaction's output would appear to have a missing box and could be returned in `EliminateTransactions`.

## Fix

- Keep the existing single-pass priority order.
- Defer a valid transaction when the resulting candidate exceeds the applicable limits, leaving the accepted prefix and fee transaction unchanged.
- Record deferred output IDs with content-based identity.
- Transitively defer later regular-input and data-input dependents without eliminating them.
- Preserve existing invalid and double-spend handling for transactions outside a deferred family.

## Regression coverage

The properties cover size and cost head-of-line blocking, fee and no-fee overflow branches, regular and data-input dependency propagation, and conflicts inside and outside deferred families. The size and descendant fixtures now measure the complete serialized transaction section and permit an exact byte fit. Cost equality remains excluded.

The [assertion update](https://github.com/a-shannon/ergo/compare/1b276802edb3e36c2d73462c5e0b5aa8cbc412f0...f75bda15cb1b859a505a264c5b5a5b167d2c9809) changes only `CandidateGeneratorPropSpec.scala`. It uses the existing `BlockTransactions(...).bytes.length` writer, so it has no dependency on the `BlockTransactions.sizeOf` API introduced by #2520. Production selection and the cost assertions are unchanged by this increment.

## Validation

- Assertion update at `f75bda15cb1b859a505a264c5b5a5b167d2c9809`: `CandidateGeneratorPropSpec` passed 16/16, with no failures, errors, or skipped tests. Source inputs remained unchanged throughout the run.
- Current-head GitHub CI is [7/8](https://github.com/ergoplatform/ergo/actions/runs/34783918811). Integration executed: 12 passed, one failed, one ignored. DeepRollBackSpec timed out after ten minutes waiting for convergence at height 252. Production and integration sources are unchanged by this assertion update; the cause remains unproved. A maintainer rerun of only the failed job on the unchanged head is requested.
- Prior `v6.0.7` replay: `CandidateGeneratorSpec` passed 19/19 and `CandidateGeneratorPropSpec` passed 16/16; `git diff --check` passed on `721dbf783`.
- Independent review of the `v6.0.7` replay found no blocker or duplicate implementation.

## Scope

This remains a focused candidate-selection fix. It does not introduce package scoring or change data-input CPFP policy. #2303 is complementary; #2462 changes fee collection and may require a later combined rebase if it lands first.

## Composition with transaction-section budgeting

[#2520](https://github.com/ergoplatform/ergo/pull/2520) changes complete-section sizing and final serialization recovery in the same selection loop. The [published composition](https://github.com/a-shannon/ergo/commit/5f171a53a65e6b22615780647aeceb2386f87858) preserves this PR's deferral behavior and passes 48/48 focused tests. Its [two-file increment after #2520](https://github.com/a-shannon/ergo/compare/d904fd1da9697ce6d5471e4416570c7bd0cf8ced...5f171a53a65e6b22615780647aeceb2386f87858) makes that conflict resolution directly reviewable. The adapted size assertions are now included in this PR itself. Enforcement of complete-section budgets, including rejection one byte below the required size, remains part of #2520.

For a common release line, review #2520 first and then adapt this deferral change. This PR retains its `v6.0.7` target at `f75bda15cb1b859a505a264c5b5a5b167d2c9809`. The linked composition validates the exact commits shown above and is not an already integrated release. Current ownership and merge order are tracked in [#2533](https://github.com/ergoplatform/ergo/issues/2533).
