### PR TITLE
Bound untrusted counts in input block message specs (102, 104, 105)

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionIdsMessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionIdsMessageSpec.scala
@@ -29,6 +29,9 @@ object InputBlockTransactionIdsMessageSpec extends MessageSpecInputBlocks[InputB
   override def parse(r: Reader): InputBlockTransactionIdsData = {
     val subBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize))
     val txsCount = r.getUInt().toIntExact
+    // every weak id takes exactly WeakIdLength bytes, so a bigger count is not possible to fulfil
+    require(txsCount.toLong * ErgoTransaction.WeakIdLength <= r.remaining,
+      s"Too many transaction ids declared: $txsCount, while only ${r.remaining} bytes remaining")
     val transactionIds = (1 to txsCount).map { _ =>
       r.getBytes(ErgoTransaction.WeakIdLength)
     }

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsMessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsMessageSpec.scala
@@ -30,6 +30,8 @@ object InputBlockTransactionsMessageSpec extends MessageSpecInputBlocks[InputBlo
   override def parse(r: Reader): InputBlockTransactionsData = {
     val subBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize))
     val txsCount = r.getUInt().toIntExact
+    // every serialized transaction takes at least one byte, so a bigger count is not possible to fulfil
+    require(txsCount <= r.remaining, s"Too many transactions declared: $txsCount, while only ${r.remaining} bytes remaining")
 
     val txs = new Array[ErgoTransaction](txsCount)
     cfor(0)(_ < txsCount, _ + 1) { i =>

--- a/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsRequestMessageSpec.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/network/message/inputblocks/InputBlockTransactionsRequestMessageSpec.scala
@@ -32,6 +32,9 @@ object InputBlockTransactionsRequestMessageSpec
   override def parse(r: Reader): InputBlockTransactionsRequest = {
     val inputBlockId = bytesToId(r.getBytes(Constants.ModifierIdSize))
     val cnt          = r.getUInt().toIntExact
+    // every weak id takes exactly WeakIdLength bytes, so a bigger count is not possible to fulfil
+    require(cnt.toLong * ErgoTransaction.WeakIdLength <= r.remaining,
+      s"Too many transaction ids declared: $cnt, while only ${r.remaining} bytes remaining")
     val txIds        = (1 to cnt).map(_ => r.getBytes(ErgoTransaction.WeakIdLength))
     InputBlockTransactionsRequest(inputBlockId, txIds)
   }

--- a/ergo-core/src/test/scala/org/ergoplatform/network/InputBlockMessageSpecsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/network/InputBlockMessageSpecsSpec.scala
@@ -17,6 +17,10 @@ import org.ergoplatform.utils.{ErgoCorePropertyTest, SerializationTests}
 import org.scalacheck.Gen
 import scorex.crypto.authds.merkle.BatchMerkleProof
 import scorex.crypto.hash.Blake2b256
+import scorex.util.{ByteArrayBuilder, ModifierId, idToBytes}
+import scorex.util.serialization.VLQByteBufferWriter
+
+import scala.util.{Failure, Try}
 
 class InputBlockMessageSpecsSpec extends ErgoCorePropertyTest with SerializationTests {
   import org.ergoplatform.utils.generators.CoreObjectGenerators._
@@ -54,6 +58,34 @@ class InputBlockMessageSpecsSpec extends ErgoCorePropertyTest with Serialization
     inputBlockId <- modifierIdGen
     txIds <- Gen.listOf(genBytes(ErgoTransaction.WeakIdLength)).map(_.take(5))
   } yield InputBlockTransactionsRequest(inputBlockId, txIds)
+
+  /**
+    * Builds a raw message payload with an arbitrary declared count, so that counts which do not
+    * match the actual payload can be fed to the parsers.
+    */
+  private def payloadWithDeclaredCount(inputBlockId: ModifierId,
+                                       declaredCount: Long,
+                                       payload: Array[Byte]): Array[Byte] = {
+    val w = new VLQByteBufferWriter(new ByteArrayBuilder())
+    w.putBytes(idToBytes(inputBlockId))
+    w.putUInt(declaredCount)
+    w.putBytes(payload)
+    w.result().toBytes
+  }
+
+  private def weakIds(n: Int): Array[Byte] =
+    Array.tabulate(n * ErgoTransaction.WeakIdLength)(i => (i % 256).toByte)
+
+  /**
+    * True iff parsing was rejected by the structural count bound (an `IllegalArgumentException`
+    * thrown by `require` before any allocation or per-element reading is done).
+    */
+  private def rejectedByCountBound(res: Try[_]): Boolean = res match {
+    case Failure(e: IllegalArgumentException) =>
+      Option(e.getMessage).exists(_.contains("Too many transaction"))
+    case _ =>
+      false
+  }
 
   property("InputBlockAnnouncement serialization roundtrip") {
     forAll(inputBlockInfoGen) { info =>
@@ -245,5 +277,187 @@ class InputBlockMessageSpecsSpec extends ErgoCorePropertyTest with Serialization
     
     zeroTxIdsRecovered.inputBlockId shouldEqual zeroTxIdsData.inputBlockId
     zeroTxIdsRecovered.transactionIds.map(_.toSeq) shouldEqual zeroTxIdsData.transactionIds.map(_.toSeq)
+  }
+
+  //
+  // Structural bounds on untrusted counts (messages 102, 104, 105)
+  //
+
+  property("InputBlockTransactionsData parsing rejects tx count exceeding remaining bytes") {
+    forAll(modifierIdGen) { blockId =>
+      // a 39 byte payload (about 52 bytes once framed as a P2P message), but a million
+      // transactions declared
+      val bytes = payloadWithDeclaredCount(blockId, 1000000L, Array.fill(4)(0.toByte))
+      bytes.length should be < 64
+
+      val res = inputBlockTransactionsMessageSpec.parseBytesTry(bytes)
+      rejectedByCountBound(res) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionsData parsing rejects Int.MaxValue tx count without allocating") {
+    forAll(modifierIdGen) { blockId =>
+      val bytes = payloadWithDeclaredCount(blockId, Int.MaxValue.toLong, Array.fill(4)(0.toByte))
+
+      // An Array[ErgoTransaction] of Int.MaxValue elements needs gigabytes of heap, so had the
+      // allocation been attempted this would have died with a (fatal, uncatchable by Try)
+      // OutOfMemoryError instead of returning a Failure. Getting the require message back proves
+      // the parser bailed out before `new Array[ErgoTransaction](txsCount)`.
+      val res = inputBlockTransactionsMessageSpec.parseBytesTry(bytes)
+      rejectedByCountBound(res) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionsData parsing accepts tx count equal to remaining bytes, rejects one above") {
+    forAll(modifierIdGen) { blockId =>
+      val payload = Array.fill(8)(0.toByte)
+
+      // One byte per transaction is a deliberately conservative lower bound, not a tight one:
+      // ErgoTransactionSerializer delegates to ErgoLikeTransactionSerializer, which writes four
+      // collection counts even for an empty transaction, so four bytes is the real minimum. The
+      // guard only has to be sound, so at count == remaining it must not fire - whatever the
+      // transaction parser then makes of the bytes
+      val atBound = inputBlockTransactionsMessageSpec.parseBytesTry(
+        payloadWithDeclaredCount(blockId, payload.length.toLong, payload))
+      rejectedByCountBound(atBound) shouldBe false
+
+      val aboveBound = inputBlockTransactionsMessageSpec.parseBytesTry(
+        payloadWithDeclaredCount(blockId, payload.length.toLong + 1, payload))
+      rejectedByCountBound(aboveBound) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionsData with realistic tx count still roundtrips") {
+    forAll(modifierIdGen, Gen.listOfN(3, invalidErgoTransactionGen)) { (blockId, txs) =>
+      val data = InputBlockTransactionsData(blockId, txs)
+      val recovered = inputBlockTransactionsMessageSpec.parseBytes(inputBlockTransactionsMessageSpec.toBytes(data))
+
+      recovered.inputBlockId shouldEqual blockId
+      recovered.transactions shouldEqual txs
+    }
+  }
+
+  property("InputBlockTransactionsData with zero tx count parses to empty") {
+    forAll(modifierIdGen) { blockId =>
+      val recovered = inputBlockTransactionsMessageSpec.parseBytes(
+        payloadWithDeclaredCount(blockId, 0L, Array.emptyByteArray))
+
+      recovered.inputBlockId shouldEqual blockId
+      recovered.transactions shouldBe empty
+    }
+  }
+
+  property("InputBlockTransactionsRequest parsing rejects id count exceeding remaining bytes") {
+    forAll(modifierIdGen) { blockId =>
+      val bytes = payloadWithDeclaredCount(blockId, 1000000L, weakIds(2))
+      bytes.length should be < 64
+
+      val res = inputBlockTransactionsRequestMessageSpec.parseBytesTry(bytes)
+      rejectedByCountBound(res) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionsRequest parsing rejects Int.MaxValue id count safely") {
+    forAll(modifierIdGen) { blockId =>
+      val res = inputBlockTransactionsRequestMessageSpec.parseBytesTry(
+        payloadWithDeclaredCount(blockId, Int.MaxValue.toLong, weakIds(2)))
+
+      // Int.MaxValue * WeakIdLength overflows Int arithmetic, the check is done in Long
+      rejectedByCountBound(res) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionsRequest parsing accepts id count whose ids exactly fill the remaining bytes, rejects one above") {
+    forAll(modifierIdGen) { blockId =>
+      val payload = weakIds(5)
+
+      val recovered = inputBlockTransactionsRequestMessageSpec.parseBytes(
+        payloadWithDeclaredCount(blockId, 5L, payload))
+      recovered.inputBlockId shouldEqual blockId
+      recovered.txIds.length shouldBe 5
+
+      val aboveBound = inputBlockTransactionsRequestMessageSpec.parseBytesTry(
+        payloadWithDeclaredCount(blockId, 6L, payload))
+      rejectedByCountBound(aboveBound) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionsRequest with realistic id count still roundtrips") {
+    forAll(modifierIdGen) { blockId =>
+      val txIds = Seq.tabulate(5)(i => Array.fill(ErgoTransaction.WeakIdLength)(i.toByte))
+      val request = InputBlockTransactionsRequest(blockId, txIds)
+      val recovered = inputBlockTransactionsRequestMessageSpec.parseBytes(
+        inputBlockTransactionsRequestMessageSpec.toBytes(request))
+
+      recovered.inputBlockId shouldEqual blockId
+      recovered.txIds.map(_.toSeq) shouldEqual txIds.map(_.toSeq)
+    }
+  }
+
+  property("InputBlockTransactionsRequest with zero id count parses to empty") {
+    forAll(modifierIdGen) { blockId =>
+      val recovered = inputBlockTransactionsRequestMessageSpec.parseBytes(
+        payloadWithDeclaredCount(blockId, 0L, Array.emptyByteArray))
+
+      recovered.inputBlockId shouldEqual blockId
+      recovered.txIds shouldBe empty
+    }
+  }
+
+  property("InputBlockTransactionIdsData parsing rejects id count exceeding remaining bytes") {
+    forAll(modifierIdGen) { blockId =>
+      val bytes = payloadWithDeclaredCount(blockId, 1000000L, weakIds(2))
+      bytes.length should be < 64
+
+      val res = inputBlockTransactionIdsMessageSpec.parseBytesTry(bytes)
+      rejectedByCountBound(res) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionIdsData parsing rejects Int.MaxValue id count safely") {
+    forAll(modifierIdGen) { blockId =>
+      val res = inputBlockTransactionIdsMessageSpec.parseBytesTry(
+        payloadWithDeclaredCount(blockId, Int.MaxValue.toLong, weakIds(2)))
+
+      // Int.MaxValue * WeakIdLength overflows Int arithmetic, the check is done in Long
+      rejectedByCountBound(res) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionIdsData parsing accepts id count whose ids exactly fill the remaining bytes, rejects one above") {
+    forAll(modifierIdGen) { blockId =>
+      val payload = weakIds(5)
+
+      val recovered = inputBlockTransactionIdsMessageSpec.parseBytes(
+        payloadWithDeclaredCount(blockId, 5L, payload))
+      recovered.inputBlockId shouldEqual blockId
+      recovered.transactionIds.length shouldBe 5
+
+      val aboveBound = inputBlockTransactionIdsMessageSpec.parseBytesTry(
+        payloadWithDeclaredCount(blockId, 6L, payload))
+      rejectedByCountBound(aboveBound) shouldBe true
+    }
+  }
+
+  property("InputBlockTransactionIdsData with realistic id count still roundtrips") {
+    forAll(modifierIdGen) { blockId =>
+      val txIds = Seq.tabulate(5)(i => Array.fill(ErgoTransaction.WeakIdLength)(i.toByte))
+      val data = InputBlockTransactionIdsData(blockId, txIds)
+      val recovered = inputBlockTransactionIdsMessageSpec.parseBytes(
+        inputBlockTransactionIdsMessageSpec.toBytes(data))
+
+      recovered.inputBlockId shouldEqual blockId
+      recovered.transactionIds.map(_.toSeq) shouldEqual txIds.map(_.toSeq)
+    }
+  }
+
+  property("InputBlockTransactionIdsData with zero id count parses to empty") {
+    forAll(modifierIdGen) { blockId =>
+      val recovered = inputBlockTransactionIdsMessageSpec.parseBytes(
+        payloadWithDeclaredCount(blockId, 0L, Array.emptyByteArray))
+
+      recovered.inputBlockId shouldEqual blockId
+      recovered.transactionIds shouldBe empty
+    }
   }
 }


### PR DESCRIPTION
Target branch: `weak-blocks`. Found during a security review of v6.5.0-RC3 (db98dcd).

## Problem

Three input block message specs read a count from the wire and then allocate or iterate on it with no check that the message actually carries enough bytes to back that count.

**`InputBlockTransactionsMessageSpec` (104) is the serious one.** It did:

```scala
val txsCount = r.getUInt().toIntExact
val txs = new Array[ErgoTransaction](txsCount)
```

The array is allocated before a single transaction byte is read, so a 39 byte payload declaring a million transactions - or `Int.MaxValue` of them - requests a correspondingly huge reference array. The resulting `OutOfMemoryError` is fatal - `Try` does not catch it, and `build.sbt` sets `-XX:+ExitOnOutOfMemoryError` - so one unsolicited message from any connected peer is enough to take the node down.

`InputBlockTransactionsRequestMessageSpec` (105) and `InputBlockTransactionIdsMessageSpec` (102) have the same unbounded count driving a `(1 to cnt).map`. Less severe, since on Scala 2.12 the map applies the function as it iterates, so the reader runs dry and throws rather than allocating up front - verified by running `(1 to Int.MaxValue).map` with a function that throws on call 101 under a 512m heap, which failed after exactly 101 calls with no `OutOfMemoryError`. A tiny message still drives pointless work and intermediate allocation.

## Fix

Structural `r.remaining` checks, matching the pattern already used in this package (`HandshakeSerializer`, `NipopowProofSpec`, `InputBlockMessageSpec`, `ModePeerFeature`). No new constant, no magic number, no wire format change, `serialize` untouched. Eight added lines across the three specs.

- **104**: `require(txsCount <= r.remaining, ...)` placed before the allocation. Every serialized transaction occupies at least one byte, so a count larger than the remaining byte count is invalid by definition. This is a deliberately conservative bound rather than a tight one - `ErgoLikeTransactionSerializer` writes four collection counts even for an empty transaction, so the real minimum is four bytes.
- **105 / 102**: `require(cnt.toLong * ErgoTransaction.WeakIdLength <= r.remaining, ...)`. Each weak id is exactly `WeakIdLength` bytes and is not length-prefixed, so this bound is exact. The multiplication is done in `Long` so a count near `Int.MaxValue` cannot overflow the check itself.

`require` is deliberate rather than `MaliciousBehaviorException`: `Synchronizer.parseAndHandle` treats any `parseBytesTry` failure as malicious and calls `penalizeMaliciousPeer`, which `ErgoNodeViewSynchronizer` implements as `PermanentPenalty`. A plain `require` already yields a permanent ban, and it matches the existing specs in this package.

Note that for 104 the resulting bound is relative to message size rather than absolute: a large frame can still declare a proportionally large count. Allocation is now proportional to the received payload - roughly four bytes of reference-array storage per remaining payload byte on typical compressed-oops JVMs, up to eight without compressed oops. That is a decisive improvement, since the attacker must now deliver a proportionally huge frame instead of triggering a multi-gigabyte allocation from a 39 byte payload, but large-frame memory exhaustion is not fully closed until a global declared-frame-length limit exists - see follow-up 3.

## Tests

15 new properties in `InputBlockMessageSpecsSpec`, covering each of the three specs: a count far exceeding the available bytes, a count of `Int.MaxValue`, a count exactly at the bound (accepted) and one above it (rejected), a zero count, and a realistic message still round-tripping through serialize/parse unchanged.

For 104 the `Int.MaxValue` case asserts the failure is the `require`'s `IllegalArgumentException`. An `Array[ErgoTransaction]` of that size needs gigabytes of heap, so had the allocation been attempted the test would have died with a fatal `OutOfMemoryError` rather than returning a `Failure` - getting the require message back is what proves the parser bailed out before `new Array[ErgoTransaction](txsCount)`.

`sbt ergoCore/compile` is clean; the suite runs 23 tests, all passing.

## Follow-ups (not addressed here)

1. **Message 100 `InputBlockAnnouncement`** - the optional weak-id count is still unbounded. It is covered incidentally by the existing `MaxMessageSize` check on the whole message, but a count-derived bound would be more direct.
2. **Handler-level gating for unsolicited 102/104 data** - these bounds make parsing safe, but nothing stops a peer from sending transaction id / data messages that were never requested. That gating belongs above the serializer.
3. **Global maximum declared frame length in `MessageSerializer`** - a single ceiling on declared payload length would give defence in depth for every message type, rather than relying on each spec to bound itself.

Happy to split any of these into separate PRs.
