### PR TITLE
Bound pending Matrix transaction synchronization state

### DIFF
--- a/.github/actions/bootstrap-sigmastate/action.yml
+++ b/.github/actions/bootstrap-sigmastate/action.yml
@@ -1,0 +1,102 @@
+name: Bootstrap pinned SigmaState
+description: Build the unavailable SigmaState snapshot from its exact source commit
+
+inputs:
+  scala-version:
+    description: Full Scala version used by the consuming Ergo job
+    required: true
+  ergo-build-file:
+    description: Ergo build file that declares the pinned SigmaState version
+    required: false
+    default: build.sbt
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 8 for SigmaState
+      uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+      with:
+        distribution: temurin
+        java-version: '8'
+
+    - name: Set up sbt
+      uses: sbt/setup-sbt@7b0c62920c0c6e456e829dcaad762cff5048167f # v1
+
+    - name: Build and publish SigmaState locally
+      shell: bash
+      env:
+        ERGO_BUILD_FILE: ${{ inputs.ergo-build-file }}
+        SIGMASTATE_REPOSITORY: https://github.com/ergoplatform/sigmastate-interpreter.git
+        SIGMASTATE_SCALA_VERSION: ${{ inputs.scala-version }}
+      run: |
+        set -euo pipefail
+
+        unset GITHUB_TOKEN SONATYPE_USERNAME SONATYPE_PASSWORD PGP_PASSPHRASE
+
+        ergo_build="${GITHUB_WORKSPACE}/${ERGO_BUILD_FILE}"
+        if [[ ! -f "${ergo_build}" ]]; then
+          echo "::error::Ergo build file not found: ${ERGO_BUILD_FILE}"
+          exit 1
+        fi
+
+        declared_version="$(sed -nE 's/^[[:space:]]*val[[:space:]]+sigmaStateVersion[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' "${ergo_build}")"
+        case "${declared_version}" in
+          6.0.2-30-59782d92-SNAPSHOT)
+            SIGMASTATE_COMMIT=59782d92065eec3abd0dc47af22e25141857b2ee
+            ;;
+          6.0.5-22-368a860b-SNAPSHOT)
+            SIGMASTATE_COMMIT=368a860be033af94aa14895381f42099b3646db6
+            ;;
+          *)
+            echo "::error::Unsupported SigmaState declaration: ${declared_version:-<missing>}"
+            exit 1
+            ;;
+        esac
+        SIGMASTATE_VERSION="${declared_version}"
+
+        case "${SIGMASTATE_SCALA_VERSION}" in
+          2.11.12|2.12.20|2.13.16) ;;
+          *)
+            echo "::error::Unsupported Scala version: ${SIGMASTATE_SCALA_VERSION}"
+            exit 1
+            ;;
+        esac
+
+        sigma_dir="$(mktemp -d "${RUNNER_TEMP}/sigmastate.XXXXXX")"
+        git -C "${sigma_dir}" init
+        git -C "${sigma_dir}" remote add origin "${SIGMASTATE_REPOSITORY}"
+        git -C "${sigma_dir}" fetch --no-tags --depth=1 origin "${SIGMASTATE_COMMIT}"
+        git -C "${sigma_dir}" checkout --detach FETCH_HEAD
+
+        actual_commit="$(git -C "${sigma_dir}" rev-parse HEAD)"
+        if [[ "${actual_commit}" != "${SIGMASTATE_COMMIT}" ]]; then
+          echo "::error::SigmaState checkout mismatch: expected ${SIGMASTATE_COMMIT}, got ${actual_commit}"
+          exit 1
+        fi
+
+        (
+          cd "${sigma_dir}"
+          sbt -batch -J-Xms512m -J-Xmx4g \
+            "++${SIGMASTATE_SCALA_VERSION}!" \
+            "set ThisBuild / version := \"${SIGMASTATE_VERSION}\"" \
+            "show ThisBuild / version" \
+            "show scalaVersion" \
+            publishLocal
+        )
+
+        scala_binary="${SIGMASTATE_SCALA_VERSION%.*}"
+        ivy_dir="${HOME}/.ivy2/local/org.scorexfoundation/sigma-state_${scala_binary}/${SIGMASTATE_VERSION}"
+        ivy_file="${ivy_dir}/ivys/ivy.xml"
+        main_jar="${ivy_dir}/jars/sigma-state_${scala_binary}.jar"
+        tests_jar="${ivy_dir}/jars/sigma-state_${scala_binary}-tests.jar"
+
+        if [[ ! -s "${ivy_file}" || ! -s "${main_jar}" || ! -s "${tests_jar}" ]]; then
+          echo "::error::SigmaState local publication is missing its Ivy descriptor or JARs"
+          exit 1
+        fi
+
+        if ! grep -Fq "revision=\"${SIGMASTATE_VERSION}\"" "${ivy_file}" || \
+           ! grep -Fq "name=\"scala-library\" rev=\"${SIGMASTATE_SCALA_VERSION}\"" "${ivy_file}"; then
+          echo "::error::SigmaState local publication does not match the requested version and Scala toolchain"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java }}
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
@@ -46,6 +41,16 @@ jobs:
               ~/AppData/Local/Coursier/Cache/v1
               ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Build pinned SigmaState dependency
+        uses: ./.github/actions/bootstrap-sigmastate
+        with:
+          scala-version: ${{ matrix.scala }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Runs wallet tests
         run: sbt ++${{ matrix.scala }} ergoWallet/test
@@ -73,11 +78,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java }}
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
@@ -89,6 +89,16 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Build pinned SigmaState dependency
+        uses: ./.github/actions/bootstrap-sigmastate
+        with:
+          scala-version: ${{ matrix.scala }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Runs ergo-core tests
         run: sbt ++${{ matrix.scala }} ergoCore/test
@@ -114,11 +124,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java }}
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
@@ -130,6 +135,16 @@ jobs:
               ~/AppData/Local/Coursier/Cache/v1
               ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Build pinned SigmaState dependency
