### PR TITLE
Ship loopback REST defaults and require a non-default API key

### DIFF
--- a/doc/rest-api-security.md
+++ b/doc/rest-api-security.md
@@ -1,0 +1,40 @@
+# REST API configuration migration
+
+The bundled REST API now binds to `127.0.0.1` (port `9053` on mainnet,
+`9052` otherwise). Protected routes return HTTP 403 until the operator configures
+an API key hash. Public routes remain accessible on the configured interface.
+
+A node can now start with `scorex.restApi.apiKeyHash = null`, leaving protected
+routes disabled. An omitted key inherits the same default. Empty or malformed
+hashes cannot authenticate a request. The former bundled `hello` credential is
+rejected even if its hash remains in an existing configuration.
+
+## Configure authenticated access
+
+Choose a unique, high-entropy API key. Set `scorex.restApi.apiKeyHash` to its
+64-character, lowercase hexadecimal Blake2b256 hash in the operator's node
+configuration. Send the original key in the `api_key` request header. Store the
+key securely and do not reuse credentials from examples or integration tests.
+
+Wallet, scan, node administration, block submission and other routes that
+already require authentication now enforce this configuration requirement.
+Existing clients with a correctly configured, non-default key keep working.
+Clients that relied on `null` or `hello` must configure a new key before using
+protected routes. P2P networking and consensus rules are unchanged.
+
+## Configure remote or container access
+
+An existing explicit `scorex.restApi.bindAddress` continues to override the
+bundled default. Operators who require remote REST access must set that address
+explicitly, configure an API key, and restrict access with network controls.
+Use an encrypted connection for API credentials, such as a TLS reverse proxy
+or a secured tunnel; the bind address and API key do not provide encryption.
+
+In a container, a host port mapping cannot reach a service bound only to the
+container's loopback interface. Set the container's REST bind address explicitly
+(for example, `0.0.0.0:9053` on mainnet), then limit the published host port to a
+trusted interface and apply the same authentication and transport controls.
+
+The shipped local node profiles with `apiKeyHash = null` also require an
+operator-supplied hash for protected routes. Public health and query routes
+remain available without a key.

--- a/src/it/resources/devnetTemplate.conf
+++ b/src/it/resources/devnetTemplate.conf
@@ -56,8 +56,7 @@ scorex {
   restApi {
     bindAddress = "0.0.0.0:9051"
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # Test-only credential used by NodeApi.
+    apiKeyHash = "2688dbbdcefcbc8852b756efdd976905a21dcc0016dab48edca0f10f791fdcde"
   }
 }

--- a/src/it/resources/mainnetTemplate.conf
+++ b/src/it/resources/mainnetTemplate.conf
@@ -13,7 +13,8 @@ scorex {
   }
   restApi {
     bindAddress = "0.0.0.0:9051"
-    apiKeyHash = null
+    # Test-only credential used by NodeApi.
+    apiKeyHash = "2688dbbdcefcbc8852b756efdd976905a21dcc0016dab48edca0f10f791fdcde"
     timeout = 20s
   }
 }

