### PR TITLE
Align Akka HTTP dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ publishArtifact in (Compile, packageDoc) := false
 
 val circeVersion = "0.14.15"
 val akkaVersion = "2.6.10"
-val akkaHttpVersion = "10.2.4"
+val akkaHttpVersion = "10.2.10"
 
 val sigmaStateVersion = "6.0.6"
 val ficusVersion = "1.4.7"


### PR DESCRIPTION
Withdrawn after checking the effective baseline dependency graph. Although `build.sbt` declares Akka HTTP 10.2.4, master at `5528ef569a41ebccbc8658212e6ee3c97d990b96` already resolves `akka-http`, `akka-http-core` and `akka-parsing` to 10.2.7. That runtime version includes the CVE-2021-42697 fix. The original security-remediation premise for this PR was therefore incorrect.

The proposed 10.2.10 alignment passed 144 local HTTP tests and assembly. Seven CI jobs passed, but the integration job had an unresolved `DeepRollBackSpec` convergence timeout (12 of 13 tests passed). This result does not justify treating the upgrade as an urgent security fix.

Closing this proposal instead of requesting integration or a maintainer rerun. A future dependency upgrade should have a separate compatibility rationale and resolve the integration result. No runtime CVE exposure is established by the older declared version alone.