+        uses: ./.github/actions/bootstrap-sigmastate
+        with:
+          scala-version: ${{ matrix.scala }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Runs node tests
         run: sbt -Denv=test clean ++${{ matrix.scala }} test
@@ -149,11 +164,6 @@ jobs:
            path: it
            fetch-depth: 0
 
-       - name: Setup Java and Scala
-         uses: olafurpg/setup-scala@v10
-         with:
-           java-version: ${{ matrix.java }}
-
        - name: Cache sbt
          uses: actions/cache@v4
          with:
@@ -165,6 +175,17 @@ jobs:
              ~/AppData/Local/Coursier/Cache/v1
              ~/Library/Caches/Coursier/v1
            key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+       - name: Build pinned SigmaState dependency
+         uses: ./it/.github/actions/bootstrap-sigmastate
+         with:
+           scala-version: ${{ matrix.scala }}
+           ergo-build-file: it/build.sbt
+
+       - name: Setup Java and Scala
+         uses: olafurpg/setup-scala@v10
+         with:
+           java-version: ${{ matrix.java }}
 
        - name: Runs it node tests
          run: |

--- a/ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosSolution.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosSolution.scala
@@ -49,14 +49,14 @@ case class WeakAutolykosSolution(pk: EcPointType, n: Array[Byte]) {
 
 object WeakAutolykosSolution extends ApiCodecs {
 
-  implicit val jsonEncoder: Encoder[WeakAutolykosSolution] = { s: WeakAutolykosSolution =>
+  implicit val jsonEncoder: Encoder[WeakAutolykosSolution] = Encoder.instance { s: WeakAutolykosSolution =>
     Map(
       "pk" -> s.pk.asJson,
       "n" -> Algos.encode(s.n).asJson
     ).asJson
   }
 
-  implicit val jsonDecoder: Decoder[WeakAutolykosSolution] = { c: HCursor =>
+  implicit val jsonDecoder: Decoder[WeakAutolykosSolution] = Decoder.instance { c: HCursor =>
     for {
       pkOpt <- c.downField("pk").as[Option[EcPointType]]
       n <- c.downField("n").as[Array[Byte]]

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -31,6 +31,7 @@ import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import sigma.exceptions.SoftFieldAccessException
 import sigma.serialization.{ConstantStore, SigmaByteReader, SigmaByteWriter}
 
+import java.lang.reflect.InvocationTargetException
 import java.util
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -152,8 +153,8 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
     val costTry = verifier.verify(box.ergoTree, ctx, proof, messageToSign)
     val (isCostValid, scriptCost: Long) =
       costTry match {
-        case Failure(t) if t.isInstanceOf[SoftFieldAccessException] =>
-          return Invalid(Seq(new SoftFieldsAccessError(t.asInstanceOf[SoftFieldAccessException], id)))
+        case Failure(ErgoTransaction.SoftFieldFailure(cause)) =>
+          return Invalid(Seq(new SoftFieldsAccessError(cause, id)))
         case Failure(t) =>
           log.warn(s"Tx verification failed: ${t.getMessage}", t)
           log.warn(s"Tx $id verification context: " +
@@ -492,6 +493,20 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
 }
 
 object ErgoTransaction extends ApiCodecs with ScorexLogging with ScorexEncoding {
+
+  private object SoftFieldFailure {
+    def unapply(error: Throwable): Option[SoftFieldAccessException] = {
+      @scala.annotation.tailrec
+      def unwrap(current: Throwable, remaining: Int): Option[SoftFieldAccessException] = current match {
+        case cause: SoftFieldAccessException => Some(cause)
+        case wrapper: InvocationTargetException if remaining > 0 =>
+          unwrap(wrapper.getTargetException, remaining - 1)
+        case _ => None
+      }
+      // Only reflection wrappers are transparent; unrelated failures keep their normal rejection path.
+      unwrap(error, 16)
+    }
+  }
 
   /**
     * 6 bytes long transaction id, not cryptographically strong, used in p2p protocol only

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.mining
 
+import cats.syntax.either._
 import com.google.common.primitives.Ints
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.mining
 
-import com.google.common.primitives.Ints
+import cats.syntax.either._
+import com.google.common.primitives.{Ints, Longs}
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.settings.{ErgoValidationSettingsUpdate, Parameters}
@@ -8,15 +9,18 @@ import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalacheck.Gen
 import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
-import org.ergoplatform.OrderingSolutionFound
+import org.ergoplatform.{InputSolutionFound, OrderingSolutionFound}
 
 class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoCoreTestConstants._
   import org.ergoplatform.utils.generators.ErgoCoreGenerators._
 
+  // This specification searches for ordering headers, without stopping at input-block hits.
+  private val orderingOnlyParams = Parameters(0, Parameters.DefaultParameters, ErgoValidationSettingsUpdate.empty)
+    .withNumOfSubblocksPerBlock(1)
+
   property("generated solution should be valid") {
     val pow = new AutolykosPowScheme(powScheme.k, powScheme.n)
-    val defaultParams = Parameters(0, Parameters.DefaultParameters, ErgoValidationSettingsUpdate.empty)
     forAll(invalidHeaderGen,
             Gen.choose(100, 120),
             Gen.choose[Byte](1, 2)) { (inHeader, difficulty, ver) =>
@@ -28,7 +32,7 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
       val b = pow.getB(h.nBits)
       val hbs = Ints.toByteArray(h.height)
       val N = pow.calcN(h)
-      pow.checkNonces(ver, hbs, msg, sk, x, b, N, 0, 1000, defaultParams) match {
+      pow.checkNonces(ver, hbs, msg, sk, x, b, N, 0, 1000, orderingOnlyParams) match {
         case OrderingSolutionFound(as) =>
           val nh = h.copy(powSolution = as)
           pow.validate(nh) shouldBe 'success
@@ -40,7 +44,7 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
 
             val invalidHeader2 = Iterator.iterate(0L)(_ + 1000L).take(50)
               .flatMap { startNonce =>
-                pow.checkNonces(ver, hbs, msg2, sk, x, b, N, startNonce, startNonce + 1000, defaultParams) match {
+                pow.checkNonces(ver, hbs, msg2, sk, x, b, N, startNonce, startNonce + 1000, orderingOnlyParams) match {
                   case OrderingSolutionFound(as2) => Some(h.copy(powSolution = as2))
                   case _                          => None
                 }
@@ -51,6 +55,29 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
           }
         case _ =>
       }
+    }
+  }
+
+  property("ordering-only search continues past an input-block hit in the same nonce window") {
+    val pow = new AutolykosPowScheme(powScheme.k, powScheme.n)
+    val msg = Array.fill[Byte](32)(0)
+    val height = Ints.toByteArray(1)
+    val target = pow.getB(DifficultySerializer.encodeCompactBits(100))
+    val n = pow.calcN(2, 1)
+    val inputParams = Parameters(0, Parameters.DefaultParameters, ErgoValidationSettingsUpdate.empty)
+
+    val input = pow.checkNonces(2, height, msg, BigInt(1), BigInt(2), target, n, 0, 1000, inputParams) match {
+      case InputSolutionFound(solution) => solution
+      case other => fail(s"Expected an input-block hit before the ordering solution, got $other")
+    }
+    input.d should be > target
+    input.d should be <= (target * inputParams.subBlocksPerBlock)
+
+    pow.checkNonces(2, height, msg, BigInt(1), BigInt(2), target, n, 0, 1000, orderingOnlyParams) match {
+      case OrderingSolutionFound(solution) =>
+        solution.d should be <= target
+        Longs.fromByteArray(solution.n) should be > Longs.fromByteArray(input.n)
+      case other => fail(s"Expected an ordering solution in the same nonce window, got $other")
     }
   }
 

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/llm_generated/WeakAutolykosSolutionCodecsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/llm_generated/WeakAutolykosSolutionCodecsSpec.scala
@@ -1,0 +1,41 @@
+package org.ergoplatform.mining.llm_generated
+
+import io.circe.Json
+import org.ergoplatform.AutolykosSolution.pkForV2
+import org.ergoplatform.mining.{WeakAutolykosSolution, groupElemToBytes}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigma.crypto.CryptoConstants
+
+class WeakAutolykosSolutionCodecsSpec extends AnyFlatSpec with Matchers {
+  private val publicKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+  private val nonce = Array[Byte](0, 1, 2, 3, 4, 5, 6, 7)
+  private val nonceJson = Json.fromString("0001020304050607")
+
+  it should "preserve the exact public key and nonce JSON fields" in {
+    val solution = WeakAutolykosSolution(CryptoConstants.dlogGroup.generator, nonce)
+    val expected = Json.obj("pk" -> Json.fromString(publicKeyHex), "n" -> nonceJson)
+
+    WeakAutolykosSolution.jsonEncoder(solution) shouldBe expected
+    val decoded = WeakAutolykosSolution.jsonDecoder.decodeJson(expected).right.get
+    decoded.encodedPk.toSeq shouldBe solution.encodedPk.toSeq
+    decoded.n.toSeq shouldBe nonce.toSeq
+  }
+
+  it should "retain the default public key when pk is absent" in {
+    val decoded = WeakAutolykosSolution.jsonDecoder.decodeJson(Json.obj("n" -> nonceJson)).right.get
+
+    decoded.encodedPk.toSeq shouldBe groupElemToBytes(pkForV2).toSeq
+    decoded.n.toSeq shouldBe nonce.toSeq
+  }
+
+  it should "reject a missing or malformed nonce" in {
+    Seq(
+      Json.obj("pk" -> Json.fromString(publicKeyHex)),
+      Json.obj("n" -> Json.fromString("not-hex")),
+      Json.obj("n" -> Json.fromInt(1))
+    ).foreach { json =>
+      WeakAutolykosSolution.jsonDecoder.decodeJson(json).isLeft shouldBe true
+    }
+  }
+}

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/mempool/llm_generated/SoftFieldValidationSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/mempool/llm_generated/SoftFieldValidationSpec.scala
@@ -1,0 +1,76 @@
+package org.ergoplatform.modifiers.mempool
+
+import java.lang.reflect.InvocationTargetException
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoLikeContext, Input}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoCoreTestConstants._
+import org.ergoplatform.validation.SoftFieldsAccessError
+import org.ergoplatform.wallet.interpreter.ErgoInterpreter
+import scorex.util.bytesToId
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.exceptions.SoftFieldAccessException
+import sigma.interpreter.ProverResult
+import sigmastate.interpreter.Interpreter.{ScriptEnv, VerificationResult}
+import scala.util.{Failure, Try}
+
+class SoftFieldValidationSpec extends ErgoCorePropertyTest {
+  private val box = new ErgoBox(
+    value = 1000000000L, ergoTree = TrueTree, creationHeight = 0,
+    additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+    transactionId = bytesToId(Array.fill(32)(1.toByte)), index = 0
+  )
+  private val tx = ErgoTransaction(
+    IndexedSeq(Input(box.id, ProverResult.empty)),
+    IndexedSeq(new ErgoBoxCandidate(box.value, TrueTree, emptyStateContext.currentHeight))
+  )
+
+  private def failureReturnedBy(cause: Throwable): Throwable = {
+    implicit val verifier: ErgoInterpreter = new ErgoInterpreter(parameters) {
+      override def verify(env: ScriptEnv, exp: ErgoTree, context: ErgoLikeContext,
+                          proof: Array[Byte], message: Array[Byte]): Try[VerificationResult] = Failure(cause)
+    }
+    val result = tx.statefulValidity(IndexedSeq(box), IndexedSeq.empty, emptyStateContext,
+      accumulatedCost = 0L, softFieldsAllowed = false)
+    result.isFailure shouldBe true
+    result.failed.get
+  }
+
+  property("direct soft-field failures retain their classification and cause") {
+    val cause = new SoftFieldAccessException("minerPubKey")
+    val error = failureReturnedBy(cause)
+    error shouldBe a[SoftFieldsAccessError]
+    error.getCause shouldBe cause
+  }
+
+  property("reflection-wrapped soft-field failures retain their classification and cause") {
+    val cause = new SoftFieldAccessException("minerPubKey")
+    val error = failureReturnedBy(new InvocationTargetException(cause))
+    error shouldBe a[SoftFieldsAccessError]
+    error.getCause shouldBe cause
+  }
+
+  property("nested reflection calls preserve the soft-field classification") {
+    val cause = new SoftFieldAccessException("timestamp")
+    val error = failureReturnedBy(new InvocationTargetException(new InvocationTargetException(cause)))
+    error shouldBe a[SoftFieldsAccessError]
+    error.getCause shouldBe cause
+  }
+
+  property("unrelated interpreter failures retain ordinary rejection") {
+    Seq(new IllegalArgumentException("invalid input"),
+      new InvocationTargetException(new IllegalArgumentException("invalid input")),
+      new InvocationTargetException(null),
+      new IllegalStateException(new SoftFieldAccessException("minerPubKey"))).foreach { cause =>
+      failureReturnedBy(cause).isInstanceOf[SoftFieldsAccessError] shouldBe false
+    }
+  }
+
+  property("reflection unwrapping observes its depth limit") {
+    def wrapped(depth: Int): Throwable = (1 to depth).foldLeft[Throwable](
+      new SoftFieldAccessException("minerPubKey")) { (cause, _) => new InvocationTargetException(cause) }
+    failureReturnedBy(wrapped(16)) shouldBe a[SoftFieldsAccessError]
+    failureReturnedBy(wrapped(17)).isInstanceOf[SoftFieldsAccessError] shouldBe false
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackIsolationSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackIsolationSpec.scala
@@ -1,0 +1,58 @@
+package org.ergoplatform.it
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.io.Tcp
+import akka.testkit.{ExplicitlyTriggeredScheduler, TestActorRef, TestProbe}
+import com.typesafe.config.ConfigFactory
+import org.ergoplatform.network.message.MessageConstants.MessageCode
+import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.RandomPeerExcluding
+import org.ergoplatform.settings.ScorexSettings
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController
+
+import java.net.InetSocketAddress
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+class DeepRollBackIsolationSpec extends AnyFlatSpec with Matchers {
+  "Isolated rollback mining" should "disable automatic peer selection and reject incoming connections" in {
+    val ordinaryConfig = ConfigFactory.load()
+    val isolatedNetwork = ScorexSettings.fromConfig(
+      DeepRollBackSpec.isolatedMiningConfig.withFallback(ordinaryConfig).resolve()).network
+    ScorexSettings.fromConfig(ordinaryConfig).network.maxConnections should be > 0
+
+    implicit val system: ActorSystem = ActorSystem("RollbackIsolation", ConfigFactory.parseString(
+      "akka.scheduler.implementation = akka.testkit.ExplicitlyTriggeredScheduler"))
+    implicit val ec: ExecutionContext = system.dispatcher
+    try {
+      def controller(maxConnections: Int): (TestActorRef[NetworkController], TestProbe) = {
+        val peers = TestProbe()
+        val tcp = TestProbe()
+        val controllerSettings = settings.copy(scorexSettings = settings.scorexSettings.copy(
+          network = settings.scorexSettings.network.copy(maxConnections = maxConnections)))
+        val ref = TestActorRef(new NetworkController(controllerSettings, peers.ref,
+          ScorexContext(Seq.empty, None, None), tcp.ref, _ => Map.empty[MessageCode, ActorRef]))
+        tcp.expectMsgType[Tcp.Bind]
+        ref ! Tcp.Bound(controllerSettings.scorexSettings.network.bindAddress)
+        (ref, peers)
+      }
+
+      val (isolated, isolatedPeers) = controller(isolatedNetwork.maxConnections)
+      val (_, ordinaryPeers) = controller(maxConnections = 1)
+      system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler].timePasses(5.seconds)
+      ordinaryPeers.expectMsgType[RandomPeerExcluding](3.seconds)
+      isolatedPeers.expectNoMessage(200.millis)
+
+      val incoming = TestProbe()
+      incoming.send(isolated, Tcp.Connected(new InetSocketAddress("127.0.0.2", 9000),
+        settings.scorexSettings.network.bindAddress))
+      incoming.expectMsg(Tcp.Close)
+      isolatedPeers.expectNoMessage(200.millis)
+    } finally {
+      Await.result(system.terminate(), 10.seconds)
+    }
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -2,13 +2,15 @@ package org.ergoplatform.it
 
 import java.io.File
 import java.util.concurrent.TimeoutException
-import com.typesafe.config.Config
-import org.ergoplatform.it.api.NodeApi.NodeInfo
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.{NodeInfo, nodeInfoDecoder}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.freespec.AnyFreeSpec
 import scala.async.Async
-import scala.concurrent.{Await, Future, blocking}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
@@ -45,41 +47,114 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(allowLocalConfig)
 
+  private val observations = new ConvergenceObservations
+  private val seedObservations = new ConvergenceObservations
+  @volatile private var lastSeedObservation = "Initial seed has not been sampled"
+
+  private def waitForSettledSeed(
+    nodeA: Node,
+    nodeB: Node,
+    timeout: FiniteDuration
+  ): Future[(NodeInfo, NodeInfo)] = {
+    def infoProbe(node: Node): seedObservations.Probe[NodeInfo] =
+      seedObservations.probe(node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+        require(response.getStatusCode == 200, "Unexpected seed observation status")
+        node.ergoJsonAnswerAs[NodeInfo](response.getResponseBody)
+      })
+
+    val probeA = infoProbe(nodeA)
+    val probeB = infoProbe(nodeB)
+    def describe(result: Either[String, NodeInfo]): String = result.fold(
+      error => s"errorClass=$error",
+      info => s"headersHeight=${info.bestHeaderHeightOpt}; fullHeight=${info.bestBlockHeightOpt}; " +
+        s"headerId=${info.bestHeaderIdOpt.map(ConvergenceObservations.headerId)}; " +
+        s"fullId=${info.bestBlockIdOpt.map(ConvergenceObservations.headerId)}; mining=${info.isMining}")
+    seedObservations.until(timeout.fromNow, 1.second, 5.seconds) { budget =>
+      probeA.sample(budget).zip(probeB.sample(budget)).map { pair =>
+        lastSeedObservation = s"A=${describe(pair._1)}; B=${describe(pair._2)}"
+        log.info(s"Initial shared-chain readiness: $lastSeedObservation")
+        pair
+      }
+    } {
+      case (Right(a), Right(b)) =>
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, ErgoHistoryUtils.GenesisHeight)
+      case _ => false
+    }(
+      s"Initial chain did not settle with mining disabled and matching full/header tips; $lastSeedObservation"
+    ).map { case (a, b) => (a.toOption.get, b.toOption.get) }
+  }
+
+  private case class NodeSnapshot(info: Option[NodeInfo])
+  private val probes = scala.collection.mutable.Map.empty[
+    Node, (observations.Probe[NodeInfo], observations.Probe[Int])]
+
+  @volatile private var lastObservation = "No node pair observed"
+  private var recentObservations = Vector.empty[String]
+
+  private def remember(phase: String, label: String, endpoint: String, summary: String): Unit = synchronized {
+    val observation = s"$phase $label $endpoint sampledAt=${System.currentTimeMillis()} $summary"
+    recentObservations = (recentObservations :+ observation).takeRight(12)
+    lastObservation = recentObservations.mkString("; ")
+    log.info(observation)
+  }
+
+  private def snapshot(phase: String, label: String, node: Node, budget: FiniteDuration): Future[NodeSnapshot] = {
+    val (statusProbe, peerProbe) = probes.getOrElseUpdate(node, (
+      observations.probe(node.singleGet("/info", _.setRequestTimeout(5000))
+        .map { r =>
+          require(r.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[NodeInfo](r.getResponseBody)
+        }),
+      observations.probe(node.singleGet("/peers/connected", _.setRequestTimeout(5000)).map { r =>
+        require(r.getStatusCode == 200, "Unexpected observation status")
+        node.ergoJsonAnswerAs[Json](r.getResponseBody).asArray.getOrElse(
+          throw new IllegalArgumentException("Expected peer array")).size
+      })
+    ))
+    val status = statusProbe.sample(budget).map {
+      case Right(info) =>
+        val summary = Json.obj(
+          "headersHeight" -> info.bestHeaderHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "fullHeight" -> info.bestBlockHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "bestHeaderId" -> info.bestHeaderIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null),
+          "bestFullHeaderId" -> info.bestBlockIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null)
+        )
+        remember(phase, label, "status", summary.noSpaces)
+        Some(info)
+      case Left(error) =>
+        remember(phase, label, "status", s"errorClass=$error")
+        None
+    }
+    val peers = peerProbe.sample(budget).map { result =>
+      val summary = result.fold(error => s"errorClass=$error", count => s"connectedPeerCount=$count")
+      remember(phase, label, "peers", summary)
+    }
+    status.zip(peers).map { case (info, _) => NodeSnapshot(info) }
+  }
+
+  private def observeNodes(
+    phase: String,
+    nodeA: Node,
+    nodeB: Node,
+    budget: FiniteDuration = 5.seconds
+  ): Future[(NodeSnapshot, NodeSnapshot)] = {
+    snapshot(phase, "A", nodeA, budget).zip(snapshot(phase, "B", nodeB, budget))
+  }
+
   private def waitForSameBestBlock(
     nodeA: Node,
     nodeB: Node,
     minHeight: Int,
     timeout: FiniteDuration
   ): Future[(NodeInfo, NodeInfo)] = {
-    def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo): Boolean = {
-      val sameHeight =
-        infoA.bestBlockHeightOpt.nonEmpty &&
-          infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
-      val sameBlock =
-        infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
-      val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
-      sameHeight && sameBlock && highEnough
-    }
-
-    def retryAfterDelay(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      Future {
-        blocking(Thread.sleep(1000))
-      }.flatMap(_ => loop(deadline))
-
-    def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
-        if (sameBestBlock(infoA, infoB)) {
-          Future.successful((infoA, infoB))
-        } else if (deadline.isOverdue()) {
-          Future.failed(new TimeoutException(
-            s"Nodes did not converge to the same best full block at height >= $minHeight"
-          ))
-        } else {
-          retryAfterDelay(deadline)
-        }
-      }
-
-    loop(timeout.fromNow)
+    observations.until(timeout.fromNow, 1.second, 5.seconds)(
+      budget => observeNodes("convergence", nodeA, nodeB, budget)
+    ) { case (a, b) =>
+      a.info.exists(infoA => b.info.exists(infoB => ConvergenceObservations.sameBestBlock(infoA, infoB, minHeight)))
+    }(
+      s"Nodes did not converge to the same best full block at height >= $minHeight; " +
+        s"recent observations: $lastObservation"
+    ).map { case (a, b) => (a.info.get, b.info.get) }
   }
 
   "Deep rollback handling" in {
@@ -100,34 +175,44 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       val genesisAGen = Async.await(minerAGen.headerIdsByHeight(ErgoHistoryUtils.GenesisHeight)).head
       val genesisBGen = Async.await(minerBGen.headerIdsByHeight(ErgoHistoryUtils.GenesisHeight)).head
 
-      val minerAGenBestHeight = Async.await(minerAGen.fullHeight)
-      val minerBGenBestHeight = Async.await(minerBGen.fullHeight)
-
-      log.info("heightA: " + minerAGenBestHeight)
-      log.info("heightB: " + minerBGenBestHeight)
-
       genesisAGen shouldBe genesisBGen
+      Async.await(observeNodes("initial shared chain", minerAGen, minerBGen))
 
-      // 2. Stop all nodes
+      // Freeze the producer while B can still retrieve every header's full block.
       docker.stopNode(minerAGen.containerId)
+      val minerASeed: Node = docker.startDevNetNode(minerAConfigNonGen,
+        specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
+      val (seedA, seedB) = Async.await(waitForSettledSeed(minerASeed, minerBGen, 2.minutes))
+      val seedHeight = seedA.bestBlockHeightOpt.get
+      require(seedHeight < chainLength,
+        s"Initial shared chain already reached $seedHeight; isolated node B must mine to $chainLength")
+      log.info(s"Settled shared chain: heightA=$seedHeight, heightB=${seedB.bestBlockHeightOpt.get}")
+
+      // 2. Stop the restarted A and B only after both have the complete shared seed.
+      docker.stopNode(minerASeed.containerId)
       docker.stopNode(minerBGen.containerId)
 
-      val minerAIsolated: Node = docker.startDevNetNode(minerAConfig, isolatedPeersConfig,
+      val minerAIsolated: Node = docker.startDevNetNode(DeepRollBackSpec.isolatedMiningConfig.withFallback(minerAConfig), isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
 
       // 1. Let nodeA mine `chainLength + delta` blocks in isolation
       Async.await(minerAIsolated.waitForHeight(chainLength + delta))
 
-      val minerBIsolated: Node = docker.startDevNetNode(minerBConfig, isolatedPeersConfig,
+      val minerBIsolated: Node = docker.startDevNetNode(DeepRollBackSpec.isolatedMiningConfig.withFallback(minerBConfig), isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
+      Async.await(observeNodes("isolated miners started", minerAIsolated, minerBIsolated))
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
       Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
+
+      Async.await(minerAIsolated.connectedPeers) shouldBe empty
+      Async.await(minerBIsolated.connectedPeers) shouldBe empty
 
       log.info("Mining phase done")
 
       val minerABestHeight = Async.await(minerAIsolated.fullHeight)
       val minerBBestHeight = Async.await(minerBIsolated.fullHeight)
+      Async.await(observeNodes("isolated mining complete", minerAIsolated, minerBIsolated))
 
       docker.stopNode(minerAIsolated.containerId)
       docker.stopNode(minerBIsolated.containerId)
@@ -143,7 +228,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerB: Node = docker.startDevNetNode(minerBConfigNonGen,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
-
+      Async.await(observeNodes("restarted without mining", minerA, minerB))
 
       val isMiningAOpt = Async.await(minerA.info).isMining
       log.info("isminingA: " + isMiningAOpt)
@@ -162,7 +247,23 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
-    Await.result(result, 20.minutes)
+    try {
+      Await.result(result, 20.minutes)
+    } catch {
+      case error: TimeoutException =>
+        log.error(s"Deep rollback timed out; last initial-seed observation: $lastSeedObservation")
+        log.error(s"Deep rollback timed out; last observation: $lastObservation")
+        throw error
+    } finally {
+      seedObservations.close()
+      observations.close()
+    }
   }
 
+}
+
+object DeepRollBackSpec {
+  // The retained peer database survives restarts. Disable automatic outgoing connections
+  // and incoming admission during mining; final restarts use the ordinary node configs.
+  private[it] val isolatedMiningConfig: Config = ConfigFactory.parseString("scorex.network.maxConnections = 0")
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -1,8 +1,9 @@
 package org.ergoplatform.it
 
 import com.typesafe.config.Config
+import io.circe.Json
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.ergoplatform.it.util.ConvergenceObservations
+import org.ergoplatform.it.util.{ConvergenceObservations, UtxoSyncFailureDiagnostics}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -75,7 +76,12 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
     catch {
       case error: java.util.concurrent.TimeoutException =>
         log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
-        throw error
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(error, nodes.map { node => () =>
+          node.singleGet("/info", _.setRequestTimeout(2000)).map { response =>
+            require(response.getStatusCode == 200, "Unexpected diagnostic status")
+            node.ergoJsonAnswerAs[Json](response.getResponseBody)
+          }
+        })(snapshot => log.error(s"UTXO post-failure diagnostics: $snapshot"))
     } finally observations.close()
   }
 

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  /** Both nodes report mining disabled and share a completely applied selected header tip. */
+  def sameFullyAppliedNonMiningBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean =
+    infoA.isMining.contains(false) && infoB.isMining.contains(false) &&
+      sameBestBlock(infoA, infoB, minHeight) &&
+      infoA.bestBlockIdOpt.exists(_.nonEmpty) &&
+      infoA.bestHeaderHeightOpt == infoA.bestBlockHeightOpt &&
+      infoB.bestHeaderHeightOpt == infoB.bestBlockHeightOpt &&
+      infoA.bestHeaderIdOpt == infoA.bestBlockIdOpt &&
+      infoB.bestHeaderIdOpt == infoB.bestBlockIdOpt
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,145 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  "Fully applied block agreement" should "accept a complete shared tip at the minimum height" in {
+    val info = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 12) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 13) shouldBe false
+  }
+
+  it should "reject a shared 21-header 12-full-block seed despite full-block agreement" in {
+    val lagging = NodeInfo(Some("header21"), Some("block12"), Some(21), Some(12), None, Some(false))
+    ConvergenceObservations.sameBestBlock(lagging, lagging, 1) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(lagging, lagging, 1) shouldBe false
+  }
+
+  private val completeSeed = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+
+  Seq[(String, NodeInfo => NodeInfo)](
+    "missing header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = None)),
+    "missing full-block height" -> ((info: NodeInfo) => info.copy(bestBlockHeightOpt = None)),
+    "missing header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = None)),
+    "missing full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = None)),
+    "different header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = Some("other"))),
+    "different full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = Some("other"))),
+    "different header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = Some(21))),
+    "unknown mining status" -> ((info: NodeInfo) => info.copy(isMining = None)),
+    "active mining" -> ((info: NodeInfo) => info.copy(isMining = Some(true)))
+  ).foreach { case (fault, change) =>
+    Seq("A", "B").foreach { side =>
+      it should s"reject $fault on node $side independently" in {
+        val (a, b) = if (side == "A") (change(completeSeed), completeSeed)
+                     else (completeSeed, change(completeSeed))
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, 1) shouldBe false
+      }
+    }
+  }
+
+  it should "reject two empty tip identifiers" in {
+    val empty = completeSeed.copy(bestHeaderIdOpt = Some(""), bestBlockIdOpt = Some(""))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(empty, empty, 1) shouldBe false
+  }
+
+  it should "reject different complete tips at the same height" in {
+    val other = completeSeed.copy(bestHeaderIdOpt = Some("other"), bestBlockIdOpt = Some("other"))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  it should "reject different complete heights independently of matching IDs" in {
+    val other = completeSeed.copy(bestHeaderHeightOpt = Some(13), bestBlockHeightOpt = Some(13))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  "Full block agreement" should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
@@ -1,0 +1,60 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/** Additional observations after failure, with their own bound and no effect on the assertion. */
+object UtxoSyncFailureDiagnostics {
+  private val requestBudget = 2.seconds
+  private val collectionBudget = 2500.millis
+  private val numericFields = Seq("headersHeight", "fullHeight", "headersScore", "fullBlocksScore", "peersCount")
+  private val headerFields = Seq("bestHeaderId", "bestFullHeaderId", "genesisBlockId")
+
+  def project(node: Int, sampledAt: Long, response: Either[String, Json]): Json = {
+    val identity = Seq("node" -> Json.fromInt(node), "sampledAt" -> Json.fromLong(sampledAt))
+    def failed(errorClass: String): Json = {
+      val safeClass = if (errorClass.matches("[A-Za-z_$][A-Za-z0-9_$]{0,127}")) errorClass else "ObservationFailure"
+      Json.obj((identity :+ ("errorClass" -> Json.fromString(safeClass))): _*)
+    }
+    response match {
+      case Left(errorClass) => failed(errorClass)
+      case Right(body) if !body.isObject => failed("InvalidInfoResponse")
+      case Right(body) =>
+        def field(name: String)(decode: Json => Option[Json]): (String, Json) = {
+          val value = body.hcursor.downField(name).focus match {
+            case None => Json.Null
+            case Some(value) if value.isNull => Json.Null
+            case Some(value) => decode(value).getOrElse(Json.fromString("invalid"))
+          }
+          name -> value
+        }
+        val numbers = numericFields.map(name => field(name) { value =>
+          value.asNumber.flatMap(_.toBigInt).filter(_ >= 0).map(Json.fromBigInt)
+        })
+        val headers = headerFields.map(name => field(name) { value =>
+          value.asString.map(id => Json.fromString(ConvergenceObservations.headerId(id)))
+        })
+        val mining = field("isMining")(_.asBoolean.map(Json.fromBoolean))
+        Json.obj((identity ++ numbers ++ headers :+ mining): _*)
+    }
+  }
+
+  def rethrowAfterCapture(original: TimeoutException, requests: Seq[() => Future[Json]])
+                         (emit: String => Unit)(implicit ec: ExecutionContext): Unit = {
+    try {
+      val observations = new ConvergenceObservations
+      try {
+        val snapshots = requests.zipWithIndex.map { case (request, index) =>
+          observations.probe(Future(request()).flatMap(response => response))
+            .sample(requestBudget).map(response => project(index, System.currentTimeMillis(), response))
+        }
+        // This bound starts only after the synchronization assertion has already failed.
+        val result = Await.result(Future.sequence(snapshots), collectionBudget)
+        emit(Json.arr(result: _*).noSpaces)
+      } finally observations.close()
+    } finally throw original
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
@@ -1,0 +1,111 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class UtxoSyncFailureDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private val marker = "untrusted-extra-value"
+  private val header = "ab" * 32
+
+  "Failure diagnostics" should "preserve only typed diagnostic fields and exact cumulative scores" in {
+    val score = BigInt("123456789012345678901234567890")
+    val body = Json.obj(
+      "headersHeight" -> Json.fromInt(13), "fullHeight" -> Json.fromInt(9),
+      "headersScore" -> Json.fromBigInt(score), "fullBlocksScore" -> Json.fromBigInt(score - 4),
+      "bestHeaderId" -> Json.fromString(header), "bestFullHeaderId" -> Json.fromString(header),
+      "genesisBlockId" -> Json.fromString(header), "isMining" -> Json.True,
+      "peersCount" -> Json.fromInt(3), "name" -> Json.fromString(marker),
+      "address" -> Json.fromString(marker), "sampledAt" -> Json.fromString(marker))
+    val result = UtxoSyncFailureDiagnostics.project(2, 123L, Right(body))
+    result.hcursor.get[BigInt]("headersScore") shouldBe Right(score)
+    result.hcursor.get[BigInt]("fullBlocksScore") shouldBe Right(score - 4)
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right(header)
+    result.hcursor.get[Int]("headersHeight") shouldBe Right(13)
+    result.hcursor.get[Int]("fullHeight") shouldBe Right(9)
+    result.hcursor.get[Boolean]("isMining") shouldBe Right(true)
+    result.hcursor.get[Int]("peersCount") shouldBe Right(3)
+    result.hcursor.get[Int]("node") shouldBe Right(2)
+    result.hcursor.get[Long]("sampledAt") shouldBe Right(123L)
+    result.asObject.get.keys.toSet shouldBe Set("node", "sampledAt", "headersHeight", "fullHeight",
+      "headersScore", "fullBlocksScore", "bestHeaderId", "bestFullHeaderId", "genesisBlockId", "isMining", "peersCount")
+    result.noSpaces should not include marker
+  }
+
+  it should "mark malformed fields and preserve missing fields without copying their contents" in {
+    val body = Json.obj("headersHeight" -> Json.fromString(marker), "fullHeight" -> Json.fromInt(-1),
+      "headersScore" -> Json.arr(Json.fromString(marker)), "isMining" -> Json.fromString(marker),
+      "bestHeaderId" -> Json.fromString(marker), "genesisBlockId" -> Json.obj("secret" -> Json.fromString(marker)))
+    val result = UtxoSyncFailureDiagnostics.project(0, 1L, Right(body))
+    Seq("headersHeight", "fullHeight", "headersScore", "isMining", "genesisBlockId").foreach { key =>
+      result.hcursor.get[String](key) shouldBe Right("invalid")
+    }
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right("invalid-header-id")
+    Seq("fullBlocksScore", "peersCount", "bestFullHeaderId").foreach { key =>
+      result.hcursor.downField(key).focus shouldBe Some(Json.Null)
+    }
+    result.noSpaces should not include marker
+    UtxoSyncFailureDiagnostics.project(0, 1L, Right(Json.fromString(marker)))
+      .hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    UtxoSyncFailureDiagnostics.project(0, 1L, Left("bad/class: " + marker)).noSpaces should not include marker
+  }
+
+  it should "retain the original timeout when transport or request creation fails" in {
+    val original = new TimeoutException("original assertion")
+    var captured = ""
+    val requests = Seq[() => Future[Json]](
+      () => Future.successful(Json.obj("name" -> Json.fromString(marker))),
+      () => Future.failed(new IOException(marker)),
+      () => throw new IllegalStateException(marker),
+      () => Future.successful(Json.fromString(marker)))
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, requests)(value => captured = value)
+    }
+    (thrown eq original) shouldBe true
+    val snapshots = parse(captured).toOption.get.asArray.get
+    snapshots.size shouldBe 4
+    snapshots.map(_.hcursor.get[Int]("node").toOption.get) shouldBe Vector(0, 1, 2, 3)
+    snapshots(1).hcursor.get[String]("errorClass") shouldBe Right("IOException")
+    snapshots(2).hcursor.get[String]("errorClass") shouldBe Right("IllegalStateException")
+    snapshots(3).hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    captured should not include marker
+  }
+
+  it should "retain the original timeout if emitting diagnostics fails" in {
+    val original = new TimeoutException("original assertion")
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, Seq(() => Future.successful(Json.obj()))) { _ =>
+        throw new IllegalArgumentException(marker)
+      }
+    }
+    (thrown eq original) shouldBe true
+  }
+
+  it should "start all pending requests and finish collection under its separate bound" in {
+    val original = new TimeoutException("original assertion")
+    val started = new AtomicInteger(0)
+    val pending = Seq.fill(4)(Promise[Json]())
+    var captured = ""
+    val thrown = intercept[TimeoutException] {
+      Await.result(Future {
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, pending.map { promise => () =>
+          started.incrementAndGet()
+          promise.future
+        })(value => captured = value)
+      }, 4.seconds)
+    }
+    (thrown eq original) shouldBe true
+    started.get() shouldBe 4
+    parse(captured).toOption.get.asArray.get.foreach { snapshot =>
+      snapshot.hcursor.get[String]("errorClass") shouldBe Right("TimeoutException")
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -30,7 +30,7 @@ import scorex.crypto.authds.LeafData
 import scorex.crypto.authds.merkle.BatchMerkleProof
 import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
-import scorex.util.{ModifierId, ScorexLogging, idToBytes}
+import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 import sigma.data.{Digest32Coll, ProveDlog}
 import sigma.crypto.CryptoFacade
 import sigma.interpreter.ProverResult
@@ -1032,6 +1032,7 @@ object CandidateGenerator extends ScorexLogging {
     var remainingTxs = transactions
     val accInput = MutableArray.empty[CostedTransaction]
     val accOrdering = MutableArray.empty[CostedTransaction]
+    val deferredOutputs = scala.collection.mutable.Set.empty[ModifierId]
     var lastFeeTx: Option[CostedTransaction] = None
     val invalidTxs = MutableArray.empty[ModifierId]
     var done = false
@@ -1046,7 +1047,19 @@ object CandidateGenerator extends ScorexLogging {
 
       remainingTxs.headOption match {
         case Some(tx) =>
-          if (!inputsNotSpent(tx, stateWithTxs) || doublespend(allCurrent, tx)) {
+          def dependsOn(outputIds: collection.Set[ModifierId]): Boolean =
+            tx.inputs.exists(i => outputIds.contains(bytesToId(i.boxId))) ||
+              tx.dataInputs.exists(i => outputIds.contains(bytesToId(i.boxId)))
+
+          def deferTx(): Unit = {
+            deferredOutputs ++= tx.outputs.map(b => bytesToId(b.id))
+            remainingTxs = remainingTxs.tail
+          }
+
+          if (dependsOn(deferredOutputs)) {
+            // Preserve descendants for a later candidate when their dependencies are available.
+            deferTx()
+          } else if (!inputsNotSpent(tx, stateWithTxs) || doublespend(allCurrent, tx)) {
             // Mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
             // Do these checks before validating the scripts to save time
             log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
@@ -1066,6 +1079,14 @@ object CandidateGenerator extends ScorexLogging {
             def collectFeeAndCheckLimits(newTxs: Seq[CostedTransaction],
                                          inputTx: Boolean,
                                          costConsumed: Int): Boolean = {
+              val otherPartition = if (inputTx) currentOrdering else currentInput
+              val otherOutputs = otherPartition.flatMap(_.outputs).map(b => bytesToId(b.id)).toSet
+              if (dependsOn(otherOutputs)) {
+                // Each payload must be executable without the other candidate's new outputs.
+                // Deferral is a selection decision, not evidence that the transaction is invalid.
+                deferTx()
+                return true
+              }
               val newBoxes = newTxs.flatMap(_._1.outputs)
 
               collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -1021,6 +1021,8 @@ object CandidateGenerator extends ScorexLogging {
 
     val currentHeight = us.stateContext.currentHeight
     val nextHeight = upcomingContext.currentHeight
+    // Use the candidate header version, including the first block of an activation epoch.
+    val inputBlocksEnabled = upcomingContext.sigmaPreHeader.version >= Header.Interpreter60Version
 
     log.info(
       s"Assembling a block candidate for block #$nextHeight from ${transactions.length} transactions available"
@@ -1147,11 +1149,11 @@ object CandidateGenerator extends ScorexLogging {
             }
 
             // Check validity and calculate transaction cost
-            validateTx(softFieldsAllowed = false) match {
+            validateTx(softFieldsAllowed = !inputBlocksEnabled) match {
               case Success(costConsumed) =>
                 val newTxs = acc :+ (tx -> costConsumed)
-                collectFeeAndCheckLimits(newTxs, inputTx = true, costConsumed)
-              case Failure(e) if e.isInstanceOf[SoftFieldsAccessError] =>
+                collectFeeAndCheckLimits(newTxs, inputTx = inputBlocksEnabled, costConsumed)
+              case Failure(e) if inputBlocksEnabled && e.isInstanceOf[SoftFieldsAccessError] =>
                 log.info(s"Rechecking transaction: $tx.id")
                 validateTx(softFieldsAllowed = true) match {
                   case Success(costConsumed) =>

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.{Header, HeaderWithoutPow}
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
-import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer, UnconfirmedTransaction}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.network.message.inputblocks.InputBlockTransactionsData
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.EliminateTransactions
@@ -21,6 +21,7 @@ import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.history.{ErgoHistoryReader, ErgoHistoryUtils}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, UtxoStateReader}
+import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.settings.{Algos, ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
 import org.ergoplatform.subblocks.InputBlockAnnouncement
 import org.ergoplatform.validation.SoftFieldsAccessError
@@ -32,6 +33,8 @@ import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 import sigma.data.{Digest32Coll, ProveDlog}
+import sigma.Extensions.ArrayOps
+import sigma.ast.syntax.ErgoBoxRType
 import sigma.crypto.CryptoFacade
 import sigma.interpreter.ProverResult
 import sigma.validation.ReplacedRule
@@ -720,7 +723,8 @@ object CandidateGenerator extends ScorexLogging {
         state.stateContext.currentParameters.maxBlockSize,
         state,
         upcomingContext,
-        newTransactionCandidates
+        newTransactionCandidates,
+        previousOrderingBlockTransactions
       )
 
       // filter out transactions included in previous input-blocks
@@ -860,18 +864,20 @@ object CandidateGenerator extends ScorexLogging {
     ).headOption
   }
 
+  val MaxFeeBoxesPerTransaction: Int = 100
+
   def collectFees(
     currentHeight: Int,
     txs: Seq[ErgoTransaction],
     minerPk: ProveDlog,
     stateContext: ErgoStateContext
-  ): Option[ErgoTransaction] = {
-    collectRewards(None, currentHeight, txs, minerPk, stateContext, Colls.emptyColl).headOption
+  ): Seq[ErgoTransaction] = {
+    collectRewards(None, currentHeight, txs, minerPk, stateContext, Colls.emptyColl)
   }
 
   /**
-    * Generate from 0 to 2 transaction that collecting rewards from fee boxes in block transactions `txs` and
-    * emission box `emissionBoxOpt`
+    * Generate at most one emission transaction, followed by fee transactions with at most
+    * MaxFeeBoxesPerTransaction inputs each, preserving the complete fee payout.
     */
   def collectRewards(
     emissionBoxOpt: Option[ErgoBox],
@@ -967,38 +973,15 @@ object CandidateGenerator extends ScorexLogging {
     val feeBoxes: Seq[ErgoBox] = ErgoState
       .newBoxes(txs)
       .filter(b => java.util.Arrays.equals(b.propositionBytes, propositionBytes) && !inputs.exists(i => java.util.Arrays.equals(i.boxId, b.id)))
-    val feeTxOpt: Option[ErgoTransaction] = if (feeBoxes.nonEmpty) {
-      // todo: sub-blocks: fix tx fee collection , old code is commented out below for now
-      /*
-       import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
-       import sigma.ast.syntax.ErgoBoxRType
-       import sigma.Extensions.ArrayOps
+    val feeTxs = feeBoxes.grouped(MaxFeeBoxesPerTransaction).map { chunk =>
+      val feeAmount = chunk.map(_.value).sum
+      val feeAssets = chunk.toArray.toColl.flatMap(_.additionalTokens).take(MaxAssetsPerBox)
+      val feeInputs = chunk.map(b => new Input(b.id, ProverResult.empty))
+      val minerBox = new ErgoBoxCandidate(feeAmount, minerProp, nextHeight, feeAssets, Map())
+      ErgoTransaction(feeInputs.toIndexedSeq, IndexedSeq.empty, IndexedSeq(minerBox))
+    }.toSeq
 
-       val feeAmount = feeBoxes.map(_.value).sum
-       val feeAssets =
-        feeBoxes.toArray.toColl.flatMap(_.additionalTokens).take(MaxAssetsPerBox)
-       val inputs = feeBoxes.map(b => new Input(b.id, ProverResult.empty))
-       val minerBox =
-        new ErgoBoxCandidate(feeAmount, minerProp, nextHeight, feeAssets, Map())
-       Some(ErgoTransaction(inputs.toIndexedSeq, IndexedSeq(), IndexedSeq(minerBox)))
-      */
-      None
-    } else {
-      None
-    }
-
-    Seq(emissionTxOpt, feeTxOpt).flatten
-  }
-
-  /**
-    * Helper function which decides whether transactions can fit into a block with given cost and size limits
-    */
-  private def correctLimits(
-    blockTxs: Seq[CostedTransaction],
-    maxBlockCost: Long,
-    maxBlockSize: Long
-  ): Boolean = {
-    blockTxs.map(_._2).sum < maxBlockCost && blockTxs.map(_._1.size).sum < maxBlockSize
+    emissionTxOpt.toSeq ++ feeTxs
   }
 
   /**
@@ -1008,6 +991,11 @@ object CandidateGenerator extends ScorexLogging {
     * Resulting transactions total cost does not exceed `maxBlockCost`, total size does not exceed `maxBlockSize`,
     * and the miner's transaction is correct.
     *
+    * The accepted input-block prefix supplies common state to both candidate payloads. Its transactions
+    * are not returned again; its collectible fees belong only to the ordering payload. Each new input
+    * payload must also leave the accumulated prefix within the conservative ordering budget.
+    * Prefix-only rewards may remain unclaimed when the mandatory transactions consume the budget.
+    *
     * @return - input block transactions to include, ordering blocks transactions to include, transaction ids turned out to be invalid.
     */
   def collectTxs(
@@ -1016,7 +1004,8 @@ object CandidateGenerator extends ScorexLogging {
                   maxBlockSize: Int,
                   us: UtxoStateReader,
                   upcomingContext: ErgoStateContext,
-                  transactions: Seq[ErgoTransaction]
+                  transactions: Seq[ErgoTransaction],
+                  inputBlockTransactions: Seq[ErgoTransaction] = Seq.empty
                 ): (Seq[ErgoTransaction], Seq[ErgoTransaction], Seq[ModifierId]) = {
 
     val currentHeight = us.stateContext.currentHeight
@@ -1030,21 +1019,118 @@ object CandidateGenerator extends ScorexLogging {
 
     val verifier: ErgoInterpreter = ErgoInterpreter(upcomingContext.currentParameters)
 
+    val transactionSizes = scala.collection.mutable.Map.empty[(Header.Version, ModifierId, ModifierId), Int]
+    val feeCosts = scala.collection.mutable.Map.empty[ModifierId, Int]
+
+    def unsignedSize(value: Long): Int = {
+      var remaining = value
+      var size = 1
+      while (remaining >= 128L) {
+        remaining = remaining >>> 7
+        size += 1
+      }
+      size
+    }
+
+    def correctLimits(blockTxs: Seq[CostedTransaction], costLimit: Long,
+                      sizeLimit: Long, blockVersion: Header.Version): Boolean = {
+      if (blockTxs.map(_._2.toLong).sum > costLimit) false
+      else if (blockTxs.isEmpty) true
+      else {
+        // Match BlockTransactionsSerializer, including its version marker and count.
+        val framing = 32L + unsignedSize(blockTxs.size.toLong) +
+          (if (blockVersion > Header.InitialVersion)
+            unsignedSize(BlockTransactionsSerializer.MaxTransactionsInBlock.toLong + blockVersion) else 0)
+        val bytes = blockTxs.map { case (tx, _) =>
+          val key = (blockVersion, tx.id, bytesToId(tx.witnessSerializedId))
+          transactionSizes.getOrElseUpdate(key, {
+            if (blockVersion >= sigma.VersionContext.V6SoftForkVersion) {
+              sigma.VersionContext.withVersions(blockVersion, blockVersion) {
+                ErgoTransactionSerializer.toBytes(tx).length
+              }
+            } else ErgoTransactionSerializer.toBytes(tx).length
+          }).toLong
+        }.sum
+        framing + bytes <= sizeLimit
+      }
+    }
+
     // Mutable state for iterative transaction processing
-    var remainingTxs = transactions
+    val version = upcomingContext.sigmaPreHeader.version
+    val prefixIds = inputBlockTransactions.map(_.id).toSet
+    val prefixState = us.withTransactions(inputBlockTransactions)
+    val prefix = inputBlockTransactions.map { tx =>
+      val cost = prefixState.validateWithCost(tx, upcomingContext,
+        upcomingContext.currentParameters.maxBlockCost, Some(verifier), softFieldsAllowed = true).get
+      tx -> cost
+    }
+    require(correctLimits(prefix, upcomingContext.currentParameters.maxBlockCost, maxBlockSize, version),
+      "Selected input transactions exceed the ordering block limits")
+    // A mandatory prefix can consume the conservative mining cost gap. Keep that valid prefix,
+    // but give optional transactions no additional cost allowance in that case.
+    val orderingCostLimit = math.max(maxBlockCost.toLong, prefix.map(_._2.toLong).sum)
+    var remainingTxs = transactions.filterNot(tx => prefixIds.contains(tx.id))
     val accInput = MutableArray.empty[CostedTransaction]
     val accOrdering = MutableArray.empty[CostedTransaction]
     val deferredOutputs = scala.collection.mutable.Set.empty[ModifierId]
-    var lastFeeTx: Option[CostedTransaction] = None
+    var lastFeeTxs = Seq.empty[CostedTransaction]
     val invalidTxs = MutableArray.empty[ModifierId]
     var done = false
 
-    while (!done) {
-      val acc: Seq[CostedTransaction] = accInput ++ accOrdering
+    def feesFor(ordering: Seq[CostedTransaction]): Option[Seq[CostedTransaction]] = {
+      val sources = inputBlockTransactions ++ ordering.map(_._1)
+      val boxes = sources.flatMap(_.outputs).map(b => bytesToId(b.id) -> b).toMap
+      val costedFees = collectFees(currentHeight, sources, minerPk, upcomingContext)
+        .foldLeft(Try(Vector.empty[CostedTransaction])) { (result, feeTx) =>
+          result.flatMap { accumulated =>
+            val checkedCost = feeCosts.get(feeTx.id) match {
+              case Some(cost) => Success(cost)
+              case None =>
+                val inputs = feeTx.inputs.flatMap(i => boxes.get(bytesToId(i.boxId)))
+                feeTx.statefulValidity(inputs, IndexedSeq.empty, upcomingContext)(verifier).map { cost =>
+                  feeCosts.put(feeTx.id, cost)
+                  cost
+                }
+            }
+            checkedCost.map(cost => accumulated :+ (feeTx -> cost))
+          }
+        }
+      costedFees match {
+        case Success(allFees) =>
+          val newOutputIds = ordering.flatMap(_._1.outputs).map(b => bytesToId(b.id)).toSet
+          val (required, optional) = allFees.partition { case (tx, _) =>
+            tx.inputs.exists(i => newOutputIds.contains(bytesToId(i.boxId)))
+          }
+          val base = prefix ++ ordering
+          if (!correctLimits(base ++ required, orderingCostLimit, maxBlockSize, version)) {
+            None
+          } else {
+            var selected: Seq[CostedTransaction] = required
+            // Already selected input transactions remain mandatory. Optional rewards must not
+            // prevent their ordering confirmation when only part of the fee collection fits.
+            optional.iterator.takeWhile { feeTx =>
+              if (correctLimits(base ++ selected :+ feeTx, orderingCostLimit, maxBlockSize, version)) {
+                selected = selected :+ feeTx
+                true
+              } else false
+            }.foreach(_ => ())
+            Some(selected)
+          }
+        case Failure(error) =>
+          log.warn(s"Fee collection is not selectable: ${error.getMessage}")
+          None
+      }
+    }
 
+    lastFeeTxs = feesFor(Seq.empty).getOrElse(Seq.empty)
+
+    while (!done) {
       def currentInput: Seq[ErgoTransaction] = accInput.map(_._1)
-      def currentOrdering: Seq[ErgoTransaction] = (accOrdering ++ lastFeeTx.toSeq).map(_._1)
-      val allCurrent = currentInput ++ currentOrdering
+      def currentOrdering: Seq[ErgoTransaction] = (accOrdering ++ lastFeeTxs).map(_._1)
+      // Generated fee rewards can change as selection proceeds, so their outputs are not
+      // stable dependencies for user transactions in this candidate.
+      val feeOutputIds = lastFeeTxs.flatMap(_._1.outputs).map(b => bytesToId(b.id)).toSet
+      val allCurrent = inputBlockTransactions ++ currentInput ++ accOrdering.map(_._1)
       val stateWithTxs = us.withTransactions(allCurrent)
 
       remainingTxs.headOption match {
@@ -1058,7 +1144,7 @@ object CandidateGenerator extends ScorexLogging {
             remainingTxs = remainingTxs.tail
           }
 
-          if (dependsOn(deferredOutputs)) {
+          if (dependsOn(deferredOutputs) || dependsOn(feeOutputIds)) {
             // Preserve descendants for a later candidate when their dependencies are available.
             deferTx()
           } else if (!inputsNotSpent(tx, stateWithTxs) || doublespend(allCurrent, tx)) {
@@ -1078,8 +1164,7 @@ object CandidateGenerator extends ScorexLogging {
                 softFieldsAllowed)
             }
 
-            def collectFeeAndCheckLimits(newTxs: Seq[CostedTransaction],
-                                         inputTx: Boolean,
+            def collectFeeAndCheckLimits(inputTx: Boolean,
                                          costConsumed: Int): Boolean = {
               val otherPartition = if (inputTx) currentOrdering else currentInput
               val otherOutputs = otherPartition.flatMap(_.outputs).map(b => bytesToId(b.id)).toSet
@@ -1089,56 +1174,30 @@ object CandidateGenerator extends ScorexLogging {
                 deferTx()
                 return true
               }
-              val newBoxes = newTxs.flatMap(_._1.outputs)
-
-              collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
-                case Some(feeTx) =>
-                  val boxesToSpend = feeTx.inputs.flatMap(i =>
-                    newBoxes.find(b => java.util.Arrays.equals(b.id, i.boxId))
-                  )
-                  feeTx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier) match {
-                    case Success(cost) =>
-                      val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
-                      if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                        if (inputTx) {
-                          accInput += ((tx, costConsumed))
-                          lastFeeTx = Some(feeTx -> cost)
-                        } else {
-                          accOrdering += ((tx, costConsumed))
-                          lastFeeTx = Some(feeTx -> cost)
-                        }
-                        remainingTxs = remainingTxs.tail
-                        true // continue
-                      } else {
-                        lazy val totalCost = (accOrdering ++ lastFeeTx.toSeq).map(_._2).sum
-                        log.debug(s"Finishing block assembly on limits overflow, " +
-                                  s"cost is $totalCost, cost limit: $maxBlockCost")
-                        done = true
-                        false // stop
-                      }
-                    case Failure(e) =>
-                      log.warn(
-                        s"Fee collecting tx is invalid, not including it, " +
-                          s"details: ${e.getMessage} from ${stateWithTxs.stateContext}"
-                      )
-                      done = true
-                      false // stop
-                  }
-                case None =>
-                  log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
-                  val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
-                  if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                    if (inputTx) {
-                      accInput += ((tx, costConsumed))
-                    } else {
-                      accOrdering += ((tx, costConsumed))
-                    }
+              val costed = tx -> costConsumed
+              if (inputTx) {
+                if (correctLimits(accInput :+ costed, maxBlockCost, maxBlockSize, version) &&
+                  correctLimits(prefix ++ accInput :+ costed,
+                    math.min(orderingCostLimit, upcomingContext.currentParameters.maxBlockCost.toLong),
+                    maxBlockSize, version)) {
+                  accInput += costed
+                  remainingTxs = remainingTxs.tail
+                  true
+                } else {
+                  done = true
+                  false
+                }
+              } else {
+                feesFor(accOrdering :+ costed) match {
+                  case Some(fees) =>
+                    accOrdering += costed
+                    lastFeeTxs = fees
                     remainingTxs = remainingTxs.tail
-                    true // continue
-                  } else {
+                    true
+                  case None =>
                     done = true
-                    false // stop
-                  }
+                    false
+                }
               }
             }
 
@@ -1151,14 +1210,12 @@ object CandidateGenerator extends ScorexLogging {
             // Check validity and calculate transaction cost
             validateTx(softFieldsAllowed = !inputBlocksEnabled) match {
               case Success(costConsumed) =>
-                val newTxs = acc :+ (tx -> costConsumed)
-                collectFeeAndCheckLimits(newTxs, inputTx = inputBlocksEnabled, costConsumed)
+                collectFeeAndCheckLimits(inputTx = inputBlocksEnabled, costConsumed)
               case Failure(e) if inputBlocksEnabled && e.isInstanceOf[SoftFieldsAccessError] =>
                 log.info(s"Rechecking transaction: $tx.id")
                 validateTx(softFieldsAllowed = true) match {
                   case Success(costConsumed) =>
-                    val newTxs = acc :+ (tx -> costConsumed)
-                    collectFeeAndCheckLimits(newTxs, inputTx = false, costConsumed)
+                    collectFeeAndCheckLimits(inputTx = false, costConsumed)
                   case Failure(e) =>
                     failTx(e)
                 }
@@ -1171,10 +1228,16 @@ object CandidateGenerator extends ScorexLogging {
       }
     }
 
-    val res = (accInput.map(_._1), accOrdering.map(_._1), invalidTxs)
+    val res = (accInput.map(_._1), (accOrdering ++ lastFeeTxs).map(_._1), invalidTxs)
+    val feeProposition = upcomingContext.chainSettings.monetary.feePropositionBytes
+    val unclaimed = ErgoState.newBoxes(inputBlockTransactions ++ res._2)
+      .count(b => java.util.Arrays.equals(b.propositionBytes, feeProposition))
+    if (unclaimed > 0) {
+      log.warn(s"Ordering candidate leaves $unclaimed fee boxes unclaimed; they remain in the UTXO set")
+    }
     log.debug(
-      s"Collected ${res._1.length} transactions for block #$currentHeight, " +
-        s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")
+      s"Collected ${res._1.length} input and ${res._2.length} ordering transactions for block #$currentHeight, " +
+        s"invalid transaction ids (total:${res._3.length}): ${res._3}")
 
     res
   }

--- a/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
+++ b/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.mining
 
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Props, Stash}
 import akka.pattern.StatusReply
-import org.ergoplatform.AutolykosSolution
+import org.ergoplatform.{AutolykosSolution, SolutionFound}
 import org.ergoplatform.mining.CandidateGenerator.GenerateCandidate
 import org.ergoplatform.nodeView.state.DigestState
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetDataFromCurrentView
@@ -191,6 +191,9 @@ class ErgoMiner(
       minerState.candidateGeneratorRef forward genCandidate
 
     case solution: AutolykosSolution =>
+      minerState.candidateGeneratorRef forward solution
+
+    case solution: SolutionFound =>
       minerState.candidateGeneratorRef forward solution
 
     case ReadMinerPk => // used in /mining/rewardAddress API method

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1291,35 +1291,22 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
    * Key: input block id
    * Value: InputBlockDiffData containing creation time, weak transaction IDs, and cached transactions
    *
-   * Entries are automatically cleaned up after LocalInputBlockChunksTTL (10 minutes) to prevent memory exhaustion.
+   * Entry and retained-weight budgets apply globally and per remote address, in addition to expiry.
    */
-  private val localInputBlockChunks = mutable.Map[ModifierId, ErgoNodeViewSynchronizer.InputBlockDiffData]()
+  private val localInputBlockChunks = new InputBlockPendingCache(
+    InputBlockPendingCache.MaxEntries, InputBlockPendingCache.MaxPeerEntries,
+    InputBlockPendingCache.MaxWeight, InputBlockPendingCache.MaxPeerWeight,
+    ErgoNodeViewSynchronizer.LocalInputBlockChunksTTL.toMillis)
+
+  private def inputBlockPeerKey(remote: ConnectedPeer): String =
+    Option(remote.connectionId.remoteAddress.getAddress)
+      .fold(remote.connectionId.remoteAddress.getHostString)(_.getHostAddress)
 
   /**
-   * Cleanup old entries from localInputBlockChunks cache.
-   *
-   * This method removes entries that have been in the cache longer than LocalInputBlockChunksTTL.
-   * It should be called periodically to prevent memory exhaustion from stale entries.
-   *
-   * Algorithm:
-   * 1. Calculate the cutoff time (current time - TTL)
-   * 2. Filter out entries older than the cutoff time
-   * 3. Log the number of cleaned entries for monitoring
+   * Release expired entries even when no further reads or admissions occur.
    */
   private def cleanupLocalInputBlockChunks(): Unit = {
-    val now = System.currentTimeMillis()
-    val cutoffTime = now - ErgoNodeViewSynchronizer.LocalInputBlockChunksTTL.toMillis
-
-    val oldEntries = localInputBlockChunks.filter { case (_, data) =>
-      data.created < cutoffTime
-    }
-
-    if (oldEntries.nonEmpty) {
-      oldEntries.keys.foreach { id =>
-        localInputBlockChunks.remove(id)
-      }
-      log.debug(s"Cleaned up ${oldEntries.size} expired local input block chunk entries")
-    }
+    localInputBlockChunks.prune()
   }
 
   private def weakIdsDiff(mp: ErgoMemPoolReader,
@@ -1355,15 +1342,18 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
                                             onMissing: Seq[WeakId] => Unit): Unit = {
     val (diff, mempoolTxs) = weakIdsDiff(mp, wIds)
     if (diff.isEmpty) {
+      localInputBlockChunks.remove(subBlockId)
       onReady(mempoolTxs)
     } else {
       val ibdd = InputBlockDiffData(System.currentTimeMillis(), wIds, mempoolTxs)
-      localInputBlockChunks.put(subBlockId, ibdd)
-
-      val req = InputBlockTransactionsRequest(subBlockId, diff)
-      val msg = Message(InputBlockTransactionsRequestMessageSpec, Right(req), None)
-      networkControllerRef ! SendToNetwork(msg, SendToPeer(remote))
-      onMissing(diff)
+      if (localInputBlockChunks.put(subBlockId, ibdd, inputBlockPeerKey(remote), remote.handlerRef.toString)) {
+        val req = InputBlockTransactionsRequest(subBlockId, diff)
+        val msg = Message(InputBlockTransactionsRequestMessageSpec, Right(req), None)
+        networkControllerRef ! SendToNetwork(msg, SendToPeer(remote))
+        onMissing(diff)
+      } else {
+        log.debug(s"Deferring input block $subBlockId while pending synchronization budget is full")
+      }
     }
   }
 
@@ -1744,6 +1734,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       }
 
       if (allFound) {
+        localInputBlockChunks.remove(subBlockId)
         val res = InputBlockTransactionsData(subBlockId, resTxs)
         viewHolderRef ! ProcessInputBlockTransactions(res)
       } else {
@@ -1998,6 +1989,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
     case DisconnectedPeer(connectedPeer) =>
       syncTracker.clearStatus(connectedPeer)
+      localInputBlockChunks.removeConnection(connectedPeer.handlerRef.toString)
   }
 
   protected def sendLocalSyncInfo(historyReader: ErgoHistory): Receive = {
@@ -2262,6 +2254,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
       if (historyReader.fullBlockHeight > 0) {
         log.warn(s"Chain is stuck! $error\nDelivery tracker State:\n$deliveryTracker\nSync tracker state:\n$syncTracker")
         deliveryTracker.reset()
+        localInputBlockChunks.clear()
       } else {
         log.debug("Got ChainIsStuck signal when no full-blocks applied yet")
       }

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -75,7 +75,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private var syncInfoV1CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV1)] = Option.empty
 
-  private var syncInfoV2CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV2)] = Option.empty
+  private val syncInfoV2Cache = new SyncInfoV2Cache
 
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 
@@ -315,14 +315,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   /** Get V2 sync info from cache or load it from history and add to cache */
   private def getV2SyncInfo(history: ErgoHistory, full: Boolean): ErgoSyncInfoV2 = {
-    val headersHeight = history.headersHeight
-    syncInfoV2CacheByHeadersHeight
-      .collect { case (height, syncInfo) if height == headersHeight => syncInfo }
-      .getOrElse {
-        val v2SyncInfo = history.syncInfoV2(full)
-        syncInfoV2CacheByHeadersHeight = Some(headersHeight -> v2SyncInfo)
-        v2SyncInfo
-      }
+    syncInfoV2Cache.getOrElseUpdate(history.bestHeaderIdOpt, full)(history.syncInfoV2(full))
   }
 
   /**
@@ -1658,6 +1651,22 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
+  /** Single-entry cache owned by the synchronizer actor. */
+  private[network] final class SyncInfoV2Cache {
+    private var cached: Option[(Option[ModifierId], Boolean, ErgoSyncInfoV2)] = None
+
+    def getOrElseUpdate(bestHeaderId: Option[ModifierId], full: Boolean)
+                       (build: => ErgoSyncInfoV2): ErgoSyncInfoV2 = {
+      cached.collect {
+        case (tip, mode, info) if tip == bestHeaderId && mode == full => info
+      }.getOrElse {
+        val info = build
+        cached = Some((bestHeaderId, full, info))
+        info
+      }
+    }
+  }
 
   private def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,

--- a/src/main/scala/org/ergoplatform/network/InputBlockPendingCache.scala
+++ b/src/main/scala/org/ergoplatform/network/InputBlockPendingCache.scala
@@ -1,0 +1,90 @@
+package org.ergoplatform.network
+
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.InputBlockDiffData
+import org.ergoplatform.network.message.MessageConstants
+import org.ergoplatform.settings.Parameters
+import scorex.util.ModifierId
+
+import scala.collection.mutable
+
+/** Actor-confined pending transaction diffs. Limits are local resource policy, not consensus rules. */
+private[network] final class InputBlockPendingCache(maxEntries: Int,
+                                                   maxPeerEntries: Int,
+                                                   maxWeight: Long,
+                                                   maxPeerWeight: Long,
+                                                   ttlMillis: Long,
+                                                   clock: () => Long = () => System.currentTimeMillis()) {
+  require(maxEntries > 0 && maxPeerEntries > 0 && maxWeight > 0 && maxPeerWeight > 0 && ttlMillis > 0)
+
+  private case class Entry(data: InputBlockDiffData, owner: String, connection: String, weight: Long)
+  private val entries = mutable.Map.empty[ModifierId, Entry]
+  private var totalWeight = 0L
+
+  def size: Int = entries.size
+  def retainedWeight: Long = totalWeight
+
+  def get(id: ModifierId): Option[InputBlockDiffData] = {
+    prune()
+    entries.get(id).map(_.data)
+  }
+
+  /** Reject overflow without evicting another in-flight request. Replacements retain their original deadline. */
+  def put(id: ModifierId, data: InputBlockDiffData, owner: String, connection: String): Boolean = {
+    prune()
+    val previous = entries.get(id)
+    val weight = InputBlockPendingCache.weightOf(data)
+    val owned = entries.valuesIterator.filter(_.owner == owner).toVector
+    val priorWeight = previous.fold(0L)(_.weight)
+    val added = if (previous.isDefined) 0 else 1
+    if (previous.exists(p => p.owner != owner || p.connection != connection) ||
+        entries.size + added > maxEntries || owned.size + added > maxPeerEntries ||
+        weight > maxWeight - (totalWeight - priorWeight) ||
+        weight > maxPeerWeight - (owned.map(_.weight).sum - priorWeight)) {
+      false
+    } else {
+      val retained = previous.fold(data)(p => data.copy(created = p.data.created))
+      entries.put(id, Entry(retained, owner, connection, weight))
+      totalWeight += weight - priorWeight
+      true
+    }
+  }
+
+  def remove(id: ModifierId): Unit = {
+    entries.remove(id).foreach(e => totalWeight -= e.weight)
+  }
+
+  def removeConnection(connection: String): Unit = {
+    entries.iterator.collect { case (id, e) if e.connection == connection => id }.toVector.foreach(remove)
+  }
+
+  def prune(): Unit = {
+    val now = clock()
+    entries.iterator.collect {
+      case (id, e) if now - e.data.created >= ttlMillis => id
+    }.toVector.foreach(remove)
+  }
+
+  def clear(): Unit = {
+    entries.clear()
+    totalWeight = 0L
+  }
+}
+
+private[network] object InputBlockPendingCache {
+  // Allow two default-length chains from one address and eight globally. These are local
+  // concurrency limits, not restrictions on the number of input blocks a chain may contain.
+  val MaxEntries: Int = 8 * Parameters.SubsPerBlockDefault
+  val MaxPeerEntries: Int = 2 * Parameters.SubsPerBlockDefault
+  // A weak ID occupies 6 wire bytes but is charged 38 retained bytes. Eight transport
+  // envelopes per peer leave room for this expansion and ordinary cached transactions.
+  // The shared budget is twice that (~250 MiB). Overflow defers new work; it never evicts
+  // another in-flight entry. Weight includes shared references and object allowances;
+  // it is an accounting proxy, not an exact JVM heap-size measurement or a consensus limit.
+  val MaxPeerWeight: Long = 8L * MessageConstants.MaxMessageSize
+  val MaxWeight: Long = 2L * MaxPeerWeight
+
+  def weightOf(data: InputBlockDiffData): Long = {
+    256L + data.weakTxsIds.foldLeft(0L)((sum, id) => sum + 32L + id.length) +
+      data.txs.foldLeft(0L)((sum, tx) => sum + 64L + tx.size.toLong)
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -369,6 +369,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
           applyFromCacheLoop(headersCache)
 
+          // Newly accepted headers may unblock sections received before their headers.
+          applyFromCacheLoop(modifiersCache)
+
           val cleared = headersCache.cleanOverfull()
           val upd = BlockSectionsProcessingCacheUpdate(
             headersCache.size,

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -403,8 +403,14 @@ trait ErgoHistoryReader
       }
 
       val headers = offsets.flatMap(offset => bestHeaderAtHeight(h - offset))
+      // Keep a shared starting point in full summaries when it is available locally.
+      val genesisAnchor = if (full) {
+        bestHeaderAtHeight(GenesisHeight).filterNot(genesis => headers.exists(_.id == genesis.id)).toSeq
+      } else {
+        Seq.empty
+      }
 
-      ErgoSyncInfoV2(headers)
+      ErgoSyncInfoV2(headers.toSeq ++ genesisAnchor)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -71,7 +71,7 @@ trait ToDownloadProcessor
             val toDownload = headersAtThisHeight.flatMap(requiredModifiersForHeader).filter { case (mtid, mid) => condition(mtid, mid) }
             // add new modifiers to download to accumulator
             val newAcc = toDownload.foldLeft(acc) { case (newAcc, (mType, mId)) => newAcc.adjust(mType)(_.fold(Vector(mId))(_ :+ mId)) }
-            continuation(height + 1, newAcc, maxHeight)
+            if (height == maxHeight) newAcc else continuation(height + 1, newAcc, maxHeight)
           } else {
             acc
           }
@@ -84,8 +84,21 @@ trait ToDownloadProcessor
         // do not download full blocks if no headers-chain synced yet or SPV mode
         Map.empty
       case Some(fb) if farAwayFromBeingSynced(fb) =>
-        // when far away from blockchain tip
-        continuation(fb.height + 1, Map.empty, fb.height + FullBlocksToDownloadAhead)
+        // A different best headers-chain may need block sections below the old full-chain tip.
+        val commonAncestor = if (isInBestChain(fb.id)) {
+          None
+        } else {
+          val parentSteps = Math.max(0L, nodeSettings.keepVersions.toLong)
+          val limit = Math.min(fb.height.toLong, parentSteps + 1L).toInt
+          headerChainBack(limit, fb.header, h => isInBestChain(h.id)).headOption
+            .filter(h => isInBestChain(h.id))
+        }
+        val fromHeight = commonAncestor
+          .map(h => Math.max(minimalFullBlockHeight, h.height + 1))
+          .getOrElse(fb.height + 1)
+        // Extending the scan backward must preserve forward progress beyond the existing full-chain tip.
+        val maxHeight = Math.min(fb.height.toLong + FullBlocksToDownloadAhead, Int.MaxValue.toLong).toInt
+        continuation(fromHeight, Map.empty, maxHeight)
       case Some(fb) =>
         // when blockchain is about to be synced,
         // download children blocks of last 100 full blocks applied to the best chain, to get block sections from forks

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -265,7 +265,9 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
         defaultMinerPk,
         emptyStateContext
       )
-      txs.length shouldBe 2
+      val feeBoxes = blockTxs.flatMap(_.outputs)
+      val chunkSize = CandidateGenerator.MaxFeeBoxesPerTransaction
+      txs.length shouldBe 1 + (feeBoxes.size + chunkSize - 1) / chunkSize
 
       val emissionTx = txs.head
       emissionTx.outputs.length shouldBe 2
@@ -274,12 +276,16 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
         defaultMinerPk
       )
 
-      val feeTx = txs.last
-      feeTx.outputs.length shouldBe 1
-      feeTx.outputs.head.value shouldBe blockTxs.flatMap(_.outputs).map(_.value).sum
-      feeTx.outputs.head.propositionBytes shouldEqual expectedRewardOutputScriptBytes(
-        defaultMinerPk
-      )
+      val feeTxs = txs.tail
+      feeTxs.foreach { feeTx =>
+        feeTx.inputs.length should be <= chunkSize
+        feeTx.outputs.length shouldBe 1
+        feeTx.outputs.head.propositionBytes shouldEqual expectedRewardOutputScriptBytes(defaultMinerPk)
+      }
+      feeTxs.flatMap(_.outputs).map(_.value).sum shouldBe feeBoxes.map(_.value).sum
+      val spent = feeTxs.flatMap(_.inputs).map(in => in.boxId.toSeq)
+      spent.distinct.size shouldBe spent.size
+      spent.toSet shouldBe feeBoxes.map(_.id.toSeq).toSet
     }
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -159,7 +159,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
           upcomingContext,
           Seq(head)
         )
-        ._1
+        ._2
       fromSmallMempool.size shouldBe 2
       fromSmallMempool.contains(head) shouldBe true
 
@@ -172,7 +172,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
           upcomingContext,
           txsWithFees
         )
-        ._1
+        ._2
 
       val newBoxes = fromBigMempool.flatMap(_.outputs)
       val costs: Seq[Int] = fromBigMempool.map { tx =>
@@ -320,7 +320,8 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Verify we collected some transactions
-    result._1.length should be > 0
+    result._1 shouldBe empty
+    result._2.length should be > 0
     // Invalid transactions should be tracked
     result._3.length should be >= 0
   }
@@ -429,6 +430,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     invalid shouldBe empty
+    inputCollected shouldBe empty
     (inputCollected ++ orderingCollected) should contain theSameElementsAs zeroFeeTxs
   }
 
@@ -505,11 +507,12 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // At least tx3 should be included (non-conflicting)
-    result._1.exists(_.id sameElements tx3.id) shouldBe true
+    result._1 shouldBe empty
+    result._2.exists(_.id sameElements tx3.id) shouldBe true
     
     // At most 2 transactions should be included (one of tx1/tx2, plus tx3)
-    result._1.length should be <= 2
-    result._1.length should be >= 1
+    result._2.length should be <= 2
+    result._2.length should be >= 1
 
     // At least one of the conflicting txs should be in invalid list (result._3)
     // Both result._3 and tx.id are ModifierId (String type)
@@ -561,7 +564,8 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Valid transaction should be collected
-    result._1.exists(_.id sameElements validTx.id) shouldBe true
+    result._1 shouldBe empty
+    result._2.exists(_.id sameElements validTx.id) shouldBe true
     // Invalid transaction should be in the invalid list (result._3)
     result._3.contains(invalidTx.id) shouldBe true
   }
@@ -640,11 +644,12 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Should have collected some transactions but not all
-    result._1.length should be > 0
-    result._1.length should be < manyTxs.length
+    result._1 shouldBe empty
+    result._2.length should be > 0
+    result._2.length should be < manyTxs.length
 
     // Verify total cost doesn't exceed limit
-    val totalCost = result._1.map { tx =>
+    val totalCost = result._2.map { tx =>
       us.validateWithCost(tx, upcomingContext, Int.MaxValue, Some(verifier), true).getOrElse(0)
     }.sum
 
@@ -690,11 +695,12 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Should have collected some transactions but not all
-    result._1.length should be > 0
-    result._1.length should be < manyTxs.length
+    result._1 shouldBe empty
+    result._2.length should be > 0
+    result._2.length should be < manyTxs.length
 
     // Verify total size doesn't exceed limit
-    val totalSize = result._1.map(_.size).sum
+    val totalSize = result._2.map(_.size).sum
     totalSize should be <= smallSizeLimit
   }
 
@@ -740,7 +746,8 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Should collect all valid transactions
-    validTxs.foreach(tx => result._1.exists(_.id sameElements tx.id) shouldEqual true)
+    result._1 shouldBe empty
+    validTxs.foreach(tx => result._2.exists(_.id sameElements tx.id) shouldEqual true)
 
     // At least one double-spend should be in invalid list (result._3)
     result._3.length should be >= 1

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.mining
 
+import com.google.common.io.Files.createTempDir
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
@@ -21,7 +22,7 @@ import org.ergoplatform.nodeView.state.{StateType, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedOrderingBlock}
 import org.ergoplatform.settings.NetworkType.DevNet60
-import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader, NetworkType}
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.utils.generators.ValidBlocksGenerators.{createUtxoState, validFullBlock, validTransactionsFromBoxHolder}
 import org.ergoplatform.utils.generators.ChainGenerator.{applyChain, genHeaderChain}
@@ -50,6 +51,31 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   private val candidateGenDelay: FiniteDuration    = 3.seconds
   private val blockValidationDelay: FiniteDuration = 2.seconds
 
+  private val actorSystems = scala.collection.mutable.ArrayBuffer.empty[ActorSystem]
+
+  private def newActorSystem(): ActorSystem = {
+    val system = ActorSystem()
+    actorSystems += system
+    system
+  }
+
+  override protected def withFixture(test: NoArgTest): org.scalatest.Outcome = {
+    try super.withFixture(test)
+    finally {
+      val systemsToStop = actorSystems.toVector
+      actorSystems.clear()
+      systemsToStop.foreach(system => TestKit.shutdownActorSystem(system))
+    }
+  }
+
+  private def expectOrderingBlockApplied(replyProbe: TestProbe, blockProbe: TestProbe, block: ErgoFullBlock): Unit = {
+    replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
+    blockProbe.fishForMessage(newBlockDelay) {
+      case FullBlockApplied(header) => header.id == block.header.id
+      case _ => false
+    }
+  }
+
   val defaultSettings: ErgoSettings = {
     val empty = ErgoSettingsReader.read()
     val nodeSettings = empty.nodeSettings.copy(
@@ -60,13 +86,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       verifyTransactions           = true
     )
     val chainSettings = empty.chainSettings.copy(blockInterval = 1.seconds)
-    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings)
+    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings, networkType = NetworkType.Tests)
   }
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
@@ -90,7 +116,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
@@ -160,8 +186,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "let multiple miners compete" in new TestKit(ActorSystem()) {
+  it should "let multiple miners compete" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
+    val countProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
     val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
@@ -184,25 +211,27 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
 
-    m1.tell(ErgoMiningThread.GetSolvedBlocksCount, testProbe.ref)
+    eventually(timeout(newBlockDelay), interval(100.millis)) {
+      m1.tell(ErgoMiningThread.GetSolvedBlocksCount, countProbe.ref)
 
-    val m1Count =
-      testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
-    m2.tell(ErgoMiningThread.GetSolvedBlocksCount, testProbe.ref)
+      val m1Count =
+        countProbe.expectMsgClass(candidateGenDelay, classOf[ErgoMiningThread.SolvedBlocksCount])
+      m2.tell(ErgoMiningThread.GetSolvedBlocksCount, countProbe.ref)
 
-    val m2Count =
-      testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
-    m3.tell(ErgoMiningThread.GetSolvedBlocksCount, testProbe.ref)
+      val m2Count =
+        countProbe.expectMsgClass(candidateGenDelay, classOf[ErgoMiningThread.SolvedBlocksCount])
+      m3.tell(ErgoMiningThread.GetSolvedBlocksCount, countProbe.ref)
 
-    val m3Count =
-      testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
+      val m3Count =
+        countProbe.expectMsgClass(candidateGenDelay, classOf[ErgoMiningThread.SolvedBlocksCount])
 
-    List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
+      List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
+    }
     system.terminate()
   }
 
   it should "cache candidate until newly mined block is applied" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
@@ -245,17 +274,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after explicit forced regeneration" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
+    val testDir = s"${defaultSettings.directory}-explicit-forced-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
+          directory = testDir
         )
 
     val viewHolderRef: ActorRef =
@@ -282,21 +318,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
         val block = result match {
           case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+          case other => fail(s"Expected an ordering block solution, got $other")
         }
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // build new transaction that uses miner's reward as input
@@ -320,7 +345,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         .get
     )
 
-    // candidate should be regenerated immediately after a mempool change
+    // Solve the current candidate before explicitly regenerating it with the new transaction.
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
@@ -331,44 +356,39 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
         val block = result match {
           case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+          case other => fail(s"Expected an ordering block solution, got $other")
         }
 
-        // this triggers mempool change that triggers candidate regeneration
+        // Add a transaction before explicitly forcing candidate regeneration.
         viewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(tx, None))
-        expectNoMessage(candidateGenDelay)
-        candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
+        eventually(timeout(candidateGenDelay), interval(100.millis)) {
+          await((readersHolderRef ? GetReaders).mapTo[Readers]).m.contains(tx.id) shouldBe true
+          System.currentTimeMillis() should be > candidate.candidateBlock.timestamp
+        }
+        candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true, optPk = None), testProbe.ref)
         testProbe.expectMsgPF(candidateGenDelay) {
           case StatusReply.Success(regeneratedCandidate: Candidate) =>
-            // regeneratedCandidate now contains new transaction
-            regeneratedCandidate.candidateBlock shouldNot be(
-              candidate.candidateBlock
-            )
+            regeneratedCandidate.candidateBlock.timestamp should be > candidate.candidateBlock.timestamp
+            regeneratedCandidate.candidateBlock.transactions.map(_.id) should contain(tx.id)
+            block.header.version shouldBe Header.InitialVersion
+            powScheme.validate(block.header).isSuccess shouldBe true
+            val currentBlock = CandidateGenerator.completeOrderingBlock(regeneratedCandidate.candidateBlock, block.header.powSolution)
+            powScheme.validate(currentBlock.header).isFailure shouldBe true
         }
 
         // we are submitting solution for previous candidate
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
     system.terminate()
   }
 
   it should "pool transactions should be removed from pool when block is mined" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
     val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
@@ -400,17 +420,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // build new transaction that uses miner's reward as input
@@ -449,17 +459,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         testProbe.expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // new transaction should be cleared from pool after applying new block
@@ -477,12 +477,40 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "6.0 pool transactions should be added to 6.0 block" in new TestKit(
-    ActorSystem()
+  it should "include version 6 script transactions through an input block and subsequent ordering block" in new TestKit(
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
+    val settings60 = defaultSettings60.copy(
+      directory = createTempDir.getAbsolutePath,
+      chainSettings = defaultSettings60.chainSettings.copy(
+        initialDifficultyHex = "0080",
+        powScheme = new AutolykosPowScheme(
+          defaultSettings60.chainSettings.powScheme.k,
+          defaultSettings60.chainSettings.powScheme.n
+        )
+      )
+    )
+    val powScheme = settings60.chainSettings.powScheme
+
+    def mine(candidate: Candidate, inputBlock: Boolean): ErgoFullBlock = {
+      val deadline = 30.seconds.fromNow
+      var nonce = 0L
+      while (nonce < 100000L && deadline.hasTimeLeft()) {
+        powScheme.proveCandidate(candidate.candidateBlock, defaultMinerSecret.w,
+          nonce, nonce + 1L, candidate.parameters) match {
+          case org.ergoplatform.OrderingBlockFound(block) if !inputBlock => return block
+          case org.ergoplatform.InputBlockFound(block) if inputBlock => return block
+          case _ => ()
+        }
+        nonce += 1L
+      }
+      fail(s"No ${if (inputBlock) "input" else "ordering"} solution within $nonce nonces and 30 seconds")
+    }
+
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings60)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -490,7 +518,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings60
+        settings60
       )
 
     val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
@@ -502,28 +530,12 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val result = defaultSettings.chainSettings.powScheme
-          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
-        val block = result match {
-          case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
-        }
+        val block = mine(candidate, inputBlock = false)
         // let's pretend we are mining at least a bit so it is realistic
         expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // build new transaction that uses miner's reward as input
@@ -557,36 +569,42 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       inputs = IndexedSeq(new Input(spendingBox.id, emptyProverResult)),
       outputCandidates = IndexedSeq(o2))
 
-    testProbe.expectNoMessage(200.millis)
-    // mine a block with that transaction
-    candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false, optPk = None), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(candidate: Candidate) =>
-        val result = defaultSettings.chainSettings.powScheme
-          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
-        val block = result match {
-          case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
-        }
-        testProbe.expectNoMessage(200.millis)
-        candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
+    candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = true, optPk = None), testProbe.ref)
+    val inputCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) => candidate
+    }
+    inputCandidate.candidateBlock.version shouldBe Header.Interpreter60Version
+    inputCandidate.candidateBlock.inputBlockTransactions.map(_.id) should contain theSameElementsInOrderAs Seq(tx.id, tx2.id)
+    val inputBlock = mine(inputCandidate, inputBlock = true)
+    candidateGenerator.tell(org.ergoplatform.InputSolutionFound(inputBlock.header.powSolution), testProbe.ref)
+    testProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+    eventually(timeout(newBlockDelay), interval(100.millis)) {
+      val updatedReaders = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      updatedReaders.h.bestInputBlock().map(_.id) shouldBe Some(inputBlock.id)
+      updatedReaders.h.getBestOrderingCollectedInputBlocksTransactions().map(_.id) should contain theSameElementsInOrderAs Seq(tx.id, tx2.id)
+      val confirmedState = updatedReaders.s.asInstanceOf[UtxoStateReader]
+      confirmedState.boxById(rewardBox.id) shouldBe Some(rewardBox)
+      tx2.outputs.foreach(o => confirmedState.boxById(o.id) shouldBe None)
     }
 