--- a/src/it/resources/testnetTemplate.conf
+++ b/src/it/resources/testnetTemplate.conf
@@ -13,6 +13,7 @@ scorex {
   }
   restApi {
     bindAddress = "0.0.0.0:9051"
-    apiKeyHash = null
+    # Test-only credential used by NodeApi.
+    apiKeyHash = "2688dbbdcefcbc8852b756efdd976905a21dcc0016dab48edca0f10f791fdcde"
   }
 }

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackIsolationSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackIsolationSpec.scala
@@ -1,0 +1,58 @@
+package org.ergoplatform.it
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.io.Tcp
+import akka.testkit.{ExplicitlyTriggeredScheduler, TestActorRef, TestProbe}
+import com.typesafe.config.ConfigFactory
+import org.ergoplatform.network.message.MessageConstants.MessageCode
+import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.RandomPeerExcluding
+import org.ergoplatform.settings.ScorexSettings
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController
+
+import java.net.InetSocketAddress
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+class DeepRollBackIsolationSpec extends AnyFlatSpec with Matchers {
+  "Isolated rollback mining" should "disable automatic peer selection and reject incoming connections" in {
+    val ordinaryConfig = ConfigFactory.load()
+    val isolatedNetwork = ScorexSettings.fromConfig(
+      DeepRollBackSpec.isolatedMiningConfig.withFallback(ordinaryConfig).resolve()).network
+    ScorexSettings.fromConfig(ordinaryConfig).network.maxConnections should be > 0
+
+    implicit val system: ActorSystem = ActorSystem("RollbackIsolation", ConfigFactory.parseString(
+      "akka.scheduler.implementation = akka.testkit.ExplicitlyTriggeredScheduler"))
+    implicit val ec: ExecutionContext = system.dispatcher
+    try {
+      def controller(maxConnections: Int): (TestActorRef[NetworkController], TestProbe) = {
+        val peers = TestProbe()
+        val tcp = TestProbe()
+        val controllerSettings = settings.copy(scorexSettings = settings.scorexSettings.copy(
+          network = settings.scorexSettings.network.copy(maxConnections = maxConnections)))
+        val ref = TestActorRef(new NetworkController(controllerSettings, peers.ref,
+          ScorexContext(Seq.empty, None, None), tcp.ref, _ => Map.empty[MessageCode, ActorRef]))
+        tcp.expectMsgType[Tcp.Bind]
+        ref ! Tcp.Bound(controllerSettings.scorexSettings.network.bindAddress)
+        (ref, peers)
+      }
+
+      val (isolated, isolatedPeers) = controller(isolatedNetwork.maxConnections)
+      val (_, ordinaryPeers) = controller(maxConnections = 1)
+      system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler].timePasses(5.seconds)
+      ordinaryPeers.expectMsgType[RandomPeerExcluding](3.seconds)
+      isolatedPeers.expectNoMessage(200.millis)
+
+      val incoming = TestProbe()
+      incoming.send(isolated, Tcp.Connected(new InetSocketAddress("127.0.0.2", 9000),
+        settings.scorexSettings.network.bindAddress))
+      incoming.expectMsg(Tcp.Close)
+      isolatedPeers.expectNoMessage(200.millis)
+    } finally {
+      Await.result(system.terminate(), 10.seconds)
+    }
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -2,13 +2,15 @@ package org.ergoplatform.it
 
 import java.io.File
 import java.util.concurrent.TimeoutException
-import com.typesafe.config.Config
-import org.ergoplatform.it.api.NodeApi.NodeInfo
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.{NodeInfo, nodeInfoDecoder}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.freespec.AnyFreeSpec
 import scala.async.Async
-import scala.concurrent.{Await, Future, blocking}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
@@ -45,41 +47,114 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(allowLocalConfig)
 
+  private val observations = new ConvergenceObservations
+  private val seedObservations = new ConvergenceObservations
+  @volatile private var lastSeedObservation = "Initial seed has not been sampled"
+
+  private def waitForSettledSeed(
+    nodeA: Node,
+    nodeB: Node,
+    timeout: FiniteDuration
+  ): Future[(NodeInfo, NodeInfo)] = {
+    def infoProbe(node: Node): seedObservations.Probe[NodeInfo] =
+      seedObservations.probe(node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+        require(response.getStatusCode == 200, "Unexpected seed observation status")
+        node.ergoJsonAnswerAs[NodeInfo](response.getResponseBody)
+      })
+
+    val probeA = infoProbe(nodeA)
+    val probeB = infoProbe(nodeB)
+    def describe(result: Either[String, NodeInfo]): String = result.fold(
+      error => s"errorClass=$error",
+      info => s"headersHeight=${info.bestHeaderHeightOpt}; fullHeight=${info.bestBlockHeightOpt}; " +
+        s"headerId=${info.bestHeaderIdOpt.map(ConvergenceObservations.headerId)}; " +
+        s"fullId=${info.bestBlockIdOpt.map(ConvergenceObservations.headerId)}; mining=${info.isMining}")
+    seedObservations.until(timeout.fromNow, 1.second, 5.seconds) { budget =>
+      probeA.sample(budget).zip(probeB.sample(budget)).map { pair =>
+        lastSeedObservation = s"A=${describe(pair._1)}; B=${describe(pair._2)}"
+        log.info(s"Initial shared-chain readiness: $lastSeedObservation")
+        pair
+      }
+    } {
+      case (Right(a), Right(b)) =>
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, ErgoHistoryUtils.GenesisHeight)
+      case _ => false
+    }(
+      s"Initial chain did not settle with mining disabled and matching full/header tips; $lastSeedObservation"
+    ).map { case (a, b) => (a.toOption.get, b.toOption.get) }
+  }
+
+  private case class NodeSnapshot(info: Option[NodeInfo])
+  private val probes = scala.collection.mutable.Map.empty[
+    Node, (observations.Probe[NodeInfo], observations.Probe[Int])]
+
+  @volatile private var lastObservation = "No node pair observed"
+  private var recentObservations = Vector.empty[String]
+
+  private def remember(phase: String, label: String, endpoint: String, summary: String): Unit = synchronized {
+    val observation = s"$phase $label $endpoint sampledAt=${System.currentTimeMillis()} $summary"
+    recentObservations = (recentObservations :+ observation).takeRight(12)
+    lastObservation = recentObservations.mkString("; ")
+    log.info(observation)
+  }
+
+  private def snapshot(phase: String, label: String, node: Node, budget: FiniteDuration): Future[NodeSnapshot] = {
+    val (statusProbe, peerProbe) = probes.getOrElseUpdate(node, (
+      observations.probe(node.singleGet("/info", _.setRequestTimeout(5000))
+        .map { r =>
+          require(r.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[NodeInfo](r.getResponseBody)
+        }),
+      observations.probe(node.singleGet("/peers/connected", _.setRequestTimeout(5000)).map { r =>
+        require(r.getStatusCode == 200, "Unexpected observation status")
+        node.ergoJsonAnswerAs[Json](r.getResponseBody).asArray.getOrElse(
+          throw new IllegalArgumentException("Expected peer array")).size
+      })
+    ))
+    val status = statusProbe.sample(budget).map {
+      case Right(info) =>
+        val summary = Json.obj(
+          "headersHeight" -> info.bestHeaderHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "fullHeight" -> info.bestBlockHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "bestHeaderId" -> info.bestHeaderIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null),
+          "bestFullHeaderId" -> info.bestBlockIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null)
+        )
+        remember(phase, label, "status", summary.noSpaces)
+        Some(info)
+      case Left(error) =>
+        remember(phase, label, "status", s"errorClass=$error")
+        None
+    }
+    val peers = peerProbe.sample(budget).map { result =>
+      val summary = result.fold(error => s"errorClass=$error", count => s"connectedPeerCount=$count")
+      remember(phase, label, "peers", summary)
+    }
+    status.zip(peers).map { case (info, _) => NodeSnapshot(info) }
+  }
+
+  private def observeNodes(
+    phase: String,
+    nodeA: Node,
+    nodeB: Node,
+    budget: FiniteDuration = 5.seconds
+  ): Future[(NodeSnapshot, NodeSnapshot)] = {
+    snapshot(phase, "A", nodeA, budget).zip(snapshot(phase, "B", nodeB, budget))
+  }
+
   private def waitForSameBestBlock(
     nodeA: Node,
     nodeB: Node,
     minHeight: Int,
     timeout: FiniteDuration
   ): Future[(NodeInfo, NodeInfo)] = {
-    def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo): Boolean = {
-      val sameHeight =
-        infoA.bestBlockHeightOpt.nonEmpty &&
-          infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
-      val sameBlock =
-        infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
-      val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
-      sameHeight && sameBlock && highEnough
-    }
-
-    def retryAfterDelay(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      Future {
-        blocking(Thread.sleep(1000))
-      }.flatMap(_ => loop(deadline))
-
-    def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
-        if (sameBestBlock(infoA, infoB)) {
-          Future.successful((infoA, infoB))
-        } else if (deadline.isOverdue()) {
-          Future.failed(new TimeoutException(
-            s"Nodes did not converge to the same best full block at height >= $minHeight"
-          ))
-        } else {
-          retryAfterDelay(deadline)
-        }
-      }
-
-    loop(timeout.fromNow)
+    observations.until(timeout.fromNow, 1.second, 5.seconds)(
+      budget => observeNodes("convergence", nodeA, nodeB, budget)
+    ) { case (a, b) =>
+      a.info.exists(infoA => b.info.exists(infoB => ConvergenceObservations.sameBestBlock(infoA, infoB, minHeight)))
+    }(
+      s"Nodes did not converge to the same best full block at height >= $minHeight; " +
+        s"recent observations: $lastObservation"
+    ).map { case (a, b) => (a.info.get, b.info.get) }
   }
 
   "Deep rollback handling" in {
@@ -100,34 +175,44 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       val genesisAGen = Async.await(minerAGen.headerIdsByHeight(ErgoHistoryUtils.GenesisHeight)).head
       val genesisBGen = Async.await(minerBGen.headerIdsByHeight(ErgoHistoryUtils.GenesisHeight)).head
 
-      val minerAGenBestHeight = Async.await(minerAGen.fullHeight)
-      val minerBGenBestHeight = Async.await(minerBGen.fullHeight)
-
-      log.info("heightA: " + minerAGenBestHeight)
-      log.info("heightB: " + minerBGenBestHeight)
-
       genesisAGen shouldBe genesisBGen
+      Async.await(observeNodes("initial shared chain", minerAGen, minerBGen))
 
-      // 2. Stop all nodes
+      // Freeze the producer while B can still retrieve every header's full block.
       docker.stopNode(minerAGen.containerId)
+      val minerASeed: Node = docker.startDevNetNode(minerAConfigNonGen,
+        specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
+      val (seedA, seedB) = Async.await(waitForSettledSeed(minerASeed, minerBGen, 2.minutes))
+      val seedHeight = seedA.bestBlockHeightOpt.get
+      require(seedHeight < chainLength,
+        s"Initial shared chain already reached $seedHeight; isolated node B must mine to $chainLength")
+      log.info(s"Settled shared chain: heightA=$seedHeight, heightB=${seedB.bestBlockHeightOpt.get}")
+
+      // 2. Stop the restarted A and B only after both have the complete shared seed.
+      docker.stopNode(minerASeed.containerId)
       docker.stopNode(minerBGen.containerId)
 
-      val minerAIsolated: Node = docker.startDevNetNode(minerAConfig, isolatedPeersConfig,
+      val minerAIsolated: Node = docker.startDevNetNode(DeepRollBackSpec.isolatedMiningConfig.withFallback(minerAConfig), isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
 
       // 1. Let nodeA mine `chainLength + delta` blocks in isolation
       Async.await(minerAIsolated.waitForHeight(chainLength + delta))
 
-      val minerBIsolated: Node = docker.startDevNetNode(minerBConfig, isolatedPeersConfig,
+      val minerBIsolated: Node = docker.startDevNetNode(DeepRollBackSpec.isolatedMiningConfig.withFallback(minerBConfig), isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
+      Async.await(observeNodes("isolated miners started", minerAIsolated, minerBIsolated))
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
       Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
+
+      Async.await(minerAIsolated.connectedPeers) shouldBe empty
+      Async.await(minerBIsolated.connectedPeers) shouldBe empty
 
       log.info("Mining phase done")
 
       val minerABestHeight = Async.await(minerAIsolated.fullHeight)
       val minerBBestHeight = Async.await(minerBIsolated.fullHeight)
+      Async.await(observeNodes("isolated mining complete", minerAIsolated, minerBIsolated))
 
       docker.stopNode(minerAIsolated.containerId)
       docker.stopNode(minerBIsolated.containerId)
@@ -143,7 +228,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerB: Node = docker.startDevNetNode(minerBConfigNonGen,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
-
+      Async.await(observeNodes("restarted without mining", minerA, minerB))
 
       val isMiningAOpt = Async.await(minerA.info).isMining
       log.info("isminingA: " + isMiningAOpt)
@@ -162,7 +247,23 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
-    Await.result(result, 20.minutes)
+    try {
+      Await.result(result, 20.minutes)
+    } catch {
+      case error: TimeoutException =>
+        log.error(s"Deep rollback timed out; last initial-seed observation: $lastSeedObservation")
+        log.error(s"Deep rollback timed out; last observation: $lastObservation")
+        throw error
+    } finally {
+      seedObservations.close()
+      observations.close()
+    }
   }
 
+}
+
+object DeepRollBackSpec {
+  // The retained peer database survives restarts. Disable automatic outgoing connections
+  // and incoming admission during mining; final restarts use the ordinary node configs.
+  private[it] val isolatedMiningConfig: Config = ConfigFactory.parseString("scorex.network.maxConnections = 0")
 }

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
@@ -1,0 +1,57 @@
+package org.ergoplatform.it
+
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ForkResolutionDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  import ForkResolutionDiagnostics._
+
+  "Fork observations" should "retain independently accepted results while later selections change" in {
+    val first = latch(Vector.fill[Option[String]](4)(None), Vector(Some("a"), None, Some("a"), None))
+    val later = latch(first, Vector(None, Some("a"), None, Some("a")))
+    later shouldBe Vector.fill(4)(Some("a"))
+    latch(later, Vector.fill(4)(Some("b"))) shouldBe later
+  }
+
+  it should "retain missing results until their own predicate succeeds" in {
+    latch(Vector(Some("a"), None), Vector(None, None)) shouldBe Vector(Some("a"), None)
+  }
+
+  it should "report the fixed target separately from the current selected header" in {
+    val target = "ab" * 32
+    val current = "cd" * 32
+    val snapshot = Snapshot(Right(NodeInfo(None, None, Some(25), Some(20), None, Some(false))),
+      Right(3), Right(Seq(current, target)), Right(20), reachable = true)
+    val text = describe("match-anchor", 2, Some(10), Some(target), snapshot)
+    text should include(s"fixed=Some($target)")
+    text should include(s"selected=$current")
+    text should include("headerHeight=Some(25) fullHeight=Some(20) mining=Some(false)")
+    text should include("peerCount=3")
+  }
+
+  it should "exclude response text, addresses and paths from observed fields" in {
+    val payload = "http://example.invalid/private/location"
+    val snapshot = Snapshot(Right(NodeInfo(Some(payload), Some(payload), Some(1), Some(1), Some(payload), None)),
+      Left(payload), Right(Seq(payload)), Right(1), reachable = true)
+    val text = describe("match-anchor", 0, Some(1), Some(payload), snapshot)
+    text should not include payload
+    text should include("peerErrorClass=ObservationError")
+    text should include("selected=invalid-header-id")
+    text should include("fixed=Some(invalid-header-id)")
+    describe("initial-height", 0, None, None,
+      Snapshot(Left("TimeoutException"), Left("IOException"), Left("ParsingFailure"),
+        Left("TimeoutException"), reachable = false)) should
+      include("statusErrorClass=TimeoutException peerErrorClass=IOException headerErrorClass=ParsingFailure")
+  }
+
+  it should "keep supplementary failures out of the startup and height acceptance gates" in {
+    val snapshot = Snapshot(Left("ParsingFailure"), Left("TimeoutException"), Left("IOException"),
+      Right(20), reachable = true)
+    startupReached(snapshot) shouldBe Some(())
+    heightReached(20)(snapshot) shouldBe Some(20)
+    heightReached(21)(snapshot) shouldBe None
+    heightReached(20)(snapshot.copy(fullHeight = Left("ParsingFailure"))) shouldBe None
+    startupReached(snapshot.copy(reachable = false)) shouldBe None
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
@@ -1,20 +1,24 @@
 package org.ergoplatform.it
 
 import java.io.File
-import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
 import com.typesafe.config.Config
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.NodeInfo
 import org.ergoplatform.it.container.Docker.{ExtraConfig, noExtraConfig}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.scalatest.concurrent.Eventually
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.async.Async
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Try
+import scala.util.control.NonFatal
 
-class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite with Eventually {
+class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite {
+
+  import ForkResolutionDiagnostics._
 
   val nodesQty: Int = 4
 
@@ -43,24 +47,107 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
 
   def localVolume(n: Int): String = s"$localDataDir/fork-resolution-spec/node-$n/data"
 
+  private var phase = "initial-start"
+  private var recent = Vector.empty[String]
+  private val active = new AtomicBoolean(true)
+
+  private def enter(next: String): Unit = synchronized {
+    requireActive()
+    phase = next
+    log.info(s"Fork resolution phase=$phase")
+  }
+
+  private def remember(entry: String): Unit = synchronized {
+    recent = (recent :+ entry).takeRight(nodesQty * 3)
+  }
+
+  private def evidence: String = synchronized { s"phase=$phase; ${recent.mkString("; ")}" }
+
   def clearPeerDatabases(): Unit = {
-    volumesMapping.foreach { case (localVolume, remoteVolume) =>
+    volumesMapping.zipWithIndex.foreach { case ((localVolume, remoteVolume), index) =>
+      requireActive()
+      remember(s"phase=$phase node=$index operation=clear-peers")
       docker.removeFromMountedVolume(localVolume, remoteVolume, "peers")
     }
   }
 
-  def startNodesWithBinds(nodeConfigs: List[Config],
+  private def startNodesWithBinds(nodeConfigs: List[Config], observations: ConvergenceObservations,
+                          deadline: Option[Deadline] = None,
                           configEnrich: ExtraConfig = noExtraConfig): List[Node] = {
-    log.trace(s"Starting ${nodeConfigs.size} containers")
-    val nodes: Try[List[Node]] = nodeConfigs
+    val nodes = nodeConfigs
       .map(_.withFallback(specialDataDirConfig(remoteVolume)))
       .zip(volumesMapping)
-      .map { case (cfg, vol) => docker.startDevNetNode(cfg, configEnrich, Some(vol)) }
-      .sequence
-    implicit val patienceConfig: PatienceConfig = PatienceConfig((nodeConfigs.size * 2).seconds, 3.second)
-    eventually {
-      Await.result(Future.traverse(nodes.get)(_.waitForStartup), 180.seconds)
+      .zipWithIndex.map { case ((cfg, vol), index) =>
+        requireActive()
+        deadline.foreach(d => requireTime(d))
+        remember(s"phase=$phase node=$index operation=start")
+        docker.startDevNetNode(cfg, configEnrich, Some(vol)).get
+      }
+    val startupDeadline = deadline.map(d => d.timeLeft.min(180.seconds).fromNow).getOrElse(180.seconds.fromNow)
+    waitFor(nodes, observations, startupDeadline, None, None)(startupReached)
+    nodes
+  }
+
+  private def requireTime(deadline: Deadline): Unit = {
+    requireActive()
+    if (deadline.isOverdue()) throw new java.util.concurrent.TimeoutException("Fork resolution deadline")
+  }
+
+  private def requireActive(): Unit = {
+    if (!active.get()) throw new java.util.concurrent.CancellationException("Fork resolution finished")
+  }
+
+  private def waitFor[A](nodes: List[Node], observations: ConvergenceObservations, deadline: Deadline,
+                         headerHeight: Option[Int], fixedSample: Option[String])
+                        (accept: Snapshot => Option[A]): Vector[A] = {
+    val currentPhase = phase
+    val probes = nodes.map { node =>
+      def json(path: String): Future[Json] = {
+        requireTime(deadline)
+        node.singleGet(path, _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[Json](response.getResponseBody)
+        }
+      }
+      val status = observations.probe {
+        requireTime(deadline)
+        node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          val parsed = Try(node.ergoJsonAnswerAs[Json](response.getResponseBody))
+          val info = parsed.flatMap(j => Try(j.as[NodeInfo].fold(throw _, identity)))
+            .toEither.left.map(_.getClass.getSimpleName)
+          // Height gates retain NodeApi.fullHeight's exact field/default semantics.
+          val height = parsed.flatMap(j => Try(j.hcursor.downField("fullHeight").as[Option[Int]]
+            .fold(throw _, identity).getOrElse(0))).toEither.left.map(_.getClass.getSimpleName)
+          (info, height)
+        }
+      }
+      val peers = observations.probe(json("/peers/connected").map(_.asArray.get.size))
+      val headers = headerHeight.map { height =>
+        observations.probe(json(s"/blocks/at/$height").map(_.as[Seq[String]].fold(throw _, identity)))
+      }
+      (status, peers, headers)
     }
+    var accepted = Vector.fill[Option[A]](nodes.size)(None)
+    val result = observations.until(deadline, 100.millis, 5.seconds) { budget =>
+      requireTime(deadline)
+      Future.traverse(probes.zipWithIndex) { case ((status, peers, headers), index) =>
+        val infoResult = status.sample(budget)
+        val peerResult = peers.sample(budget)
+        val headerResult = headers.map(_.sample(budget)).getOrElse(Future.successful(Right(Seq.empty[String])))
+        infoResult.zip(peerResult).zip(headerResult).map { case ((status, peerCount), ids) =>
+          val snapshot = Snapshot(status.flatMap(_._1), peerCount, ids,
+            status.flatMap(_._2), status.isRight)
+          remember(describe(currentPhase, index, headerHeight, fixedSample, snapshot) +
+            s" sampledAt=${System.currentTimeMillis()}")
+          accept(snapshot)
+        }
+      }.map { observed =>
+        accepted = latch(accepted, observed.toVector)
+        accepted
+      }
+    }(_.forall(_.isDefined))(s"Fork resolution did not complete; $evidence")
+    Await.result(result, deadline.timeLeft.max(Duration.Zero)).map(_.get)
   }
 
   // Testing scenario:
@@ -71,38 +158,84 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
   // 5. Check that nodes reached consensus on created forks;
   it should "Fork resolution after isolated mining" in {
 
-    log.info(minerConfig.toString)
-    onlineSyncNodesConfig.foreach(x => log.info(x.toString))
-
-    val nodes: List[Node] = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig)
-
-    val result = Async.async {
-      val initMaxHeight = Async.await(Future.traverse(nodes)(_.fullHeight).map(_.max))
-      Async.await(Future.traverse(nodes)(_.waitForHeight(initMaxHeight + commonChainLength, 100.millis)))
-      val isolatedNodes = Async.await {
-        nodes.foreach(node => docker.stopNode(node.containerId))
+    val observations = new ConvergenceObservations
+    try {
+      enter("initial-start")
+      val nodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations)
+      // Match the original budget: initial startup precedes the 15-minute scenario deadline.
+      val deadline = 15.minutes.fromNow
+      val result = Future {
+        enter("initial-height")
+        val initMaxHeight = waitFor(nodes, observations, deadline, None, None)(_.fullHeight.toOption).max
+        val forkHeight = initMaxHeight + commonChainLength + forkLength
+        enter(s"common-height target=${initMaxHeight + commonChainLength}")
+        waitFor(nodes, observations, deadline, Some(initMaxHeight + commonChainLength), None)(
+          heightReached(initMaxHeight + commonChainLength))
+        def stop(current: List[Node]): Unit = current.zipWithIndex.foreach { case (node, index) =>
+          requireTime(deadline)
+          remember(s"phase=$phase node=$index operation=stop")
+          docker.stopNode(node.containerId)
+        }
+        enter("isolate-stop")
+        stop(nodes)
+        enter("isolate-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: offlineMiningNodesConfig, isolatedPeersConfig))
-      }
-      val forkHeight = initMaxHeight + commonChainLength + forkLength
-      Async.await(Future.traverse(isolatedNodes)(_.waitForHeight(forkHeight, 100.millis)))
-      val regularNodes = Async.await {
-        isolatedNodes.foreach(node => docker.stopNode(node.containerId))
+        enter("isolate-start")
+        val isolatedNodes = startNodesWithBinds(minerConfig +: offlineMiningNodesConfig,
+          observations, Some(deadline), isolatedPeersConfig)
+        enter(s"isolated-height target=$forkHeight")
+        waitFor(isolatedNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight))
+        enter("reconnect-stop")
+        stop(isolatedNodes)
+        enter("reconnect-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: onlineSyncNodesConfig))
+        enter("reconnect-start")
+        val regularNodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations, Some(deadline))
+        enter(s"reconnected-height target=${forkHeight + syncLength}")
+        waitFor(regularNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight + syncLength))
+        enter("select-anchor")
+        val sample = waitFor(regularNodes.take(1), observations, deadline, Some(forkHeight), None)(
+          _.headers.toOption).head.headOption.value
+        enter("match-anchor")
+        val headers = waitFor(regularNodes, observations, deadline, Some(forkHeight), Some(sample))(
+          _.headers.toOption.filter(_.headOption.contains(sample)))
+        val headerIdsAtSameHeight = headers.map(_.headOption.value)
+        headerIdsAtSameHeight should contain only sample
+        log.info(s"Fork resolution completed; $evidence")
       }
-      Async.await(Future.traverse(regularNodes)(_.waitForHeight(forkHeight + syncLength, 100.millis)))
-      val sample = Async.await(regularNodes.head.headerIdsByHeight(forkHeight)).headOption.value
-      val headers = Async.await(Future.traverse(regularNodes) { node =>
-        node.waitFor[Seq[String]](_.headerIdsByHeight(forkHeight), _.headOption.contains(sample), 100.millis)
-      })
-
-      log.debug(s"Headers at height $forkHeight: ${headers.mkString(",")}")
-      val headerIdsAtSameHeight = headers.map(_.headOption.value)
-      headerIdsAtSameHeight should contain only sample
+      Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    } catch {
+      case NonFatal(error) =>
+        log.error(s"Fork resolution failed errorClass=${error.getClass.getSimpleName}; $evidence")
+        throw error
+    } finally {
+      active.set(false)
+      observations.close()
     }
-
-    Await.result(result, 15.minutes)
   }
 
+}
+
+private[it] object ForkResolutionDiagnostics {
+  final case class Snapshot(info: Either[String, NodeInfo], peers: Either[String, Int],
+                            headers: Either[String, Seq[String]], fullHeight: Either[String, Int],
+                            reachable: Boolean)
+
+  def startupReached(snapshot: Snapshot): Option[Unit] = if (snapshot.reachable) Some(()) else None
+
+  def heightReached(target: Int)(snapshot: Snapshot): Option[Int] =
+    snapshot.fullHeight.toOption.filter(_ >= target)
+
+  def latch[A](previous: Vector[Option[A]], observed: Vector[Option[A]]): Vector[Option[A]] =
+    previous.zip(observed).map { case (accepted, current) => accepted.orElse(current) }
+
+  def describe(phase: String, index: Int, height: Option[Int], fixedSample: Option[String], snapshot: Snapshot): String = {
+    def error(value: String): String = if (value.matches("[A-Za-z0-9_$]+")) value else "ObservationError"
+    val info = snapshot.info.fold(e => s"statusErrorClass=${error(e)}", value =>
+      s"headerHeight=${value.bestHeaderHeightOpt} fullHeight=${value.bestBlockHeightOpt} mining=${value.isMining}")
+    val peers = snapshot.peers.fold(e => s"peerErrorClass=${error(e)}", count => s"peerCount=$count")
+    val selected = snapshot.headers.fold(e => s"headerErrorClass=${error(e)}", ids =>
+      s"selected=${ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing")}")
+    s"phase=$phase node=$index height=$height fixed=${fixedSample.map(ConvergenceObservations.headerId)} $info $peers $selected"
+  }
 }

--- a/src/it/scala/org/ergoplatform/it/RestApiStartupSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/RestApiStartupSpec.scala
@@ -1,0 +1,40 @@
+package org.ergoplatform.it
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class RestApiStartupSpec extends AnyFlatSpec with IntegrationSuite {
+
+  private val noApiKeyConfig: Config = ConfigFactory.parseString(
+    """
+      |scorex.restApi.apiKeyHash = null
+    """.stripMargin
+  )
+
+  private val nodeConfig: Config = noApiKeyConfig
+    .withFallback(nonGeneratingPeerConfig)
+    .withFallback(nodeSeedConfigs.head)
+    .withFallback(allowLocalConfig)
+
+  private val node: Node =
+    docker.startDevNetNode(nodeConfig, sequentialTopologyConfig).get
+
+  it should "start with no REST API key while rejecting protected wallet status" in {
+    val result = for {
+      started <- node.waitForStartup
+      info <- started.singleGet("/info")
+      missingKey <- started.singleGet("/wallet/status")
+      dummyKey <- started.singleGet("/wallet/status", _.setHeader("api_key", "dummy"))
+    } yield {
+      info.getStatusCode shouldBe 200
+      missingKey.getStatusCode shouldBe 403
+      dummyKey.getStatusCode shouldBe 403
+    }
+
+    Await.result(result, 90.seconds)
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -1,8 +1,9 @@
 package org.ergoplatform.it
 
 import com.typesafe.config.Config
+import io.circe.Json
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.ergoplatform.it.util.ConvergenceObservations
+import org.ergoplatform.it.util.{ConvergenceObservations, UtxoSyncFailureDiagnostics}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -75,7 +76,12 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
     catch {
       case error: java.util.concurrent.TimeoutException =>
         log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
-        throw error
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(error, nodes.map { node => () =>
+          node.singleGet("/info", _.setRequestTimeout(2000)).map { response =>
+            require(response.getStatusCode == 200, "Unexpected diagnostic status")
+            node.ergoJsonAnswerAs[Json](response.getResponseBody)
+          }
+        })(snapshot => log.error(s"UTXO post-failure diagnostics: $snapshot"))
     } finally observations.close()
   }
 

--- a/src/it/scala/org/ergoplatform/it/api/NodeApi.scala
+++ b/src/it/scala/org/ergoplatform/it/api/NodeApi.scala
@@ -49,13 +49,13 @@ trait NodeApi {
 
   def getWihApiKey(path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] = retrying {
     _get(s"http://$restAddress:$nodeRestPort$path")
-      .setHeader("api_key", "hello")
+      .setHeader("api_key", "ergo-integration-test-key")
       .build()
   }
 
   def post(url: String, port: Int, path: String, f: RequestBuilder => RequestBuilder = identity): Future[Response] =
     retrying(f(
-      _post(s"$url:$port$path").setHeader("api_key", "hello")
+      _post(s"$url:$port$path").setHeader("api_key", "ergo-integration-test-key")
     ).build())
 
   def postJson[A: Encoder](path: String, body: A): Future[Response] =

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  /** Both nodes report mining disabled and share a completely applied selected header tip. */
+  def sameFullyAppliedNonMiningBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean =
+    infoA.isMining.contains(false) && infoB.isMining.contains(false) &&
+      sameBestBlock(infoA, infoB, minHeight) &&
+      infoA.bestBlockIdOpt.exists(_.nonEmpty) &&
+      infoA.bestHeaderHeightOpt == infoA.bestBlockHeightOpt &&
+      infoB.bestHeaderHeightOpt == infoB.bestBlockHeightOpt &&
+      infoA.bestHeaderIdOpt == infoA.bestBlockIdOpt &&
+      infoB.bestHeaderIdOpt == infoB.bestBlockIdOpt
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,145 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  "Fully applied block agreement" should "accept a complete shared tip at the minimum height" in {
+    val info = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 12) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 13) shouldBe false
+  }
+
+  it should "reject a shared 21-header 12-full-block seed despite full-block agreement" in {
+    val lagging = NodeInfo(Some("header21"), Some("block12"), Some(21), Some(12), None, Some(false))
+    ConvergenceObservations.sameBestBlock(lagging, lagging, 1) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(lagging, lagging, 1) shouldBe false
+  }
+
+  private val completeSeed = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+
+  Seq[(String, NodeInfo => NodeInfo)](
+    "missing header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = None)),
+    "missing full-block height" -> ((info: NodeInfo) => info.copy(bestBlockHeightOpt = None)),
+    "missing header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = None)),
+    "missing full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = None)),
+    "different header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = Some("other"))),
+    "different full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = Some("other"))),
+    "different header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = Some(21))),
+    "unknown mining status" -> ((info: NodeInfo) => info.copy(isMining = None)),
+    "active mining" -> ((info: NodeInfo) => info.copy(isMining = Some(true)))
+  ).foreach { case (fault, change) =>
+    Seq("A", "B").foreach { side =>
+      it should s"reject $fault on node $side independently" in {
+        val (a, b) = if (side == "A") (change(completeSeed), completeSeed)
+                     else (completeSeed, change(completeSeed))
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, 1) shouldBe false
+      }
+    }
+  }
+
+  it should "reject two empty tip identifiers" in {
+    val empty = completeSeed.copy(bestHeaderIdOpt = Some(""), bestBlockIdOpt = Some(""))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(empty, empty, 1) shouldBe false
+  }
+
+  it should "reject different complete tips at the same height" in {
+    val other = completeSeed.copy(bestHeaderIdOpt = Some("other"), bestBlockIdOpt = Some("other"))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  it should "reject different complete heights independently of matching IDs" in {
+    val other = completeSeed.copy(bestHeaderHeightOpt = Some(13), bestBlockHeightOpt = Some(13))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  "Full block agreement" should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
@@ -1,0 +1,60 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/** Additional observations after failure, with their own bound and no effect on the assertion. */
+object UtxoSyncFailureDiagnostics {
+  private val requestBudget = 2.seconds
+  private val collectionBudget = 2500.millis
+  private val numericFields = Seq("headersHeight", "fullHeight", "headersScore", "fullBlocksScore", "peersCount")
+  private val headerFields = Seq("bestHeaderId", "bestFullHeaderId", "genesisBlockId")
+
+  def project(node: Int, sampledAt: Long, response: Either[String, Json]): Json = {
+    val identity = Seq("node" -> Json.fromInt(node), "sampledAt" -> Json.fromLong(sampledAt))
+    def failed(errorClass: String): Json = {
+      val safeClass = if (errorClass.matches("[A-Za-z_$][A-Za-z0-9_$]{0,127}")) errorClass else "ObservationFailure"
+      Json.obj((identity :+ ("errorClass" -> Json.fromString(safeClass))): _*)
+    }
+    response match {
+      case Left(errorClass) => failed(errorClass)
+      case Right(body) if !body.isObject => failed("InvalidInfoResponse")
+      case Right(body) =>
+        def field(name: String)(decode: Json => Option[Json]): (String, Json) = {
+          val value = body.hcursor.downField(name).focus match {
+            case None => Json.Null
+            case Some(value) if value.isNull => Json.Null
+            case Some(value) => decode(value).getOrElse(Json.fromString("invalid"))
+          }
+          name -> value
+        }
+        val numbers = numericFields.map(name => field(name) { value =>
+          value.asNumber.flatMap(_.toBigInt).filter(_ >= 0).map(Json.fromBigInt)
+        })
+        val headers = headerFields.map(name => field(name) { value =>
+          value.asString.map(id => Json.fromString(ConvergenceObservations.headerId(id)))
+        })
+        val mining = field("isMining")(_.asBoolean.map(Json.fromBoolean))
+        Json.obj((identity ++ numbers ++ headers :+ mining): _*)
+    }
+  }
+
+  def rethrowAfterCapture(original: TimeoutException, requests: Seq[() => Future[Json]])
+                         (emit: String => Unit)(implicit ec: ExecutionContext): Unit = {
+    try {
+      val observations = new ConvergenceObservations
+      try {
+        val snapshots = requests.zipWithIndex.map { case (request, index) =>
+          observations.probe(Future(request()).flatMap(response => response))
+            .sample(requestBudget).map(response => project(index, System.currentTimeMillis(), response))
+        }
+        // This bound starts only after the synchronization assertion has already failed.
+        val result = Await.result(Future.sequence(snapshots), collectionBudget)
+        emit(Json.arr(result: _*).noSpaces)
+      } finally observations.close()
+    } finally throw original
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
@@ -1,0 +1,111 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class UtxoSyncFailureDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private val marker = "untrusted-extra-value"
+  private val header = "ab" * 32
+
+  "Failure diagnostics" should "preserve only typed diagnostic fields and exact cumulative scores" in {
+    val score = BigInt("123456789012345678901234567890")
+    val body = Json.obj(
+      "headersHeight" -> Json.fromInt(13), "fullHeight" -> Json.fromInt(9),
+      "headersScore" -> Json.fromBigInt(score), "fullBlocksScore" -> Json.fromBigInt(score - 4),
+      "bestHeaderId" -> Json.fromString(header), "bestFullHeaderId" -> Json.fromString(header),
+      "genesisBlockId" -> Json.fromString(header), "isMining" -> Json.True,
+      "peersCount" -> Json.fromInt(3), "name" -> Json.fromString(marker),
+      "address" -> Json.fromString(marker), "sampledAt" -> Json.fromString(marker))
+    val result = UtxoSyncFailureDiagnostics.project(2, 123L, Right(body))
+    result.hcursor.get[BigInt]("headersScore") shouldBe Right(score)
+    result.hcursor.get[BigInt]("fullBlocksScore") shouldBe Right(score - 4)
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right(header)
+    result.hcursor.get[Int]("headersHeight") shouldBe Right(13)
+    result.hcursor.get[Int]("fullHeight") shouldBe Right(9)
+    result.hcursor.get[Boolean]("isMining") shouldBe Right(true)
+    result.hcursor.get[Int]("peersCount") shouldBe Right(3)
+    result.hcursor.get[Int]("node") shouldBe Right(2)
+    result.hcursor.get[Long]("sampledAt") shouldBe Right(123L)
+    result.asObject.get.keys.toSet shouldBe Set("node", "sampledAt", "headersHeight", "fullHeight",
+      "headersScore", "fullBlocksScore", "bestHeaderId", "bestFullHeaderId", "genesisBlockId", "isMining", "peersCount")
+    result.noSpaces should not include marker
+  }
+
+  it should "mark malformed fields and preserve missing fields without copying their contents" in {
+    val body = Json.obj("headersHeight" -> Json.fromString(marker), "fullHeight" -> Json.fromInt(-1),
+      "headersScore" -> Json.arr(Json.fromString(marker)), "isMining" -> Json.fromString(marker),
+      "bestHeaderId" -> Json.fromString(marker), "genesisBlockId" -> Json.obj("secret" -> Json.fromString(marker)))
+    val result = UtxoSyncFailureDiagnostics.project(0, 1L, Right(body))
+    Seq("headersHeight", "fullHeight", "headersScore", "isMining", "genesisBlockId").foreach { key =>
+      result.hcursor.get[String](key) shouldBe Right("invalid")
+    }
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right("invalid-header-id")
+    Seq("fullBlocksScore", "peersCount", "bestFullHeaderId").foreach { key =>
+      result.hcursor.downField(key).focus shouldBe Some(Json.Null)
+    }
+    result.noSpaces should not include marker
+    UtxoSyncFailureDiagnostics.project(0, 1L, Right(Json.fromString(marker)))
+      .hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    UtxoSyncFailureDiagnostics.project(0, 1L, Left("bad/class: " + marker)).noSpaces should not include marker
+  }
+
+  it should "retain the original timeout when transport or request creation fails" in {
+    val original = new TimeoutException("original assertion")
+    var captured = ""
+    val requests = Seq[() => Future[Json]](
+      () => Future.successful(Json.obj("name" -> Json.fromString(marker))),
+      () => Future.failed(new IOException(marker)),
+      () => throw new IllegalStateException(marker),
+      () => Future.successful(Json.fromString(marker)))
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, requests)(value => captured = value)
+    }
+    (thrown eq original) shouldBe true
+    val snapshots = parse(captured).toOption.get.asArray.get
+    snapshots.size shouldBe 4
+    snapshots.map(_.hcursor.get[Int]("node").toOption.get) shouldBe Vector(0, 1, 2, 3)
+    snapshots(1).hcursor.get[String]("errorClass") shouldBe Right("IOException")
+    snapshots(2).hcursor.get[String]("errorClass") shouldBe Right("IllegalStateException")
+    snapshots(3).hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    captured should not include marker
+  }
+
+  it should "retain the original timeout if emitting diagnostics fails" in {
+    val original = new TimeoutException("original assertion")
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, Seq(() => Future.successful(Json.obj()))) { _ =>
+        throw new IllegalArgumentException(marker)
+      }
+    }
+    (thrown eq original) shouldBe true
+  }
+
+  it should "start all pending requests and finish collection under its separate bound" in {
+    val original = new TimeoutException("original assertion")
+    val started = new AtomicInteger(0)
+    val pending = Seq.fill(4)(Promise[Json]())
+    var captured = ""
+    val thrown = intercept[TimeoutException] {
+      Await.result(Future {
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, pending.map { promise => () =>
+          started.incrementAndGet()
+          promise.future
+        })(value => captured = value)
+      }, 4.seconds)
+    }
+    (thrown eq original) shouldBe true
+    started.get() shouldBe 4
+    parse(captured).toOption.get.asArray.get.foreach { snapshot =>
+      snapshot.hcursor.get[String]("errorClass") shouldBe Right("TimeoutException")
+    }
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -415,13 +415,13 @@ scorex {
 
   # Node's REST API settings
   restApi {
-    # Network address to bind to
-    bindAddress = "0.0.0.0:9052"
+    # REST is local by default. Remote access requires an explicit bind address.
+    bindAddress = "127.0.0.1:9052"
 
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # Protected routes reject requests until a unique key hash is configured.
+    # The former public "hello" credential is no longer accepted.
+    apiKeyHash = null
 
     # Enable/disable CORS support.
     # This is an optional param. It would allow cors in case if this setting is set.

--- a/src/main/resources/devnet.conf
+++ b/src/main/resources/devnet.conf
@@ -65,6 +65,7 @@ scorex {
     ]
   }
   restApi {
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # Protected routes reject requests until a unique key hash is configured.
+    apiKeyHash = null
   }
 }

--- a/src/main/resources/mainnet.conf
+++ b/src/main/resources/mainnet.conf
@@ -145,10 +145,9 @@ scorex {
   restApi {
 
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # Protected routes reject requests until a unique key hash is configured.
+    apiKeyHash = null
 
-    bindAddress = "0.0.0.0:9053"
+    bindAddress = "127.0.0.1:9053"
   }
 }

--- a/src/main/resources/testnet.conf
+++ b/src/main/resources/testnet.conf
@@ -101,8 +101,7 @@ scorex {
   }
   restApi {
     # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
-    # Below is the hash of "hello" string.
-    # Change it!
-    apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+    # Protected routes reject requests until a unique key hash is configured.
+    apiKeyHash = null
   }
 }

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -37,10 +37,9 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   private val ergoSettings: ErgoSettings = ErgoSettingsReader.read(args)
 
-  require(
-    ergoSettings.scorexSettings.restApi.apiKeyHash.isDefined,
-    "API key hash must be set"
-  )
+  if (ergoSettings.scorexSettings.restApi.apiKeyHash.isEmpty) {
+    log.warn("No API key hash configured. Protected REST routes are disabled.")
+  }
   log.info(s"Working directory: ${ergoSettings.directory}")
   log.info(s"Secret directory: ${ergoSettings.walletSettings.secretStorage.secretDir}")
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -75,7 +75,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private var syncInfoV1CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV1)] = Option.empty
 
-  private var syncInfoV2CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV2)] = Option.empty
+  private val syncInfoV2Cache = new SyncInfoV2Cache
 
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 
@@ -315,14 +315,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   /** Get V2 sync info from cache or load it from history and add to cache */
   private def getV2SyncInfo(history: ErgoHistory, full: Boolean): ErgoSyncInfoV2 = {
-    val headersHeight = history.headersHeight
-    syncInfoV2CacheByHeadersHeight
-      .collect { case (height, syncInfo) if height == headersHeight => syncInfo }
-      .getOrElse {
-        val v2SyncInfo = history.syncInfoV2(full)
-        syncInfoV2CacheByHeadersHeight = Some(headersHeight -> v2SyncInfo)
-        v2SyncInfo
-      }
+    syncInfoV2Cache.getOrElseUpdate(history.bestHeaderIdOpt, full)(history.syncInfoV2(full))
   }
 
   /**
@@ -1658,6 +1651,22 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
+  /** Single-entry cache owned by the synchronizer actor. */
+  private[network] final class SyncInfoV2Cache {
+    private var cached: Option[(Option[ModifierId], Boolean, ErgoSyncInfoV2)] = None
+
+    def getOrElseUpdate(bestHeaderId: Option[ModifierId], full: Boolean)
+                       (build: => ErgoSyncInfoV2): ErgoSyncInfoV2 = {
+      cached.collect {
+        case (tip, mode, info) if tip == bestHeaderId && mode == full => info
+      }.getOrElse {
+        val info = build
+        cached = Some((bestHeaderId, full, info))
+        info
+      }
+    }
+  }
 
   private def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -403,8 +403,14 @@ trait ErgoHistoryReader
       }
 
       val headers = offsets.flatMap(offset => bestHeaderAtHeight(h - offset))
