### PR TITLE
Clarify rule 414 validation failures without registration changes

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/settings/ErgoValidationSettings.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/settings/ErgoValidationSettings.scala
@@ -33,7 +33,16 @@ case class ErgoValidationSettings(rules: Map[Short, RuleStatus],
   override val isFailFast: Boolean = true
 
   override def getError(id: Short, invalidMod: InvalidModifier): ValidationResult.Invalid = {
-    rules.get(id).map(_.invalidMod(invalidMod)).getOrElse(ModifierValidator.fatal(invalidMod.error, invalidMod.modifierId, invalidMod.modifierTypeId))
+    rules.get(id).map(_.invalidMod(invalidMod)).getOrElse {
+      // Rule 414 remains unregistered to preserve existing update parsing
+      // and activation semantics.
+      val error = if (id == ValidationRules.exMatchParameters60) {
+        s"Validation rule 414 (exMatchParameters60) failed. ${invalidMod.error}"
+      } else {
+        invalidMod.error
+      }
+      ModifierValidator.fatal(error, invalidMod.modifierId, invalidMod.modifierTypeId)
+    }
   }
 
   override def isActive(id: Short): Boolean = {

--- a/ergo-core/src/test/scala/org/ergoplatform/settings/ErgoValidationSettingsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/settings/ErgoValidationSettingsSpec.scala
@@ -1,0 +1,61 @@
+package org.ergoplatform.settings
+
+import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ScorexEncoding
+import org.ergoplatform.validation.ModifierValidator
+
+import scala.util.{Failure, Success}
+
+class ErgoValidationSettingsSpec extends ErgoCorePropertyTest with ScorexEncoding {
+
+  private val modifierId = scorex.util.bytesToId(Array.fill(32)(0: Byte))
+
+  property("exMatchParameters60 stays active when absent from rulesSpec") {
+    ValidationRules.rulesSpec.contains(ValidationRules.exMatchParameters60) shouldBe false
+
+    val initial = ErgoValidationSettings.initial
+    initial.isActive(ValidationRules.exMatchParameters60) shouldBe true
+
+    val update = ErgoValidationSettingsUpdate(
+      Seq(ValidationRules.exMatchParameters60),
+      Seq.empty
+    )
+    val updated = initial.updated(update)
+    updated.isActive(ValidationRules.exMatchParameters60) shouldBe true
+
+    val parsed = ErgoValidationSettings.parseExtension(updated.toExtensionCandidate).get
+    parsed.isActive(ValidationRules.exMatchParameters60) shouldBe true
+    parsed.updateFromInitial.rulesToDisable should contain(
+      ValidationRules.exMatchParameters60
+    )
+  }
+
+  property("exMatchParameters60 validateNoFailure reports a named diagnostic") {
+    val valid = ModifierValidator(ErgoValidationSettings.initial)
+      .validateNoFailure(
+        ValidationRules.exMatchParameters60,
+        Success(()),
+        modifierId,
+        Extension.modifierTypeId
+      )
+      .result
+    valid.isValid shouldBe true
+
+    val invalid = ModifierValidator(ErgoValidationSettings.initial)
+      .validateNoFailure(
+        ValidationRules.exMatchParameters60,
+        Failure(new IllegalArgumentException("missing parameter 130")),
+        modifierId,
+        Extension.modifierTypeId
+      )
+      .result
+
+    invalid.isValid shouldBe false
+    invalid.errors.head.isFatal shouldBe true
+    invalid.errors.head.message should include("rule 414")
+    invalid.errors.head.message should include("exMatchParameters60")
+    invalid.errors.head.message should include("missing parameter 130")
+  }
+
+}


### PR DESCRIPTION
When `exMatchParameters60` fails, report a fatal diagnostic that identifies rule 414 and retains the original failure detail. Other registered and unregistered rule diagnostics keep their existing behavior.

Related to #2492. This addresses diagnostics only and does not close the registration question. Rule 414 remains absent from `rulesSpec`, active by default, and unaffected by an attempted serialized disable. Registering it would require a separate compatibility decision: a non-disableable entry changes acceptance of existing update bytes, while a disableable entry makes disabling the rule effective.

Validation:
- Regression test failed on the previous diagnostic and passes with this change.
- 25 tests passed across `ErgoValidationSettingsSpec`, `VotingSpecification` and `SerializationCoreTests`.
- Tests cover update round-trip, continued activation, successful validation and fatal failure through `ModifierValidator.validateNoFailure`.
- Independent review found no blocking issue in the source/test diff.
- All eight upstream CI jobs passed for `b326687b1733f25ee1a3c666813d853cb2f717a8`, including node and integration tests: [CI run](https://github.com/ergoplatform/ergo/actions/runs/33930654586).

Maintainer review remains pending. This does not change the parameter-matching call order addressed by #2422.