-    // new transactions should be cleared from pool after applying new block
-    await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 0
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true, optPk = None), testProbe.ref)
+    val orderingCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) => candidate
+    }
+    orderingCandidate.candidateBlock.transactions.map(_.id) should contain allOf (tx.id, tx2.id)
+    orderingCandidate.candidateBlock.inputBlockTransactions shouldBe empty
+    val orderingBlock = mine(orderingCandidate, inputBlock = false)
+    candidateGenerator.tell(OrderingSolutionFound(orderingBlock.header.powSolution), testProbe.ref)
+    expectOrderingBlockApplied(testProbe, blockProbe, orderingBlock)
+
+    // These transactions were supplied directly as mandatory candidates.
+    val confirmedReaders = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    confirmedReaders.m.size shouldBe 0
+    val confirmedState = confirmedReaders.s.asInstanceOf[UtxoStateReader]
+    confirmedState.boxById(rewardBox.id) shouldBe None
+    confirmedState.boxById(spendingBox.id) shouldBe None
+    tx2.outputs.foreach(o => confirmedState.boxById(o.id) shouldBe Some(o))
 
     // validate total amount of transactions created
     val blocks: IndexedSeq[ErgoFullBlock] = readers.h
@@ -603,7 +621,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "use custom miner public key when provided via optPk" in new TestKit(ActorSystem()) {
+  it should "use custom miner public key when provided via optPk" in new TestKit(newActorSystem()) {
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
@@ -643,7 +661,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "use default minerPk when optPk is None" in new TestKit(ActorSystem()) {
+  it should "use default minerPk when optPk is None" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
@@ -675,7 +693,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "generate different candidates for different optPk values" in new TestKit(ActorSystem()) {
+  it should "generate different candidates for different optPk values" in new TestKit(newActorSystem()) {
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
@@ -725,7 +743,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "handle optPk with empty transactions" in new TestKit(ActorSystem()) {
+  it should "handle optPk with empty transactions" in new TestKit(newActorSystem()) {
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
@@ -764,7 +782,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
+  it should "ignore cached candidate when forced = true" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
@@ -772,6 +790,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
@@ -839,18 +858,23 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {
+  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
     val testDir = s"${defaultSettings.directory}-preserve-candidate-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
           directory = testDir
         )
 
@@ -875,22 +899,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     val initBlock = powScheme
       .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000, initCandidate.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
     candidateGenerator.tell(OrderingSolutionFound(initBlock.header.powSolution), testProbe.ref)
-    // Wait for both the direct mining ACK and the async local block application
-    var ackSeen = false
-    var appliedSeen = false
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) =>
-        ackSeen = true
-        ackSeen && appliedSeen
-      case FullBlockApplied(header) if header.id == initBlock.header.id =>
-        appliedSeen = true
-        ackSeen && appliedSeen
-      case _ => false
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, initBlock)
 
     // Get first candidate after chain is established
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -899,48 +911,56 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // Force regeneration - this should preserve candidate1 as cachedPreviousCandidate
-    val candidate2 = eventually(timeout(candidateGenDelay), interval(100.millis)) {
-      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-      testProbe.expectMsgPF(500.millis) {
-        case StatusReply.Success(c: Candidate) => c
-      }
+    eventually(timeout(candidateGenDelay), interval(1.millis)) {
+      System.currentTimeMillis() should be > candidate1.candidateBlock.timestamp
+    }
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+    val candidate2 = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
     }
 
     // candidate2 should be different from candidate1 (regenerated)
-    candidate2.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    candidate2.candidateBlock.timestamp should be > candidate1.candidateBlock.timestamp
 
     // Solve a block using candidate1 (the "previous" candidate)
     val solvedBlock = powScheme
       .proveCandidate(candidate1.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate1.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
+
+    // Real version 1 PoW binds the solution to the previous candidate's header.
+    solvedBlock.header.version shouldBe Header.InitialVersion
+    powScheme.validate(solvedBlock.header).isSuccess shouldBe true
+    val currentBlock = CandidateGenerator.completeOrderingBlock(candidate2.candidateBlock, solvedBlock.header.powSolution)
+    powScheme.validate(currentBlock.header).isFailure shouldBe true
 
     // Submit solution - should succeed because candidate1 should be in cachedPreviousCandidate
     candidateGenerator.tell(OrderingSolutionFound(solvedBlock.header.powSolution), testProbe.ref)
 
-    // CandidateGenerator should accept the solution against cachedPreviousCandidate.
-    testProbe.expectMsgPF(blockValidationDelay) {
-      case StatusReply.Success(()) =>
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, solvedBlock)
 
     system.terminate()
   }
 
-  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(ActorSystem()) {
+  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
     // Use unique directory to avoid state conflicts
     val testDir = s"${defaultSettings.directory}-multi-forced-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
           directory = testDir
         )
 
@@ -965,22 +985,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     val initBlock = powScheme
       .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000, initCandidate.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
     candidateGenerator.tell(OrderingSolutionFound(initBlock.header.powSolution), testProbe.ref)
-    // Wait for both StatusReply and FullBlockApplied messages
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case _: FullBlockApplied => true
-      case _ => false
-    }
-    // Try to consume the second message if it exists
-    try {
-      testProbe.expectMsgClass(1.second, classOf[Any])
-    } catch {
-      case _: AssertionError => // No more messages, that's fine
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, initBlock)
 
     // Now get candidate after chain is established
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -989,6 +997,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // Force regenerate first time
+    eventually(timeout(candidateGenDelay), interval(1.millis)) {
+      System.currentTimeMillis() should be > candidate1.candidateBlock.timestamp
+    }
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
     val candidate2 = testProbe.fishForMessage(candidateGenDelay) {
       case StatusReply.Success(_: Candidate) => true
@@ -998,6 +1009,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // Force regenerate second time
+    eventually(timeout(candidateGenDelay), interval(1.millis)) {
+      System.currentTimeMillis() should be > candidate2.candidateBlock.timestamp
+    }
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
     val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
       case StatusReply.Success(_: Candidate) => true
@@ -1006,31 +1020,31 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case StatusReply.Success(c: Candidate) => c
     }
 
-    // All candidates should have increasing or equal timestamps
-    candidate2.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-    candidate3.candidateBlock.timestamp should be >= candidate2.candidateBlock.timestamp
+    // Each regeneration must produce a distinct header.
+    candidate2.candidateBlock.timestamp should be > candidate1.candidateBlock.timestamp
+    candidate3.candidateBlock.timestamp should be > candidate2.candidateBlock.timestamp
 
     // Solve block with candidate2 (should be in cachedPreviousCandidate after candidate3 generation)
     val solvedBlock = powScheme
       .proveCandidate(candidate2.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate2.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
+
+    // The latest candidate must reject this real solution so the previous candidate is used.
+    solvedBlock.header.version shouldBe Header.InitialVersion
+    powScheme.validate(solvedBlock.header).isSuccess shouldBe true
+    val currentBlock = CandidateGenerator.completeOrderingBlock(candidate3.candidateBlock, solvedBlock.header.powSolution)
+    powScheme.validate(currentBlock.header).isFailure shouldBe true
 
     candidateGenerator.tell(OrderingSolutionFound(solvedBlock.header.powSolution), testProbe.ref)
 
-    // Should successfully apply the block
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case _: FullBlockApplied => true
-      case _ => false
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, solvedBlock)
 
     system.terminate()
   }
 
-  it should "return cached candidate immediately when forced = false" in new TestKit(ActorSystem()) {
+  it should "return cached candidate immediately when forced = false" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
@@ -1071,18 +1085,23 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after explicit forced regeneration following mempool admission" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
     val testDir = s"${defaultSettings.directory}-mempool-forced-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 100.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
           directory = testDir
         )
 
@@ -1102,43 +1121,36 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val bootstrapBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val result = defaultSettings.chainSettings.powScheme
+        val result = powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
         val block = result match {
           case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+          case other => fail(s"Expected an ordering block solution, got $other")
         }
         // let's pretend we are mining at least a bit so it is realistic
         expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
+        block
     }
 
-    // Get candidate and solve it
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidateToSolve = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+    // The block probe can observe application before the generator updates its cache.
+    val candidateToSolve = eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate.candidateBlock.parentOpt.map(_.id) shouldBe Some(bootstrapBlock.id)
+      candidate
     }
 
     val solvedBlock = powScheme
       .proveCandidate(candidateToSolve.candidateBlock, defaultMinerSecret.w, 0, 1000, candidateToSolve.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
 
     // Build new transaction to trigger mempool change
@@ -1161,35 +1173,36 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Submit transaction to mempool
     viewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(tx, None))
 
-    // Wait for candidate to be regenerated with new tx
-    testProbe.expectNoMessage(200.millis)
+    eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      await((readersHolderRef ? GetReaders).mapTo[Readers]).m.contains(tx.id) shouldBe true
+      System.currentTimeMillis() should be > candidateToSolve.candidateBlock.timestamp
+    }
 