+      // Keep a shared starting point in full summaries when it is available locally.
+      val genesisAnchor = if (full) {
+        bestHeaderAtHeight(GenesisHeight).filterNot(genesis => headers.exists(_.id == genesis.id)).toSeq
+      } else {
+        Seq.empty
+      }
 
-      ErgoSyncInfoV2(headers)
+      ErgoSyncInfoV2(headers.toSeq ++ genesisAnchor)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -71,7 +71,7 @@ trait ToDownloadProcessor
             val toDownload = headersAtThisHeight.flatMap(requiredModifiersForHeader).filter { case (mtid, mid) => condition(mtid, mid) }
             // add new modifiers to download to accumulator
             val newAcc = toDownload.foldLeft(acc) { case (newAcc, (mType, mId)) => newAcc.adjust(mType)(_.fold(Vector(mId))(_ :+ mId)) }
-            continuation(height + 1, newAcc, maxHeight)
+            if (height == maxHeight) newAcc else continuation(height + 1, newAcc, maxHeight)
           } else {
             acc
           }
@@ -84,8 +84,21 @@ trait ToDownloadProcessor
         // do not download full blocks if no headers-chain synced yet or SPV mode
         Map.empty
       case Some(fb) if farAwayFromBeingSynced(fb) =>
-        // when far away from blockchain tip
-        continuation(fb.height + 1, Map.empty, fb.height + FullBlocksToDownloadAhead)
+        // A different best headers-chain may need block sections below the old full-chain tip.
+        val commonAncestor = if (isInBestChain(fb.id)) {
+          None
+        } else {
+          val parentSteps = Math.max(0L, nodeSettings.keepVersions.toLong)
+          val limit = Math.min(fb.height.toLong, parentSteps + 1L).toInt
+          headerChainBack(limit, fb.header, h => isInBestChain(h.id)).headOption
+            .filter(h => isInBestChain(h.id))
+        }
+        val fromHeight = commonAncestor
+          .map(h => Math.max(minimalFullBlockHeight, h.height + 1))
+          .getOrElse(fb.height + 1)
+        // Extending the scan backward must preserve forward progress beyond the existing full-chain tip.
+        val maxHeight = Math.min(fb.height.toLong + FullBlocksToDownloadAhead, Int.MaxValue.toLong).toInt
+        continuation(fromHeight, Map.empty, maxHeight)
       case Some(fb) =>
         // when blockchain is about to be synced,
         // download children blocks of last 100 full blocks applied to the best chain, to get block sections from forks

