### PR TITLE
Test that proofsForTransactions() does not modify the UTXO set tree along a growing chain

### DIFF
--- a/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/UtxoStateSpecification.scala
@@ -439,6 +439,49 @@ class UtxoStateSpecification extends ErgoCorePropertyTest with OptionValues {
     }
   }
 
+  property("proofsForTransactions() does not modify the UTXO set tree along a growing chain") {
+    // Chain-scale variant of the invariants above, as asked in #1614: at every height of a
+    // growing chain, generating proofs must leave the tree untouched and be repeatable, and
+    // the block built from those proofs must be applicable, landing exactly on the promised digest.
+    // The issue literally asks for 500 blocks of 500 transactions; that would take hours in CI,
+    // so the chain is kept short here - the invariants checked are the same at any scale.
+    val blocksInChain = 20
+
+    var bh = BoxHolder(Seq(genesisEmissionBox))
+    var us = createUtxoState(bh, parameters)
+    var height: Int = GenesisHeight
+
+    (0 until blocksInChain) foreach { _ =>
+      val header: Header = defaultHeaderGen.sample.value
+      val t = validTransactionsFromBoxHolder(bh, new RandomWrapper(Some(height)))
+      val txs = t._1
+      bh = t._2
+
+      val rootBefore = us.rootDigest
+      // proof generation leaves the tree at the same root
+      val (adProofBytes, adDigest) = us.proofsForTransactions(txs).get
+      us.rootDigest.sameElements(rootBefore) shouldBe true
+      // and is repeatable, still without touching the tree
+      val (adProofBytes2, adDigest2) = us.proofsForTransactions(txs).get
+      ADProofs.proofDigest(adProofBytes2) shouldBe ADProofs.proofDigest(adProofBytes)
+      adDigest2 shouldBe adDigest
+      us.rootDigest.sameElements(rootBefore) shouldBe true
+
+      val realHeader = header.copy(stateRoot = adDigest,
+        ADProofsRoot = ADProofs.proofDigest(adProofBytes),
+        height = height,
+        parentId = us.stateContext.lastHeaderOpt.map(_.id).getOrElse(Header.GenesisParentId))
+      val adProofs = ADProofs(realHeader.id, adProofBytes)
+      val bt = BlockTransactions(realHeader.id, Header.InitialVersion, txs)
+      val fb = ErgoFullBlock(realHeader, bt, genExtension(realHeader, us.stateContext), Some(adProofs))
+      // the state accepts the block built from those proofs and lands exactly on the promised root
+      us = us.applyModifier(fb, None)(_ => ()).get
+      us.rootDigest.sameElements(fb.header.stateRoot) shouldBe true
+      height = height + 1
+    }
+    us.closeStorage()
+  }
+
   property("proofsForTransactions() fails if a transaction is spending an output created by a follow-up transaction") {
     forAll(boxesHolderGen) { bh =>
       val txsFromHolder = validTransactionsFromBoxHolder(bh)._1


### PR DESCRIPTION
Addresses #1614.

**What was already covered, and what was missing.** `UtxoStateSpecification` already checks that a `proofsForTransactions()` call does not change the state digest on a fresh state ("proofsForTransactions() does not change state digest") and that it is deterministic there ("proofsForTransactions() to be deterministic"). No test checked the same invariants while a chain grows - a tree with real history, with proofs generated between block applications, which is how the node actually uses it. I asked about this reading of the scope in an issue comment on 2026-08-11 and heard no objection.

**The new property**, `proofsForTransactions() does not modify the UTXO set tree along a growing chain`, builds a chain of valid full blocks the same way the neighbouring concurrency test does, and at every height asserts:

1. the tree root is unchanged after generating proofs (`rootDigest` before == after);
2. a second call returns the identical proof digest and state digest, and still leaves the root untouched;
3. the block assembled from those proofs (`stateRoot = adDigest`, `ADProofsRoot = ADProofs.proofDigest(...)`) is accepted by `applyModifier`, and the state lands exactly on the promised digest.

**On the numbers in the issue**: the literal 500 blocks x 500 transactions would take hours in CI, so the chain here is 20 blocks with the standard generator transactions - the invariants are the same at any scale, and the length is a one-line constant. Happy to raise it, or to add an `ignored` long-run variant with the literal numbers, if preferred.

**Verified the test bites**: injecting a mutation into `proofsForTransactions` (staging an extra `Insert` on the persistent prover and committing it) makes the property fail on the root check; on clean master it is green, and the full `UtxoStateSpecification` suite passes locally (22/22).

Note: the issue shows a years-old assignee with no linked work; if that work is still planned I am happy to defer.