-    // Request new candidate - should be regenerated due to mempool change
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+    // Explicitly regenerate after the transaction has entered the mempool.
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
     val regeneratedCandidate = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(c: Candidate) => c
     }
 
-    // Should include the new transaction
-    regeneratedCandidate.candidateBlock.transactions.size should be >= candidateToSolve.candidateBlock.transactions.size
+    regeneratedCandidate.candidateBlock.timestamp should be > candidateToSolve.candidateBlock.timestamp
+    regeneratedCandidate.candidateBlock.transactions.map(_.id) should contain(tx.id)
+    solvedBlock.header.version shouldBe Header.InitialVersion
+    powScheme.validate(solvedBlock.header).isSuccess shouldBe true
+    val currentBlock = CandidateGenerator.completeOrderingBlock(regeneratedCandidate.candidateBlock, solvedBlock.header.powSolution)
+    powScheme.validate(currentBlock.header).isFailure shouldBe true
 
     // Submit solution for the old candidate (should still work via cachedPreviousCandidate)
     candidateGenerator.tell(OrderingSolutionFound(solvedBlock.header.powSolution), testProbe.ref)
 
-    // Should successfully apply the block
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != solvedBlock.header.parentId => true
-      case _ => false
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, solvedBlock)
 
     system.terminate()
   }
 
   it should "correctly complete input block from candidate and solution" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