--- a/src/main/scala/scorex/core/api/http/ApiDirectives.scala
+++ b/src/main/scala/scorex/core/api/http/ApiDirectives.scala
@@ -10,7 +10,8 @@ trait ApiDirectives extends CorsHandler with ScorexEncoding {
   val apiKeyHeaderName: String
 
   lazy val withAuth: Directive0 = optionalHeaderValueByName(apiKeyHeaderName).flatMap {
-    case _ if settings.apiKeyHash.isEmpty => pass
+    case _ if settings.apiKeyHash.isEmpty || settings.apiKeyHash.contains(ApiDirectives.LegacyDefaultKeyHash) =>
+      reject(AuthorizationFailedRejection)
     case None => reject(AuthorizationFailedRejection)
     case Some(key) =>
       val keyHashStr: String = encoder.encode(Blake2b256(key))
@@ -21,4 +22,9 @@ trait ApiDirectives extends CorsHandler with ScorexEncoding {
       }
   }
 
+}
+
+object ApiDirectives {
+  // The former bundled credential is public and must not grant privileged access.
+  private val LegacyDefaultKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
 }

--- a/src/test/scala/org/ergoplatform/http/routes/ApiTestAuth.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ApiTestAuth.scala
@@ -1,0 +1,18 @@
+package org.ergoplatform.http.routes
+
+import org.ergoplatform.settings.ErgoSettings
+import scorex.crypto.hash.Blake2b256
+import scorex.util.encode.Base16
+
+object ApiTestAuth {
+  val ApiKeyHeaderName: String = "api_key"
+  val ApiKey: String = "route-spec-api-key"
+  val ApiKeyHash: String = Base16.encode(Blake2b256(ApiKey))
+
+  def settingsWithApiKey(settings: ErgoSettings): ErgoSettings =
+    settings.copy(
+      scorexSettings = settings.scorexSettings.copy(
+        restApi = settings.scorexSettings.restApi.copy(apiKeyHash = Some(ApiKeyHash))
+      )
+    )
+}