@@ -1204,7 +1217,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       defaultMinerPk,
       Seq.empty,
       None,
-      defaultSettings
+      defaultSettings60
     )
 
     // If we can't generate a candidate (e.g., due to lack of proper history), skip this test
@@ -1284,7 +1297,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   it should "exclude applied transactions from stale mempool and not eliminate them" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
 
     val testDir = s"${defaultSettings.directory}-a1-stale-${System.currentTimeMillis()}"
@@ -1356,7 +1369,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   it should "discard candidate when history and state are out of sync" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
 
     val testDir = s"${defaultSettings.directory}-b1-sync-${System.currentTimeMillis()}"

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -904,10 +904,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(OrderingSolutionFound(initBlock.header.powSolution), testProbe.ref)
     expectOrderingBlockApplied(testProbe, blockProbe, initBlock)
 
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+    // The block probe can observe application before the generator updates its cache.
+    val candidate1 = eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate.candidateBlock.parentOpt.map(_.id) shouldBe Some(initBlock.id)
+      candidate
     }
 
     // Force regeneration - this should preserve candidate1 as cachedPreviousCandidate

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -10,17 +10,17 @@ import org.ergoplatform.mining.ErgoMiner.StartMining
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.FullBlockApplied
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{FailedTransaction, FullBlockApplied}
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.LocallyGeneratedTransaction
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.wallet._
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
-import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader, NetworkType}
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input, OrderingBlockFound, OrderingSolutionFound}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import sigma.ast.{ErgoTree, SigmaAnd, SigmaPropConstant}
@@ -44,6 +44,23 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
   private val candidateGenDelay: FiniteDuration    = 3.seconds
   private val blockValidationDelay: FiniteDuration = 2.seconds
 
+  private val actorSystems = scala.collection.mutable.ArrayBuffer.empty[ActorSystem]
+
+  private def newActorSystem(): ActorSystem = {
+    val system = ActorSystem()
+    actorSystems += system
+    system
+  }
+
+  override protected def withFixture(test: NoArgTest): org.scalatest.Outcome = {
+    try super.withFixture(test)
+    finally {
+      val systemsToStop = actorSystems.toVector
+      actorSystems.clear()
+      systemsToStop.foreach(system => TestKit.shutdownActorSystem(system))
+    }
+  }
+
   private def getWorkMessage(minerRef: ActorRef, mandatoryTransactions: Seq[ErgoTransaction]): WorkMessage =
     await(minerRef.askWithStatus(GenerateCandidate(mandatoryTransactions, reply = true, forced = false, optPk = None)).mapTo[Candidate].map(_.externalVersion))
 
@@ -57,10 +74,10 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
       offlineGeneration = true,
       verifyTransactions = true)
     val chainSettings = empty.chainSettings.copy(blockInterval = 2.seconds)
-    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings)
+    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings, networkType = NetworkType.Tests)
   }
 
-  it should "not include too costly transactions" in new TestKit(ActorSystem()) {
+  it should "not include too costly transactions" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
@@ -95,15 +112,13 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     val unsignedTx = new UnsignedErgoTransaction(IndexedSeq(input), IndexedSeq(), outputs)
     val tx = defaultProver.sign(unsignedTx, IndexedSeq(boxToSpend), IndexedSeq(), r.s.stateContext).get
     nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(ErgoTransaction(tx), None))
-    expectNoMessage(1 seconds)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 0
-
-    //check that tx is included into UTXO set
-    val state = await((readersHolderRef ? GetReaders).mapTo[Readers]).s.asInstanceOf[UtxoState]
-    tx.outputs.foreach(o => state.boxById(o.id).get shouldBe o)
+    val state = eventually(timeout(newBlockDelay), interval(100.millis)) {
+      val readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      readers.m.size shouldBe 0
+      val appliedState = readers.s.asInstanceOf[UtxoState]
+      tx.outputs.foreach(o => appliedState.boxById(o.id) shouldBe Some(o))
+      appliedState
+    }
 
     // try to spend all the boxes with complex scripts
     val costlyInputs = tx.outputs.map(o => Input(o.id, emptyProverResult))
@@ -121,15 +136,17 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
       ).get
     txCost shouldBe 439080
 
+    val rejectionProbe = new TestProbe(system)
+    system.eventStream.subscribe(rejectionProbe.ref, classOf[FailedTransaction])
+
     // send costly transaction to the mempool
     nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(ErgoTransaction(costlyTx), None))
 
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
+    rejectionProbe.expectMsgPF(newBlockDelay) {
+      case FailedTransaction(rejected, _) => rejected.id shouldBe costlyTx.id
+    }
 
-    // costly tx was removed from mempool
-    expectNoMessage(1 second)
+    // costly tx was rejected before mempool admission
     await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 0
     // costly tx was not included
     val state2 = await((readersHolderRef ? GetReaders).mapTo[Readers]).s.asInstanceOf[UtxoState]
@@ -137,7 +154,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     costlyTx.outputs.foreach(o => state2.boxById(o.id) shouldBe None)
   }
 
-  it should "not freeze while mempool is full" in new TestKit(ActorSystem()) {
+  it should "not freeze while mempool is full" in new TestKit(newActorSystem()) {
     // generate amount of transactions, twice more than can fit in one block
     val desiredSize: Int = Math.ceil((parameters.maxBlockCost / ErgoInterpreter.interpreterInitCost) * 1.2).toInt
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
@@ -214,7 +231,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     }
   }
 
-  it should "include only one transaction from 2 spending the same box" in new TestKit(ActorSystem()) {
+  it should "include only one transaction from 2 spending the same box" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
@@ -262,12 +279,13 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     minerRef.tell(GenerateCandidate(Seq(tx2), reply = true, forced = false, optPk = None), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = extractFullBlockFromProveResult(
-          defaultSettings.chainSettings.powScheme
-            .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
-        )
+        val block = defaultSettings.chainSettings.powScheme
+          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters) match {
+          case OrderingBlockFound(fullBlock) => fullBlock
+          case other => fail(s"Expected an ordering block solution, got $other")
+        }
         testProbe.expectNoMessage(200.millis)
-        minerRef.tell(block.header.powSolution, testProbe.ref)
+        minerRef.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
@@ -292,7 +310,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     system.terminate()
   }
 
-  it should "prepare external candidate" in new TestKit(ActorSystem()) {
+  it should "prepare external candidate" in new TestKit(newActorSystem()) {
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
 
     val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings)
@@ -313,7 +331,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     system.terminate()
   }
 
-  it should "include mandatory transactions" in new TestKit(ActorSystem()) {
+  it should "include mandatory transactions" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/ErgoMinerSolutionForwardingSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/ErgoMinerSolutionForwardingSpec.scala
@@ -1,0 +1,70 @@
+package org.ergoplatform.mining
+
+import akka.actor.{ActorSystem, Props}
+import akka.pattern.StatusReply
+import akka.testkit.{TestKit, TestProbe}
+import org.ergoplatform.{AutolykosSolution, InputSolutionFound, OrderingSolutionFound, SolutionFound}
+import org.ergoplatform.mining.ErgoMiner.MinerState
+import org.ergoplatform.settings.ErgoSettingsReader
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sigma.data.ProveDlog
+
+import scala.concurrent.duration._
+
+class ErgoMinerSolutionForwardingSpec
+  extends TestKit(ActorSystem("ErgoMinerSolutionForwardingSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private val settings = ErgoSettingsReader.read()
+  private val publicKey = ProveDlog(genPk(BigInt(1)))
+  private val solution = new AutolykosSolution(
+    publicKey.value,
+    AutolykosSolution.wForV2,
+    Array.fill[Byte](8)(0),
+    AutolykosSolution.dForV2
+  )
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  private def assertForwarded(message: SolutionFound): Unit = {
+    val candidateGenerator = TestProbe()
+    val requester = TestProbe()
+    val unusedReader = TestProbe()
+    val miner = system.actorOf(Props(new ErgoMiner(
+      settings,
+      unusedReader.ref,
+      unusedReader.ref,
+      None
+    ) {
+      // Exercise the production started receive without booting a wallet or miner.
+      override def preStart(): Unit =
+        context.become(started(MinerState(None, publicKey, candidateGenerator.ref)))
+    }))
+
+    try {
+      requester.send(miner, message)
+      candidateGenerator.expectMsg(3.seconds, message)
+      candidateGenerator.lastSender shouldBe requester.ref
+      val accepted = StatusReply.success(())
+      candidateGenerator.reply(accepted)
+      requester.expectMsg(3.seconds, accepted)
+    } finally {
+      system.stop(miner)
+    }
+  }
+
+  "ErgoMiner" should "forward an ordering solution with its original sender and reply" in {
+    assertForwarded(OrderingSolutionFound(solution))
+  }
+
+  it should "forward an input solution with its original sender and reply" in {
+    assertForwarded(InputSolutionFound(solution))
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixFeeSelectionSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixFeeSelectionSpec.scala
@@ -1,0 +1,455 @@
+package org.ergoplatform.mining
+
+import com.google.common.io.Files.createTempDir
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.modifiers.history.BlockTransactions
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.nodeView.state.{BoxHolder, UtxoState}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.{ErgoCompilerHelpers, ErgoCorePropertyTest}
+import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultMinerPk, emptyVSUpdate, parameters}
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import scorex.util.bytesToId
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.interpreter.ProverResult
+
+class MatrixFeeSelectionSpec extends ErgoCorePropertyTest with ErgoCompilerHelpers {
+  private val fee = 1000000L
+  private val delay = settings.chainSettings.monetary.minerRewardDelay
+  private val feeTree = ErgoTreePredef.feeProposition(delay)
+  private val rewardTree = ErgoTreePredef.rewardOutputScript(delay, defaultMinerPk)
+  private val orderingTree = compileSourceV5("CONTEXT.minerPubKey.size >= 0", 0)
+
+  private def box(index: Byte, tree: ErgoTree = TrueTree): ErgoBox = new ErgoBox(
+    value = 1000000000L, ergoTree = tree, creationHeight = 0,
+    additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+    transactionId = bytesToId(Array.fill(32)(index)), index = 0
+  )
+
+  private def payment(source: ErgoBox): ErgoTransaction = ErgoTransaction(
+    IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+    IndexedSeq(
+      new ErgoBoxCandidate(source.value - fee, TrueTree, 1),
+      new ErgoBoxCandidate(fee, feeTree, 1)
+    )
+  )
+
+  private def state(boxes: Seq[ErgoBox], protocolCost: Int = parameters.maxBlockCost): UtxoState =
+    UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, parameters.withBlockCost(protocolCost))
+
+  private def select(boxes: Seq[ErgoBox], transactions: Seq[ErgoTransaction], version: Byte,
+                     prefix: Seq[ErgoTransaction] = Seq.empty,
+                     maxCost: Int = parameters.maxBlockCost,
+                     maxSize: Int = parameters.maxBlockSize,
+                     protocolCost: Int = parameters.maxBlockCost) = {
+    val us = state(boxes, protocolCost)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, version)
+    val result = CandidateGenerator.collectTxs(defaultMinerPk, maxCost,
+      maxSize, us, context, transactions, prefix)
+    Seq(prefix ++ result._1, prefix ++ result._2).filter(_.nonEmpty).foreach { payload =>
+      us.proofsForTransactions(payload).isSuccess shouldBe true
+      payload.foldLeft(Vector.empty[ErgoTransaction]) { (applied, tx) =>
+        us.withTransactions(applied).validateWithCost(tx, context, protocolCost,
+          None, softFieldsAllowed = true).isSuccess shouldBe true
+        applied :+ tx
+      }
+    }
+    result
+  }
+
+  private def payloadCost(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction], version: Byte): Int = {
+    val us = state(boxes, 10000000)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, version)
+    val (_, cost) = txs.foldLeft((Vector.empty[ErgoTransaction], 0)) { case ((applied, total), tx) =>
+      val txCost = us.withTransactions(applied).validateWithCost(tx, context, 10000000,
+        None, softFieldsAllowed = true).get
+      (applied :+ tx, total + txCost)
+    }
+    cost
+  }
+
+  private def sectionSize(txs: Seq[ErgoTransaction]): Int =
+    BlockTransactions(bytesToId(Array.fill[Byte](32)(0)), Header.Interpreter60Version, txs).size
+
+  private def transactionCost(boxes: Seq[ErgoBox], tx: ErgoTransaction,
+                              prefix: Seq[ErgoTransaction] = Seq.empty): Int = {
+    val us = state(boxes)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, Header.Interpreter60Version)
+    us.withTransactions(prefix).validateWithCost(tx, context, parameters.maxBlockCost,
+      None, softFieldsAllowed = true).get
+  }
+
+  private def assertFeeReward(reward: ErgoTransaction, payments: Seq[ErgoTransaction]): Unit = {
+    reward.inputs.map(in => bytesToId(in.boxId)) should contain theSameElementsAs
+      payments.map(tx => bytesToId(tx.outputs.last.id))
+    reward.dataInputs shouldBe empty
+    reward.outputs should have size 1
+    val output = reward.outputs.head
+    output.value shouldBe payments.size.toLong * fee
+    output.value should be > 0L
+    output.propositionBytes.toSeq shouldBe rewardTree.bytes.toSeq
+    output.creationHeight shouldBe 1
+    output.additionalTokens.length shouldBe 0
+  }
+
+  Seq(Header.InitialVersion, Header.HardeningVersion, Header.Interpreter50Version).foreach { version =>
+    property(s"version $version collects the payment fee into the exact delayed miner reward") {
+      val source = box(1)
+      val tx = payment(source)
+      val (input, ordering, invalid) = select(Seq(source), Seq(tx), version)
+      input shouldBe empty
+      invalid shouldBe empty
+      ordering should have size 2
+      ordering.head.id shouldBe tx.id
+      assertFeeReward(ordering.last, Seq(tx))
+    }
+  }
+
+  property("version 4 collects an ordering payment fee in its ordering payload") {
+    val source = box(2, orderingTree)
+    val tx = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering should have size 2
+    ordering.head.id shouldBe tx.id
+    assertFeeReward(ordering.last, Seq(tx))
+  }
+
+  property("version 4 leaves a new input payment fee out of the alternative ordering payload") {
+    val source = box(3)
+    val tx = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    input.map(_.id) shouldBe Seq(tx.id)
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("independent mixed payments collect only the ordering source fee") {
+    val inputSource = box(4)
+    val orderingSource = box(5, orderingTree)
+    val inputTx = payment(inputSource)
+    val orderingTx = payment(orderingSource)
+    val (input, ordering, invalid) = select(Seq(inputSource, orderingSource),
+      Seq(inputTx, orderingTx), Header.Interpreter60Version)
+    input.map(_.id) shouldBe Seq(inputTx.id)
+    invalid shouldBe empty
+    ordering should have size 2
+    ordering.head.id shouldBe orderingTx.id
+    assertFeeReward(ordering.last, Seq(orderingTx))
+  }
+
+  property("an accepted input payment produces its fee reward with an empty new pool") {
+    val source = box(10)
+    val accepted = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq.empty,
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering should have size 1
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("an accepted input payment duplicated in the pool is skipped without invalidation") {
+    val source = box(11)
+    val accepted = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq(accepted),
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering should have size 1
+    ordering.map(_.id) should not contain accepted.id
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("a descendant of an accepted input payment uses the accepted prefix state") {
+    val source = box(12)
+    val accepted = payment(source)
+    val child = payment(accepted.outputs.head)
+    val (input, ordering, invalid) = select(Seq(source), Seq(child),
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input.map(_.id) shouldBe Seq(child.id)
+    invalid shouldBe empty
+    ordering should have size 1
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("new input fees remain excluded while accepted input fees are collected") {
+    val acceptedSource = box(13)
+    val newSource = box(14)
+    val accepted = payment(acceptedSource)
+    val fresh = payment(newSource)
+    val (input, ordering, invalid) = select(Seq(acceptedSource, newSource), Seq(fresh),
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input.map(_.id) shouldBe Seq(fresh.id)
+    invalid shouldBe empty
+    ordering should have size 1
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("an ordering payment is not admitted when its fee reward exceeds the size budget") {
+    val source = box(15, orderingTree)
+    val tx = payment(source)
+    val (_, complete, _) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    complete should have size 2
+    val budget = sectionSize(Seq(tx))
+    sectionSize(complete) should be > budget
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version,
+      maxSize = budget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("an ordering payment is not admitted when its fee reward exceeds the cost budget") {
+    val source = box(16, orderingTree)
+    val tx = payment(source)
+    val (_, complete, _) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    complete should have size 2
+    val budget = transactionCost(Seq(source), tx)
+    budget should be > 0
+    transactionCost(Seq(source), complete.last, Seq(tx)) should be > 0
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version,
+      maxCost = budget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  Seq("size", "cost").foreach { limit =>
+    property(s"an accepted prefix remains valid with its fee unspent when the reward exceeds the $limit budget") {
+      val source = box(17)
+      val accepted = payment(source)
+      val (_, complete, _) = select(Seq(source), Seq.empty, Header.Interpreter60Version,
+        prefix = Seq(accepted))
+      complete should have size 1
+      val prefixSize = sectionSize(Seq(accepted))
+      sectionSize(Seq(accepted) ++ complete) should be > prefixSize
+      val prefixCost = transactionCost(Seq(source), accepted)
+      transactionCost(Seq(source), complete.head, Seq(accepted)) should be > 0
+      val (input, ordering, invalid) = select(Seq(source), Seq.empty, Header.Interpreter60Version,
+        prefix = Seq(accepted),
+        maxCost = if (limit == "cost") prefixCost else parameters.maxBlockCost,
+        maxSize = if (limit == "size") prefixSize else parameters.maxBlockSize)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe empty
+      val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(Seq(accepted) ++ ordering)
+      unspent.map(b => bytesToId(b.id)) should contain(bytesToId(accepted.outputs.last.id))
+    }
+  }
+
+  Seq(true, false).foreach { fits =>
+    property(s"new input growth is ${if (fits) "accepted" else "deferred"} according to the cumulative conservative cost allowance") {
+      val sources = Seq(box(18), box(19))
+      val txs = sources.map { source =>
+        ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+          IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+      }
+      val costs = txs.map(tx => transactionCost(sources, tx))
+      costs.foreach(_ should be > 0)
+      val total = costs.sum
+      total should be < parameters.maxBlockCost
+      val allowance = if (fits) total + 100 else costs.max + (total - costs.max) / 2
+      allowance should be > costs.max
+      allowance should be < parameters.maxBlockCost
+      if (fits) total should be <= allowance else total should be > allowance
+      val (input, ordering, invalid) = select(sources, Seq(txs.last),
+        Header.Interpreter60Version, prefix = Seq(txs.head), maxCost = allowance)
+      input.map(_.id) shouldBe (if (fits) Seq(txs.last.id) else Seq.empty)
+      ordering shouldBe empty
+      invalid shouldBe empty
+    }
+  }
+
+  property("a mandatory prefix above the conservative allowance is retained without additional input growth") {
+    val sources = Seq(box(22), box(23), box(24))
+    val txs = sources.map { source =>
+      ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+    }
+    val costs = txs.map(tx => transactionCost(sources, tx))
+    costs.foreach(_ should be > 0)
+    val prefixCost = costs.take(2).sum
+    val allowance = costs.max + (prefixCost - costs.max) / 2
+    allowance should be > costs.max
+    prefixCost should be > allowance
+    costs.sum should be < parameters.maxBlockCost
+    val (input, ordering, invalid) = select(sources, Seq(txs.last),
+      Header.Interpreter60Version, prefix = txs.take(2), maxCost = allowance)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+    val retained = org.ergoplatform.nodeView.state.ErgoState.newBoxes(txs.take(2) ++ ordering)
+    retained.map(b => bytesToId(b.id)).toSet shouldBe
+      txs.take(2).flatMap(_.outputs).map(b => bytesToId(b.id)).toSet
+  }
+
+  property("a new input payment is deferred when its accepted prefix fills the ordering size budget") {
+    val acceptedSource = box(20)
+    val newSource = box(21)
+    val accepted = payment(acceptedSource)
+    val fresh = payment(newSource)
+    val budget = math.max(sectionSize(Seq(accepted)), sectionSize(Seq(fresh)))
+    sectionSize(Seq(accepted, fresh)) should be > budget
+    val (input, ordering, invalid) = select(Seq(acceptedSource, newSource), Seq(fresh),
+      Header.Interpreter60Version, prefix = Seq(accepted), maxSize = budget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+    val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(Seq(accepted) ++ ordering)
+    unspent.map(b => bytesToId(b.id)) should contain(bytesToId(accepted.outputs.last.id))
+  }
+
+  for {
+    version <- Seq(Header.InitialVersion, Header.Interpreter50Version, Header.Interpreter60Version)
+    count <- Seq(127, 128)
+  } {
+    property(s"version $version matches serialized section capacity for $count transactions") {
+      val sources = (0 until count).map(i => box(i.toByte, orderingTree))
+      val transactions = sources.map { source =>
+        ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+          IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+      }
+      def serializedSize(txs: Seq[ErgoTransaction]): Int =
+        BlockTransactions(bytesToId(Array.fill[Byte](32)(0)), version, txs).size
+      val totalCost = payloadCost(sources, transactions, version)
+      totalCost should be > parameters.maxBlockCost
+      val testProtocolCost = totalCost + 100000
+      testProtocolCost should be > totalCost
+      val exactSize = serializedSize(transactions)
+      val (input, ordering, invalid) = select(sources, transactions, version, maxSize = exactSize,
+        maxCost = testProtocolCost, protocolCost = testProtocolCost)
+      input shouldBe empty
+      invalid shouldBe empty
+      ordering.map(_.id) shouldBe transactions.map(_.id)
+      serializedSize(ordering) shouldBe exactSize
+
+      val (shortInput, shortOrdering, shortInvalid) =
+        select(sources, transactions, version, maxSize = exactSize - 1,
+          maxCost = testProtocolCost, protocolCost = testProtocolCost)
+      shortInput shouldBe empty
+      shortInvalid shouldBe empty
+      shortOrdering.map(_.id) shouldBe transactions.dropRight(1).map(_.id)
+      serializedSize(shortOrdering) should be <= (exactSize - 1)
+    }
+  }
+
+  property("cumulative prefix and new input cost cannot exceed the consensus ordering budget") {
+    val sources = Seq(box(30), box(31))
+    val txs = sources.map { source =>
+      ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+    }
+    val individualCosts = txs.map(tx => payloadCost(sources, Seq(tx), Header.Interpreter60Version))
+    individualCosts.foreach(_ should be > 0)
+    // Exact measured cost leaves only a rounded JIT allowance after initialization.
+    // Give each script headroom while keeping the combined payload over budget.
+    val consensusBudget = individualCosts.max + (individualCosts.sum - individualCosts.max) / 2
+    consensusBudget should be > individualCosts.max
+    individualCosts.sum should be > consensusBudget
+    val restrictedState = state(sources, consensusBudget)
+    val restrictedContext = restrictedState.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, Header.Interpreter60Version)
+    val verifier = org.ergoplatform.wallet.interpreter.ErgoInterpreter(restrictedContext.currentParameters)
+    val prefixState = restrictedState.withTransactions(Seq(txs.head))
+    val restrictedCosts = txs.map { tx =>
+      val validated = prefixState.validateWithCost(tx, restrictedContext, consensusBudget,
+        Some(verifier), softFieldsAllowed = true)
+      withClue("Each transaction must validate individually under the restricted consensus context: ") {
+        validated.isSuccess shouldBe true
+      }
+      validated.get
+    }
+    restrictedCosts.foreach(_ should be <= consensusBudget)
+    restrictedCosts.sum should be > consensusBudget
+    val (input, ordering, invalid) = select(sources, Seq(txs.last), Header.Interpreter60Version,
+      prefix = Seq(txs.head), maxCost = consensusBudget, protocolCost = consensusBudget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("an accepted prefix collects only the optional fee chunk that fits") {
+    val sources = (0 to 100).map(i => box(i.toByte))
+    val accepted = sources.map(payment)
+    val testProtocolCost = 10000000
+    val (_, rewards, _) = select(sources, Seq.empty, Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost)
+    rewards should have size 2
+    val budget = sectionSize(accepted ++ rewards.take(1))
+    sectionSize(accepted ++ rewards) should be > budget
+    val (input, ordering, invalid) = select(sources, Seq.empty, Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost, maxSize = budget)
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering.map(_.id) shouldBe rewards.take(1).map(_.id)
+    val collectedIds = ordering.flatMap(_.inputs).map(in => bytesToId(in.boxId)).toSet
+    assertFeeReward(ordering.head, accepted.filter(tx => collectedIds.contains(bytesToId(tx.outputs.last.id))))
+    val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(accepted ++ ordering)
+      .filter(b => b.propositionBytes.toSeq == feeTree.bytes.toSeq)
+    unspent.map(b => bytesToId(b.id)).toSet shouldBe
+      accepted.map(tx => bytesToId(tx.outputs.last.id)).toSet.diff(collectedIds)
+    unspent should not be empty
+  }
+
+  property("a new ordering payment retains its required fee chunk ahead of optional prefix fees") {
+    val prefixSources = (0 until 100).map(i => box(i.toByte))
+    val newSource = box((-1).toByte, orderingTree)
+    val sources = prefixSources :+ newSource
+    val accepted = prefixSources.map(payment)
+    val fresh = payment(newSource)
+    val testProtocolCost = 10000000
+    val (_, complete, _) = select(sources, Seq(fresh), Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost)
+    complete.head.id shouldBe fresh.id
+    val rewards = complete.tail
+    rewards should have size 2
+    val (required, optional) = rewards.partition(_.inputs.exists(in =>
+      bytesToId(in.boxId) == bytesToId(fresh.outputs.last.id)))
+    required should have size 1
+    optional should have size 1
+    val budget = sectionSize(accepted ++ Seq(fresh) ++ required)
+    sectionSize(accepted ++ complete) should be > budget
+    val (input, ordering, invalid) = select(sources, Seq(fresh), Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost, maxSize = budget)
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering.map(_.id) shouldBe (Seq(fresh) ++ required).map(_.id)
+    val collectedIds = required.head.inputs.map(in => bytesToId(in.boxId)).toSet
+    assertFeeReward(required.head, (accepted :+ fresh).filter(tx => collectedIds.contains(bytesToId(tx.outputs.last.id))))
+    val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(accepted ++ ordering)
+      .filter(b => b.propositionBytes.toSeq == feeTree.bytes.toSeq)
+    unspent.map(b => bytesToId(b.id)).toSet shouldBe
+      accepted.map(tx => bytesToId(tx.outputs.last.id)).toSet.diff(collectedIds)
+    unspent should not be empty
+  }
+
+  property("fee reward batches consume all fee boxes when there are more than one hundred") {
+    val batchSize = 100
+    val sources = (0 to batchSize).map(i => box(i.toByte))
+    val payments = sources.map(payment)
+    val us = state(sources)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, Header.InitialVersion)
+    val rewards = CandidateGenerator.collectRewards(None, us.stateContext.currentHeight,
+      payments, defaultMinerPk, context)
+    rewards should have size 2
+    val consumed = rewards.flatMap(_.inputs).map(in => bytesToId(in.boxId))
+    consumed should contain theSameElementsAs payments.map(tx => bytesToId(tx.outputs.last.id))
+    consumed.distinct.size shouldBe payments.size
+    rewards.foreach { reward =>
+      reward.inputs should not be empty
+      reward.inputs.size should be <= batchSize
+      val consumedIds = reward.inputs.map(in => bytesToId(in.boxId)).toSet
+      assertFeeReward(reward, payments.filter(tx => consumedIds.contains(bytesToId(tx.outputs.last.id))))
+    }
+    rewards.flatMap(_.outputs).map(_.value).sum shouldBe payments.size.toLong * fee
+    us.proofsForTransactions(payments ++ rewards).isSuccess shouldBe true
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.mining
+
+import com.google.common.io.Files.createTempDir
+import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, Input}
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.nodeView.state.{BoxHolder, UtxoState}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.{ErgoCompilerHelpers, ErgoCorePropertyTest}
+import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultMinerPk, emptyVSUpdate, parameters}
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import scorex.util.bytesToId
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.interpreter.ProverResult
+
+class MatrixTransactionSelectionSpec extends ErgoCorePropertyTest with ErgoCompilerHelpers {
+  private val orderingTree = compileSourceV5("CONTEXT.minerPubKey.size >= 0", 0)
+
+  private def box(index: Byte, tree: ErgoTree = TrueTree): ErgoBox = new ErgoBox(
+    value = 1000000000L, ergoTree = tree, creationHeight = 0,
+    additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+    transactionId = bytesToId(Array.fill(32)(index)), index = 0
+  )
+
+  private def spend(input: ErgoBox, outputTree: ErgoTree = TrueTree,
+                    dataInputs: IndexedSeq[DataInput] = IndexedSeq.empty): ErgoTransaction =
+    ErgoTransaction(IndexedSeq(Input(input.id, ProverResult.empty)), dataInputs,
+      IndexedSeq(new ErgoBoxCandidate(input.value, outputTree, 1)))
+
+  private def select(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction]) = {
+    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, parameters)
+    val context = state.stateContext.upcoming(defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
+      Array.emptyByteArray, emptyVSUpdate, 4.toByte)
+    val result = CandidateGenerator.collectTxs(defaultMinerPk, parameters.maxBlockCost,
+      parameters.maxBlockSize, state, context, txs)
+    // Both selected payloads must have a UTXO proof independently of the other new payload.
+    Seq(result._1, result._2).filter(_.nonEmpty).foreach { payload =>
+      state.proofsForTransactions(payload).isSuccess shouldBe true
+    }
+    result
+  }
+
+  property("ordinary and soft-field transactions enter their respective partitions") {
+    val inputBox = box(1)
+    val orderingBox = box(2, orderingTree)
+    val inputTx = spend(inputBox)
+    val orderingTx = spend(orderingBox)
+    val (input, ordering, invalid) = select(Seq(inputBox, orderingBox), Seq(inputTx, orderingTx))
+    input shouldBe Seq(inputTx)
+    ordering shouldBe Seq(orderingTx)
+    invalid shouldBe empty
+  }
+
+  property("input-only dependency chains remain in the input payload") {
+    val initial = box(3)
+    val parent = spend(initial)
+    val child = spend(parent.outputs.head)
+    val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child))
+    input shouldBe Seq(parent, child)
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("ordering-only dependency chains remain in the ordering payload") {
+    val initial = box(4, orderingTree)
+    val parent = spend(initial, orderingTree)
+    val child = spend(parent.outputs.head)
+    val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child))
+    input shouldBe empty
+    ordering shouldBe Seq(parent, child)
+    invalid shouldBe empty
+  }
+
+  property("cross-partition spending dependencies and descendants are deferred without elimination") {
+    Seq(false, true).foreach { orderingParent =>
+      val initial = box(5, if (orderingParent) orderingTree else TrueTree)
+      val parent = spend(initial, if (orderingParent) TrueTree else orderingTree)
+      val child = spend(parent.outputs.head)
+      val grandchild = spend(child.outputs.head)
+      val independentBox = box(10)
+      val independent = spend(independentBox)
+      val (input, ordering, invalid) = select(Seq(initial, independentBox), Seq(parent, child, grandchild, independent))
+      (input ++ ordering) should contain theSameElementsAs Seq(parent, independent)
+      invalid shouldBe empty
+    }
+  }
+
+  property("cross-partition data dependencies are deferred in either direction") {
+    Seq(false, true).foreach { orderingParent =>
+      val first = box(6, if (orderingParent) orderingTree else TrueTree)
+      val second = box(7, if (orderingParent) TrueTree else orderingTree)
+      val parent = spend(first)
+      val child = spend(second, dataInputs = IndexedSeq(DataInput(parent.outputs.head.id)))
+      val (input, ordering, invalid) = select(Seq(first, second), Seq(parent, child))
+      (input ++ ordering) shouldBe Seq(parent)
+      invalid shouldBe empty
+    }
+  }
+
+  property("same-partition data dependencies remain selectable") {
+    val first = box(8)
+    val second = box(9)
+    val parent = spend(first)
+    val child = spend(second, dataInputs = IndexedSeq(DataInput(parent.outputs.head.id)))
+    val (input, ordering, invalid) = select(Seq(first, second), Seq(parent, child))
+    input shouldBe Seq(parent, child)
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
@@ -3,8 +3,10 @@ package org.ergoplatform.mining
 import com.google.common.io.Files.createTempDir
 import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, Input}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.state.{BoxHolder, UtxoState}
-import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.settings.Parameters
+import org.ergoplatform.settings.Constants.{FalseTree, TrueTree}
 import org.ergoplatform.utils.{ErgoCompilerHelpers, ErgoCorePropertyTest}
 import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultMinerPk, emptyVSUpdate, parameters}
 import org.ergoplatform.utils.ErgoNodeTestConstants.settings
@@ -27,17 +29,88 @@ class MatrixTransactionSelectionSpec extends ErgoCorePropertyTest with ErgoCompi
     ErgoTransaction(IndexedSeq(Input(input.id, ProverResult.empty)), dataInputs,
       IndexedSeq(new ErgoBoxCandidate(input.value, outputTree, 1)))
 
-  private def select(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction]) = {
-    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, parameters)
+  private def select(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction],
+                     version: Byte = Header.Interpreter60Version,
+                     currentVersion: Byte = Header.InitialVersion,
+                     maxCost: Int = parameters.maxBlockCost,
+                     maxSize: Int = parameters.maxBlockSize) = {
+    val currentParameters = Parameters(parameters.height,
+      parameters.parametersTable.updated(Parameters.BlockVersion, currentVersion.toInt), parameters.proposedUpdate)
+    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, currentParameters)
     val context = state.stateContext.upcoming(defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
-      Array.emptyByteArray, emptyVSUpdate, 4.toByte)
-    val result = CandidateGenerator.collectTxs(defaultMinerPk, parameters.maxBlockCost,
-      parameters.maxBlockSize, state, context, txs)
+      Array.emptyByteArray, emptyVSUpdate, version)
+    val result = CandidateGenerator.collectTxs(defaultMinerPk, maxCost,
+      maxSize, state, context, txs)
     // Both selected payloads must have a UTXO proof independently of the other new payload.
     Seq(result._1, result._2).filter(_.nonEmpty).foreach { payload =>
       state.proofsForTransactions(payload).isSuccess shouldBe true
     }
     result
+  }
+
+  Seq(Header.InitialVersion, Header.HardeningVersion, Header.Interpreter50Version).foreach { version =>
+    property(s"version $version includes ordinary transactions and their descendants in ordering blocks") {
+      val initial = box(11)
+      val parent = spend(initial)
+      val child = spend(parent.outputs.head)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child), version)
+      input shouldBe empty
+      ordering shouldBe Seq(parent, child)
+      invalid shouldBe empty
+    }
+  }
+
+  property("the first version 4 candidate partitions transactions while current parameters are version 3") {
+    val inputBox = box(12)
+    val orderingBox = box(13, orderingTree)
+    val inputTx = spend(inputBox)
+    val orderingTx = spend(orderingBox)
+    val (input, ordering, invalid) = select(Seq(inputBox, orderingBox), Seq(inputTx, orderingTx),
+      Header.Interpreter60Version, Header.Interpreter50Version)
+    input shouldBe Seq(inputTx)
+    ordering shouldBe Seq(orderingTx)
+    invalid shouldBe empty
+  }
+
+  property("legacy candidates keep dependencies between ordinary and context-dependent transactions") {
+    Seq(false, true).foreach { contextDependentParent =>
+      val initial = box(14, if (contextDependentParent) orderingTree else TrueTree)
+      val parent = spend(initial, if (contextDependentParent) TrueTree else orderingTree)
+      val child = spend(parent.outputs.head)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child), Header.Interpreter50Version)
+      input shouldBe empty
+      ordering shouldBe Seq(parent, child)
+      invalid shouldBe empty
+    }
+  }
+
+  Seq(Header.Interpreter50Version, Header.Interpreter60Version).foreach { version =>
+    property(s"version $version rejects an unsatisfied script") {
+      val initial = box(15, FalseTree)
+      val tx = spend(initial)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(tx), version)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe Seq(tx.id)
+    }
+
+    property(s"version $version rejects a transaction exceeding the validation cost budget") {
+      val initial = box(16)
+      val tx = spend(initial)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(tx), version, maxCost = 1)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe Seq(tx.id)
+    }
+
+    property(s"version $version leaves a valid transaction unselected when the payload is full") {
+      val initial = box(17)
+      val tx = spend(initial)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(tx), version, maxSize = 1)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe empty
+    }
   }
 
   property("ordinary and soft-field transactions enter their respective partitions") {

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -1501,17 +1501,14 @@ class ErgoNodeViewSynchronizerSpecification
 
       // Verify that localInputBlockChunks was populated
       val localInputBlockChunksField =
-        classOf[ErgoNodeViewSynchronizer].getDeclaredField("localInputBlockChunks")
+        classOf[ErgoNodeViewSynchronizer].getDeclaredFields.find(_.getName.endsWith("localInputBlockChunks")).get
       localInputBlockChunksField.setAccessible(true)
       val localInputBlockChunks = localInputBlockChunksField
         .get(synchronizer)
-        .asInstanceOf[scala.collection.mutable.Map[
-          String,
-          ErgoNodeViewSynchronizer.InputBlockDiffData
-        ]]
+        .asInstanceOf[InputBlockPendingCache]
 
-      localInputBlockChunks.contains(inputBlockId) shouldBe true
-      val cachedData = localInputBlockChunks(inputBlockId)
+      localInputBlockChunks.get(inputBlockId).isDefined shouldBe true
+      val cachedData = localInputBlockChunks.get(inputBlockId).get
       cachedData.weakTxsIds shouldBe Seq(fakeWeakId)
       cachedData.txs shouldBe empty // no txs found in mempool
     }