--- a/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/BlocksApiRouteSpec.scala
@@ -27,7 +27,8 @@ class BlocksApiRouteSpec
 
   val prefix = "/blocks"
 
-  val route: Route = BlocksApiRoute(nodeViewRef, digestReadersRef, settings).route
+  val protectedSettings = ApiTestAuth.settingsWithApiKey(settings)
+  val route: Route = BlocksApiRoute(nodeViewRef, digestReadersRef, protectedSettings).route
 
   val headerIdBytes: ModifierId = history.lastHeaders(1).headers.head.id
   val headerIdString: String    = Algos.encode(headerIdBytes)
@@ -47,7 +48,8 @@ class BlocksApiRouteSpec
     val block: ErgoFullBlock = validFullBlock(parentOpt = None, st, bh)
     val blockJson: UniversalEntity =
       HttpEntity(block.asJson.toString).withContentType(ContentTypes.`application/json`)
-    Post(prefix, blockJson) ~> route ~> check {
+    Post(prefix, blockJson) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
     }
   }

--- a/src/test/scala/org/ergoplatform/http/routes/MiningApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/MiningApiRouteSpec.scala
@@ -32,13 +32,7 @@ class MiningApiRouteSpec
   val localSetting: ErgoSettings = settings.copy(nodeSettings = settings.nodeSettings.copy(useExternalMiner = true))
   val route: Route = MiningApiRoute(minerRef, localSetting).route
 
-  val settingsWithAuth: ErgoSettings = localSetting.copy(
-    scorexSettings = localSetting.scorexSettings.copy(
-      restApi = localSetting.scorexSettings.restApi.copy(
-        apiKeyHash = Some("e1c7ef7b3b742c5ae8f52c24d2c5f5c5dccd9c23a41fa6e76e5a6b62c8f72a10")
-      )
-    )
-  )
+  val settingsWithAuth: ErgoSettings = ApiTestAuth.settingsWithApiKey(localSetting)
   val routeWithAuth: Route = MiningApiRoute(minerRef, settingsWithAuth).route
 
   val solution = AutolykosSolution(genECPoint.sample.get, genECPoint.sample.get, Array.fill(32)(9: Byte), BigInt(0))