@@ -1572,11 +1569,11 @@ class ErgoNodeViewSynchronizerSpecification
       // Pre-populate localInputBlockChunks with tx1 (local tx from mempool) but not tx2
       val testSynchronizer = testSynchronizerRef.underlyingActor
       val localInputBlockChunksField =
-        classOf[ErgoNodeViewSynchronizer].getDeclaredField("localInputBlockChunks")
+        classOf[ErgoNodeViewSynchronizer].getDeclaredFields.find(_.getName.endsWith("localInputBlockChunks")).get
       localInputBlockChunksField.setAccessible(true)
       val localInputBlockChunks = localInputBlockChunksField
         .get(testSynchronizer)
-        .asInstanceOf[scala.collection.mutable.Map[ModifierId, InputBlockDiffData]]
+        .asInstanceOf[InputBlockPendingCache]
 
       localInputBlockChunks.put(
         inputBlockId,
@@ -1584,7 +1581,9 @@ class ErgoNodeViewSynchronizerSpecification
           System.currentTimeMillis(),
           Seq(tx1.weakId, tx2.weakId), // both weakIds expected
           Seq(tx1) // only tx1 is in local cache (tx2 comes from peer)
-        )
+        ),
+        peer.connectionId.remoteAddress.getHostString,
+        peer.handlerRef.toString
       )
 
       // Create peer transaction data containing tx2 (missing from local)
@@ -1592,6 +1591,8 @@ class ErgoNodeViewSynchronizerSpecification
 
       // Call processInputBlockTransactions directly
       testSynchronizer.processInputBlockTransactions(peerTxsData, testHist, peer)
+      localInputBlockChunks.get(inputBlockId) shouldBe None
+      localInputBlockChunks.retainedWeight shouldBe 0L
 
       // Verify ProcessInputBlockTransactions was sent to viewHolderRef with merged tx array
       // Note: The probe also receives GetNodeViewChanges from synchronizer preStart, so we fish for the right message
@@ -1720,17 +1721,14 @@ class ErgoNodeViewSynchronizerSpecification
 
       // Use reflection to access private field
       val localInputBlockChunksField =
-        classOf[ErgoNodeViewSynchronizer].getDeclaredField("localInputBlockChunks")
+        classOf[ErgoNodeViewSynchronizer].getDeclaredFields.find(_.getName.endsWith("localInputBlockChunks")).get
       localInputBlockChunksField.setAccessible(true)
       val localInputBlockChunks = localInputBlockChunksField
         .get(synchronizerMock)
-        .asInstanceOf[scala.collection.mutable.Map[
-          ModifierId,
-          ErgoNodeViewSynchronizer.InputBlockDiffData
-        ]]
+        .asInstanceOf[InputBlockPendingCache]
 
-      localInputBlockChunks.put(oldSubBlockId1, oldData1)
-      localInputBlockChunks.put(oldSubBlockId2, oldData2)
+      localInputBlockChunks.put(oldSubBlockId1, oldData1, "peer", "connection")
+      localInputBlockChunks.put(oldSubBlockId2, oldData2, "peer", "connection")
 
       // Create recent entry (should NOT be cleaned up)
       val recentTime = System.currentTimeMillis()
@@ -1741,10 +1739,10 @@ class ErgoNodeViewSynchronizerSpecification
         Seq(tx1.weakId, tx2.weakId),
         Seq(tx1, tx2)
       )
-      localInputBlockChunks.put(recentSubBlockId, recentData)
+      localInputBlockChunks.put(recentSubBlockId, recentData, "peer", "connection")
 
-      // Verify all entries are present before cleanup
-      localInputBlockChunks.size shouldBe 3
+      // Admission prunes expired entries even before the scheduled cleanup.
+      localInputBlockChunks.size shouldBe 1
 
       // Trigger cleanup
       synchronizerMockRef ! ErgoNodeViewSynchronizer.CleanupLocalInputBlockChunks
@@ -1752,9 +1750,9 @@ class ErgoNodeViewSynchronizerSpecification
       // Verify old entries are removed and recent entry remains
       eventually {
         localInputBlockChunks.size shouldBe 1
-        localInputBlockChunks.contains(recentSubBlockId) shouldBe true
-        localInputBlockChunks.contains(oldSubBlockId1) shouldBe false
-        localInputBlockChunks.contains(oldSubBlockId2) shouldBe false
+        localInputBlockChunks.get(recentSubBlockId).isDefined shouldBe true
+        localInputBlockChunks.get(oldSubBlockId1) shouldBe None
+        localInputBlockChunks.get(oldSubBlockId2) shouldBe None
       }
     }
   }
@@ -1762,20 +1760,16 @@ class ErgoNodeViewSynchronizerSpecification
   property("NodeViewSynchronizer: cleanupLocalInputBlockChunks handles empty cache") {
     withFixture2 { ctx =>
       import ctx._
-      import scorex.util.ModifierId
 
       val synchronizerMock = synchronizerMockRef.underlyingActor
 
       // Access the localInputBlockChunks map via reflection
       val localInputBlockChunksField =
-        classOf[ErgoNodeViewSynchronizer].getDeclaredField("localInputBlockChunks")
+        classOf[ErgoNodeViewSynchronizer].getDeclaredFields.find(_.getName.endsWith("localInputBlockChunks")).get
       localInputBlockChunksField.setAccessible(true)
       val localInputBlockChunks = localInputBlockChunksField
         .get(synchronizerMock)
-        .asInstanceOf[scala.collection.mutable.Map[
-          ModifierId,
-          ErgoNodeViewSynchronizer.InputBlockDiffData
-        ]]
+        .asInstanceOf[InputBlockPendingCache]
 
       // Ensure cache is empty
       localInputBlockChunks.clear()
@@ -3028,11 +3022,11 @@ class ErgoNodeViewSynchronizerSpecification
       // Pre-populate with tx1 weakId but a fake weakId that won't be found
       val fakeWeakId: Array[Byte] = Array.fill(32)(0xFF.toByte)
       val localInputBlockChunksField =
-        classOf[ErgoNodeViewSynchronizer].getDeclaredField("localInputBlockChunks")
+        classOf[ErgoNodeViewSynchronizer].getDeclaredFields.find(_.getName.endsWith("localInputBlockChunks")).get
       localInputBlockChunksField.setAccessible(true)
       val localInputBlockChunks = localInputBlockChunksField
         .get(testSynchronizerRef.underlyingActor)
-        .asInstanceOf[scala.collection.mutable.Map[ModifierId, InputBlockDiffData]]
+        .asInstanceOf[InputBlockPendingCache]
 
       localInputBlockChunks.put(
         inputBlockId,
@@ -3040,7 +3034,9 @@ class ErgoNodeViewSynchronizerSpecification
           System.currentTimeMillis(),
           Seq(tx1.weakId, fakeWeakId), // fakeWeakId won't be found
           Seq(tx1)
-        )
+        ),
+        peer.connectionId.remoteAddress.getHostString,
+        peer.handlerRef.toString
       )
 
       // Peer sends tx1 only — fakeWeakId is missing

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -6,8 +6,9 @@ import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetNodeViewChanges
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader, ErgoSyncInfoMessageSpec, ErgoSyncInfoV2}
-import org.ergoplatform.nodeView.mempool.ErgoMemPool
+import org.ergoplatform.nodeView.mempool.{ErgoMemPool, ErgoMemPoolReader}
 import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
 import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.sanity.ErgoSanity._
@@ -67,7 +68,27 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     }
   }
 
-  class NodeViewHolderMock extends ErgoNodeViewHolder[UtxoState](settings)
+  private def isolatedNodeSettings(prototype: ErgoSettings): ErgoSettings = {
+    val directory = createTempDir
+    prototype.copy(directory = directory.getAbsolutePath,
+      walletSettings = prototype.walletSettings.copy(secretStorage =
+        prototype.walletSettings.secretStorage.copy(
+          secretDir = new java.io.File(directory, "keystore").getAbsolutePath)))
+  }
+
+  class NodeViewHolderMock(nodeSettings: ErgoSettings) extends ErgoNodeViewHolder[UtxoState](nodeSettings)
+
+  class InjectedReadersNodeViewHolder(nodeSettings: ErgoSettings,
+                                     injectedHistory: ErgoHistoryReader,
+                                     injectedMempool: ErgoMemPoolReader) extends NodeViewHolderMock(nodeSettings) {
+    // This fixture owns its history and mempool; startup replies must use those same readers.
+    override protected def getNodeViewChanges: Receive = {
+      case request: GetNodeViewChanges =>
+        if (request.history) sender() ! ChangedHistory(injectedHistory)
+        super.getNodeViewChanges(request.copy(history = false, mempool = false))
+        if (request.mempool) sender() ! ChangedMempool(injectedMempool)
+    }
+  }
 
   class SynchronizerMock(networkControllerRef: ActorRef,
                          viewHolderRef: ActorRef,
@@ -129,7 +150,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val h = localHistoryGen.sample.get
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     val s = localStateGen.sample.get
-    val settings = ErgoSettingsReader.read()
+    val settings = isolatedNodeSettings(ErgoSettingsReader.read())
     val pool = ErgoMemPool.empty(settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
@@ -138,9 +159,7 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new InjectedReadersNodeViewHolder(settings, h, pool)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -174,15 +193,14 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   }
 
   class Synchronizer2Fixture extends AkkaFixture {
+    val settings: ErgoSettings = isolatedNodeSettings(org.ergoplatform.utils.ErgoNodeTestConstants.settings)
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val ncProbe = TestProbe("NetworkControllerProbe")
     val pchProbe = TestProbe("PeerHandlerProbe")
     val syncTracker = ErgoSyncTracker(settings.scorexSettings.network)
     val deliveryTracker: DeliveryTracker = DeliveryTracker.empty(settings)
 
-    // each test should always start with empty history
-    deleteRecursive(ErgoHistory.historyDir(settings))
-    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock))
+    val nodeViewHolderMockRef = system.actorOf(Props(new NodeViewHolderMock(settings)))
 
     val synchronizerMockRef = system.actorOf(Props(
       new SynchronizerMock(
@@ -509,6 +527,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
   property("NodeViewSynchronizer: Message: SyncInfoSpec V2 - unknown peer") {
     withFixture { ctx =>
       import ctx._
+
+      // Replay a late startup request before observing the peer response. The fixture's
+      // injected history and mempool must not be replaced by the holder's empty readers.
+      val startupReaders = TestProbe("StartupReaders")
+      startupReaders.send(nodeViewHolder,
+        GetNodeViewChanges(history = true, state = false, vault = false, mempool = true))
+      val changedHistory = startupReaders.expectMsgType[ChangedHistory](3.seconds)
+      val changedMempool = startupReaders.expectMsgType[ChangedMempool](3.seconds)
+      synchronizer ! changedHistory
+      synchronizer ! changedMempool
 
       val sync = ErgoSyncInfoV2(Seq(altchain.last))
 

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -510,14 +510,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }
@@ -545,14 +547,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }

--- a/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.network
+
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.SyncInfoV2Cache
+import org.ergoplatform.nodeView.history.ErgoSyncInfoV2
+import org.ergoplatform.utils.generators.ChainGenerator.genHeaderChain
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class SyncInfoV2CacheSpec extends AnyPropSpec with Matchers {
+  private val headers = genHeaderChain(3, diffBitsOpt = None, useRealTs = false).headers
+  private val tip = headers.last
+  private val fullSummary = ErgoSyncInfoV2(Seq(tip, headers.head))
+  private val reducedSummary = ErgoSyncInfoV2(Seq(tip))
+
+  property("reuse a summary only for the same tip and requested mode") {
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+      cache.getOrElseUpdate(Some(tip.id), full) {
+        fail("An unchanged tip and mode should reuse the cached summary")
+      } shouldBe expected
+    }
+  }
+
+  property("alternating reduced and full requests preserves each requested summary") {
+    val cache = new SyncInfoV2Cache
+    Seq(false, true, false, true).foreach { full =>
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+    }
+  }
+
+  property("a different best header at the same height replaces the cached summary") {
+    val otherTip = genHeaderChain(1, prefixOpt = Some(headers(1)),
+      diffBitsOpt = None, useRealTs = false).last
+    otherTip.height shouldBe tip.height
+    otherTip.id should not be tip.id
+
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val original = if (full) fullSummary else reducedSummary
+      val replacement = ErgoSyncInfoV2(if (full) Seq(otherTip, headers.head) else Seq(otherTip))
+      cache.getOrElseUpdate(Some(tip.id), full)(original) shouldBe original
+      cache.getOrElseUpdate(Some(otherTip.id), full)(replacement) shouldBe replacement
+      cache.getOrElseUpdate(Some(otherTip.id), full) {
+        fail("The replacement tip should now be cached")
+      } shouldBe replacement
+    }
+  }
+
+  property("empty history and populated history do not share cached summaries") {
+    val cache = new SyncInfoV2Cache
+    val empty = ErgoSyncInfoV2(Nil)
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+    cache.getOrElseUpdate(None, full = true) {
+      fail("An unchanged empty history should reuse its summary")
+    } shouldBe empty
+    cache.getOrElseUpdate(Some(tip.id), full = true)(fullSummary) shouldBe fullSummary
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/network/llm_generated/InputBlockPendingCacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/llm_generated/InputBlockPendingCacheSpec.scala
@@ -1,0 +1,118 @@
+package org.ergoplatform.network.llm_generated
+
+import org.ergoplatform.network.InputBlockPendingCache
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.InputBlockDiffData
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import scorex.util.ModifierId
+
+class InputBlockPendingCacheSpec extends AnyPropSpec with Matchers {
+  import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+  private def id(n: Int): ModifierId = ModifierId @@ n.toString
+  private def data(time: Long = 0L): InputBlockDiffData =
+    InputBlockDiffData(time, Seq(Array.fill(6)(1.toByte)), Seq.empty)
+  private val weight: Long = InputBlockPendingCache.weightOf(data())
+
+  property("defaults accommodate two ordinary chains and ID-array accounting for a transport envelope") {
+    InputBlockPendingCache.MaxPeerEntries should be >= 2 * org.ergoplatform.settings.Parameters.SubsPerBlockDefault
+    val idCount = org.ergoplatform.network.message.MessageConstants.MaxMessageSize.toLong / 6L
+    InputBlockPendingCache.MaxPeerWeight should be >= 256L + idCount * 38L
+  }
+
+  property("retained transaction bytes and repeated references are charged") {
+    val tx = validErgoTransactionGenTemplate(0, 0).sample.get._2
+    val retained = data().copy(txs = Seq(tx, tx))
+    InputBlockPendingCache.weightOf(retained) shouldBe weight + 2L * (64L + tx.size)
+    val cache = new InputBlockPendingCache(10, 10, weight, weight, 100, () => 0L)
+    cache.put(id(1), retained, "a", "a") shouldBe false
+    cache.size shouldBe 0
+    cache.retainedWeight shouldBe 0L
+  }
+
+  property("global and peer entry limits preserve admitted entries") {
+    val cache = new InputBlockPendingCache(3, 2, weight * 10, weight * 10, 100, () => 0L)
+    cache.put(id(1), data(), "peer-a", "peer-a") shouldBe true
+    cache.put(id(2), data(), "peer-a", "peer-a") shouldBe true
+    cache.put(id(3), data(), "peer-a", "peer-a") shouldBe false
+    cache.put(id(3), data(), "peer-b", "peer-b") shouldBe true
+    cache.put(id(4), data(), "peer-c", "peer-c") shouldBe false
+    cache.size shouldBe 3
+    cache.get(id(1)).isDefined shouldBe true
+  }
+
+  property("global retained weight is inclusive and released on completion") {
+    val cache = new InputBlockPendingCache(10, 10, weight * 2, weight * 10, 100, () => 0L)
+    cache.put(id(1), data(), "a", "a") shouldBe true
+    cache.put(id(2), data(), "b", "b") shouldBe true
+    cache.put(id(3), data(), "c", "c") shouldBe false
+    cache.retainedWeight shouldBe weight * 2
+    cache.remove(id(1))
+    cache.retainedWeight shouldBe weight
+    cache.put(id(3), data(), "c", "c") shouldBe true
+  }
+
+  property("peer retained weight is independent of the global budget") {
+    val cache = new InputBlockPendingCache(10, 10, weight * 10, weight, 100, () => 0L)
+    cache.put(id(1), data(), "a", "a") shouldBe true
+    cache.put(id(2), data(), "a", "a") shouldBe false
+    cache.put(id(2), data(), "b", "b") shouldBe true
+    cache.removeConnection("a")
+    cache.put(id(3), data(), "a", "a") shouldBe true
+  }
+
+  property("replacement charges only the difference and never steals another owner's entry") {
+    val cache = new InputBlockPendingCache(1, 1, weight, weight, 100, () => 0L)
+    cache.put(id(1), data(), "a", "a") shouldBe true
+    cache.put(id(1), data(), "a", "a") shouldBe true
+    cache.retainedWeight shouldBe weight
+    cache.put(id(1), data(), "b", "b") shouldBe false
+    val larger = data().copy(weakTxsIds = Seq(Array.fill(64)(1.toByte)))
+    cache.put(id(1), larger, "a", "a") shouldBe false
+    cache.retainedWeight shouldBe weight
+    cache.get(id(1)).get.weakTxsIds.head.length shouldBe 6
+  }
+
+  property("expiry is enforced on access and admission without waiting for a cleanup tick") {
+    var now = 0L
+    val cache = new InputBlockPendingCache(1, 1, weight, weight, 100, () => now)
+    cache.put(id(1), data(), "a", "a") shouldBe true
+    now = 99
+    cache.get(id(1)).isDefined shouldBe true
+    cache.put(id(1), data(now), "a", "a") shouldBe true
+    now = 100
+    cache.get(id(1)) shouldBe None
+    cache.retainedWeight shouldBe 0L
+    cache.put(id(2), data(now), "b", "b") shouldBe true
+    now = 200
+    cache.put(id(3), data(now), "c", "c") shouldBe true
+    cache.size shouldBe 1
+  }
+
+  property("abandonment and recovery clear all associated accounting") {
+    val cache = new InputBlockPendingCache(3, 3, weight * 3, weight * 3, 100, () => 0L)
+    cache.put(id(1), data(), "a", "a") shouldBe true
+    cache.put(id(2), data(), "b", "b") shouldBe true
+    cache.removeConnection("a")
+    cache.get(id(1)) shouldBe None
+    cache.retainedWeight shouldBe weight
+    cache.clear()
+    cache.size shouldBe 0
+    cache.retainedWeight shouldBe 0L
+    cache.put(id(3), data(), "a", "a") shouldBe true
+  }
+
+  property("disconnect releases only its connection while address quotas remain shared") {
+    val cache = new InputBlockPendingCache(10, 2, weight * 10, weight * 2, 100, () => 0L)
+    cache.put(id(1), data(), "shared-address", "connection-a") shouldBe true
+    cache.put(id(2), data(), "shared-address", "connection-b") shouldBe true
+    cache.put(id(1), data(), "shared-address", "connection-b") shouldBe false
+    cache.put(id(3), data(), "shared-address", "connection-c") shouldBe false
+    cache.removeConnection("connection-a")
+    cache.get(id(1)) shouldBe None
+    cache.get(id(2)).isDefined shouldBe true
+    cache.retainedWeight shouldBe weight
+    cache.put(id(3), data(), "shared-address", "connection-c") shouldBe true
+    cache.put(id(4), data(), "shared-address", "connection-d") shouldBe false
+    cache.retainedWeight shouldBe weight * 2
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
@@ -1,0 +1,158 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NetworkObjectTypeId, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.{BlockTransactions, HeaderChain}
+import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.initSettings
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators.invalidErgoTransactionGen
+import scorex.util.ModifierId
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
+
+  // These in-memory records exercise scheduling, not block or chain validation.
+  private val template = defaultHeaderGen.sample.get
+  private val transaction = invalidErgoTransactionGen.sample.get
+  private val maximumHeightHeader = template.copy(height = Int.MaxValue)
+  private val bestChain = (1 to 300).foldLeft(Vector.empty[Header]) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.lastOption.map(_.id).getOrElse(Header.GenesisParentId))
+  }
+  private val oldChain = (21 to 60).foldLeft(bestChain.take(20)) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.last.id, timestamp = template.timestamp + 1)
+  }
+
+  private class SchedulingReader(fullHeader: Header,
+                                 retainedVersions: Int = 50,
+                                 minimumHeight: Int = 1,
+                                 synced: Boolean = true,
+                                 verify: Boolean = true,
+                                 tipHeight: Int = 300,
+                                 missingHeader: Option[ModifierId] = None) extends ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = initSettings.copy(nodeSettings = initSettings.nodeSettings.copy(
+      keepVersions = retainedVersions, verifyTransactions = verify, stateType = StateType.Utxo))
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Scheduling snapshots do not process sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Scheduling snapshots do not validate sections")
+
+    private val headersById = (bestChain ++ oldChain :+ maximumHeightHeader).map(h => h.id -> h).toMap
+    var traversals: Vector[(Int, ModifierId)] = Vector.empty
+    var heightLookups: Vector[Int] = Vector.empty
+    override def bestFullBlockOpt: Option[ErgoFullBlock] = Some(ErgoFullBlock(fullHeader,
+      BlockTransactions(fullHeader.id, fullHeader.version, Seq(transaction)), Extension(fullHeader.id, Seq.empty), None))
+    override def bestHeaderIdOpt: Option[ModifierId] = Some(bestChain(tipHeight - 1).id)
+    override def estimatedTip(): Option[Int] = Some(tipHeight)
+    override def minimalFullBlockHeight: Int = minimumHeight
+    override def isHeadersChainSynced: Boolean = synced
+    override def isInBestChain(id: ModifierId): Boolean = bestChain.exists(_.id == id)
+    override def headerIdsAtHeight(height: Int): Seq[ModifierId] = {
+      heightLookups :+= height
+      (bestChain :+ maximumHeightHeader).find(_.height == height).map(_.id).toSeq
+    }
+    override def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T] =
+      headersById.get(id).filterNot(h => missingHeader.contains(h.id)).collect { case section: T => section }
+    override def headerChainBack(limit: Int, startHeader: Header, until: Header => Boolean): HeaderChain = {
+      traversals :+= limit -> startHeader.id
+      super.headerChainBack(limit, startHeader, until)
+    }
+  }
+
+  private def expected(reader: SchedulingReader, heights: Range): Map[NetworkObjectTypeId.Value, Seq[ModifierId]] =
+    heights.flatMap(h => reader.requiredModifiersForHeader(bestChain(h - 1)))
+      .groupBy(_._1).map { case (kind, sections) => kind -> sections.map(_._2) }
+
+  private val acceptAll: (NetworkObjectTypeId.Value, ModifierId) => Boolean = (_, _) => true
+
+  property("linear far-behind downloads retain the forward window without walking history") {
+    val reader = new SchedulingReader(bestChain(59))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe empty
+  }
+
+  property("ancestor scheduling extends backward without shortening the forward window") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 40)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
+    reader.traversals shouldBe Vector(41 -> oldChain.last.id)
+  }
+
+  property("a truncated traversal does not infer a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 39)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(40 -> oldChain.last.id)
+  }
+
+  property("non-positive retention does not walk to a parent") {
+    Seq(0, -1, Int.MinValue).foreach { retained =>
+      val reader = new SchedulingReader(oldChain.last, retainedVersions = retained)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+      reader.traversals shouldBe Vector(1 -> oldChain.last.id)
+    }
+  }
+
+  property("a missing parent does not turn a partial traversal into a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, missingHeader = Some(oldChain(39).id))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(51 -> oldChain.last.id)
+  }
+
+  property("ancestor scheduling respects the minimum retained full-block height") {
+    Seq(30, 253).foreach { minimumHeight =>
+      val reader = new SchedulingReader(oldChain.last, minimumHeight = minimumHeight)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, minimumHeight to 252)
+    }
+  }
+
+  property("maximum retention does not overflow the traversal bound") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = Int.MaxValue)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
+    reader.traversals shouldBe Vector(60 -> oldChain.last.id)
+  }
+
+  property("a download window ending at the maximum height terminates without wrapping") {
+    val fullHeader = oldChain.last.copy(height = Int.MaxValue - 191)
+    val reader = new SchedulingReader(fullHeader, minimumHeight = Int.MaxValue) {
+      override def estimatedTip(): Option[Int] = Some(Int.MaxValue)
+    }
+    val sections = reader.requiredModifiersForHeader(maximumHeightHeader)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe
+      sections.groupBy(_._1).map { case (kind, entries) => kind -> entries.map(_._2) }
+    reader.heightLookups shouldBe Vector(Int.MaxValue)
+  }
+
+  property("ancestor scheduling preserves per-type caps and the section filter") {
+    val reader = new SchedulingReader(oldChain.last)
+    val firstSections = reader.requiredModifiersForHeader(bestChain(20))
+    val excluded = firstSections.head._2
+    val result = reader.nextModifiersToDownload(2, (_, id) => id != excluded)
+    val all = expected(reader, 21 to 22)
+    result shouldBe all.map { case (kind, ids) => kind -> ids.filterNot(_ == excluded) }
+    result.values.foreach(_.size should be <= 2)
+  }
+
+  property("unsynced and non-verifying readers do not schedule sections or walk history") {
+    Seq(new SchedulingReader(oldChain.last, synced = false), new SchedulingReader(oldChain.last, verify = false))
+      .foreach { reader =>
+        reader.nextModifiersToDownload(1000, acceptAll) shouldBe empty
+        reader.traversals shouldBe empty
+      }
+  }
+
+  property("near-tip scheduling retains its existing lookback without walking history") {
+    val reader = new SchedulingReader(oldChain.last, tipHeight = 100)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 1 to 300)
+    reader.traversals shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
@@ -18,6 +18,9 @@ import scala.util.Try
 
 class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
 
+  // V2 parser bound; some supported branches keep the production constant private.
+  private val maxSyncHeaders = 50
+
   private def newHistory(): ErgoHistory =
     generateHistory(
       verifyTransactions = false,
@@ -91,7 +94,7 @@ class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
         full.lastHeaders.count(_.id == chain.head.id) shouldBe 1
         full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
         full.lastHeaders.size should be <= 5
-        full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+        full.lastHeaders.size should be <= maxSyncHeaders
         full.height shouldBe Some(height)
         checkRoundtrip(full)
 
@@ -121,7 +124,7 @@ class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
       full.lastHeaders.count(_.height == 1) shouldBe 1
       full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
       full.lastHeaders.size should be <= 5
-      full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+      full.lastHeaders.size should be <= maxSyncHeaders
       full.height shouldBe Some(heights.head)
       checkRoundtrip(full)
 

--- a/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
@@ -1,0 +1,193 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.HeaderChain
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.HistoryTestHelpers.generateHistory
+import org.ergoplatform.utils.generators.ChainGenerator.{applyHeaderChain, genHeaderChain}
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import scorex.crypto.hash.Digest32
+
+import scala.util.Try
+
+class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
+
+  private def newHistory(): ErgoHistory =
+    generateHistory(
+      verifyTransactions = false,
+      stateType = StateType.Digest,
+      PoPoWBootstrap = false,
+      blocksToKeep = 0,
+      epochLength = 1000
+    )
+
+  private def checkRoundtrip(summary: ErgoSyncInfoV2): Unit = {
+    val bytes = ErgoSyncInfoSerializer.toBytes(summary)
+    val decoded = ErgoSyncInfoSerializer.parseBytes(bytes).asInstanceOf[ErgoSyncInfoV2]
+    decoded.lastHeaders.map(_.id) shouldBe summary.lastHeaders.map(_.id)
+    decoded.height shouldBe summary.height
+    ErgoSyncInfoSerializer.toBytes(decoded).sameElements(bytes) shouldBe true
+  }
+
+  // These snapshots exercise summary selection, not header or chain validity.
+  private def snapshotReader(headers: Seq[Header]): ErgoHistoryReader = new ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = null
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Summary snapshots do not process block sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Summary snapshots do not validate block sections")
+    override def bestHeaderOpt: Option[Header] = headers.sortBy(_.height).lastOption
+    override def headersHeight: Int = bestHeaderOpt.map(_.height).getOrElse(0)
+    override def isEmpty: Boolean = headers.isEmpty
+    override def bestHeaderAtHeight(height: Int): Option[Header] = headers.find(_.height == height)
+  }
+
+  property("full and reduced sync summaries remain empty for empty history") {
+    val history = newHistory()
+    try {
+      Seq(true, false).foreach { full =>
+        val summary = history.syncInfoV2(full)
+        summary.lastHeaders shouldBe empty
+        summary.nonEmpty shouldBe false
+        summary.height shouldBe None
+        checkRoundtrip(summary)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("linear history summaries retain recent samples and exactly one genesis anchor") {
+    var history = newHistory()
+    try {
+      val chain = genHeaderChain(17, history, diffBitsOpt = None, useRealTs = false)
+      val expectedHeights = Seq(
+        1 -> Seq(1),
+        2 -> Seq(2, 1),
+        10 -> Seq(10, 1),
+        17 -> Seq(17, 1)
+      )
+      var appliedHeight = 0
+      expectedHeights.foreach { case (height, heights) =>
+        history = applyHeaderChain(history, HeaderChain(chain.headers.slice(appliedHeight, height)))
+        appliedHeight = height
+        history.headersHeight shouldBe height
+
+        val full = history.syncInfoV2(full = true)
+        val expectedIds = heights.map(h => chain.headers(h - 1).id)
+        full.lastHeaders.map(_.id) shouldBe expectedIds
+        full.lastHeaders.map(_.height) shouldBe heights
+        full.lastHeaders.head.id shouldBe history.bestHeaderOpt.get.id
+        full.lastHeaders.last.id shouldBe chain.head.id
+        full.lastHeaders.count(_.id == chain.head.id) shouldBe 1
+        full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+        full.lastHeaders.size should be <= 5
+        full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+        full.height shouldBe Some(height)
+        checkRoundtrip(full)
+
+        val reduced = history.syncInfoV2(full = false)
+        reduced.lastHeaders.map(_.id) shouldBe Seq(chain.headers(height - 1).id)
+        reduced.height shouldBe Some(height)
+        checkRoundtrip(reduced)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("full summary snapshots preserve sparse samples and deduplicate the genesis anchor") {
+    val template = defaultHeaderGen.sample.get
+    val cases = Seq(
+      Seq(129, 113, 1),
+      Seq(513, 497, 385, 1),
+      Seq(600, 584, 472, 88, 1)
+    )
+    cases.foreach { heights =>
+      val headers = heights.map(height => template.copy(height = height))
+      val reader = snapshotReader(headers)
+      val full = reader.syncInfoV2(full = true)
+      full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+      full.lastHeaders.map(_.height) shouldBe heights
+      full.lastHeaders.count(_.height == 1) shouldBe 1
+      full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+      full.lastHeaders.size should be <= 5
+      full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+      full.height shouldBe Some(heights.head)
+      checkRoundtrip(full)
+
+      val reduced = reader.syncInfoV2(full = false)
+      reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+      checkRoundtrip(reduced)
+    }
+  }
+
+  property("full summary preserves available samples when genesis is unavailable") {
+    val template = defaultHeaderGen.sample.get
+    val headers = Seq(600, 584, 472, 88).map(height => template.copy(height = height))
+    val reader = snapshotReader(headers)
+    reader.bestHeaderAtHeight(1) shouldBe None
+    val full = reader.syncInfoV2(full = true)
+    full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+    full.height shouldBe Some(600)
+    checkRoundtrip(full)
+    val reduced = reader.syncInfoV2(full = false)
+    reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+    checkRoundtrip(reduced)
+  }
+
+  Seq((3, 9, 13), (18, 249, 70)).foreach { case (sharedHeight, heightA, heightB) =>
+    property(s"full summaries recover both fork continuations after shared height $sharedHeight at tips $heightA/$heightB") {
+      var historyA = newHistory()
+      var historyB = newHistory()
+      try {
+        // Exercise stored header histories and the actual summary/continuation methods.
+        // Full block application and network delivery are separate integration contracts.
+        val shared = genHeaderChain(sharedHeight, historyA, diffBitsOpt = None, useRealTs = false)
+        val branchA = genHeaderChain(heightA - sharedHeight, prefixOpt = Some(shared.last),
+          control = historyA.difficultyCalculator, extensionHash = Digest32 @@ Array.fill[Byte](32)(1),
+          diffBitsOpt = None, useRealTs = false).headers.tail
+        val branchB = genHeaderChain(heightB - sharedHeight, prefixOpt = Some(shared.last),
+          control = historyB.difficultyCalculator, extensionHash = Digest32 @@ Array.fill[Byte](32)(2),
+          diffBitsOpt = None, useRealTs = false).headers.tail
+        val chainA = shared.headers ++ branchA
+        val chainB = shared.headers ++ branchB
+        historyA = applyHeaderChain(historyA, HeaderChain(chainA))
+        historyB = applyHeaderChain(historyB, HeaderChain(chainB))
+        historyA.headersHeight shouldBe heightA
+        historyB.headersHeight shouldBe heightB
+        branchA.head.id should not be branchB.head.id
+        historyA.contains(branchB.head.id) shouldBe false
+        historyB.contains(branchA.head.id) shouldBe false
+
+        Seq((historyA, historyB, chainA), (historyB, historyA, chainB)).foreach {
+          case (local, peer, localChain) =>
+            val sparseHeaders = ErgoHistoryReader.FullV2SyncOffsets.toSeq
+              .flatMap(offset => peer.bestHeaderAtHeight(peer.headersHeight - offset))
+            sparseHeaders should not be empty
+            sparseHeaders.exists(header => local.contains(header.id)) shouldBe false
+            local.continuationIdsV2(ErgoSyncInfoV2(sparseHeaders), size = 400) shouldBe empty
+
+            val full = peer.syncInfoV2(full = true)
+            checkRoundtrip(full)
+            val continuation = local.continuationIdsV2(full, size = 400)
+            continuation.map(_._2) shouldBe localChain.tail.map(_.id)
+            continuation.map(_._1).distinct shouldBe Seq(Header.modifierTypeId)
+            continuation.map(_._2) should contain(localChain(sharedHeight).id)
+            full.lastHeaders.last.id shouldBe shared.head.id
+        }
+      } finally {
+        try historyA.closeStorage() finally historyB.closeStorage()
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/MempoolBlockClearingSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/MempoolBlockClearingSpec.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.mempool
 
-import org.ergoplatform.{ErgoBox, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
 import org.ergoplatform.mining.InputBlockFields
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
@@ -79,24 +79,22 @@ class MempoolBlockClearingSpec extends AnyFlatSpec
   private def emptyInputBlockFields: InputBlockFields = InputBlockFields.empty
 
   it should "remove transactions from mempool when block containing them is applied" in {
-    // Setup initial state with genesis block
-    val (us, bh) = createUtxoState(settings)
-    val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-
-    // Create valid transactions from available boxes and add them to mempool
-    val boxes = wus.takeBoxes(3)
-    val limit = 10000
-    val txs = validTransactionsFromBoxes(limit, boxes, new RandomWrapper)._1
-    info(s"Generated ${txs.length} transactions")
-    txs.length should be >= 1
+    val boxes = Seq(testBox1, testBox2, testBox3)
+    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir, settings, parameters)
+    val txs = boxes.map { box =>
+      ErgoTransaction(IndexedSeq(Input(box.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(box.value, box.ergoTree, box.creationHeight)))
+    }
+    txs.length shouldBe 3
     val unconfirmedTxs = txs.map(tx => UnconfirmedTransaction(tx, None))
     var pool = ErgoMemPool.empty(settings)
 
     // Add all transactions to mempool
     unconfirmedTxs.foreach { utx =>
-      val (_newPool, outcome) = pool.process(utx, wus)
-      outcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+      val (_newPool, outcome) = pool.process(utx, state)
+      withClue(s"Admission of ${utx.transaction.id}: $outcome: ") {
+        outcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+      }
       pool = _newPool
     }
 

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/HeaderBodyCacheWakeupSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/HeaderBodyCacheWakeupSpec.scala
@@ -1,0 +1,68 @@
+package org.ergoplatform.nodeView.viewholder
+
+import akka.testkit.TestProbe
+import org.ergoplatform.core.idToVersion
+import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.BlockSectionsProcessingCacheUpdate
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.ModifiersFromRemote
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
+import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestConfig, NodeViewTestOps}
+import org.ergoplatform.utils.fixtures.NodeViewFixture
+import org.ergoplatform.utils.generators.ValidBlocksGenerators._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class HeaderBodyCacheWakeupSpec extends ErgoCorePropertyTest with NodeViewTestOps {
+  import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+
+  Seq(StateType.Utxo, StateType.Digest).foreach { stateType =>
+    property(s"remote header wakes already cached block sections in $stateType state") {
+      val fixture = new NodeViewFixture(
+        NodeViewTestConfig(stateType, verifyTransactions = true, popowBootstrap = false).toSettings,
+        parameters)
+      import fixture._
+      val (generationState, boxes) = createUtxoState(fixture.settings)
+      try {
+        val prefix = validFullBlock(None, generationState, boxes)
+        val afterPrefix = WrappedUtxoState(generationState, boxes, fixture.settings)
+          .applyModifier(prefix)(_ => ()).get
+        val next = validFullBlock(Some(prefix), afterPrefix)
+        applyBlock(prefix).isSuccess shouldBe true
+        getCurrentState.version shouldBe idToVersion(prefix.id)
+
+        val cacheProbe = TestProbe()(actorSystem)
+        actorSystem.eventStream.subscribe(cacheProbe.ref, classOf[BlockSectionsProcessingCacheUpdate])
+        val sections: Seq[BlockSection] = Seq(next.blockTransactions, next.extension, next.adProofs.get)
+        sections.map(_.modifierTypeId).distinct.size shouldBe 3
+        sections.zipWithIndex.foreach { case (section, index) =>
+          nodeViewHolderRef ! ModifiersFromRemote(Seq(section))
+          val cached = cacheProbe.expectMsgType[BlockSectionsProcessingCacheUpdate](5.seconds)
+          cached.blockSectionsCacheSize shouldBe index + 1
+          cached.cleared._2 shouldBe empty
+        }
+        val beforeHeader = getCurrentView
+        beforeHeader.history.contains(next.header.id) shouldBe false
+        sections.foreach(section => beforeHeader.history.contains(section.id) shouldBe false)
+        beforeHeader.state.version shouldBe idToVersion(prefix.id)
+
+        // The cache-update event is an actor-processing barrier, not another drain trigger.
+        // No body section is resent after its prerequisite header arrives.
+        nodeViewHolderRef ! ModifiersFromRemote(Seq(next.header))
+        val afterHeader = cacheProbe.expectMsgType[BlockSectionsProcessingCacheUpdate](5.seconds)
+        afterHeader.headersCacheSize shouldBe 0
+        val current = getCurrentView
+        current.history.getFullBlock(next.header).map(_.id) shouldBe Some(next.id)
+        sections.foreach(section => current.history.contains(section.id) shouldBe true)
+        current.history.bestFullBlockIdOpt shouldBe Some(next.id)
+        current.state.version shouldBe idToVersion(next.id)
+        current.state.rootDigest.toSeq shouldBe next.header.stateRoot.toSeq
+        afterHeader.blockSectionsCacheSize shouldBe 0
+      } finally {
+        generationState.closeStorage()
+        Await.result(actorSystem.terminate(), 15.seconds)
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
Bound pending input-block transaction synchronization by global and per-address entry and retained-weight limits. Replacements retain the original expiry; completion, expiry, connection loss and stuck-chain recovery release accounting. Overflow defers new work without evicting another in-flight request or requesting a body. Multiple connections at one address share quotas, while replacement and disconnect ownership remain connection-specific. Limits derive from the existing default sub-block count and transport message limit. Retained weight is a conservative accounting proxy, not an exact heap cap; these are local resource policies, not consensus limits.

Head `7f648ec2ed32232bca12ab2ade0f5e06c8544fc5` targets `weak-blocks`. The owning pending-cache implementation, its connection accounting and its branch-specific assertions are preserved. The [new nineteen-file prerequisite increment](https://github.com/a-shannon/ergo/compare/455a2505b60c65729e2df513609f25453a093875...d2d6e6175fc7f5237aee6246323b173deae4e188) adds existing shared synchronization and mining corrections, including seven production paths and their tests.

Synchronization prerequisites are [G](https://github.com/a-shannon/ergo/commit/d62c945a4d6314c54a7b57f18a94aee8fd258aa7), owned by [#2511](https://github.com/ergoplatform/ergo/pull/2511), on shared reader fixture [R](https://github.com/a-shannon/ergo/commit/76e5ec4bfc377334fdced4bd60a61df06e6b4cb6), owned by [#2535](https://github.com/ergoplatform/ergo/pull/2535), and holder wake-up [X](https://github.com/a-shannon/ergo/commit/a772a5cbf666584db3ed981838dbc11223d502ed), owned by [#2549](https://github.com/ergoplatform/ergo/pull/2549). G fixes genesis-anchored V2 summaries, selected-tip/mode cache identity and retained-common-ancestor download scheduling. X revisits cached bodies after missing headers arrive. The exact [test compatibility follow-up](https://github.com/a-shannon/ergo/commit/ec9c33682f3cd07266ef6c4c4cd1a763f71200d0) retains the parser bound of 50 and all round-trip assertions where the production constant is private.

Mining prerequisites reuse selection/fee and soft-field correction [E](https://github.com/a-shannon/ergo/commit/e77f77c2130521b0b9ddd7594d9d11aa5c51a56b), owned by [#2504](https://github.com/ergoplatform/ergo/pull/2504), solution forwarding [F](https://github.com/a-shannon/ergo/commit/13d79b04a9e1d9ca7dbe57b4f701158a35b3b06d), owned by [#2505](https://github.com/ergoplatform/ergo/pull/2505), and exact [b43 mining fixtures](https://github.com/a-shannon/ergo/commit/b43a21c49b827f7df11448767d28c2b3c42ab5c9), owned by [#2501](https://github.com/ergoplatform/ergo/pull/2501). Review R before G and integrate these owning corrections before this consumer. The graph reuses their focused commits rather than whole PR branches.

Existing [H](https://github.com/a-shannon/ergo/commit/0f9f75c1fc1df3ff3309482b83c0475a05cdd7a2), [U](https://github.com/a-shannon/ergo/commit/bcfcd61166151d8000ae2a05a62fa4f389aa7126), [T](https://github.com/a-shannon/ergo/commit/0679fc061f13ad2169241e3ea9d96db7bcf5dba7) and [D](https://github.com/a-shannon/ergo/commit/71f33c6e45a9394557cf3af1bfb422cbc53d26cf), owned by #2535, retain their selected-header observations, settled seed, explicit isolation, deadlines and original-exception propagation. The existing [Sigma bootstrap/codec increment](https://github.com/a-shannon/ergo/compare/a4224d588716587c39f8addbf954b7c93b238739...8dfc84b6088833809bdd04ff7a52ba3fb292d8a0), owned by #2501, is unchanged and keeps the declared coordinate and pinned source.

At `455a2505`, [native IT](https://github.com/ergoplatform/ergo/actions/runs/34738328547/job/103673607536) passed 49/51 with one ignored case. DeepRollBack's settled seed passed at 19/19, then tips 248/70 stalled despite connected peers; ForkResolution also timed out. The shared corrections are independently established and relevant to the actual source, without proving an exclusive historical cause. Earlier `8dfc84b6` failed the old flattened UTXO assertion and DeepRollBack, with 11 passed, two failed and one ignored.

The preceding composition at `d2d6e617` passed normal compilation and 111/111 tests: all 88 weak synchronizer cases, V2 cache 4, header histories 6, scheduling 11 and UTXO/Digest wake-up 2. A fresh JVM also passed the DevNet60 input-to-ordering mining case, for 112/112 checks at that preceding composition. The initial compile failure on the private parser constant was preserved and closed by the exact test-only compatibility follow-up. Independent review covered the weak fixture resolution and mining joins. Previous H/U/T/D 38/38, owner cache 9 and compatibility 8 results remain historical and input-qualified. These local gates did not run Docker or establish full CI success; native CI on the new head remains pending in [#2533](https://github.com/ergoplatform/ergo/issues/2533).

This PR complements [#2435](https://github.com/ergoplatform/ergo/pull/2435)'s generic modifier-download scheduling and [#2370](https://github.com/ergoplatform/ergo/pull/2370)'s history body-admission check. Its owning correction remains the pending Matrix transaction-diff cache.

The [new four-file test increment](https://github.com/a-shannon/ergo/compare/d2d6e6175fc7f5237aee6246323b173deae4e188...7f648ec2ed32232bca12ab2ade0f5e06c8544fc5) merges exact shared [P/M/funding fixtures](https://github.com/a-shannon/ergo/commit/29e6b6c641c6b2f8e179a9a596fc566c494a8a7d). P uses actual ordering-only proofs; M starts from admissible funded state and checks the original clearing behavior; the generator preserves token/value construction while supplying sufficient funding. Direct seeded regressions exercise that generator. Review this common fixture commit once. The pending-cache production correction and its assertions remain unchanged. Normal Scala 2.12 compilation and 21/21 affected checks passed on this exact tree: core proof 5, mempool clearing 13, funding 2 and the original large-mempool property 1. Each group used one test task in a fresh JVM and data directory. Earlier synchronization and owner-cache evidence is reused only for unchanged source inputs. These local results do not replace exact-head native CI.