@@ -71,7 +65,8 @@ class MiningApiRouteSpec
   it should "return candidate with valid custom miner public key" in {
     val request = MiningRequest(Seq.empty, validPkHex)
 
-    Post(prefix + "/candidateWithTxsAndPk", request.asJson) ~> route ~> check {
+    Post(prefix + "/candidateWithTxsAndPk", request.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> routeWithAuth ~> check {
       status shouldBe StatusCodes.OK
       Try(responseAs[Json]) shouldBe 'success
     }

--- a/src/test/scala/org/ergoplatform/http/routes/ScanApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/ScanApiRouteSpec.scala
@@ -38,7 +38,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
   val ergoSettings: ErgoSettings = ErgoSettingsReader.read(
     Args(userConfigPathOpt = Some("src/test/resources/application.conf"), networkTypeOpt = None))
-  val route: Route = ScanApiRoute(utxoReadersRef, ergoSettings).route
+  val protectedSettings: ErgoSettings = ApiTestAuth.settingsWithApiKey(ergoSettings)
+  val route: Route = ScanApiRoute(utxoReadersRef, protectedSettings).route
   val sealedRoute: Route = Route.seal(route)
 
   private val predicate0 = ContainsScanningPredicate(ErgoBox.R4, ByteArrayConstant(Array(0: Byte, 1: Byte)))
@@ -48,7 +49,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
   val appRequest2 = ScanRequest("demo2", predicate1, Some(ScanWalletInteraction.Off), None)
 
   it should "register a scan" in {
-    Post(prefix + "/register", appRequest.asJson) ~> route ~> check {
+    Post(prefix + "/register", appRequest.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       Try(responseAs[ScanIdWrapper]) shouldBe 'success
     }
@@ -58,7 +60,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
     var scanId: ScanIdWrapper = ScanIdWrapper(ScanId @@ (-1000: Short)) // improper value
 
     // first, register an app
-    Post(prefix + "/register", appRequest.asJson) ~> route ~> check {
+    Post(prefix + "/register", appRequest.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[ScanIdWrapper])
       response shouldBe 'success
@@ -66,32 +69,37 @@ class ScanApiRouteSpec extends AnyFlatSpec
     }
 
     // then remove it
-    Post(prefix + "/deregister", scanId.asJson) ~> route ~> check {
+    Post(prefix + "/deregister", scanId.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       Try(responseAs[ScanIdWrapper]) shouldBe 'success
     }
 
     // second time it should be not successful
-    Post(prefix + "/deregister", scanId.asJson) ~> route ~> check {
+    Post(prefix + "/deregister", scanId.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }
 
   it should "list registered scans" in {
     // register two apps
-    Post(prefix + "/register", appRequest.asJson) ~> route ~> check {
+    Post(prefix + "/register", appRequest.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[ScanIdWrapper])
       response shouldBe 'success
     }
 
-    Post(prefix + "/register", appRequest2.asJson) ~> route ~> check {
+    Post(prefix + "/register", appRequest2.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[ScanIdWrapper])
       response shouldBe 'success
     }
 
-    Get(prefix + "/listAll") ~> route ~> check {
+    Get(prefix + "/listAll") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[Seq[Scan]])
       response shouldBe 'success
@@ -103,11 +111,13 @@ class ScanApiRouteSpec extends AnyFlatSpec
   }
 
   it should "reject scan ids outside Short range" in {
-    Get(prefix + "/unspentBoxes/70000") ~> sealedRoute ~> check {
+    Get(prefix + "/unspentBoxes/70000") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> sealedRoute ~> check {
       status shouldBe StatusCodes.BadRequest
     }
 
-    Get(prefix + "/spentBoxes/70000") ~> sealedRoute ~> check {
+    Get(prefix + "/spentBoxes/70000") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> sealedRoute ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }
@@ -118,7 +128,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
     val suffix = s"/unspentBoxes/101?minConfirmations=$minConfirmations&minInclusionHeight=$minInclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -141,7 +152,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
     val suffix = s"/unspentBoxes/101?maxConfirmations=$maxConfirmations&maxInclusionHeight=$maxInclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -161,9 +173,12 @@ class ScanApiRouteSpec extends AnyFlatSpec
     val confirmations = 15
     val inclusionHeight = 20
 
-    val suffix = s"/unspentBoxes/101?minConfirmations=$confirmations&minInclusionHeight=$inclusionHeight&maxConfirmations=$confirmations&maxInclusionHeight=$inclusionHeight"
+    val suffix =
+      s"/unspentBoxes/101?minConfirmations=$confirmations&minInclusionHeight=$inclusionHeight" +
+      s"&maxConfirmations=$confirmations&maxInclusionHeight=$inclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -177,7 +192,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
     val suffix = s"/unspentBoxes/101?minConfirmations=$minConfirmations&minInclusionHeight=$minInclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -195,7 +211,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
     val suffix = s"/spentBoxes/101?minConfirmations=$minConfirmations&minInclusionHeight=$minInclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -219,7 +236,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
     val suffix = s"/spentBoxes/101?maxConfirmations=$maxConfirmations&maxInclusionHeight=$maxInclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -242,9 +260,12 @@ class ScanApiRouteSpec extends AnyFlatSpec
     val confirmations = 15
     val inclusionHeight = 20
 
-    val suffix = s"/spentBoxes/101?minConfirmations=$confirmations&minInclusionHeight=$inclusionHeight&maxConfirmations=$confirmations&maxInclusionHeight=$inclusionHeight"
+    val suffix =
+      s"/spentBoxes/101?minConfirmations=$confirmations&minInclusionHeight=$inclusionHeight" +
+      s"&maxConfirmations=$confirmations&maxInclusionHeight=$inclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = Try(responseAs[List[Json]])
       response shouldBe 'success
@@ -258,7 +279,8 @@ class ScanApiRouteSpec extends AnyFlatSpec
 
     val suffix = s"/unspentBoxes/101?minConfirmations=$minConfirmations&maxInclusionHeight=$maxInclusionHeight"
 
-    Get(prefix + suffix) ~> route ~> check {
+    Get(prefix + suffix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       rejection shouldEqual ValidationRejection("maxInclusionHeight cannot be specified when we consider unconfirmed")
     }
   }
@@ -266,19 +288,22 @@ class ScanApiRouteSpec extends AnyFlatSpec
   it should "stop tracking a box" in {
     val scanIdBoxId = ScanIdBoxId(ScanId @@ (51: Short), ADKey @@ Random.randomBytes(32))
 
-    Post(prefix + "/stopTracking", scanIdBoxId.asJson) ~> route ~> check {
+    Post(prefix + "/stopTracking", scanIdBoxId.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
     }
   }
 
   it should "generate scan for p2s rule" in {
-    Post(prefix + "/p2sRule", "Ms7smJmdbakqfwNo") ~> route ~> check {
+    Post(prefix + "/p2sRule", "Ms7smJmdbakqfwNo") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       val res = responseAs[Json]
       res.hcursor.downField("scanId").as[Int].toOption.isDefined shouldBe true
     }
 
-    Post(prefix + "/p2sRule", "s7smJmdbakqfwNo") ~> route ~> check {
+    Post(prefix + "/p2sRule", "s7smJmdbakqfwNo") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }

--- a/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/WalletApiRouteSpec.scala
@@ -40,12 +40,14 @@ class WalletApiRouteSpec extends AnyFlatSpec
 
   val ergoSettings: ErgoSettings = ErgoSettingsReader.read(
     Args(userConfigPathOpt = Some("src/test/resources/application.conf"), networkTypeOpt = None))
-  val route: Route = WalletApiRoute(digestReadersRef, nodeViewRef, settings).route
+  val protectedSettings: ErgoSettings = ApiTestAuth.settingsWithApiKey(settings)
+  val route: Route = WalletApiRoute(digestReadersRef, nodeViewRef, protectedSettings).route
   val sealedRoute: Route = Route.seal(route)
+  val noConfigRoute: Route = Route.seal(WalletApiRoute(digestReadersRef, nodeViewRef, settings).route)
   val failingNodeViewRef = system.actorOf(NodeViewStub.failingProps())
-  val failingRoute: Route = WalletApiRoute(digestReadersRef, failingNodeViewRef, settings).route
+  val failingRoute: Route = WalletApiRoute(digestReadersRef, failingNodeViewRef, protectedSettings).route
 
-  val utxoRoute: Route = WalletApiRoute(utxoReadersRef, nodeViewRef, settings).route
+  val utxoRoute: Route = WalletApiRoute(utxoReadersRef, nodeViewRef, protectedSettings).route
 
   implicit val paymentRequestEncoder: PaymentRequestEncoder = new PaymentRequestEncoder(ergoSettings)
   implicit val assetIssueRequestEncoder: AssetIssueRequestEncoder = new AssetIssueRequestEncoder(ergoSettings)
@@ -64,14 +66,16 @@ class WalletApiRouteSpec extends AnyFlatSpec
 
 
   it should "generate arbitrary transaction" in {
-    Post(prefix + "/transaction/generate", requestsHolder.asJson) ~> route ~> check {
+    Post(prefix + "/transaction/generate", requestsHolder.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       Try(responseAs[ErgoTransaction]) shouldBe 'success
     }
   }
 
   it should "get balances" in {
-    Get(prefix + "/balances") ~> route ~> check {
+    Get(prefix + "/balances") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val json = responseAs[Json]
       log.info(s"Received balances: $json")
@@ -81,7 +85,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "get unconfirmed balances" in {
-    Get(prefix + "/balances/withUnconfirmed") ~> route ~> check {
+    Get(prefix + "/balances/withUnconfirmed") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       val json = responseAs[Json]
       log.info(s"Received total confirmed with unconfirmed balances: $json")
@@ -91,14 +96,16 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "generate & send arbitrary transaction" in {
-    Post(prefix + "/transaction/send", requestsHolder.asJson) ~> route ~> check {
+    Post(prefix + "/transaction/send", requestsHolder.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[String] should not be empty
     }
   }
 
   it should "fail when sent transaction is invalid" in {
-    Post(prefix + "/transaction/send", requestsHolder.asJson) ~> failingRoute ~> check {
+    Post(prefix + "/transaction/send", requestsHolder.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> failingRoute ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }
@@ -110,94 +117,108 @@ class WalletApiRouteSpec extends AnyFlatSpec
     } else {
       (ErgoNodeTransactionGenerators.transactionSigningRequestGen(utxoState).sample.get, utxoRoute)
     }
-    Post(prefix + "/transaction/sign", tsr.asJson) ~> r ~> check {
+    Post(prefix + "/transaction/sign", tsr.asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> r ~> check {
       status shouldBe StatusCodes.OK
       responseAs[ErgoTransaction].id shouldBe tsr.unsignedTx.id
     }
   }
 
   it should "generate & send payment transaction" in {
-    Post(prefix + "/payment/send", Seq(paymentRequest).asJson) ~> route ~> check {
+    Post(prefix + "/payment/send", Seq(paymentRequest).asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[String] should not be empty
     }
   }
 
   it should "fail when payment is invalid" in {
-    Post(prefix + "/payment/send", Seq(paymentRequest).asJson) ~> failingRoute ~> check {
+    Post(prefix + "/payment/send", Seq(paymentRequest).asJson) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> failingRoute ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }
 
   it should "return addresses" in {
-    Get(prefix + "/addresses") ~> route ~> check {
+    Get(prefix + "/addresses") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
     }
   }
 
   it should "initialize wallet" in {
-    Post(prefix + "/init", Json.obj("pass" -> "1234".asJson)) ~> route ~> check {
+    Post(prefix + "/init", Json.obj("pass" -> "1234".asJson)) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("mnemonic").as[String] shouldEqual Right(WalletActorStub.mnemonic)
     }
   }
 
   it should "restore wallet" in {
-    Post(prefix + "/restore", Json.obj("pass" -> "1234".asJson, "mnemonic" -> WalletActorStub.mnemonic.asJson, 
+    Post(prefix + "/restore", Json.obj("pass" -> "1234".asJson, "mnemonic" -> WalletActorStub.mnemonic.asJson,
       "usePre1627KeyDerivation" -> false.asJson)) ~>
-      route ~> check(status shouldBe StatusCodes.OK)
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~>
+      check(status shouldBe StatusCodes.OK)
   }
 
   it should "not restore wallet without key derivation method specified" in {
     Post(prefix + "/restore", Json.obj("pass" -> "1234".asJson, "mnemonic" -> WalletActorStub.mnemonic.asJson)) ~>
-      route ~> check(rejection shouldBe a[MissingQueryParamRejection])
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~>
+      check(rejection shouldBe a[MissingQueryParamRejection])
   }
 
   it should "unlock wallet" in {
-    Post(prefix + "/unlock", Json.obj("pass" -> "1234".asJson)) ~> route ~> check {
+    Post(prefix + "/unlock", Json.obj("pass" -> "1234".asJson)) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
     }
   }
 
   it should "check wallet" in {
     Post(prefix + "/check", Json.obj("mnemonic" -> WalletActorStub.mnemonic.asJson)) ~>
-      route ~> check {
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("matched").as[Boolean] shouldBe Right(true)
     }
   }
 
   it should "lock wallet" in {
-    Get(prefix + "/lock") ~> route ~> check {
+    Get(prefix + "/lock") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
     }
   }
 
   it should "rescan wallet post" in {
-    Post(prefix + "/rescan") ~> route ~> check {
+    Post(prefix + "/rescan") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
     }
   }
 
   it should "rescan wallet post with fromHeight" in {
-    Post(prefix + "/rescan", Json.obj("fromHeight" -> 0.asJson)) ~> route ~> check {
+    Post(prefix + "/rescan", Json.obj("fromHeight" -> 0.asJson)) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
     }
 
-    Post(prefix + "/rescan", Json.obj("fromHeight" -> (-1).asJson)) ~> route ~> check {
+    Post(prefix + "/rescan", Json.obj("fromHeight" -> (-1).asJson)) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       rejection shouldEqual ValidationRejection("fromHeight field must be >= 0", None)
     }
   }
 
   it should "derive new key according to a provided path" in {
-    Post(prefix + "/deriveKey", Json.obj("derivationPath" -> "m/1/2".asJson)) ~> route ~> check {
+    Post(prefix + "/deriveKey", Json.obj("derivationPath" -> "m/1/2".asJson)) ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(WalletActorStub.address.toString)
     }
   }
 
   it should "derive next key" in {
-    Get(prefix + "/deriveNextKey") ~> route ~> check {
+    Get(prefix + "/deriveNextKey") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       responseAs[Json].hcursor.downField("derivationPath").as[String] shouldEqual Right(WalletActorStub.path.encoded)
       responseAs[Json].hcursor.downField("address").as[String] shouldEqual Right(WalletActorStub.address.toString)
@@ -205,7 +226,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "return wallet boxes" in {
-    Get(prefix + "/boxes") ~> route ~> check {
+    Get(prefix + "/boxes") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       response.size shouldBe 3
@@ -216,7 +238,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
     val minConfirmations = 15
     val minInclusionHeight = 20
     val postfix = s"/boxes?minConfirmations=$minConfirmations&minInclusionHeight=$minInclusionHeight"
-    Get(prefix + postfix) ~> route ~> check {
+    Get(prefix + postfix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       response.size shouldBe 2
@@ -229,7 +252,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
     val maxConfirmations = 15
     val maxInclusionHeight = 20
     val postfix = s"/boxes?maxConfirmations=$maxConfirmations&maxInclusionHeight=$maxInclusionHeight"
-    Get(prefix + postfix) ~> route ~> check {
+    Get(prefix + postfix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       response.size shouldBe 1
@@ -242,7 +266,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
     val confirmations = 15
     val inclusionHeight = 20
     val postfix = s"/boxes?$confirmations&minInclusionHeight=$inclusionHeight&maxConfirmations=$confirmations&maxInclusionHeight=$inclusionHeight"
-    Get(prefix + postfix) ~> route ~> check {
+    Get(prefix + postfix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       response.isEmpty shouldBe true
@@ -255,7 +280,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
 
     val postfix = s"/boxes/unspent?minConfirmations=$minConfirmations&minInclusionHeight=$minInclusionHeight"
 
-    Get(prefix + postfix) ~> route ~> check {
+    Get(prefix + postfix) ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       response.size shouldBe 1
@@ -263,7 +289,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
       response.head.hcursor.downField("inclusionHeight").as[Int].forall(_ >= minInclusionHeight) shouldBe true
     }
 
-    Get(prefix + "/boxes/unspent") ~> route ~> check {
+    Get(prefix + "/boxes/unspent") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       response.size shouldBe 2
@@ -271,7 +298,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "return wallet transactions" in {
-    Get(prefix + "/transactions") ~> route ~> check {
+    Get(prefix + "/transactions") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[List[Json]]
       val walletTxs = WalletActorStub.walletTxs.filter { awtx =>
@@ -284,7 +312,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "return wallet transactions by scanId" in {
-    Get(prefix + "/transactionsByScanId/1") ~> route ~> check {
+    Get(prefix + "/transactionsByScanId/1") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       import AugWalletTransaction._
       status shouldBe StatusCodes.OK
       val response = responseAs[List[AugWalletTransaction]]
@@ -296,7 +325,8 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "return wallet transactions by scanId including unconfirmed txs" in {
-    Get(prefix + "/transactionsByScanId/1?includeUnconfirmed=true") ~> route ~> check {
+    Get(prefix + "/transactionsByScanId/1?includeUnconfirmed=true") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> route ~> check {
       import AugWalletTransaction._
       status shouldBe StatusCodes.OK
       val response = responseAs[List[AugWalletTransaction]]
@@ -309,21 +339,36 @@ class WalletApiRouteSpec extends AnyFlatSpec
   }
 
   it should "reject invalid transactionsByScanId values" in {
-    Get(prefix + "/transactionsByScanId/not-a-number") ~> sealedRoute ~> check {
+    Get(prefix + "/transactionsByScanId/not-a-number") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> sealedRoute ~> check {
       status shouldBe StatusCodes.BadRequest
     }
 
-    Get(prefix + "/transactionsByScanId/32768") ~> sealedRoute ~> check {
+    Get(prefix + "/transactionsByScanId/32768") ~>
+      addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~> sealedRoute ~> check {
       status shouldBe StatusCodes.BadRequest
     }
   }
 
   it should "get lock status" in {
-    Get(prefix + "/status") ~> route ~> check {
+    Get(prefix + "/status") ~> addHeader(ApiTestAuth.ApiKeyHeaderName, ApiTestAuth.ApiKey) ~>
+      route ~> check {
       status shouldBe StatusCodes.OK
       val response = responseAs[Json]
       response.hcursor.downField("isUnlocked").as[Boolean] shouldBe Right(true)
       response.hcursor.downField("isInitialized").as[Boolean] shouldBe Right(true)
+    }
+  }
+
+  it should "reject wallet status without an API key" in {
+    Get(prefix + "/status") ~> sealedRoute ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+
+  it should "reject wallet status when no API key is configured" in {
+    Get(prefix + "/status") ~> noConfigRoute ~> check {
+      status shouldBe StatusCodes.Forbidden
     }
   }
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -6,8 +6,9 @@ import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
-import org.ergoplatform.nodeView.mempool.ErgoMemPool
+import org.ergoplatform.nodeView.mempool.{ErgoMemPool, ErgoMemPoolReader}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
@@ -67,7 +68,27 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  class NodeViewHolderMock extends ErgoNodeViewHolder[UtxoState](settings)
+  private def isolatedNodeSettings(prototype: ErgoSettings): ErgoSettings = {
+    val directory = createTempDir
+    prototype.copy(directory = directory.getAbsolutePath,
+      walletSettings = prototype.walletSettings.copy(secretStorage =
+        prototype.walletSettings.secretStorage.copy(
+          secretDir = new java.io.File(directory, "keystore").getAbsolutePath)))
+  }
+
+  class NodeViewHolderMock(nodeSettings: ErgoSettings) extends ErgoNodeViewHolder[UtxoState](nodeSettings)
+
+  class InjectedReadersNodeViewHolder(nodeSettings: ErgoSettings,
+                                     injectedHistory: ErgoHistoryReader,
+                                     injectedMempool: ErgoMemPoolReader) extends NodeViewHolderMock(nodeSettings) {
+    // This fixture owns its history and mempool; startup replies must use those same readers.
+    override protected def getNodeViewChanges: Receive = {
+      case request: GetNodeViewChanges =>
+        if (request.history) sender() ! ChangedHistory(injectedHistory)
+        super.getNodeViewChanges(request.copy(history = false, mempool = false))
+        if (request.mempool) sender() ! ChangedMempool(injectedMempool)
+    }
+  }
 
   class SynchronizerMock(networkControllerRef: ActorRef,
                          viewHolderRef: ActorRef,
@@ -129,7 +150,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val h = localHistoryGen.sample.get
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     val s = localStateGen.sample.get
-    val settings = ErgoSettingsReader.read()
+    val settings = isolatedNodeSettings(ErgoSettingsReader.read())
     val pool = ErgoMemPool.empty(settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
@@ -138,9 +159,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new InjectedReadersNodeViewHolder(settings, h, pool)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -174,15 +193,14 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   }
 
   class Synchronizer2Fixture extends AkkaFixture {
+    val settings: ErgoSettings = isolatedNodeSettings(org.ergoplatform.utils.ErgoNodeTestConstants.settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock(settings)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -509,6 +527,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - unknown peer") {
     withFixture { ctx =>
       import ctx._
+
+      // Replay a late startup request before observing the peer response. The fixture's
+      // injected history and mempool must not be replaced by the holder's empty readers.
+      val startupReaders = TestProbe("StartupReaders")
+      startupReaders.send(nodeViewHolder,
+        GetNodeViewChanges(history = true, state = false, vault = false, mempool = true))
+      val changedHistory = startupReaders.expectMsgType[ChangedHistory](3.seconds)
+      val changedMempool = startupReaders.expectMsgType[ChangedMempool](3.seconds)
+      synchronizer ! changedHistory
+      synchronizer ! changedMempool
 
       val sync = ErgoSyncInfoV2(Seq(altchain.last))
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -510,14 +510,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }
@@ -545,14 +547,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }

--- a/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.network
+
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.SyncInfoV2Cache
+import org.ergoplatform.nodeView.history.ErgoSyncInfoV2
+import org.ergoplatform.utils.generators.ChainGenerator.genHeaderChain
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class SyncInfoV2CacheSpec extends AnyPropSpec with Matchers {
+  private val headers = genHeaderChain(3, diffBitsOpt = None, useRealTs = false).headers
+  private val tip = headers.last
+  private val fullSummary = ErgoSyncInfoV2(Seq(tip, headers.head))
+  private val reducedSummary = ErgoSyncInfoV2(Seq(tip))
+
+  property("reuse a summary only for the same tip and requested mode") {
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+      cache.getOrElseUpdate(Some(tip.id), full) {
+        fail("An unchanged tip and mode should reuse the cached summary")
+      } shouldBe expected
+    }
+  }
+
+  property("alternating reduced and full requests preserves each requested summary") {
+    val cache = new SyncInfoV2Cache
+    Seq(false, true, false, true).foreach { full =>
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+    }
+  }
+
+  property("a different best header at the same height replaces the cached summary") {
+    val otherTip = genHeaderChain(1, prefixOpt = Some(headers(1)),
+      diffBitsOpt = None, useRealTs = false).last
+    otherTip.height shouldBe tip.height
+    otherTip.id should not be tip.id
+
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val original = if (full) fullSummary else reducedSummary
+      val replacement = ErgoSyncInfoV2(if (full) Seq(otherTip, headers.head) else Seq(otherTip))
+      cache.getOrElseUpdate(Some(tip.id), full)(original) shouldBe original
+      cache.getOrElseUpdate(Some(otherTip.id), full)(replacement) shouldBe replacement
+      cache.getOrElseUpdate(Some(otherTip.id), full) {
+        fail("The replacement tip should now be cached")
+      } shouldBe replacement
+    }
+  }
+
+  property("empty history and populated history do not share cached summaries") {
+    val cache = new SyncInfoV2Cache
+    val empty = ErgoSyncInfoV2(Nil)
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+    cache.getOrElseUpdate(None, full = true) {
+      fail("An unchanged empty history should reuse its summary")
+    } shouldBe empty
+    cache.getOrElseUpdate(Some(tip.id), full = true)(fullSummary) shouldBe fullSummary
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
@@ -1,0 +1,158 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NetworkObjectTypeId, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.{BlockTransactions, HeaderChain}
+import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.initSettings
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators.invalidErgoTransactionGen
+import scorex.util.ModifierId
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
+
+  // These in-memory records exercise scheduling, not block or chain validation.
+  private val template = defaultHeaderGen.sample.get
+  private val transaction = invalidErgoTransactionGen.sample.get
+  private val maximumHeightHeader = template.copy(height = Int.MaxValue)
+  private val bestChain = (1 to 300).foldLeft(Vector.empty[Header]) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.lastOption.map(_.id).getOrElse(Header.GenesisParentId))
+  }
+  private val oldChain = (21 to 60).foldLeft(bestChain.take(20)) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.last.id, timestamp = template.timestamp + 1)
+  }
+
+  private class SchedulingReader(fullHeader: Header,
+                                 retainedVersions: Int = 50,
+                                 minimumHeight: Int = 1,
+                                 synced: Boolean = true,
+                                 verify: Boolean = true,
+                                 tipHeight: Int = 300,
+                                 missingHeader: Option[ModifierId] = None) extends ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = initSettings.copy(nodeSettings = initSettings.nodeSettings.copy(
+      keepVersions = retainedVersions, verifyTransactions = verify, stateType = StateType.Utxo))
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Scheduling snapshots do not process sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Scheduling snapshots do not validate sections")
+
+    private val headersById = (bestChain ++ oldChain :+ maximumHeightHeader).map(h => h.id -> h).toMap
+    var traversals: Vector[(Int, ModifierId)] = Vector.empty
+    var heightLookups: Vector[Int] = Vector.empty
+    override def bestFullBlockOpt: Option[ErgoFullBlock] = Some(ErgoFullBlock(fullHeader,
+      BlockTransactions(fullHeader.id, fullHeader.version, Seq(transaction)), Extension(fullHeader.id, Seq.empty), None))
+    override def bestHeaderIdOpt: Option[ModifierId] = Some(bestChain(tipHeight - 1).id)
+    override def estimatedTip(): Option[Int] = Some(tipHeight)
+    override def minimalFullBlockHeight: Int = minimumHeight
+    override def isHeadersChainSynced: Boolean = synced
+    override def isInBestChain(id: ModifierId): Boolean = bestChain.exists(_.id == id)
+    override def headerIdsAtHeight(height: Int): Seq[ModifierId] = {
+      heightLookups :+= height
+      (bestChain :+ maximumHeightHeader).find(_.height == height).map(_.id).toSeq
+    }
+    override def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T] =
+      headersById.get(id).filterNot(h => missingHeader.contains(h.id)).collect { case section: T => section }
+    override def headerChainBack(limit: Int, startHeader: Header, until: Header => Boolean): HeaderChain = {
+      traversals :+= limit -> startHeader.id
+      super.headerChainBack(limit, startHeader, until)
+    }
+  }
+
+  private def expected(reader: SchedulingReader, heights: Range): Map[NetworkObjectTypeId.Value, Seq[ModifierId]] =
+    heights.flatMap(h => reader.requiredModifiersForHeader(bestChain(h - 1)))
+      .groupBy(_._1).map { case (kind, sections) => kind -> sections.map(_._2) }
+
+  private val acceptAll: (NetworkObjectTypeId.Value, ModifierId) => Boolean = (_, _) => true
+
+  property("linear far-behind downloads retain the forward window without walking history") {
+    val reader = new SchedulingReader(bestChain(59))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe empty
+  }
+
+  property("ancestor scheduling extends backward without shortening the forward window") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 40)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
+    reader.traversals shouldBe Vector(41 -> oldChain.last.id)
+  }
+
+  property("a truncated traversal does not infer a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 39)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(40 -> oldChain.last.id)
+  }
+
+  property("non-positive retention does not walk to a parent") {
+    Seq(0, -1, Int.MinValue).foreach { retained =>
+      val reader = new SchedulingReader(oldChain.last, retainedVersions = retained)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+      reader.traversals shouldBe Vector(1 -> oldChain.last.id)
+    }
+  }
+
+  property("a missing parent does not turn a partial traversal into a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, missingHeader = Some(oldChain(39).id))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(51 -> oldChain.last.id)
+  }
+
+  property("ancestor scheduling respects the minimum retained full-block height") {
+    Seq(30, 253).foreach { minimumHeight =>
+      val reader = new SchedulingReader(oldChain.last, minimumHeight = minimumHeight)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, minimumHeight to 252)
+    }
+  }
+
+  property("maximum retention does not overflow the traversal bound") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = Int.MaxValue)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
+    reader.traversals shouldBe Vector(60 -> oldChain.last.id)
+  }
+
+  property("a download window ending at the maximum height terminates without wrapping") {
+    val fullHeader = oldChain.last.copy(height = Int.MaxValue - 191)
+    val reader = new SchedulingReader(fullHeader, minimumHeight = Int.MaxValue) {
+      override def estimatedTip(): Option[Int] = Some(Int.MaxValue)
+    }
+    val sections = reader.requiredModifiersForHeader(maximumHeightHeader)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe
+      sections.groupBy(_._1).map { case (kind, entries) => kind -> entries.map(_._2) }
+    reader.heightLookups shouldBe Vector(Int.MaxValue)
+  }
+
+  property("ancestor scheduling preserves per-type caps and the section filter") {
+    val reader = new SchedulingReader(oldChain.last)
+    val firstSections = reader.requiredModifiersForHeader(bestChain(20))
+    val excluded = firstSections.head._2
+    val result = reader.nextModifiersToDownload(2, (_, id) => id != excluded)
+    val all = expected(reader, 21 to 22)
+    result shouldBe all.map { case (kind, ids) => kind -> ids.filterNot(_ == excluded) }
+    result.values.foreach(_.size should be <= 2)
+  }
+
+  property("unsynced and non-verifying readers do not schedule sections or walk history") {
+    Seq(new SchedulingReader(oldChain.last, synced = false), new SchedulingReader(oldChain.last, verify = false))
+      .foreach { reader =>
+        reader.nextModifiersToDownload(1000, acceptAll) shouldBe empty
+        reader.traversals shouldBe empty
+      }
+  }
+
+  property("near-tip scheduling retains its existing lookback without walking history") {
+    val reader = new SchedulingReader(oldChain.last, tipHeight = 100)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 1 to 300)
+    reader.traversals shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
@@ -1,0 +1,193 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.HeaderChain
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.HistoryTestHelpers.generateHistory
+import org.ergoplatform.utils.generators.ChainGenerator.{applyHeaderChain, genHeaderChain}
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import scorex.crypto.hash.Digest32
+
+import scala.util.Try
+
+class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
+
+  private def newHistory(): ErgoHistory =
+    generateHistory(
+      verifyTransactions = false,
+      stateType = StateType.Digest,
+      PoPoWBootstrap = false,
+      blocksToKeep = 0,
+      epochLength = 1000
+    )
+
+  private def checkRoundtrip(summary: ErgoSyncInfoV2): Unit = {
+    val bytes = ErgoSyncInfoSerializer.toBytes(summary)
+    val decoded = ErgoSyncInfoSerializer.parseBytes(bytes).asInstanceOf[ErgoSyncInfoV2]
+    decoded.lastHeaders.map(_.id) shouldBe summary.lastHeaders.map(_.id)
+    decoded.height shouldBe summary.height
+    ErgoSyncInfoSerializer.toBytes(decoded).sameElements(bytes) shouldBe true
+  }
+
+  // These snapshots exercise summary selection, not header or chain validity.
+  private def snapshotReader(headers: Seq[Header]): ErgoHistoryReader = new ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = null
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Summary snapshots do not process block sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Summary snapshots do not validate block sections")
+    override def bestHeaderOpt: Option[Header] = headers.sortBy(_.height).lastOption
+    override def headersHeight: Int = bestHeaderOpt.map(_.height).getOrElse(0)
+    override def isEmpty: Boolean = headers.isEmpty
+    override def bestHeaderAtHeight(height: Int): Option[Header] = headers.find(_.height == height)
+  }
+
+  property("full and reduced sync summaries remain empty for empty history") {
+    val history = newHistory()
+    try {
+      Seq(true, false).foreach { full =>
+        val summary = history.syncInfoV2(full)
+        summary.lastHeaders shouldBe empty
+        summary.nonEmpty shouldBe false
+        summary.height shouldBe None
+        checkRoundtrip(summary)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("linear history summaries retain recent samples and exactly one genesis anchor") {
+    var history = newHistory()
+    try {
+      val chain = genHeaderChain(17, history, diffBitsOpt = None, useRealTs = false)
+      val expectedHeights = Seq(
+        1 -> Seq(1),
+        2 -> Seq(2, 1),
+        10 -> Seq(10, 1),
+        17 -> Seq(17, 1)
+      )
+      var appliedHeight = 0
+      expectedHeights.foreach { case (height, heights) =>
+        history = applyHeaderChain(history, HeaderChain(chain.headers.slice(appliedHeight, height)))
+        appliedHeight = height
+        history.headersHeight shouldBe height
+
+        val full = history.syncInfoV2(full = true)
+        val expectedIds = heights.map(h => chain.headers(h - 1).id)
+        full.lastHeaders.map(_.id) shouldBe expectedIds
+        full.lastHeaders.map(_.height) shouldBe heights
+        full.lastHeaders.head.id shouldBe history.bestHeaderOpt.get.id
+        full.lastHeaders.last.id shouldBe chain.head.id
+        full.lastHeaders.count(_.id == chain.head.id) shouldBe 1
+        full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+        full.lastHeaders.size should be <= 5
+        full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+        full.height shouldBe Some(height)
+        checkRoundtrip(full)
+
+        val reduced = history.syncInfoV2(full = false)
+        reduced.lastHeaders.map(_.id) shouldBe Seq(chain.headers(height - 1).id)
+        reduced.height shouldBe Some(height)
+        checkRoundtrip(reduced)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("full summary snapshots preserve sparse samples and deduplicate the genesis anchor") {
+    val template = defaultHeaderGen.sample.get
+    val cases = Seq(
+      Seq(129, 113, 1),
+      Seq(513, 497, 385, 1),
+      Seq(600, 584, 472, 88, 1)
+    )
+    cases.foreach { heights =>
+      val headers = heights.map(height => template.copy(height = height))
+      val reader = snapshotReader(headers)
+      val full = reader.syncInfoV2(full = true)
+      full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+      full.lastHeaders.map(_.height) shouldBe heights
+      full.lastHeaders.count(_.height == 1) shouldBe 1
+      full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+      full.lastHeaders.size should be <= 5
+      full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+      full.height shouldBe Some(heights.head)
+      checkRoundtrip(full)
+
+      val reduced = reader.syncInfoV2(full = false)
+      reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+      checkRoundtrip(reduced)
+    }
+  }
+
+  property("full summary preserves available samples when genesis is unavailable") {
+    val template = defaultHeaderGen.sample.get
+    val headers = Seq(600, 584, 472, 88).map(height => template.copy(height = height))
+    val reader = snapshotReader(headers)
+    reader.bestHeaderAtHeight(1) shouldBe None
+    val full = reader.syncInfoV2(full = true)
+    full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+    full.height shouldBe Some(600)
+    checkRoundtrip(full)
+    val reduced = reader.syncInfoV2(full = false)
+    reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+    checkRoundtrip(reduced)
+  }
+
+  Seq((3, 9, 13), (18, 249, 70)).foreach { case (sharedHeight, heightA, heightB) =>
+    property(s"full summaries recover both fork continuations after shared height $sharedHeight at tips $heightA/$heightB") {
+      var historyA = newHistory()
+      var historyB = newHistory()
+      try {
+        // Exercise stored header histories and the actual summary/continuation methods.
+        // Full block application and network delivery are separate integration contracts.
+        val shared = genHeaderChain(sharedHeight, historyA, diffBitsOpt = None, useRealTs = false)
+        val branchA = genHeaderChain(heightA - sharedHeight, prefixOpt = Some(shared.last),
+          control = historyA.difficultyCalculator, extensionHash = Digest32 @@ Array.fill[Byte](32)(1),
+          diffBitsOpt = None, useRealTs = false).headers.tail
+        val branchB = genHeaderChain(heightB - sharedHeight, prefixOpt = Some(shared.last),
+          control = historyB.difficultyCalculator, extensionHash = Digest32 @@ Array.fill[Byte](32)(2),
+          diffBitsOpt = None, useRealTs = false).headers.tail
+        val chainA = shared.headers ++ branchA
+        val chainB = shared.headers ++ branchB
+        historyA = applyHeaderChain(historyA, HeaderChain(chainA))
+        historyB = applyHeaderChain(historyB, HeaderChain(chainB))
+        historyA.headersHeight shouldBe heightA
+        historyB.headersHeight shouldBe heightB
+        branchA.head.id should not be branchB.head.id
+        historyA.contains(branchB.head.id) shouldBe false
+        historyB.contains(branchA.head.id) shouldBe false
+
+        Seq((historyA, historyB, chainA), (historyB, historyA, chainB)).foreach {
+          case (local, peer, localChain) =>
+            val sparseHeaders = ErgoHistoryReader.FullV2SyncOffsets.toSeq
+              .flatMap(offset => peer.bestHeaderAtHeight(peer.headersHeight - offset))
+            sparseHeaders should not be empty
+            sparseHeaders.exists(header => local.contains(header.id)) shouldBe false
+            local.continuationIdsV2(ErgoSyncInfoV2(sparseHeaders), size = 400) shouldBe empty
+
+            val full = peer.syncInfoV2(full = true)
+            checkRoundtrip(full)
+            val continuation = local.continuationIdsV2(full, size = 400)
+            continuation.map(_._2) shouldBe localChain.tail.map(_.id)
+            continuation.map(_._1).distinct shouldBe Seq(Header.modifierTypeId)
+            continuation.map(_._2) should contain(localChain(sharedHeight).id)
+            full.lastHeaders.last.id shouldBe shared.head.id
+        }
+      } finally {
+        try historyA.closeStorage() finally historyB.closeStorage()
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
+++ b/src/test/scala/org/ergoplatform/settings/ErgoSettingsSpecification.scala
@@ -62,7 +62,7 @@ class ErgoSettingsSpecification extends ErgoCorePropertyTest {
       )
     )
     settings.scorexSettings.restApi shouldBe RESTApiSettings(
-      bindAddress = new InetSocketAddress("0.0.0.0", 9052),
+      bindAddress = new InetSocketAddress("127.0.0.1", 9052),
       apiKeyHash = None,
       corsAllowedOrigin = Some("*"),
       timeout = 5.seconds,

--- a/src/test/scala/org/ergoplatform/settings/RestApiDefaultsSpec.scala
+++ b/src/test/scala/org/ergoplatform/settings/RestApiDefaultsSpec.scala
@@ -1,0 +1,31 @@
+package org.ergoplatform.settings
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+
+class RestApiDefaultsSpec extends AnyFlatSpec with Matchers {
+  private val application = ConfigFactory.parseFile(new File("src/main/resources/application.conf"))
+
+  "Bundled REST profiles" should "use loopback and leave protected routes disabled" in {
+    Seq("application" -> 9052, "mainnet" -> 9053, "testnet" -> 9052, "devnet" -> 9052).foreach {
+      case (profile, port) =>
+        val config = ConfigFactory.parseFile(new File(s"src/main/resources/$profile.conf"))
+          .withFallback(application)
+        withClue(profile) {
+          config.getString("scorex.restApi.bindAddress") shouldBe s"127.0.0.1:$port"
+          config.getIsNull("scorex.restApi.apiKeyHash") shouldBe true
+        }
+    }
+  }
+
+  it should "allow explicit operator settings to override the bundled defaults" in {
+    val config = ConfigFactory.parseString(
+      """scorex.restApi { bindAddress = "0.0.0.0:9053", apiKeyHash = "operator-hash" }"""
+    ).withFallback(application)
+    config.getString("scorex.restApi.bindAddress") shouldBe "0.0.0.0:9053"
+    config.getString("scorex.restApi.apiKeyHash") shouldBe "operator-hash"
+  }
+}

--- a/src/test/scala/scorex/core/api/http/ApiAuthenticationSpec.scala
+++ b/src/test/scala/scorex/core/api/http/ApiAuthenticationSpec.scala
@@ -1,0 +1,67 @@
+package scorex.core.api.http
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.{Directives, Route}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.ergoplatform.utils.ErgoNodeTestConstants
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.crypto.hash.Blake2b256
+import scorex.util.encode.Base16
+
+class ApiAuthenticationSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
+  private val apiKey = "api-authentication-test"
+  private val keyHash = Base16.encode(Blake2b256(apiKey))
+
+  private def routes(hash: Option[String]): Route = {
+    val api = new ApiDirectives {
+      override val settings = ErgoNodeTestConstants.settings.scorexSettings.restApi.copy(apiKeyHash = hash)
+      override val apiKeyHeaderName = "api_key"
+    }
+    import Directives._
+    Route.seal(
+      path("protected") { api.withAuth { complete(StatusCodes.OK) } } ~
+        path("public") { complete(StatusCodes.OK) }
+    )
+  }
+
+  "Protected routes" should "reject requests when no API key is configured" in {
+    Get("/protected") ~> routes(None) ~> check { status shouldBe StatusCodes.Forbidden }
+    Get("/protected").withHeaders(RawHeader("api_key", apiKey)) ~> routes(None) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+
+  it should "reject empty and malformed configured hashes" in {
+    Seq("", "not-a-hash", "00").foreach { hash =>
+      Get("/protected").withHeaders(RawHeader("api_key", apiKey)) ~> routes(Some(hash)) ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
+    }
+  }
+
+  it should "reject the former public default credential" in {
+    Get("/protected").withHeaders(RawHeader("api_key", "hello")) ~>
+      routes(Some(Base16.encode(Blake2b256("hello")))) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+
+  it should "reject missing and incorrect credentials for a configured key" in {
+    Get("/protected") ~> routes(Some(keyHash)) ~> check { status shouldBe StatusCodes.Forbidden }
+    Get("/protected").withHeaders(RawHeader("api_key", "incorrect")) ~> routes(Some(keyHash)) ~> check {
+      status shouldBe StatusCodes.Forbidden
+    }
+  }
+
+  it should "accept the configured credential" in {
+    Get("/protected").withHeaders(RawHeader("api_key", apiKey)) ~> routes(Some(keyHash)) ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  "Public routes" should "remain available without an API key" in {
+    Get("/public") ~> routes(None) ~> check { status shouldBe StatusCodes.OK }
+  }
+}


### PR DESCRIPTION
Bind bundled REST profiles to loopback, remove the publicly known `hello` credential, and reject that credential even when its hash remains in an operator configuration. Explicit operator settings continue to override bundled defaults. A node can start without an API key hash: public routes remain available, while protected routes return 403. Correctly configured non-default keys continue to work.

Operators using `hello` must configure a new key hash. Remote and container deployments relying on the implicit all-interface bind must configure their bind address explicitly. The migration guide covers authentication, container port mappings and transport protection. This retains the REST scope deferred from [#2418](https://github.com/ergoplatform/ergo/pull/2418); wallet changes were handled separately in [#2477](https://github.com/ergoplatform/ergo/pull/2477), while CORS [#2431](https://github.com/ergoplatform/ergo/pull/2431) and TLS [#2408](https://github.com/ergoplatform/ergo/pull/2408) remain separate.

Current head `84f6088ba16f384443a54adffac1c85f09d77376` targets `master`. The [latest seven-file review increment](https://github.com/a-shannon/ergo/compare/f5772c954636f7981964759b7a60acf9b65c0eeb...84f6088ba16f384443a54adffac1c85f09d77376) reuses [G](https://github.com/a-shannon/ergo/commit/d62c945a4d6314c54a7b57f18a94aee8fd258aa7), owned by [#2511](https://github.com/ergoplatform/ergo/pull/2511), on the shared [R reader prerequisite](https://github.com/a-shannon/ergo/commit/76e5ec4bfc377334fdced4bd60a61df06e6b4cb6), owned by [#2535](https://github.com/ergoplatform/ergo/pull/2535). Review and integrate R before G, then this consumer. These are exact common prerequisite commits, not a new REST or synchronization implementation. The cumulative upstream diff includes them; the REST implementation and its direct tests remain unchanged.

G adds available genesis to full V2 summaries, keys the summary cache by selected tip and full/reduced mode, and schedules block sections from a retained common ancestor while preserving the forward window. The [preceding native IT job](https://github.com/ergoplatform/ergo/actions/runs/34744409218/job/103689530538) passed 56 of 57 cases, with DeepRollBack failing final convergence after a settled shared seed and isolated mining. Both nodes were connected but retained distinct full/selected tips at heights 249 and 70. At these heights, the preceding sparse summaries omit the shared seed. A stored-history regression independently demonstrates empty continuation on that source boundary and recovery with the available genesis anchor. The run's packets and complete side-header holdings were not captured, so exclusive historical causation remains unproved.

The actual combined tree passed normal compilation and all 47 affected synchronization, V2 cache, stored-history and download-scheduling tests. Independent raw-diff review found no blockers and confirmed that all REST owner files remain unchanged. The prior G counterexample and isolated negative evidence are reused for unchanged inputs. These checks do not execute the Docker rollback scenario; new-head native CI remains a separate pending gate in [the tracker](https://github.com/ergoplatform/ergo/issues/2533).

Existing [D](https://github.com/a-shannon/ergo/commit/71f33c6e45a9394557cf3af1bfb422cbc53d26cf) and [H](https://github.com/a-shannon/ergo/commit/0f9f75c1fc1df3ff3309482b83c0475a05cdd7a2), owned by #2535, retain the fully applied non-mining seed, explicit isolation, original rollback targets and deadlines. Their 33 focused checks passed. [K](https://github.com/a-shannon/ergo/commit/a1c1bd26e89ec2f24d5c52acc1fdd35346d65371), owned by #2511, retains ForkResolution's progress conditions and fifteen-minute deadline; its H/K37 checks passed. Existing selected-header and typed failure-diagnostic support is unchanged. These pure IT results retain their preceding input closure without another broad replay.

Historical REST validation includes 189 HTTP/settings cases, authentication negatives and actual wallet routes, successful IT compilation and assembly, and a packaged devnet smoke test checking public `/info` access and protected `/wallet/status` rejection without a configured hash after reproducing the former startup failure. This new prerequisite increment does not alter that authentication behavior or claim final maintainer approval.
