### PR TITLE
Replay processed input tips during peer sync

### DIFF
--- a/.github/actions/bootstrap-sigmastate/action.yml
+++ b/.github/actions/bootstrap-sigmastate/action.yml
@@ -1,0 +1,102 @@
+name: Bootstrap pinned SigmaState
+description: Build the unavailable SigmaState snapshot from its exact source commit
+
+inputs:
+  scala-version:
+    description: Full Scala version used by the consuming Ergo job
+    required: true
+  ergo-build-file:
+    description: Ergo build file that declares the pinned SigmaState version
+    required: false
+    default: build.sbt
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 8 for SigmaState
+      uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+      with:
+        distribution: temurin
+        java-version: '8'
+
+    - name: Set up sbt
+      uses: sbt/setup-sbt@7b0c62920c0c6e456e829dcaad762cff5048167f # v1
+
+    - name: Build and publish SigmaState locally
+      shell: bash
+      env:
+        ERGO_BUILD_FILE: ${{ inputs.ergo-build-file }}
+        SIGMASTATE_REPOSITORY: https://github.com/ergoplatform/sigmastate-interpreter.git
+        SIGMASTATE_SCALA_VERSION: ${{ inputs.scala-version }}
+      run: |
+        set -euo pipefail
+
+        unset GITHUB_TOKEN SONATYPE_USERNAME SONATYPE_PASSWORD PGP_PASSPHRASE
+
+        ergo_build="${GITHUB_WORKSPACE}/${ERGO_BUILD_FILE}"
+        if [[ ! -f "${ergo_build}" ]]; then
+          echo "::error::Ergo build file not found: ${ERGO_BUILD_FILE}"
+          exit 1
+        fi
+
+        declared_version="$(sed -nE 's/^[[:space:]]*val[[:space:]]+sigmaStateVersion[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' "${ergo_build}")"
+        case "${declared_version}" in
+          6.0.2-30-59782d92-SNAPSHOT)
+            SIGMASTATE_COMMIT=59782d92065eec3abd0dc47af22e25141857b2ee
+            ;;
+          6.0.5-22-368a860b-SNAPSHOT)
+            SIGMASTATE_COMMIT=368a860be033af94aa14895381f42099b3646db6
+            ;;
+          *)
+            echo "::error::Unsupported SigmaState declaration: ${declared_version:-<missing>}"
+            exit 1
+            ;;
+        esac
+        SIGMASTATE_VERSION="${declared_version}"
+
+        case "${SIGMASTATE_SCALA_VERSION}" in
+          2.11.12|2.12.20|2.13.16) ;;
+          *)
+            echo "::error::Unsupported Scala version: ${SIGMASTATE_SCALA_VERSION}"
+            exit 1
+            ;;
+        esac
+
+        sigma_dir="$(mktemp -d "${RUNNER_TEMP}/sigmastate.XXXXXX")"
+        git -C "${sigma_dir}" init
+        git -C "${sigma_dir}" remote add origin "${SIGMASTATE_REPOSITORY}"
+        git -C "${sigma_dir}" fetch --no-tags --depth=1 origin "${SIGMASTATE_COMMIT}"
+        git -C "${sigma_dir}" checkout --detach FETCH_HEAD
+
+        actual_commit="$(git -C "${sigma_dir}" rev-parse HEAD)"
+        if [[ "${actual_commit}" != "${SIGMASTATE_COMMIT}" ]]; then
+          echo "::error::SigmaState checkout mismatch: expected ${SIGMASTATE_COMMIT}, got ${actual_commit}"
+          exit 1
+        fi
+
+        (
+          cd "${sigma_dir}"
+          sbt -batch -J-Xms512m -J-Xmx4g \
+            "++${SIGMASTATE_SCALA_VERSION}!" \
+            "set ThisBuild / version := \"${SIGMASTATE_VERSION}\"" \
+            "show ThisBuild / version" \
+            "show scalaVersion" \
+            publishLocal
+        )
+
+        scala_binary="${SIGMASTATE_SCALA_VERSION%.*}"
+        ivy_dir="${HOME}/.ivy2/local/org.scorexfoundation/sigma-state_${scala_binary}/${SIGMASTATE_VERSION}"
+        ivy_file="${ivy_dir}/ivys/ivy.xml"
+        main_jar="${ivy_dir}/jars/sigma-state_${scala_binary}.jar"
+        tests_jar="${ivy_dir}/jars/sigma-state_${scala_binary}-tests.jar"
+
+        if [[ ! -s "${ivy_file}" || ! -s "${main_jar}" || ! -s "${tests_jar}" ]]; then
+          echo "::error::SigmaState local publication is missing its Ivy descriptor or JARs"
+          exit 1
+        fi
+
+        if ! grep -Fq "revision=\"${SIGMASTATE_VERSION}\"" "${ivy_file}" || \
+           ! grep -Fq "name=\"scala-library\" rev=\"${SIGMASTATE_SCALA_VERSION}\"" "${ivy_file}"; then
+          echo "::error::SigmaState local publication does not match the requested version and Scala toolchain"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java }}
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
@@ -46,6 +41,16 @@ jobs:
               ~/AppData/Local/Coursier/Cache/v1
               ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Build pinned SigmaState dependency
+        uses: ./.github/actions/bootstrap-sigmastate
+        with:
+          scala-version: ${{ matrix.scala }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Runs wallet tests
         run: sbt ++${{ matrix.scala }} ergoWallet/test
@@ -73,11 +78,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java }}
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
@@ -89,6 +89,16 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Build pinned SigmaState dependency
+        uses: ./.github/actions/bootstrap-sigmastate
+        with:
+          scala-version: ${{ matrix.scala }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Runs ergo-core tests
         run: sbt ++${{ matrix.scala }} ergoCore/test
@@ -114,11 +124,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java }}
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
@@ -130,6 +135,16 @@ jobs:
               ~/AppData/Local/Coursier/Cache/v1
               ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Build pinned SigmaState dependency
+        uses: ./.github/actions/bootstrap-sigmastate
+        with:
+          scala-version: ${{ matrix.scala }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Runs node tests
         run: sbt -Denv=test clean ++${{ matrix.scala }} test
@@ -149,11 +164,6 @@ jobs:
            path: it
            fetch-depth: 0
 
-       - name: Setup Java and Scala
-         uses: olafurpg/setup-scala@v10
-         with:
-           java-version: ${{ matrix.java }}
-
        - name: Cache sbt
          uses: actions/cache@v4
          with:
@@ -165,6 +175,17 @@ jobs:
              ~/AppData/Local/Coursier/Cache/v1
              ~/Library/Caches/Coursier/v1
            key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+       - name: Build pinned SigmaState dependency
+         uses: ./it/.github/actions/bootstrap-sigmastate
+         with:
+           scala-version: ${{ matrix.scala }}
+           ergo-build-file: it/build.sbt
+
+       - name: Setup Java and Scala
+         uses: olafurpg/setup-scala@v10
+         with:
+           java-version: ${{ matrix.java }}
 
        - name: Runs it node tests
          run: |

--- a/ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosSolution.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosSolution.scala
@@ -49,14 +49,14 @@ case class WeakAutolykosSolution(pk: EcPointType, n: Array[Byte]) {
 
 object WeakAutolykosSolution extends ApiCodecs {
 
-  implicit val jsonEncoder: Encoder[WeakAutolykosSolution] = { s: WeakAutolykosSolution =>
+  implicit val jsonEncoder: Encoder[WeakAutolykosSolution] = Encoder.instance { s: WeakAutolykosSolution =>
     Map(
       "pk" -> s.pk.asJson,
       "n" -> Algos.encode(s.n).asJson
     ).asJson
   }
 
-  implicit val jsonDecoder: Decoder[WeakAutolykosSolution] = { c: HCursor =>
+  implicit val jsonDecoder: Decoder[WeakAutolykosSolution] = Decoder.instance { c: HCursor =>
     for {
       pkOpt <- c.downField("pk").as[Option[EcPointType]]
       n <- c.downField("n").as[Array[Byte]]

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala
@@ -31,6 +31,7 @@ import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import sigma.exceptions.SoftFieldAccessException
 import sigma.serialization.{ConstantStore, SigmaByteReader, SigmaByteWriter}
 
+import java.lang.reflect.InvocationTargetException
 import java.util
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -152,8 +153,8 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
     val costTry = verifier.verify(box.ergoTree, ctx, proof, messageToSign)
     val (isCostValid, scriptCost: Long) =
       costTry match {
-        case Failure(t) if t.isInstanceOf[SoftFieldAccessException] =>
-          return Invalid(Seq(new SoftFieldsAccessError(t.asInstanceOf[SoftFieldAccessException], id)))
+        case Failure(ErgoTransaction.SoftFieldFailure(cause)) =>
+          return Invalid(Seq(new SoftFieldsAccessError(cause, id)))
         case Failure(t) =>
           log.warn(s"Tx verification failed: ${t.getMessage}", t)
           log.warn(s"Tx $id verification context: " +
@@ -492,6 +493,20 @@ case class ErgoTransaction(override val inputs: IndexedSeq[Input],
 }
 
 object ErgoTransaction extends ApiCodecs with ScorexLogging with ScorexEncoding {
+
+  private object SoftFieldFailure {
+    def unapply(error: Throwable): Option[SoftFieldAccessException] = {
+      @scala.annotation.tailrec
+      def unwrap(current: Throwable, remaining: Int): Option[SoftFieldAccessException] = current match {
+        case cause: SoftFieldAccessException => Some(cause)
+        case wrapper: InvocationTargetException if remaining > 0 =>
+          unwrap(wrapper.getTargetException, remaining - 1)
+        case _ => None
+      }
+      // Only reflection wrappers are transparent; unrelated failures keep their normal rejection path.
+      unwrap(error, 16)
+    }
+  }
 
   /**
     * 6 bytes long transaction id, not cryptographically strong, used in p2p protocol only

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.mining
 
+import cats.syntax.either._
 import com.google.common.primitives.Ints
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/AutolykosPowSchemeSpec.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.mining
 
-import com.google.common.primitives.Ints
+import cats.syntax.either._
+import com.google.common.primitives.{Ints, Longs}
 import org.ergoplatform.mining.difficulty.DifficultySerializer
 import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
 import org.ergoplatform.settings.{ErgoValidationSettingsUpdate, Parameters}
@@ -8,15 +9,18 @@ import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalacheck.Gen
 import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
-import org.ergoplatform.OrderingSolutionFound
+import org.ergoplatform.{InputSolutionFound, OrderingSolutionFound}
 
 class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoCoreTestConstants._
   import org.ergoplatform.utils.generators.ErgoCoreGenerators._
 
+  // This specification searches for ordering headers, without stopping at input-block hits.
+  private val orderingOnlyParams = Parameters(0, Parameters.DefaultParameters, ErgoValidationSettingsUpdate.empty)
+    .withNumOfSubblocksPerBlock(1)
+
   property("generated solution should be valid") {
     val pow = new AutolykosPowScheme(powScheme.k, powScheme.n)
-    val defaultParams = Parameters(0, Parameters.DefaultParameters, ErgoValidationSettingsUpdate.empty)
     forAll(invalidHeaderGen,
             Gen.choose(100, 120),
             Gen.choose[Byte](1, 2)) { (inHeader, difficulty, ver) =>
@@ -28,7 +32,7 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
       val b = pow.getB(h.nBits)
       val hbs = Ints.toByteArray(h.height)
       val N = pow.calcN(h)
-      pow.checkNonces(ver, hbs, msg, sk, x, b, N, 0, 1000, defaultParams) match {
+      pow.checkNonces(ver, hbs, msg, sk, x, b, N, 0, 1000, orderingOnlyParams) match {
         case OrderingSolutionFound(as) =>
           val nh = h.copy(powSolution = as)
           pow.validate(nh) shouldBe 'success
@@ -40,7 +44,7 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
 
             val invalidHeader2 = Iterator.iterate(0L)(_ + 1000L).take(50)
               .flatMap { startNonce =>
-                pow.checkNonces(ver, hbs, msg2, sk, x, b, N, startNonce, startNonce + 1000, defaultParams) match {
+                pow.checkNonces(ver, hbs, msg2, sk, x, b, N, startNonce, startNonce + 1000, orderingOnlyParams) match {
                   case OrderingSolutionFound(as2) => Some(h.copy(powSolution = as2))
                   case _                          => None
                 }
@@ -51,6 +55,29 @@ class AutolykosPowSchemeSpec extends ErgoCorePropertyTest {
           }
         case _ =>
       }
+    }
+  }
+
+  property("ordering-only search continues past an input-block hit in the same nonce window") {
+    val pow = new AutolykosPowScheme(powScheme.k, powScheme.n)
+    val msg = Array.fill[Byte](32)(0)
+    val height = Ints.toByteArray(1)
+    val target = pow.getB(DifficultySerializer.encodeCompactBits(100))
+    val n = pow.calcN(2, 1)
+    val inputParams = Parameters(0, Parameters.DefaultParameters, ErgoValidationSettingsUpdate.empty)
+
+    val input = pow.checkNonces(2, height, msg, BigInt(1), BigInt(2), target, n, 0, 1000, inputParams) match {
+      case InputSolutionFound(solution) => solution
+      case other => fail(s"Expected an input-block hit before the ordering solution, got $other")
+    }
+    input.d should be > target
+    input.d should be <= (target * inputParams.subBlocksPerBlock)
+
+    pow.checkNonces(2, height, msg, BigInt(1), BigInt(2), target, n, 0, 1000, orderingOnlyParams) match {
+      case OrderingSolutionFound(solution) =>
+        solution.d should be <= target
+        Longs.fromByteArray(solution.n) should be > Longs.fromByteArray(input.n)
+      case other => fail(s"Expected an ordering solution in the same nonce window, got $other")
     }
   }
 

--- a/ergo-core/src/test/scala/org/ergoplatform/mining/llm_generated/WeakAutolykosSolutionCodecsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/mining/llm_generated/WeakAutolykosSolutionCodecsSpec.scala
@@ -1,0 +1,41 @@
+package org.ergoplatform.mining.llm_generated
+
+import io.circe.Json
+import org.ergoplatform.AutolykosSolution.pkForV2
+import org.ergoplatform.mining.{WeakAutolykosSolution, groupElemToBytes}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigma.crypto.CryptoConstants
+
+class WeakAutolykosSolutionCodecsSpec extends AnyFlatSpec with Matchers {
+  private val publicKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+  private val nonce = Array[Byte](0, 1, 2, 3, 4, 5, 6, 7)
+  private val nonceJson = Json.fromString("0001020304050607")
+
+  it should "preserve the exact public key and nonce JSON fields" in {
+    val solution = WeakAutolykosSolution(CryptoConstants.dlogGroup.generator, nonce)
+    val expected = Json.obj("pk" -> Json.fromString(publicKeyHex), "n" -> nonceJson)
+
+    WeakAutolykosSolution.jsonEncoder(solution) shouldBe expected
+    val decoded = WeakAutolykosSolution.jsonDecoder.decodeJson(expected).right.get
+    decoded.encodedPk.toSeq shouldBe solution.encodedPk.toSeq
+    decoded.n.toSeq shouldBe nonce.toSeq
+  }
+
+  it should "retain the default public key when pk is absent" in {
+    val decoded = WeakAutolykosSolution.jsonDecoder.decodeJson(Json.obj("n" -> nonceJson)).right.get
+
+    decoded.encodedPk.toSeq shouldBe groupElemToBytes(pkForV2).toSeq
+    decoded.n.toSeq shouldBe nonce.toSeq
+  }
+
+  it should "reject a missing or malformed nonce" in {
+    Seq(
+      Json.obj("pk" -> Json.fromString(publicKeyHex)),
+      Json.obj("n" -> Json.fromString("not-hex")),
+      Json.obj("n" -> Json.fromInt(1))
+    ).foreach { json =>
+      WeakAutolykosSolution.jsonDecoder.decodeJson(json).isLeft shouldBe true
+    }
+  }
+}

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/mempool/llm_generated/SoftFieldValidationSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/mempool/llm_generated/SoftFieldValidationSpec.scala
@@ -1,0 +1,76 @@
+package org.ergoplatform.modifiers.mempool
+
+import java.lang.reflect.InvocationTargetException
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoLikeContext, Input}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoCoreTestConstants._
+import org.ergoplatform.validation.SoftFieldsAccessError
+import org.ergoplatform.wallet.interpreter.ErgoInterpreter
+import scorex.util.bytesToId
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.exceptions.SoftFieldAccessException
+import sigma.interpreter.ProverResult
+import sigmastate.interpreter.Interpreter.{ScriptEnv, VerificationResult}
+import scala.util.{Failure, Try}
+
+class SoftFieldValidationSpec extends ErgoCorePropertyTest {
+  private val box = new ErgoBox(
+    value = 1000000000L, ergoTree = TrueTree, creationHeight = 0,
+    additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+    transactionId = bytesToId(Array.fill(32)(1.toByte)), index = 0
+  )
+  private val tx = ErgoTransaction(
+    IndexedSeq(Input(box.id, ProverResult.empty)),
+    IndexedSeq(new ErgoBoxCandidate(box.value, TrueTree, emptyStateContext.currentHeight))
+  )
+
+  private def failureReturnedBy(cause: Throwable): Throwable = {
+    implicit val verifier: ErgoInterpreter = new ErgoInterpreter(parameters) {
+      override def verify(env: ScriptEnv, exp: ErgoTree, context: ErgoLikeContext,
+                          proof: Array[Byte], message: Array[Byte]): Try[VerificationResult] = Failure(cause)
+    }
+    val result = tx.statefulValidity(IndexedSeq(box), IndexedSeq.empty, emptyStateContext,
+      accumulatedCost = 0L, softFieldsAllowed = false)
+    result.isFailure shouldBe true
+    result.failed.get
+  }
+
+  property("direct soft-field failures retain their classification and cause") {
+    val cause = new SoftFieldAccessException("minerPubKey")
+    val error = failureReturnedBy(cause)
+    error shouldBe a[SoftFieldsAccessError]
+    error.getCause shouldBe cause
+  }
+
+  property("reflection-wrapped soft-field failures retain their classification and cause") {
+    val cause = new SoftFieldAccessException("minerPubKey")
+    val error = failureReturnedBy(new InvocationTargetException(cause))
+    error shouldBe a[SoftFieldsAccessError]
+    error.getCause shouldBe cause
+  }
+
+  property("nested reflection calls preserve the soft-field classification") {
+    val cause = new SoftFieldAccessException("timestamp")
+    val error = failureReturnedBy(new InvocationTargetException(new InvocationTargetException(cause)))
+    error shouldBe a[SoftFieldsAccessError]
+    error.getCause shouldBe cause
+  }
+
+  property("unrelated interpreter failures retain ordinary rejection") {
+    Seq(new IllegalArgumentException("invalid input"),
+      new InvocationTargetException(new IllegalArgumentException("invalid input")),
+      new InvocationTargetException(null),
+      new IllegalStateException(new SoftFieldAccessException("minerPubKey"))).foreach { cause =>
+      failureReturnedBy(cause).isInstanceOf[SoftFieldsAccessError] shouldBe false
+    }
+  }
+
+  property("reflection unwrapping observes its depth limit") {
+    def wrapped(depth: Int): Throwable = (1 to depth).foldLeft[Throwable](
+      new SoftFieldAccessException("minerPubKey")) { (cause, _) => new InvocationTargetException(cause) }
+    failureReturnedBy(wrapped(16)) shouldBe a[SoftFieldsAccessError]
+    failureReturnedBy(wrapped(17)).isInstanceOf[SoftFieldsAccessError] shouldBe false
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionDiagnosticsSpec.scala
@@ -1,0 +1,57 @@
+package org.ergoplatform.it
+
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ForkResolutionDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  import ForkResolutionDiagnostics._
+
+  "Fork observations" should "retain independently accepted results while later selections change" in {
+    val first = latch(Vector.fill[Option[String]](4)(None), Vector(Some("a"), None, Some("a"), None))
+    val later = latch(first, Vector(None, Some("a"), None, Some("a")))
+    later shouldBe Vector.fill(4)(Some("a"))
+    latch(later, Vector.fill(4)(Some("b"))) shouldBe later
+  }
+
+  it should "retain missing results until their own predicate succeeds" in {
+    latch(Vector(Some("a"), None), Vector(None, None)) shouldBe Vector(Some("a"), None)
+  }
+
+  it should "report the fixed target separately from the current selected header" in {
+    val target = "ab" * 32
+    val current = "cd" * 32
+    val snapshot = Snapshot(Right(NodeInfo(None, None, Some(25), Some(20), None, Some(false))),
+      Right(3), Right(Seq(current, target)), Right(20), reachable = true)
+    val text = describe("match-anchor", 2, Some(10), Some(target), snapshot)
+    text should include(s"fixed=Some($target)")
+    text should include(s"selected=$current")
+    text should include("headerHeight=Some(25) fullHeight=Some(20) mining=Some(false)")
+    text should include("peerCount=3")
+  }
+
+  it should "exclude response text, addresses and paths from observed fields" in {
+    val payload = "http://example.invalid/private/location"
+    val snapshot = Snapshot(Right(NodeInfo(Some(payload), Some(payload), Some(1), Some(1), Some(payload), None)),
+      Left(payload), Right(Seq(payload)), Right(1), reachable = true)
+    val text = describe("match-anchor", 0, Some(1), Some(payload), snapshot)
+    text should not include payload
+    text should include("peerErrorClass=ObservationError")
+    text should include("selected=invalid-header-id")
+    text should include("fixed=Some(invalid-header-id)")
+    describe("initial-height", 0, None, None,
+      Snapshot(Left("TimeoutException"), Left("IOException"), Left("ParsingFailure"),
+        Left("TimeoutException"), reachable = false)) should
+      include("statusErrorClass=TimeoutException peerErrorClass=IOException headerErrorClass=ParsingFailure")
+  }
+
+  it should "keep supplementary failures out of the startup and height acceptance gates" in {
+    val snapshot = Snapshot(Left("ParsingFailure"), Left("TimeoutException"), Left("IOException"),
+      Right(20), reachable = true)
+    startupReached(snapshot) shouldBe Some(())
+    heightReached(20)(snapshot) shouldBe Some(20)
+    heightReached(21)(snapshot) shouldBe None
+    heightReached(20)(snapshot.copy(fullHeight = Left("ParsingFailure"))) shouldBe None
+    startupReached(snapshot.copy(reachable = false)) shouldBe None
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/ForkResolutionSpec.scala
@@ -1,20 +1,24 @@
 package org.ergoplatform.it
 
 import java.io.File
-import cats.implicits._
+import java.util.concurrent.atomic.AtomicBoolean
 import com.typesafe.config.Config
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.NodeInfo
 import org.ergoplatform.it.container.Docker.{ExtraConfig, noExtraConfig}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.scalatest.concurrent.Eventually
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.async.Async
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Try
+import scala.util.control.NonFatal
 
-class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite with Eventually {
+class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite {
+
+  import ForkResolutionDiagnostics._
 
   val nodesQty: Int = 4
 
@@ -43,24 +47,107 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
 
   def localVolume(n: Int): String = s"$localDataDir/fork-resolution-spec/node-$n/data"
 
+  private var phase = "initial-start"
+  private var recent = Vector.empty[String]
+  private val active = new AtomicBoolean(true)
+
+  private def enter(next: String): Unit = synchronized {
+    requireActive()
+    phase = next
+    log.info(s"Fork resolution phase=$phase")
+  }
+
+  private def remember(entry: String): Unit = synchronized {
+    recent = (recent :+ entry).takeRight(nodesQty * 3)
+  }
+
+  private def evidence: String = synchronized { s"phase=$phase; ${recent.mkString("; ")}" }
+
   def clearPeerDatabases(): Unit = {
-    volumesMapping.foreach { case (localVolume, remoteVolume) =>
+    volumesMapping.zipWithIndex.foreach { case ((localVolume, remoteVolume), index) =>
+      requireActive()
+      remember(s"phase=$phase node=$index operation=clear-peers")
       docker.removeFromMountedVolume(localVolume, remoteVolume, "peers")
     }
   }
 
-  def startNodesWithBinds(nodeConfigs: List[Config],
+  private def startNodesWithBinds(nodeConfigs: List[Config], observations: ConvergenceObservations,
+                          deadline: Option[Deadline] = None,
                           configEnrich: ExtraConfig = noExtraConfig): List[Node] = {
-    log.trace(s"Starting ${nodeConfigs.size} containers")
-    val nodes: Try[List[Node]] = nodeConfigs
+    val nodes = nodeConfigs
       .map(_.withFallback(specialDataDirConfig(remoteVolume)))
       .zip(volumesMapping)
-      .map { case (cfg, vol) => docker.startDevNetNode(cfg, configEnrich, Some(vol)) }
-      .sequence
-    implicit val patienceConfig: PatienceConfig = PatienceConfig((nodeConfigs.size * 2).seconds, 3.second)
-    eventually {
-      Await.result(Future.traverse(nodes.get)(_.waitForStartup), 180.seconds)
+      .zipWithIndex.map { case ((cfg, vol), index) =>
+        requireActive()
+        deadline.foreach(d => requireTime(d))
+        remember(s"phase=$phase node=$index operation=start")
+        docker.startDevNetNode(cfg, configEnrich, Some(vol)).get
+      }
+    val startupDeadline = deadline.map(d => d.timeLeft.min(180.seconds).fromNow).getOrElse(180.seconds.fromNow)
+    waitFor(nodes, observations, startupDeadline, None, None)(startupReached)
+    nodes
+  }
+
+  private def requireTime(deadline: Deadline): Unit = {
+    requireActive()
+    if (deadline.isOverdue()) throw new java.util.concurrent.TimeoutException("Fork resolution deadline")
+  }
+
+  private def requireActive(): Unit = {
+    if (!active.get()) throw new java.util.concurrent.CancellationException("Fork resolution finished")
+  }
+
+  private def waitFor[A](nodes: List[Node], observations: ConvergenceObservations, deadline: Deadline,
+                         headerHeight: Option[Int], fixedSample: Option[String])
+                        (accept: Snapshot => Option[A]): Vector[A] = {
+    val currentPhase = phase
+    val probes = nodes.map { node =>
+      def json(path: String): Future[Json] = {
+        requireTime(deadline)
+        node.singleGet(path, _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[Json](response.getResponseBody)
+        }
+      }
+      val status = observations.probe {
+        requireTime(deadline)
+        node.singleGet("/info", _.setRequestTimeout(5000)).map { response =>
+          require(response.getStatusCode == 200, "Unexpected observation status")
+          val parsed = Try(node.ergoJsonAnswerAs[Json](response.getResponseBody))
+          val info = parsed.flatMap(j => Try(j.as[NodeInfo].fold(throw _, identity)))
+            .toEither.left.map(_.getClass.getSimpleName)
+          // Height gates retain NodeApi.fullHeight's exact field/default semantics.
+          val height = parsed.flatMap(j => Try(j.hcursor.downField("fullHeight").as[Option[Int]]
+            .fold(throw _, identity).getOrElse(0))).toEither.left.map(_.getClass.getSimpleName)
+          (info, height)
+        }
+      }
+      val peers = observations.probe(json("/peers/connected").map(_.asArray.get.size))
+      val headers = headerHeight.map { height =>
+        observations.probe(json(s"/blocks/at/$height").map(_.as[Seq[String]].fold(throw _, identity)))
+      }
+      (status, peers, headers)
     }
+    var accepted = Vector.fill[Option[A]](nodes.size)(None)
+    val result = observations.until(deadline, 100.millis, 5.seconds) { budget =>
+      requireTime(deadline)
+      Future.traverse(probes.zipWithIndex) { case ((status, peers, headers), index) =>
+        val infoResult = status.sample(budget)
+        val peerResult = peers.sample(budget)
+        val headerResult = headers.map(_.sample(budget)).getOrElse(Future.successful(Right(Seq.empty[String])))
+        infoResult.zip(peerResult).zip(headerResult).map { case ((status, peerCount), ids) =>
+          val snapshot = Snapshot(status.flatMap(_._1), peerCount, ids,
+            status.flatMap(_._2), status.isRight)
+          remember(describe(currentPhase, index, headerHeight, fixedSample, snapshot) +
+            s" sampledAt=${System.currentTimeMillis()}")
+          accept(snapshot)
+        }
+      }.map { observed =>
+        accepted = latch(accepted, observed.toVector)
+        accepted
+      }
+    }(_.forall(_.isDefined))(s"Fork resolution did not complete; $evidence")
+    Await.result(result, deadline.timeLeft.max(Duration.Zero)).map(_.get)
   }
 
   // Testing scenario:
@@ -71,38 +158,84 @@ class ForkResolutionSpec extends AnyFlatSpec with Matchers with IntegrationSuite
   // 5. Check that nodes reached consensus on created forks;
   it should "Fork resolution after isolated mining" in {
 
-    log.info(minerConfig.toString)
-    onlineSyncNodesConfig.foreach(x => log.info(x.toString))
-
-    val nodes: List[Node] = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig)
-
-    val result = Async.async {
-      val initMaxHeight = Async.await(Future.traverse(nodes)(_.fullHeight).map(_.max))
-      Async.await(Future.traverse(nodes)(_.waitForHeight(initMaxHeight + commonChainLength, 100.millis)))
-      val isolatedNodes = Async.await {
-        nodes.foreach(node => docker.stopNode(node.containerId))
+    val observations = new ConvergenceObservations
+    try {
+      enter("initial-start")
+      val nodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations)
+      // Match the original budget: initial startup precedes the 15-minute scenario deadline.
+      val deadline = 15.minutes.fromNow
+      val result = Future {
+        enter("initial-height")
+        val initMaxHeight = waitFor(nodes, observations, deadline, None, None)(_.fullHeight.toOption).max
+        val forkHeight = initMaxHeight + commonChainLength + forkLength
+        enter(s"common-height target=${initMaxHeight + commonChainLength}")
+        waitFor(nodes, observations, deadline, Some(initMaxHeight + commonChainLength), None)(
+          heightReached(initMaxHeight + commonChainLength))
+        def stop(current: List[Node]): Unit = current.zipWithIndex.foreach { case (node, index) =>
+          requireTime(deadline)
+          remember(s"phase=$phase node=$index operation=stop")
+          docker.stopNode(node.containerId)
+        }
+        enter("isolate-stop")
+        stop(nodes)
+        enter("isolate-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: offlineMiningNodesConfig, isolatedPeersConfig))
-      }
-      val forkHeight = initMaxHeight + commonChainLength + forkLength
-      Async.await(Future.traverse(isolatedNodes)(_.waitForHeight(forkHeight, 100.millis)))
-      val regularNodes = Async.await {
-        isolatedNodes.foreach(node => docker.stopNode(node.containerId))
+        enter("isolate-start")
+        val isolatedNodes = startNodesWithBinds(minerConfig +: offlineMiningNodesConfig,
+          observations, Some(deadline), isolatedPeersConfig)
+        enter(s"isolated-height target=$forkHeight")
+        waitFor(isolatedNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight))
+        enter("reconnect-stop")
+        stop(isolatedNodes)
+        enter("reconnect-clear-peers")
         clearPeerDatabases()
-        Future.successful(startNodesWithBinds(minerConfig +: onlineSyncNodesConfig))
+        enter("reconnect-start")
+        val regularNodes = startNodesWithBinds(minerConfig +: onlineSyncNodesConfig, observations, Some(deadline))
+        enter(s"reconnected-height target=${forkHeight + syncLength}")
+        waitFor(regularNodes, observations, deadline, Some(forkHeight), None)(heightReached(forkHeight + syncLength))
+        enter("select-anchor")
+        val sample = waitFor(regularNodes.take(1), observations, deadline, Some(forkHeight), None)(
+          _.headers.toOption).head.headOption.value
+        enter("match-anchor")
+        val headers = waitFor(regularNodes, observations, deadline, Some(forkHeight), Some(sample))(
+          _.headers.toOption.filter(_.headOption.contains(sample)))
+        val headerIdsAtSameHeight = headers.map(_.headOption.value)
+        headerIdsAtSameHeight should contain only sample
+        log.info(s"Fork resolution completed; $evidence")
       }
-      Async.await(Future.traverse(regularNodes)(_.waitForHeight(forkHeight + syncLength, 100.millis)))
-      val sample = Async.await(regularNodes.head.headerIdsByHeight(forkHeight)).headOption.value
-      val headers = Async.await(Future.traverse(regularNodes) { node =>
-        node.waitFor[Seq[String]](_.headerIdsByHeight(forkHeight), _.headOption.contains(sample), 100.millis)
-      })
-
-      log.debug(s"Headers at height $forkHeight: ${headers.mkString(",")}")
-      val headerIdsAtSameHeight = headers.map(_.headOption.value)
-      headerIdsAtSameHeight should contain only sample
+      Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    } catch {
+      case NonFatal(error) =>
+        log.error(s"Fork resolution failed errorClass=${error.getClass.getSimpleName}; $evidence")
+        throw error
+    } finally {
+      active.set(false)
+      observations.close()
     }
-
-    Await.result(result, 15.minutes)
   }
 
+}
+
+private[it] object ForkResolutionDiagnostics {
+  final case class Snapshot(info: Either[String, NodeInfo], peers: Either[String, Int],
+                            headers: Either[String, Seq[String]], fullHeight: Either[String, Int],
+                            reachable: Boolean)
+
+  def startupReached(snapshot: Snapshot): Option[Unit] = if (snapshot.reachable) Some(()) else None
+
+  def heightReached(target: Int)(snapshot: Snapshot): Option[Int] =
+    snapshot.fullHeight.toOption.filter(_ >= target)
+
+  def latch[A](previous: Vector[Option[A]], observed: Vector[Option[A]]): Vector[Option[A]] =
+    previous.zip(observed).map { case (accepted, current) => accepted.orElse(current) }
+
+  def describe(phase: String, index: Int, height: Option[Int], fixedSample: Option[String], snapshot: Snapshot): String = {
+    def error(value: String): String = if (value.matches("[A-Za-z0-9_$]+")) value else "ObservationError"
+    val info = snapshot.info.fold(e => s"statusErrorClass=${error(e)}", value =>
+      s"headerHeight=${value.bestHeaderHeightOpt} fullHeight=${value.bestBlockHeightOpt} mining=${value.isMining}")
+    val peers = snapshot.peers.fold(e => s"peerErrorClass=${error(e)}", count => s"peerCount=$count")
+    val selected = snapshot.headers.fold(e => s"headerErrorClass=${error(e)}", ids =>
+      s"selected=${ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing")}")
+    s"phase=$phase node=$index height=$height fixed=${fixedSample.map(ConvergenceObservations.headerId)} $info $peers $selected"
+  }
 }

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  /** Both nodes report mining disabled and share a completely applied selected header tip. */
+  def sameFullyAppliedNonMiningBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean =
+    infoA.isMining.contains(false) && infoB.isMining.contains(false) &&
+      sameBestBlock(infoA, infoB, minHeight) &&
+      infoA.bestBlockIdOpt.exists(_.nonEmpty) &&
+      infoA.bestHeaderHeightOpt == infoA.bestBlockHeightOpt &&
+      infoB.bestHeaderHeightOpt == infoB.bestBlockHeightOpt &&
+      infoA.bestHeaderIdOpt == infoA.bestBlockIdOpt &&
+      infoB.bestHeaderIdOpt == infoB.bestBlockIdOpt
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,145 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  "Fully applied block agreement" should "accept a complete shared tip at the minimum height" in {
+    val info = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 12) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 13) shouldBe false
+  }
+
+  it should "reject a shared 21-header 12-full-block seed despite full-block agreement" in {
+    val lagging = NodeInfo(Some("header21"), Some("block12"), Some(21), Some(12), None, Some(false))
+    ConvergenceObservations.sameBestBlock(lagging, lagging, 1) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(lagging, lagging, 1) shouldBe false
+  }
+
+  private val completeSeed = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+
+  Seq[(String, NodeInfo => NodeInfo)](
+    "missing header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = None)),
+    "missing full-block height" -> ((info: NodeInfo) => info.copy(bestBlockHeightOpt = None)),
+    "missing header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = None)),
+    "missing full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = None)),
+    "different header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = Some("other"))),
+    "different full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = Some("other"))),
+    "different header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = Some(21))),
+    "unknown mining status" -> ((info: NodeInfo) => info.copy(isMining = None)),
+    "active mining" -> ((info: NodeInfo) => info.copy(isMining = Some(true)))
+  ).foreach { case (fault, change) =>
+    Seq("A", "B").foreach { side =>
+      it should s"reject $fault on node $side independently" in {
+        val (a, b) = if (side == "A") (change(completeSeed), completeSeed)
+                     else (completeSeed, change(completeSeed))
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, 1) shouldBe false
+      }
+    }
+  }
+
+  it should "reject two empty tip identifiers" in {
+    val empty = completeSeed.copy(bestHeaderIdOpt = Some(""), bestBlockIdOpt = Some(""))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(empty, empty, 1) shouldBe false
+  }
+
+  it should "reject different complete tips at the same height" in {
+    val other = completeSeed.copy(bestHeaderIdOpt = Some("other"), bestBlockIdOpt = Some("other"))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  it should "reject different complete heights independently of matching IDs" in {
+    val other = completeSeed.copy(bestHeaderHeightOpt = Some(13), bestBlockHeightOpt = Some(13))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  "Full block agreement" should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -30,7 +30,7 @@ import scorex.crypto.authds.LeafData
 import scorex.crypto.authds.merkle.BatchMerkleProof
 import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
-import scorex.util.{ModifierId, ScorexLogging, idToBytes}
+import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 import sigma.data.{Digest32Coll, ProveDlog}
 import sigma.crypto.CryptoFacade
 import sigma.interpreter.ProverResult
@@ -1032,6 +1032,7 @@ object CandidateGenerator extends ScorexLogging {
     var remainingTxs = transactions
     val accInput = MutableArray.empty[CostedTransaction]
     val accOrdering = MutableArray.empty[CostedTransaction]
+    val deferredOutputs = scala.collection.mutable.Set.empty[ModifierId]
     var lastFeeTx: Option[CostedTransaction] = None
     val invalidTxs = MutableArray.empty[ModifierId]
     var done = false
@@ -1046,7 +1047,19 @@ object CandidateGenerator extends ScorexLogging {
 
       remainingTxs.headOption match {
         case Some(tx) =>
-          if (!inputsNotSpent(tx, stateWithTxs) || doublespend(allCurrent, tx)) {
+          def dependsOn(outputIds: collection.Set[ModifierId]): Boolean =
+            tx.inputs.exists(i => outputIds.contains(bytesToId(i.boxId))) ||
+              tx.dataInputs.exists(i => outputIds.contains(bytesToId(i.boxId)))
+
+          def deferTx(): Unit = {
+            deferredOutputs ++= tx.outputs.map(b => bytesToId(b.id))
+            remainingTxs = remainingTxs.tail
+          }
+
+          if (dependsOn(deferredOutputs)) {
+            // Preserve descendants for a later candidate when their dependencies are available.
+            deferTx()
+          } else if (!inputsNotSpent(tx, stateWithTxs) || doublespend(allCurrent, tx)) {
             // Mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
             // Do these checks before validating the scripts to save time
             log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
@@ -1066,6 +1079,14 @@ object CandidateGenerator extends ScorexLogging {
             def collectFeeAndCheckLimits(newTxs: Seq[CostedTransaction],
                                          inputTx: Boolean,
                                          costConsumed: Int): Boolean = {
+              val otherPartition = if (inputTx) currentOrdering else currentInput
+              val otherOutputs = otherPartition.flatMap(_.outputs).map(b => bytesToId(b.id)).toSet
+              if (dependsOn(otherOutputs)) {
+                // Each payload must be executable without the other candidate's new outputs.
+                // Deferral is a selection decision, not evidence that the transaction is invalid.
+                deferTx()
+                return true
+              }
               val newBoxes = newTxs.flatMap(_._1.outputs)
 
               collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -1021,6 +1021,8 @@ object CandidateGenerator extends ScorexLogging {
 
     val currentHeight = us.stateContext.currentHeight
     val nextHeight = upcomingContext.currentHeight
+    // Use the candidate header version, including the first block of an activation epoch.
+    val inputBlocksEnabled = upcomingContext.sigmaPreHeader.version >= Header.Interpreter60Version
 
     log.info(
       s"Assembling a block candidate for block #$nextHeight from ${transactions.length} transactions available"
@@ -1147,11 +1149,11 @@ object CandidateGenerator extends ScorexLogging {
             }
 
             // Check validity and calculate transaction cost
-            validateTx(softFieldsAllowed = false) match {
+            validateTx(softFieldsAllowed = !inputBlocksEnabled) match {
               case Success(costConsumed) =>
                 val newTxs = acc :+ (tx -> costConsumed)
-                collectFeeAndCheckLimits(newTxs, inputTx = true, costConsumed)
-              case Failure(e) if e.isInstanceOf[SoftFieldsAccessError] =>
+                collectFeeAndCheckLimits(newTxs, inputTx = inputBlocksEnabled, costConsumed)
+              case Failure(e) if inputBlocksEnabled && e.isInstanceOf[SoftFieldsAccessError] =>
                 log.info(s"Rechecking transaction: $tx.id")
                 validateTx(softFieldsAllowed = true) match {
                   case Success(costConsumed) =>

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -11,7 +11,7 @@ import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.extension.Extension
 import org.ergoplatform.modifiers.history.header.{Header, HeaderWithoutPow}
 import org.ergoplatform.modifiers.history.popow.NipopowAlgos
-import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer, UnconfirmedTransaction}
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.network.message.inputblocks.InputBlockTransactionsData
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.EliminateTransactions
@@ -21,6 +21,7 @@ import org.ergoplatform.nodeView.history.ErgoHistoryUtils.Height
 import org.ergoplatform.nodeView.history.{ErgoHistoryReader, ErgoHistoryUtils}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.{ErgoState, ErgoStateContext, UtxoStateReader}
+import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.settings.{Algos, ErgoSettings, ErgoValidationSettingsUpdate, Parameters}
 import org.ergoplatform.subblocks.InputBlockAnnouncement
 import org.ergoplatform.validation.SoftFieldsAccessError
@@ -32,6 +33,8 @@ import scorex.crypto.hash.Digest32
 import scorex.util.encode.Base16
 import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 import sigma.data.{Digest32Coll, ProveDlog}
+import sigma.Extensions.ArrayOps
+import sigma.ast.syntax.ErgoBoxRType
 import sigma.crypto.CryptoFacade
 import sigma.interpreter.ProverResult
 import sigma.validation.ReplacedRule
@@ -720,7 +723,8 @@ object CandidateGenerator extends ScorexLogging {
         state.stateContext.currentParameters.maxBlockSize,
         state,
         upcomingContext,
-        newTransactionCandidates
+        newTransactionCandidates,
+        previousOrderingBlockTransactions
       )
 
       // filter out transactions included in previous input-blocks
@@ -860,18 +864,20 @@ object CandidateGenerator extends ScorexLogging {
     ).headOption
   }
 
+  val MaxFeeBoxesPerTransaction: Int = 100
+
   def collectFees(
     currentHeight: Int,
     txs: Seq[ErgoTransaction],
     minerPk: ProveDlog,
     stateContext: ErgoStateContext
-  ): Option[ErgoTransaction] = {
-    collectRewards(None, currentHeight, txs, minerPk, stateContext, Colls.emptyColl).headOption
+  ): Seq[ErgoTransaction] = {
+    collectRewards(None, currentHeight, txs, minerPk, stateContext, Colls.emptyColl)
   }
 
   /**
-    * Generate from 0 to 2 transaction that collecting rewards from fee boxes in block transactions `txs` and
-    * emission box `emissionBoxOpt`
+    * Generate at most one emission transaction, followed by fee transactions with at most
+    * MaxFeeBoxesPerTransaction inputs each, preserving the complete fee payout.
     */
   def collectRewards(
     emissionBoxOpt: Option[ErgoBox],
@@ -967,38 +973,15 @@ object CandidateGenerator extends ScorexLogging {
     val feeBoxes: Seq[ErgoBox] = ErgoState
       .newBoxes(txs)
       .filter(b => java.util.Arrays.equals(b.propositionBytes, propositionBytes) && !inputs.exists(i => java.util.Arrays.equals(i.boxId, b.id)))
-    val feeTxOpt: Option[ErgoTransaction] = if (feeBoxes.nonEmpty) {
-      // todo: sub-blocks: fix tx fee collection , old code is commented out below for now
-      /*
-       import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
-       import sigma.ast.syntax.ErgoBoxRType
-       import sigma.Extensions.ArrayOps
+    val feeTxs = feeBoxes.grouped(MaxFeeBoxesPerTransaction).map { chunk =>
+      val feeAmount = chunk.map(_.value).sum
+      val feeAssets = chunk.toArray.toColl.flatMap(_.additionalTokens).take(MaxAssetsPerBox)
+      val feeInputs = chunk.map(b => new Input(b.id, ProverResult.empty))
+      val minerBox = new ErgoBoxCandidate(feeAmount, minerProp, nextHeight, feeAssets, Map())
+      ErgoTransaction(feeInputs.toIndexedSeq, IndexedSeq.empty, IndexedSeq(minerBox))
+    }.toSeq
 
-       val feeAmount = feeBoxes.map(_.value).sum
-       val feeAssets =
-        feeBoxes.toArray.toColl.flatMap(_.additionalTokens).take(MaxAssetsPerBox)
-       val inputs = feeBoxes.map(b => new Input(b.id, ProverResult.empty))
-       val minerBox =
-        new ErgoBoxCandidate(feeAmount, minerProp, nextHeight, feeAssets, Map())
-       Some(ErgoTransaction(inputs.toIndexedSeq, IndexedSeq(), IndexedSeq(minerBox)))
-      */
-      None
-    } else {
-      None
-    }
-
-    Seq(emissionTxOpt, feeTxOpt).flatten
-  }
-
-  /**
-    * Helper function which decides whether transactions can fit into a block with given cost and size limits
-    */
-  private def correctLimits(
-    blockTxs: Seq[CostedTransaction],
-    maxBlockCost: Long,
-    maxBlockSize: Long
-  ): Boolean = {
-    blockTxs.map(_._2).sum < maxBlockCost && blockTxs.map(_._1.size).sum < maxBlockSize
+    emissionTxOpt.toSeq ++ feeTxs
   }
 
   /**
@@ -1008,6 +991,11 @@ object CandidateGenerator extends ScorexLogging {
     * Resulting transactions total cost does not exceed `maxBlockCost`, total size does not exceed `maxBlockSize`,
     * and the miner's transaction is correct.
     *
+    * The accepted input-block prefix supplies common state to both candidate payloads. Its transactions
+    * are not returned again; its collectible fees belong only to the ordering payload. Each new input
+    * payload must also leave the accumulated prefix within the conservative ordering budget.
+    * Prefix-only rewards may remain unclaimed when the mandatory transactions consume the budget.
+    *
     * @return - input block transactions to include, ordering blocks transactions to include, transaction ids turned out to be invalid.
     */
   def collectTxs(
@@ -1016,7 +1004,8 @@ object CandidateGenerator extends ScorexLogging {
                   maxBlockSize: Int,
                   us: UtxoStateReader,
                   upcomingContext: ErgoStateContext,
-                  transactions: Seq[ErgoTransaction]
+                  transactions: Seq[ErgoTransaction],
+                  inputBlockTransactions: Seq[ErgoTransaction] = Seq.empty
                 ): (Seq[ErgoTransaction], Seq[ErgoTransaction], Seq[ModifierId]) = {
 
     val currentHeight = us.stateContext.currentHeight
@@ -1030,21 +1019,118 @@ object CandidateGenerator extends ScorexLogging {
 
     val verifier: ErgoInterpreter = ErgoInterpreter(upcomingContext.currentParameters)
 
+    val transactionSizes = scala.collection.mutable.Map.empty[(Header.Version, ModifierId, ModifierId), Int]
+    val feeCosts = scala.collection.mutable.Map.empty[ModifierId, Int]
+
+    def unsignedSize(value: Long): Int = {
+      var remaining = value
+      var size = 1
+      while (remaining >= 128L) {
+        remaining = remaining >>> 7
+        size += 1
+      }
+      size
+    }
+
+    def correctLimits(blockTxs: Seq[CostedTransaction], costLimit: Long,
+                      sizeLimit: Long, blockVersion: Header.Version): Boolean = {
+      if (blockTxs.map(_._2.toLong).sum > costLimit) false
+      else if (blockTxs.isEmpty) true
+      else {
+        // Match BlockTransactionsSerializer, including its version marker and count.
+        val framing = 32L + unsignedSize(blockTxs.size.toLong) +
+          (if (blockVersion > Header.InitialVersion)
+            unsignedSize(BlockTransactionsSerializer.MaxTransactionsInBlock.toLong + blockVersion) else 0)
+        val bytes = blockTxs.map { case (tx, _) =>
+          val key = (blockVersion, tx.id, bytesToId(tx.witnessSerializedId))
+          transactionSizes.getOrElseUpdate(key, {
+            if (blockVersion >= sigma.VersionContext.V6SoftForkVersion) {
+              sigma.VersionContext.withVersions(blockVersion, blockVersion) {
+                ErgoTransactionSerializer.toBytes(tx).length
+              }
+            } else ErgoTransactionSerializer.toBytes(tx).length
+          }).toLong
+        }.sum
+        framing + bytes <= sizeLimit
+      }
+    }
+
     // Mutable state for iterative transaction processing
-    var remainingTxs = transactions
+    val version = upcomingContext.sigmaPreHeader.version
+    val prefixIds = inputBlockTransactions.map(_.id).toSet
+    val prefixState = us.withTransactions(inputBlockTransactions)
+    val prefix = inputBlockTransactions.map { tx =>
+      val cost = prefixState.validateWithCost(tx, upcomingContext,
+        upcomingContext.currentParameters.maxBlockCost, Some(verifier), softFieldsAllowed = true).get
+      tx -> cost
+    }
+    require(correctLimits(prefix, upcomingContext.currentParameters.maxBlockCost, maxBlockSize, version),
+      "Selected input transactions exceed the ordering block limits")
+    // A mandatory prefix can consume the conservative mining cost gap. Keep that valid prefix,
+    // but give optional transactions no additional cost allowance in that case.
+    val orderingCostLimit = math.max(maxBlockCost.toLong, prefix.map(_._2.toLong).sum)
+    var remainingTxs = transactions.filterNot(tx => prefixIds.contains(tx.id))
     val accInput = MutableArray.empty[CostedTransaction]
     val accOrdering = MutableArray.empty[CostedTransaction]
     val deferredOutputs = scala.collection.mutable.Set.empty[ModifierId]
-    var lastFeeTx: Option[CostedTransaction] = None
+    var lastFeeTxs = Seq.empty[CostedTransaction]
     val invalidTxs = MutableArray.empty[ModifierId]
     var done = false
 
-    while (!done) {
-      val acc: Seq[CostedTransaction] = accInput ++ accOrdering
+    def feesFor(ordering: Seq[CostedTransaction]): Option[Seq[CostedTransaction]] = {
+      val sources = inputBlockTransactions ++ ordering.map(_._1)
+      val boxes = sources.flatMap(_.outputs).map(b => bytesToId(b.id) -> b).toMap
+      val costedFees = collectFees(currentHeight, sources, minerPk, upcomingContext)
+        .foldLeft(Try(Vector.empty[CostedTransaction])) { (result, feeTx) =>
+          result.flatMap { accumulated =>
+            val checkedCost = feeCosts.get(feeTx.id) match {
+              case Some(cost) => Success(cost)
+              case None =>
+                val inputs = feeTx.inputs.flatMap(i => boxes.get(bytesToId(i.boxId)))
+                feeTx.statefulValidity(inputs, IndexedSeq.empty, upcomingContext)(verifier).map { cost =>
+                  feeCosts.put(feeTx.id, cost)
+                  cost
+                }
+            }
+            checkedCost.map(cost => accumulated :+ (feeTx -> cost))
+          }
+        }
+      costedFees match {
+        case Success(allFees) =>
+          val newOutputIds = ordering.flatMap(_._1.outputs).map(b => bytesToId(b.id)).toSet
+          val (required, optional) = allFees.partition { case (tx, _) =>
+            tx.inputs.exists(i => newOutputIds.contains(bytesToId(i.boxId)))
+          }
+          val base = prefix ++ ordering
+          if (!correctLimits(base ++ required, orderingCostLimit, maxBlockSize, version)) {
+            None
+          } else {
+            var selected: Seq[CostedTransaction] = required
+            // Already selected input transactions remain mandatory. Optional rewards must not
+            // prevent their ordering confirmation when only part of the fee collection fits.
+            optional.iterator.takeWhile { feeTx =>
+              if (correctLimits(base ++ selected :+ feeTx, orderingCostLimit, maxBlockSize, version)) {
+                selected = selected :+ feeTx
+                true
+              } else false
+            }.foreach(_ => ())
+            Some(selected)
+          }
+        case Failure(error) =>
+          log.warn(s"Fee collection is not selectable: ${error.getMessage}")
+          None
+      }
+    }
 
+    lastFeeTxs = feesFor(Seq.empty).getOrElse(Seq.empty)
+
+    while (!done) {
       def currentInput: Seq[ErgoTransaction] = accInput.map(_._1)
-      def currentOrdering: Seq[ErgoTransaction] = (accOrdering ++ lastFeeTx.toSeq).map(_._1)
-      val allCurrent = currentInput ++ currentOrdering
+      def currentOrdering: Seq[ErgoTransaction] = (accOrdering ++ lastFeeTxs).map(_._1)
+      // Generated fee rewards can change as selection proceeds, so their outputs are not
+      // stable dependencies for user transactions in this candidate.
+      val feeOutputIds = lastFeeTxs.flatMap(_._1.outputs).map(b => bytesToId(b.id)).toSet
+      val allCurrent = inputBlockTransactions ++ currentInput ++ accOrdering.map(_._1)
       val stateWithTxs = us.withTransactions(allCurrent)
 
       remainingTxs.headOption match {
@@ -1058,7 +1144,7 @@ object CandidateGenerator extends ScorexLogging {
             remainingTxs = remainingTxs.tail
           }
 
-          if (dependsOn(deferredOutputs)) {
+          if (dependsOn(deferredOutputs) || dependsOn(feeOutputIds)) {
             // Preserve descendants for a later candidate when their dependencies are available.
             deferTx()
           } else if (!inputsNotSpent(tx, stateWithTxs) || doublespend(allCurrent, tx)) {
@@ -1078,8 +1164,7 @@ object CandidateGenerator extends ScorexLogging {
                 softFieldsAllowed)
             }
 
-            def collectFeeAndCheckLimits(newTxs: Seq[CostedTransaction],
-                                         inputTx: Boolean,
+            def collectFeeAndCheckLimits(inputTx: Boolean,
                                          costConsumed: Int): Boolean = {
               val otherPartition = if (inputTx) currentOrdering else currentInput
               val otherOutputs = otherPartition.flatMap(_.outputs).map(b => bytesToId(b.id)).toSet
@@ -1089,56 +1174,30 @@ object CandidateGenerator extends ScorexLogging {
                 deferTx()
                 return true
               }
-              val newBoxes = newTxs.flatMap(_._1.outputs)
-
-              collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
-                case Some(feeTx) =>
-                  val boxesToSpend = feeTx.inputs.flatMap(i =>
-                    newBoxes.find(b => java.util.Arrays.equals(b.id, i.boxId))
-                  )
-                  feeTx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier) match {
-                    case Success(cost) =>
-                      val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
-                      if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                        if (inputTx) {
-                          accInput += ((tx, costConsumed))
-                          lastFeeTx = Some(feeTx -> cost)
-                        } else {
-                          accOrdering += ((tx, costConsumed))
-                          lastFeeTx = Some(feeTx -> cost)
-                        }
-                        remainingTxs = remainingTxs.tail
-                        true // continue
-                      } else {
-                        lazy val totalCost = (accOrdering ++ lastFeeTx.toSeq).map(_._2).sum
-                        log.debug(s"Finishing block assembly on limits overflow, " +
-                                  s"cost is $totalCost, cost limit: $maxBlockCost")
-                        done = true
-                        false // stop
-                      }
-                    case Failure(e) =>
-                      log.warn(
-                        s"Fee collecting tx is invalid, not including it, " +
-                          s"details: ${e.getMessage} from ${stateWithTxs.stateContext}"
-                      )
-                      done = true
-                      false // stop
-                  }
-                case None =>
-                  log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
-                  val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
-                  if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                    if (inputTx) {
-                      accInput += ((tx, costConsumed))
-                    } else {
-                      accOrdering += ((tx, costConsumed))
-                    }
+              val costed = tx -> costConsumed
+              if (inputTx) {
+                if (correctLimits(accInput :+ costed, maxBlockCost, maxBlockSize, version) &&
+                  correctLimits(prefix ++ accInput :+ costed,
+                    math.min(orderingCostLimit, upcomingContext.currentParameters.maxBlockCost.toLong),
+                    maxBlockSize, version)) {
+                  accInput += costed
+                  remainingTxs = remainingTxs.tail
+                  true
+                } else {
+                  done = true
+                  false
+                }
+              } else {
+                feesFor(accOrdering :+ costed) match {
+                  case Some(fees) =>
+                    accOrdering += costed
+                    lastFeeTxs = fees
                     remainingTxs = remainingTxs.tail
-                    true // continue
-                  } else {
+                    true
+                  case None =>
                     done = true
-                    false // stop
-                  }
+                    false
+                }
               }
             }
 
@@ -1151,14 +1210,12 @@ object CandidateGenerator extends ScorexLogging {
             // Check validity and calculate transaction cost
             validateTx(softFieldsAllowed = !inputBlocksEnabled) match {
               case Success(costConsumed) =>
-                val newTxs = acc :+ (tx -> costConsumed)
-                collectFeeAndCheckLimits(newTxs, inputTx = inputBlocksEnabled, costConsumed)
+                collectFeeAndCheckLimits(inputTx = inputBlocksEnabled, costConsumed)
               case Failure(e) if inputBlocksEnabled && e.isInstanceOf[SoftFieldsAccessError] =>
                 log.info(s"Rechecking transaction: $tx.id")
                 validateTx(softFieldsAllowed = true) match {
                   case Success(costConsumed) =>
-                    val newTxs = acc :+ (tx -> costConsumed)
-                    collectFeeAndCheckLimits(newTxs, inputTx = false, costConsumed)
+                    collectFeeAndCheckLimits(inputTx = false, costConsumed)
                   case Failure(e) =>
                     failTx(e)
                 }
@@ -1171,10 +1228,16 @@ object CandidateGenerator extends ScorexLogging {
       }
     }
 
-    val res = (accInput.map(_._1), accOrdering.map(_._1), invalidTxs)
+    val res = (accInput.map(_._1), (accOrdering ++ lastFeeTxs).map(_._1), invalidTxs)
+    val feeProposition = upcomingContext.chainSettings.monetary.feePropositionBytes
+    val unclaimed = ErgoState.newBoxes(inputBlockTransactions ++ res._2)
+      .count(b => java.util.Arrays.equals(b.propositionBytes, feeProposition))
+    if (unclaimed > 0) {
+      log.warn(s"Ordering candidate leaves $unclaimed fee boxes unclaimed; they remain in the UTXO set")
+    }
     log.debug(
-      s"Collected ${res._1.length} transactions for block #$currentHeight, " +
-        s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")
+      s"Collected ${res._1.length} input and ${res._2.length} ordering transactions for block #$currentHeight, " +
+        s"invalid transaction ids (total:${res._3.length}): ${res._3}")
 
     res
   }

--- a/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
+++ b/src/main/scala/org/ergoplatform/mining/ErgoMiner.scala
@@ -2,7 +2,7 @@ package org.ergoplatform.mining
 
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Props, Stash}
 import akka.pattern.StatusReply
-import org.ergoplatform.AutolykosSolution
+import org.ergoplatform.{AutolykosSolution, SolutionFound}
 import org.ergoplatform.mining.CandidateGenerator.GenerateCandidate
 import org.ergoplatform.nodeView.state.DigestState
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetDataFromCurrentView
@@ -191,6 +191,9 @@ class ErgoMiner(
       minerState.candidateGeneratorRef forward genCandidate
 
     case solution: AutolykosSolution =>
+      minerState.candidateGeneratorRef forward solution
+
+    case solution: SolutionFound =>
       minerState.candidateGeneratorRef forward solution
 
     case ReadMinerPk => // used in /mining/rewardAddress API method

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -382,6 +382,32 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         val v2SyncInfo = getV2SyncInfo(history, full = true)
         networkControllerRef ! SendToNetwork(Message(syncInfoSpec, Right(v2SyncInfo), None), SendToPeers(peersV2))
       }
+      sendProcessedInputTip(history, peers)
+    }
+  }
+
+  /** Share the processed input tip during ordinary sync, including when production is idle. */
+  private def sendProcessedInputTip(history: ErgoHistory, peers: Seq[ConnectedPeer]): Unit = {
+    val localHeight = history.fullBlockHeight
+    val recipients = peers.filter { peer =>
+      localHeight > 0 &&
+        SubBlocksFilter.condition(peer) &&
+        peer.mode.exists(_.stateType == StateType.Utxo) &&
+        syncTracker.statuses.get(peer).exists { status =>
+          status.status != Unknown && status.status != Nonsense && status.height > 0 &&
+            math.abs(status.height.toLong - localHeight.toLong) <= 2
+        }
+    }
+    if (recipients.nonEmpty) {
+      // The announced tip may still await transactions. Only replay the processed prefix.
+      history.bestInputBlocksChain().headOption.flatMap(history.getInputBlock).foreach { tip =>
+        val announcement = if (tip.weakTxIds.getOrElse(Seq.empty).size <= 3) tip
+          else tip.copy(weakTxIds = None)
+        val message = Message(InputBlockMessageSpec, Right(announcement), None)
+        recipients.foreach { peer =>
+          networkControllerRef ! SendToNetwork(message, SendToPeer(peer))
+        }
+      }
     }
   }
 
@@ -469,6 +495,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     if (syncSendNeeded) {
       val ownSyncInfo = getV1SyncInfo(hr)
       sendSyncToPeer(remote, ownSyncInfo)
+      sendProcessedInputTip(hr, Seq(remote))
     }
   }
 
@@ -515,6 +542,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
     if (syncSendNeeded) {
       val ownSyncInfo = getV2SyncInfo(hr, full = true)
       sendSyncToPeer(remote, ownSyncInfo)
+      sendProcessedInputTip(hr, Seq(remote))
     }
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -265,7 +265,9 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
         defaultMinerPk,
         emptyStateContext
       )
-      txs.length shouldBe 2
+      val feeBoxes = blockTxs.flatMap(_.outputs)
+      val chunkSize = CandidateGenerator.MaxFeeBoxesPerTransaction
+      txs.length shouldBe 1 + (feeBoxes.size + chunkSize - 1) / chunkSize
 
       val emissionTx = txs.head
       emissionTx.outputs.length shouldBe 2
@@ -274,12 +276,16 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
         defaultMinerPk
       )
 
-      val feeTx = txs.last
-      feeTx.outputs.length shouldBe 1
-      feeTx.outputs.head.value shouldBe blockTxs.flatMap(_.outputs).map(_.value).sum
-      feeTx.outputs.head.propositionBytes shouldEqual expectedRewardOutputScriptBytes(
-        defaultMinerPk
-      )
+      val feeTxs = txs.tail
+      feeTxs.foreach { feeTx =>
+        feeTx.inputs.length should be <= chunkSize
+        feeTx.outputs.length shouldBe 1
+        feeTx.outputs.head.propositionBytes shouldEqual expectedRewardOutputScriptBytes(defaultMinerPk)
+      }
+      feeTxs.flatMap(_.outputs).map(_.value).sum shouldBe feeBoxes.map(_.value).sum
+      val spent = feeTxs.flatMap(_.inputs).map(in => in.boxId.toSeq)
+      spent.distinct.size shouldBe spent.size
+      spent.toSet shouldBe feeBoxes.map(_.id.toSeq).toSet
     }
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -159,7 +159,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
           upcomingContext,
           Seq(head)
         )
-        ._1
+        ._2
       fromSmallMempool.size shouldBe 2
       fromSmallMempool.contains(head) shouldBe true
 
@@ -172,7 +172,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
           upcomingContext,
           txsWithFees
         )
-        ._1
+        ._2
 
       val newBoxes = fromBigMempool.flatMap(_.outputs)
       val costs: Seq[Int] = fromBigMempool.map { tx =>
@@ -320,7 +320,8 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Verify we collected some transactions
-    result._1.length should be > 0
+    result._1 shouldBe empty
+    result._2.length should be > 0
     // Invalid transactions should be tracked
     result._3.length should be >= 0
   }
@@ -429,6 +430,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     invalid shouldBe empty
+    inputCollected shouldBe empty
     (inputCollected ++ orderingCollected) should contain theSameElementsAs zeroFeeTxs
   }
 
@@ -505,11 +507,12 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // At least tx3 should be included (non-conflicting)
-    result._1.exists(_.id sameElements tx3.id) shouldBe true
+    result._1 shouldBe empty
+    result._2.exists(_.id sameElements tx3.id) shouldBe true
     
     // At most 2 transactions should be included (one of tx1/tx2, plus tx3)
-    result._1.length should be <= 2
-    result._1.length should be >= 1
+    result._2.length should be <= 2
+    result._2.length should be >= 1
 
     // At least one of the conflicting txs should be in invalid list (result._3)
     // Both result._3 and tx.id are ModifierId (String type)
@@ -561,7 +564,8 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Valid transaction should be collected
-    result._1.exists(_.id sameElements validTx.id) shouldBe true
+    result._1 shouldBe empty
+    result._2.exists(_.id sameElements validTx.id) shouldBe true
     // Invalid transaction should be in the invalid list (result._3)
     result._3.contains(invalidTx.id) shouldBe true
   }
@@ -640,11 +644,12 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Should have collected some transactions but not all
-    result._1.length should be > 0
-    result._1.length should be < manyTxs.length
+    result._1 shouldBe empty
+    result._2.length should be > 0
+    result._2.length should be < manyTxs.length
 
     // Verify total cost doesn't exceed limit
-    val totalCost = result._1.map { tx =>
+    val totalCost = result._2.map { tx =>
       us.validateWithCost(tx, upcomingContext, Int.MaxValue, Some(verifier), true).getOrElse(0)
     }.sum
 
@@ -690,11 +695,12 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Should have collected some transactions but not all
-    result._1.length should be > 0
-    result._1.length should be < manyTxs.length
+    result._1 shouldBe empty
+    result._2.length should be > 0
+    result._2.length should be < manyTxs.length
 
     // Verify total size doesn't exceed limit
-    val totalSize = result._1.map(_.size).sum
+    val totalSize = result._2.map(_.size).sum
     totalSize should be <= smallSizeLimit
   }
 
@@ -740,7 +746,8 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     )
 
     // Should collect all valid transactions
-    validTxs.foreach(tx => result._1.exists(_.id sameElements tx.id) shouldEqual true)
+    result._1 shouldBe empty
+    validTxs.foreach(tx => result._2.exists(_.id sameElements tx.id) shouldEqual true)
 
     // At least one double-spend should be in invalid list (result._3)
     result._3.length should be >= 1

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.mining
 
+import com.google.common.io.Files.createTempDir
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
@@ -21,7 +22,7 @@ import org.ergoplatform.nodeView.state.{StateType, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedOrderingBlock}
 import org.ergoplatform.settings.NetworkType.DevNet60
-import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader, NetworkType}
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.utils.generators.ValidBlocksGenerators.{createUtxoState, validFullBlock, validTransactionsFromBoxHolder}
 import org.ergoplatform.utils.generators.ChainGenerator.{applyChain, genHeaderChain}
@@ -50,6 +51,31 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   private val candidateGenDelay: FiniteDuration    = 3.seconds
   private val blockValidationDelay: FiniteDuration = 2.seconds
 
+  private val actorSystems = scala.collection.mutable.ArrayBuffer.empty[ActorSystem]
+
+  private def newActorSystem(): ActorSystem = {
+    val system = ActorSystem()
+    actorSystems += system
+    system
+  }
+
+  override protected def withFixture(test: NoArgTest): org.scalatest.Outcome = {
+    try super.withFixture(test)
+    finally {
+      val systemsToStop = actorSystems.toVector
+      actorSystems.clear()
+      systemsToStop.foreach(system => TestKit.shutdownActorSystem(system))
+    }
+  }
+
+  private def expectOrderingBlockApplied(replyProbe: TestProbe, blockProbe: TestProbe, block: ErgoFullBlock): Unit = {
+    replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
+    blockProbe.fishForMessage(newBlockDelay) {
+      case FullBlockApplied(header) => header.id == block.header.id
+      case _ => false
+    }
+  }
+
   val defaultSettings: ErgoSettings = {
     val empty = ErgoSettingsReader.read()
     val nodeSettings = empty.nodeSettings.copy(
@@ -60,13 +86,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       verifyTransactions           = true
     )
     val chainSettings = empty.chainSettings.copy(blockInterval = 1.seconds)
-    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings)
+    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings, networkType = NetworkType.Tests)
   }
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
   it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
@@ -90,7 +116,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
@@ -160,8 +186,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "let multiple miners compete" in new TestKit(ActorSystem()) {
+  it should "let multiple miners compete" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
+    val countProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
     val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
@@ -184,25 +211,27 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
 
-    m1.tell(ErgoMiningThread.GetSolvedBlocksCount, testProbe.ref)
+    eventually(timeout(newBlockDelay), interval(100.millis)) {
+      m1.tell(ErgoMiningThread.GetSolvedBlocksCount, countProbe.ref)
 
-    val m1Count =
-      testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
-    m2.tell(ErgoMiningThread.GetSolvedBlocksCount, testProbe.ref)
+      val m1Count =
+        countProbe.expectMsgClass(candidateGenDelay, classOf[ErgoMiningThread.SolvedBlocksCount])
+      m2.tell(ErgoMiningThread.GetSolvedBlocksCount, countProbe.ref)
 
-    val m2Count =
-      testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
-    m3.tell(ErgoMiningThread.GetSolvedBlocksCount, testProbe.ref)
+      val m2Count =
+        countProbe.expectMsgClass(candidateGenDelay, classOf[ErgoMiningThread.SolvedBlocksCount])
+      m3.tell(ErgoMiningThread.GetSolvedBlocksCount, countProbe.ref)
 
-    val m3Count =
-      testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
+      val m3Count =
+        countProbe.expectMsgClass(candidateGenDelay, classOf[ErgoMiningThread.SolvedBlocksCount])
 
-    List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
+      List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
+    }
     system.terminate()
   }
 
   it should "cache candidate until newly mined block is applied" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
@@ -245,17 +274,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after explicit forced regeneration" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
+    val testDir = s"${defaultSettings.directory}-explicit-forced-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
+          directory = testDir
         )
 
     val viewHolderRef: ActorRef =
@@ -282,21 +318,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
         val block = result match {
           case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+          case other => fail(s"Expected an ordering block solution, got $other")
         }
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // build new transaction that uses miner's reward as input
@@ -320,7 +345,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         .get
     )
 
-    // candidate should be regenerated immediately after a mempool change
+    // Solve the current candidate before explicitly regenerating it with the new transaction.
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
@@ -331,44 +356,39 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
         val block = result match {
           case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+          case other => fail(s"Expected an ordering block solution, got $other")
         }
 
-        // this triggers mempool change that triggers candidate regeneration
+        // Add a transaction before explicitly forcing candidate regeneration.
         viewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(tx, None))
-        expectNoMessage(candidateGenDelay)
-        candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
+        eventually(timeout(candidateGenDelay), interval(100.millis)) {
+          await((readersHolderRef ? GetReaders).mapTo[Readers]).m.contains(tx.id) shouldBe true
+          System.currentTimeMillis() should be > candidate.candidateBlock.timestamp
+        }
+        candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true, optPk = None), testProbe.ref)
         testProbe.expectMsgPF(candidateGenDelay) {
           case StatusReply.Success(regeneratedCandidate: Candidate) =>
-            // regeneratedCandidate now contains new transaction
-            regeneratedCandidate.candidateBlock shouldNot be(
-              candidate.candidateBlock
-            )
+            regeneratedCandidate.candidateBlock.timestamp should be > candidate.candidateBlock.timestamp
+            regeneratedCandidate.candidateBlock.transactions.map(_.id) should contain(tx.id)
+            block.header.version shouldBe Header.InitialVersion
+            powScheme.validate(block.header).isSuccess shouldBe true
+            val currentBlock = CandidateGenerator.completeOrderingBlock(regeneratedCandidate.candidateBlock, block.header.powSolution)
+            powScheme.validate(currentBlock.header).isFailure shouldBe true
         }
 
         // we are submitting solution for previous candidate
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
     system.terminate()
   }
 
   it should "pool transactions should be removed from pool when block is mined" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
     val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
@@ -400,17 +420,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // build new transaction that uses miner's reward as input
@@ -449,17 +459,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         testProbe.expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // new transaction should be cleared from pool after applying new block
@@ -477,12 +477,40 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "6.0 pool transactions should be added to 6.0 block" in new TestKit(
-    ActorSystem()
+  it should "include version 6 script transactions through an input block and subsequent ordering block" in new TestKit(
+    newActorSystem()
   ) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
+    val settings60 = defaultSettings60.copy(
+      directory = createTempDir.getAbsolutePath,
+      chainSettings = defaultSettings60.chainSettings.copy(
+        initialDifficultyHex = "0080",
+        powScheme = new AutolykosPowScheme(
+          defaultSettings60.chainSettings.powScheme.k,
+          defaultSettings60.chainSettings.powScheme.n
+        )
+      )
+    )
+    val powScheme = settings60.chainSettings.powScheme
+
+    def mine(candidate: Candidate, inputBlock: Boolean): ErgoFullBlock = {
+      val deadline = 30.seconds.fromNow
+      var nonce = 0L
+      while (nonce < 100000L && deadline.hasTimeLeft()) {
+        powScheme.proveCandidate(candidate.candidateBlock, defaultMinerSecret.w,
+          nonce, nonce + 1L, candidate.parameters) match {
+          case org.ergoplatform.OrderingBlockFound(block) if !inputBlock => return block
+          case org.ergoplatform.InputBlockFound(block) if inputBlock => return block
+          case _ => ()
+        }
+        nonce += 1L
+      }
+      fail(s"No ${if (inputBlock) "input" else "ordering"} solution within $nonce nonces and 30 seconds")
+    }
+
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings60)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -490,7 +518,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings60
+        settings60
       )
 
     val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
@@ -502,28 +530,12 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val result = defaultSettings.chainSettings.powScheme
-          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
-        val block = result match {
-          case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
-        }
+        val block = mine(candidate, inputBlock = false)
         // let's pretend we are mining at least a bit so it is realistic
         expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
     }
 
     // build new transaction that uses miner's reward as input
@@ -557,36 +569,42 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       inputs = IndexedSeq(new Input(spendingBox.id, emptyProverResult)),
       outputCandidates = IndexedSeq(o2))
 
-    testProbe.expectNoMessage(200.millis)
-    // mine a block with that transaction
-    candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false, optPk = None), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(candidate: Candidate) =>
-        val result = defaultSettings.chainSettings.powScheme
-          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
-        val block = result match {
-          case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
-        }
-        testProbe.expectNoMessage(200.millis)
-        candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
+    candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = true, optPk = None), testProbe.ref)
+    val inputCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) => candidate
+    }
+    inputCandidate.candidateBlock.version shouldBe Header.Interpreter60Version
+    inputCandidate.candidateBlock.inputBlockTransactions.map(_.id) should contain theSameElementsInOrderAs Seq(tx.id, tx2.id)
+    val inputBlock = mine(inputCandidate, inputBlock = true)
+    candidateGenerator.tell(org.ergoplatform.InputSolutionFound(inputBlock.header.powSolution), testProbe.ref)
+    testProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+    eventually(timeout(newBlockDelay), interval(100.millis)) {
+      val updatedReaders = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      updatedReaders.h.bestInputBlock().map(_.id) shouldBe Some(inputBlock.id)
+      updatedReaders.h.getBestOrderingCollectedInputBlocksTransactions().map(_.id) should contain theSameElementsInOrderAs Seq(tx.id, tx2.id)
+      val confirmedState = updatedReaders.s.asInstanceOf[UtxoStateReader]
+      confirmedState.boxById(rewardBox.id) shouldBe Some(rewardBox)
+      tx2.outputs.foreach(o => confirmedState.boxById(o.id) shouldBe None)
     }
 
-    // new transactions should be cleared from pool after applying new block
-    await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 0
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true, optPk = None), testProbe.ref)
+    val orderingCandidate = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(candidate: Candidate) => candidate
+    }
+    orderingCandidate.candidateBlock.transactions.map(_.id) should contain allOf (tx.id, tx2.id)
+    orderingCandidate.candidateBlock.inputBlockTransactions shouldBe empty
+    val orderingBlock = mine(orderingCandidate, inputBlock = false)
+    candidateGenerator.tell(OrderingSolutionFound(orderingBlock.header.powSolution), testProbe.ref)
+    expectOrderingBlockApplied(testProbe, blockProbe, orderingBlock)
+
+    // These transactions were supplied directly as mandatory candidates.
+    val confirmedReaders = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    confirmedReaders.m.size shouldBe 0
+    val confirmedState = confirmedReaders.s.asInstanceOf[UtxoStateReader]
+    confirmedState.boxById(rewardBox.id) shouldBe None
+    confirmedState.boxById(spendingBox.id) shouldBe None
+    tx2.outputs.foreach(o => confirmedState.boxById(o.id) shouldBe Some(o))
 
     // validate total amount of transactions created
     val blocks: IndexedSeq[ErgoFullBlock] = readers.h
@@ -603,7 +621,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "use custom miner public key when provided via optPk" in new TestKit(ActorSystem()) {
+  it should "use custom miner public key when provided via optPk" in new TestKit(newActorSystem()) {
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
@@ -643,7 +661,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "use default minerPk when optPk is None" in new TestKit(ActorSystem()) {
+  it should "use default minerPk when optPk is None" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
@@ -675,7 +693,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "generate different candidates for different optPk values" in new TestKit(ActorSystem()) {
+  it should "generate different candidates for different optPk values" in new TestKit(newActorSystem()) {
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
@@ -725,7 +743,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "handle optPk with empty transactions" in new TestKit(ActorSystem()) {
+  it should "handle optPk with empty transactions" in new TestKit(newActorSystem()) {
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
@@ -764,7 +782,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
+  it should "ignore cached candidate when forced = true" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
@@ -772,6 +790,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
@@ -839,18 +858,23 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {
+  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
     val testDir = s"${defaultSettings.directory}-preserve-candidate-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
           directory = testDir
         )
 
@@ -875,22 +899,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     val initBlock = powScheme
       .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000, initCandidate.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
     candidateGenerator.tell(OrderingSolutionFound(initBlock.header.powSolution), testProbe.ref)
-    // Wait for both the direct mining ACK and the async local block application
-    var ackSeen = false
-    var appliedSeen = false
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) =>
-        ackSeen = true
-        ackSeen && appliedSeen
-      case FullBlockApplied(header) if header.id == initBlock.header.id =>
-        appliedSeen = true
-        ackSeen && appliedSeen
-      case _ => false
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, initBlock)
 
     // Get first candidate after chain is established
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -899,48 +911,56 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // Force regeneration - this should preserve candidate1 as cachedPreviousCandidate
-    val candidate2 = eventually(timeout(candidateGenDelay), interval(100.millis)) {
-      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-      testProbe.expectMsgPF(500.millis) {
-        case StatusReply.Success(c: Candidate) => c
-      }
+    eventually(timeout(candidateGenDelay), interval(1.millis)) {
+      System.currentTimeMillis() should be > candidate1.candidateBlock.timestamp
+    }
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+    val candidate2 = testProbe.expectMsgPF(candidateGenDelay) {
+      case StatusReply.Success(c: Candidate) => c
     }
 
     // candidate2 should be different from candidate1 (regenerated)
-    candidate2.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    candidate2.candidateBlock.timestamp should be > candidate1.candidateBlock.timestamp
 
     // Solve a block using candidate1 (the "previous" candidate)
     val solvedBlock = powScheme
       .proveCandidate(candidate1.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate1.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
+
+    // Real version 1 PoW binds the solution to the previous candidate's header.
+    solvedBlock.header.version shouldBe Header.InitialVersion
+    powScheme.validate(solvedBlock.header).isSuccess shouldBe true
+    val currentBlock = CandidateGenerator.completeOrderingBlock(candidate2.candidateBlock, solvedBlock.header.powSolution)
+    powScheme.validate(currentBlock.header).isFailure shouldBe true
 
     // Submit solution - should succeed because candidate1 should be in cachedPreviousCandidate
     candidateGenerator.tell(OrderingSolutionFound(solvedBlock.header.powSolution), testProbe.ref)
 
-    // CandidateGenerator should accept the solution against cachedPreviousCandidate.
-    testProbe.expectMsgPF(blockValidationDelay) {
-      case StatusReply.Success(()) =>
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, solvedBlock)
 
     system.terminate()
   }
 
-  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(ActorSystem()) {
+  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
     // Use unique directory to avoid state conflicts
     val testDir = s"${defaultSettings.directory}-multi-forced-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
           directory = testDir
         )
 
@@ -965,22 +985,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     val initBlock = powScheme
       .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000, initCandidate.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
     candidateGenerator.tell(OrderingSolutionFound(initBlock.header.powSolution), testProbe.ref)
-    // Wait for both StatusReply and FullBlockApplied messages
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case _: FullBlockApplied => true
-      case _ => false
-    }
-    // Try to consume the second message if it exists
-    try {
-      testProbe.expectMsgClass(1.second, classOf[Any])
-    } catch {
-      case _: AssertionError => // No more messages, that's fine
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, initBlock)
 
     // Now get candidate after chain is established
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -989,6 +997,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // Force regenerate first time
+    eventually(timeout(candidateGenDelay), interval(1.millis)) {
+      System.currentTimeMillis() should be > candidate1.candidateBlock.timestamp
+    }
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
     val candidate2 = testProbe.fishForMessage(candidateGenDelay) {
       case StatusReply.Success(_: Candidate) => true
@@ -998,6 +1009,9 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
 
     // Force regenerate second time
+    eventually(timeout(candidateGenDelay), interval(1.millis)) {
+      System.currentTimeMillis() should be > candidate2.candidateBlock.timestamp
+    }
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
     val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
       case StatusReply.Success(_: Candidate) => true
@@ -1006,31 +1020,31 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case StatusReply.Success(c: Candidate) => c
     }
 
-    // All candidates should have increasing or equal timestamps
-    candidate2.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-    candidate3.candidateBlock.timestamp should be >= candidate2.candidateBlock.timestamp
+    // Each regeneration must produce a distinct header.
+    candidate2.candidateBlock.timestamp should be > candidate1.candidateBlock.timestamp
+    candidate3.candidateBlock.timestamp should be > candidate2.candidateBlock.timestamp
 
     // Solve block with candidate2 (should be in cachedPreviousCandidate after candidate3 generation)
     val solvedBlock = powScheme
       .proveCandidate(candidate2.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate2.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
+
+    // The latest candidate must reject this real solution so the previous candidate is used.
+    solvedBlock.header.version shouldBe Header.InitialVersion
+    powScheme.validate(solvedBlock.header).isSuccess shouldBe true
+    val currentBlock = CandidateGenerator.completeOrderingBlock(candidate3.candidateBlock, solvedBlock.header.powSolution)
+    powScheme.validate(currentBlock.header).isFailure shouldBe true
 
     candidateGenerator.tell(OrderingSolutionFound(solvedBlock.header.powSolution), testProbe.ref)
 
-    // Should successfully apply the block
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case _: FullBlockApplied => true
-      case _ => false
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, solvedBlock)
 
     system.terminate()
   }
 
-  it should "return cached candidate immediately when forced = false" in new TestKit(ActorSystem()) {
+  it should "return cached candidate immediately when forced = false" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
@@ -1071,18 +1085,23 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.terminate()
   }
 
-  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after explicit forced regeneration following mempool admission" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val blockProbe = new TestProbe(system)
+    system.eventStream.subscribe(blockProbe.ref, newBlockSignal)
 
     val testDir = s"${defaultSettings.directory}-mempool-forced-${System.currentTimeMillis()}"
     val settingsWithShortRegeneration: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
+          networkType = NetworkType.Tests,
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 100.millis),
-          chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
+          chainSettings = defaultSettings.chainSettings.copy(
+            initialDifficultyHex = "01",
+            powScheme = new AutolykosPowScheme(defaultSettings.chainSettings.powScheme.k,
+              defaultSettings.chainSettings.powScheme.n)
+          ),
           directory = testDir
         )
 
@@ -1102,43 +1121,36 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false, optPk = None), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val bootstrapBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val result = defaultSettings.chainSettings.powScheme
+        val result = powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
         val block = result match {
           case org.ergoplatform.OrderingBlockFound(h) => h
-          case org.ergoplatform.InputBlockFound(fb) => fb
-          case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+          case other => fail(s"Expected an ordering block solution, got $other")
         }
         // let's pretend we are mining at least a bit so it is realistic
         expectNoMessage(200.millis)
         candidateGenerator.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
+        expectOrderingBlockApplied(testProbe, blockProbe, block)
+        block
     }
 
-    // Get candidate and solve it
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidateToSolve = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+    // The block probe can observe application before the generator updates its cache.
+    val candidateToSolve = eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate.candidateBlock.parentOpt.map(_.id) shouldBe Some(bootstrapBlock.id)
+      candidate
     }
 
     val solvedBlock = powScheme
       .proveCandidate(candidateToSolve.candidateBlock, defaultMinerSecret.w, 0, 1000, candidateToSolve.parameters) match {
       case org.ergoplatform.OrderingBlockFound(h) => h
-      case org.ergoplatform.InputBlockFound(fb) => fb
-      case _ => throw new RuntimeException("Unexpected result from proveCandidate")
+      case other => fail(s"Expected an ordering block solution, got $other")
     }
 
     // Build new transaction to trigger mempool change
@@ -1161,35 +1173,36 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Submit transaction to mempool
     viewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(tx, None))
 
-    // Wait for candidate to be regenerated with new tx
-    testProbe.expectNoMessage(200.millis)
+    eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      await((readersHolderRef ? GetReaders).mapTo[Readers]).m.contains(tx.id) shouldBe true
+      System.currentTimeMillis() should be > candidateToSolve.candidateBlock.timestamp
+    }
 
-    // Request new candidate - should be regenerated due to mempool change
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+    // Explicitly regenerate after the transaction has entered the mempool.
+    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
     val regeneratedCandidate = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(c: Candidate) => c
     }
 
-    // Should include the new transaction
-    regeneratedCandidate.candidateBlock.transactions.size should be >= candidateToSolve.candidateBlock.transactions.size
+    regeneratedCandidate.candidateBlock.timestamp should be > candidateToSolve.candidateBlock.timestamp
+    regeneratedCandidate.candidateBlock.transactions.map(_.id) should contain(tx.id)
+    solvedBlock.header.version shouldBe Header.InitialVersion
+    powScheme.validate(solvedBlock.header).isSuccess shouldBe true
+    val currentBlock = CandidateGenerator.completeOrderingBlock(regeneratedCandidate.candidateBlock, solvedBlock.header.powSolution)
+    powScheme.validate(currentBlock.header).isFailure shouldBe true
 
     // Submit solution for the old candidate (should still work via cachedPreviousCandidate)
     candidateGenerator.tell(OrderingSolutionFound(solvedBlock.header.powSolution), testProbe.ref)
 
-    // Should successfully apply the block
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != solvedBlock.header.parentId => true
-      case _ => false
-    }
+    expectOrderingBlockApplied(testProbe, blockProbe, solvedBlock)
 
     system.terminate()
   }
 
   it should "correctly complete input block from candidate and solution" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
@@ -1204,7 +1217,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       defaultMinerPk,
       Seq.empty,
       None,
-      defaultSettings
+      defaultSettings60
     )
 
     // If we can't generate a candidate (e.g., due to lack of proper history), skip this test
@@ -1284,7 +1297,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   it should "exclude applied transactions from stale mempool and not eliminate them" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
 
     val testDir = s"${defaultSettings.directory}-a1-stale-${System.currentTimeMillis()}"
@@ -1356,7 +1369,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
   }
 
   it should "discard candidate when history and state are out of sync" in new TestKit(
-    ActorSystem()
+    newActorSystem()
   ) {
 
     val testDir = s"${defaultSettings.directory}-b1-sync-${System.currentTimeMillis()}"

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -904,10 +904,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(OrderingSolutionFound(initBlock.header.powSolution), testProbe.ref)
     expectOrderingBlockApplied(testProbe, blockProbe, initBlock)
 
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+    // The block probe can observe application before the generator updates its cache.
+    val candidate1 = eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate.candidateBlock.parentOpt.map(_.id) shouldBe Some(initBlock.id)
+      candidate
     }
 
     // Force regeneration - this should preserve candidate1 as cachedPreviousCandidate

--- a/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/ErgoMinerSpec.scala
@@ -10,17 +10,17 @@ import org.ergoplatform.mining.ErgoMiner.StartMining
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction, UnsignedErgoTransaction}
-import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.FullBlockApplied
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{FailedTransaction, FullBlockApplied}
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.LocallyGeneratedTransaction
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.ErgoHistoryReader
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.nodeView.wallet._
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef}
-import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.settings.{ErgoSettings, ErgoSettingsReader, NetworkType}
 import org.ergoplatform.utils.ErgoTestHelpers
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input, OrderingBlockFound, OrderingSolutionFound}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import sigma.ast.{ErgoTree, SigmaAnd, SigmaPropConstant}
@@ -44,6 +44,23 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
   private val candidateGenDelay: FiniteDuration    = 3.seconds
   private val blockValidationDelay: FiniteDuration = 2.seconds
 
+  private val actorSystems = scala.collection.mutable.ArrayBuffer.empty[ActorSystem]
+
+  private def newActorSystem(): ActorSystem = {
+    val system = ActorSystem()
+    actorSystems += system
+    system
+  }
+
+  override protected def withFixture(test: NoArgTest): org.scalatest.Outcome = {
+    try super.withFixture(test)
+    finally {
+      val systemsToStop = actorSystems.toVector
+      actorSystems.clear()
+      systemsToStop.foreach(system => TestKit.shutdownActorSystem(system))
+    }
+  }
+
   private def getWorkMessage(minerRef: ActorRef, mandatoryTransactions: Seq[ErgoTransaction]): WorkMessage =
     await(minerRef.askWithStatus(GenerateCandidate(mandatoryTransactions, reply = true, forced = false, optPk = None)).mapTo[Candidate].map(_.externalVersion))
 
@@ -57,10 +74,10 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
       offlineGeneration = true,
       verifyTransactions = true)
     val chainSettings = empty.chainSettings.copy(blockInterval = 2.seconds)
-    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings)
+    empty.copy(nodeSettings = nodeSettings, chainSettings = chainSettings, networkType = NetworkType.Tests)
   }
 
-  it should "not include too costly transactions" in new TestKit(ActorSystem()) {
+  it should "not include too costly transactions" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
@@ -95,15 +112,13 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     val unsignedTx = new UnsignedErgoTransaction(IndexedSeq(input), IndexedSeq(), outputs)
     val tx = defaultProver.sign(unsignedTx, IndexedSeq(boxToSpend), IndexedSeq(), r.s.stateContext).get
     nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(ErgoTransaction(tx), None))
-    expectNoMessage(1 seconds)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 0
-
-    //check that tx is included into UTXO set
-    val state = await((readersHolderRef ? GetReaders).mapTo[Readers]).s.asInstanceOf[UtxoState]
-    tx.outputs.foreach(o => state.boxById(o.id).get shouldBe o)
+    val state = eventually(timeout(newBlockDelay), interval(100.millis)) {
+      val readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      readers.m.size shouldBe 0
+      val appliedState = readers.s.asInstanceOf[UtxoState]
+      tx.outputs.foreach(o => appliedState.boxById(o.id) shouldBe Some(o))
+      appliedState
+    }
 
     // try to spend all the boxes with complex scripts
     val costlyInputs = tx.outputs.map(o => Input(o.id, emptyProverResult))
@@ -121,15 +136,17 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
       ).get
     txCost shouldBe 439080
 
+    val rejectionProbe = new TestProbe(system)
+    system.eventStream.subscribe(rejectionProbe.ref, classOf[FailedTransaction])
+
     // send costly transaction to the mempool
     nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(ErgoTransaction(costlyTx), None))
 
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
+    rejectionProbe.expectMsgPF(newBlockDelay) {
+      case FailedTransaction(rejected, _) => rejected.id shouldBe costlyTx.id
+    }
 
-    // costly tx was removed from mempool
-    expectNoMessage(1 second)
+    // costly tx was rejected before mempool admission
     await((readersHolderRef ? GetReaders).mapTo[Readers]).m.size shouldBe 0
     // costly tx was not included
     val state2 = await((readersHolderRef ? GetReaders).mapTo[Readers]).s.asInstanceOf[UtxoState]
@@ -137,7 +154,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     costlyTx.outputs.foreach(o => state2.boxById(o.id) shouldBe None)
   }
 
-  it should "not freeze while mempool is full" in new TestKit(ActorSystem()) {
+  it should "not freeze while mempool is full" in new TestKit(newActorSystem()) {
     // generate amount of transactions, twice more than can fit in one block
     val desiredSize: Int = Math.ceil((parameters.maxBlockCost / ErgoInterpreter.interpreterInitCost) * 1.2).toInt
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
@@ -214,7 +231,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     }
   }
 
-  it should "include only one transaction from 2 spending the same box" in new TestKit(ActorSystem()) {
+  it should "include only one transaction from 2 spending the same box" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
@@ -262,12 +279,13 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     minerRef.tell(GenerateCandidate(Seq(tx2), reply = true, forced = false, optPk = None), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = extractFullBlockFromProveResult(
-          defaultSettings.chainSettings.powScheme
-            .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters)
-        )
+        val block = defaultSettings.chainSettings.powScheme
+          .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000, candidate.parameters) match {
+          case OrderingBlockFound(fullBlock) => fullBlock
+          case other => fail(s"Expected an ordering block solution, got $other")
+        }
         testProbe.expectNoMessage(200.millis)
-        minerRef.tell(block.header.powSolution, testProbe.ref)
+        minerRef.tell(OrderingSolutionFound(block.header.powSolution), testProbe.ref)
 
         // we fish either for ack or SSM as the order is non-deterministic
         testProbe.fishForMessage(blockValidationDelay) {
@@ -292,7 +310,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     system.terminate()
   }
 
-  it should "prepare external candidate" in new TestKit(ActorSystem()) {
+  it should "prepare external candidate" in new TestKit(newActorSystem()) {
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)
 
     val nodeViewHolderRef: ActorRef = ErgoNodeViewRef(ergoSettings)
@@ -313,7 +331,7 @@ class ErgoMinerSpec extends AnyFlatSpec with ErgoTestHelpers with Eventually {
     system.terminate()
   }
 
-  it should "include mandatory transactions" in new TestKit(ActorSystem()) {
+  it should "include mandatory transactions" in new TestKit(newActorSystem()) {
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
     val ergoSettings: ErgoSettings = defaultSettings.copy(directory = createTempDir.getAbsolutePath)

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/ErgoMinerSolutionForwardingSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/ErgoMinerSolutionForwardingSpec.scala
@@ -1,0 +1,70 @@
+package org.ergoplatform.mining
+
+import akka.actor.{ActorSystem, Props}
+import akka.pattern.StatusReply
+import akka.testkit.{TestKit, TestProbe}
+import org.ergoplatform.{AutolykosSolution, InputSolutionFound, OrderingSolutionFound, SolutionFound}
+import org.ergoplatform.mining.ErgoMiner.MinerState
+import org.ergoplatform.settings.ErgoSettingsReader
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sigma.data.ProveDlog
+
+import scala.concurrent.duration._
+
+class ErgoMinerSolutionForwardingSpec
+  extends TestKit(ActorSystem("ErgoMinerSolutionForwardingSpec"))
+    with AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private val settings = ErgoSettingsReader.read()
+  private val publicKey = ProveDlog(genPk(BigInt(1)))
+  private val solution = new AutolykosSolution(
+    publicKey.value,
+    AutolykosSolution.wForV2,
+    Array.fill[Byte](8)(0),
+    AutolykosSolution.dForV2
+  )
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  private def assertForwarded(message: SolutionFound): Unit = {
+    val candidateGenerator = TestProbe()
+    val requester = TestProbe()
+    val unusedReader = TestProbe()
+    val miner = system.actorOf(Props(new ErgoMiner(
+      settings,
+      unusedReader.ref,
+      unusedReader.ref,
+      None
+    ) {
+      // Exercise the production started receive without booting a wallet or miner.
+      override def preStart(): Unit =
+        context.become(started(MinerState(None, publicKey, candidateGenerator.ref)))
+    }))
+
+    try {
+      requester.send(miner, message)
+      candidateGenerator.expectMsg(3.seconds, message)
+      candidateGenerator.lastSender shouldBe requester.ref
+      val accepted = StatusReply.success(())
+      candidateGenerator.reply(accepted)
+      requester.expectMsg(3.seconds, accepted)
+    } finally {
+      system.stop(miner)
+    }
+  }
+
+  "ErgoMiner" should "forward an ordering solution with its original sender and reply" in {
+    assertForwarded(OrderingSolutionFound(solution))
+  }
+
+  it should "forward an input solution with its original sender and reply" in {
+    assertForwarded(InputSolutionFound(solution))
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixFeeSelectionSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixFeeSelectionSpec.scala
@@ -1,0 +1,455 @@
+package org.ergoplatform.mining
+
+import com.google.common.io.Files.createTempDir
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTreePredef, Input}
+import org.ergoplatform.modifiers.history.BlockTransactions
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.nodeView.state.{BoxHolder, UtxoState}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.{ErgoCompilerHelpers, ErgoCorePropertyTest}
+import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultMinerPk, emptyVSUpdate, parameters}
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import scorex.util.bytesToId
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.interpreter.ProverResult
+
+class MatrixFeeSelectionSpec extends ErgoCorePropertyTest with ErgoCompilerHelpers {
+  private val fee = 1000000L
+  private val delay = settings.chainSettings.monetary.minerRewardDelay
+  private val feeTree = ErgoTreePredef.feeProposition(delay)
+  private val rewardTree = ErgoTreePredef.rewardOutputScript(delay, defaultMinerPk)
+  private val orderingTree = compileSourceV5("CONTEXT.minerPubKey.size >= 0", 0)
+
+  private def box(index: Byte, tree: ErgoTree = TrueTree): ErgoBox = new ErgoBox(
+    value = 1000000000L, ergoTree = tree, creationHeight = 0,
+    additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+    transactionId = bytesToId(Array.fill(32)(index)), index = 0
+  )
+
+  private def payment(source: ErgoBox): ErgoTransaction = ErgoTransaction(
+    IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+    IndexedSeq(
+      new ErgoBoxCandidate(source.value - fee, TrueTree, 1),
+      new ErgoBoxCandidate(fee, feeTree, 1)
+    )
+  )
+
+  private def state(boxes: Seq[ErgoBox], protocolCost: Int = parameters.maxBlockCost): UtxoState =
+    UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, parameters.withBlockCost(protocolCost))
+
+  private def select(boxes: Seq[ErgoBox], transactions: Seq[ErgoTransaction], version: Byte,
+                     prefix: Seq[ErgoTransaction] = Seq.empty,
+                     maxCost: Int = parameters.maxBlockCost,
+                     maxSize: Int = parameters.maxBlockSize,
+                     protocolCost: Int = parameters.maxBlockCost) = {
+    val us = state(boxes, protocolCost)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, version)
+    val result = CandidateGenerator.collectTxs(defaultMinerPk, maxCost,
+      maxSize, us, context, transactions, prefix)
+    Seq(prefix ++ result._1, prefix ++ result._2).filter(_.nonEmpty).foreach { payload =>
+      us.proofsForTransactions(payload).isSuccess shouldBe true
+      payload.foldLeft(Vector.empty[ErgoTransaction]) { (applied, tx) =>
+        us.withTransactions(applied).validateWithCost(tx, context, protocolCost,
+          None, softFieldsAllowed = true).isSuccess shouldBe true
+        applied :+ tx
+      }
+    }
+    result
+  }
+
+  private def payloadCost(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction], version: Byte): Int = {
+    val us = state(boxes, 10000000)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, version)
+    val (_, cost) = txs.foldLeft((Vector.empty[ErgoTransaction], 0)) { case ((applied, total), tx) =>
+      val txCost = us.withTransactions(applied).validateWithCost(tx, context, 10000000,
+        None, softFieldsAllowed = true).get
+      (applied :+ tx, total + txCost)
+    }
+    cost
+  }
+
+  private def sectionSize(txs: Seq[ErgoTransaction]): Int =
+    BlockTransactions(bytesToId(Array.fill[Byte](32)(0)), Header.Interpreter60Version, txs).size
+
+  private def transactionCost(boxes: Seq[ErgoBox], tx: ErgoTransaction,
+                              prefix: Seq[ErgoTransaction] = Seq.empty): Int = {
+    val us = state(boxes)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, Header.Interpreter60Version)
+    us.withTransactions(prefix).validateWithCost(tx, context, parameters.maxBlockCost,
+      None, softFieldsAllowed = true).get
+  }
+
+  private def assertFeeReward(reward: ErgoTransaction, payments: Seq[ErgoTransaction]): Unit = {
+    reward.inputs.map(in => bytesToId(in.boxId)) should contain theSameElementsAs
+      payments.map(tx => bytesToId(tx.outputs.last.id))
+    reward.dataInputs shouldBe empty
+    reward.outputs should have size 1
+    val output = reward.outputs.head
+    output.value shouldBe payments.size.toLong * fee
+    output.value should be > 0L
+    output.propositionBytes.toSeq shouldBe rewardTree.bytes.toSeq
+    output.creationHeight shouldBe 1
+    output.additionalTokens.length shouldBe 0
+  }
+
+  Seq(Header.InitialVersion, Header.HardeningVersion, Header.Interpreter50Version).foreach { version =>
+    property(s"version $version collects the payment fee into the exact delayed miner reward") {
+      val source = box(1)
+      val tx = payment(source)
+      val (input, ordering, invalid) = select(Seq(source), Seq(tx), version)
+      input shouldBe empty
+      invalid shouldBe empty
+      ordering should have size 2
+      ordering.head.id shouldBe tx.id
+      assertFeeReward(ordering.last, Seq(tx))
+    }
+  }
+
+  property("version 4 collects an ordering payment fee in its ordering payload") {
+    val source = box(2, orderingTree)
+    val tx = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering should have size 2
+    ordering.head.id shouldBe tx.id
+    assertFeeReward(ordering.last, Seq(tx))
+  }
+
+  property("version 4 leaves a new input payment fee out of the alternative ordering payload") {
+    val source = box(3)
+    val tx = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    input.map(_.id) shouldBe Seq(tx.id)
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("independent mixed payments collect only the ordering source fee") {
+    val inputSource = box(4)
+    val orderingSource = box(5, orderingTree)
+    val inputTx = payment(inputSource)
+    val orderingTx = payment(orderingSource)
+    val (input, ordering, invalid) = select(Seq(inputSource, orderingSource),
+      Seq(inputTx, orderingTx), Header.Interpreter60Version)
+    input.map(_.id) shouldBe Seq(inputTx.id)
+    invalid shouldBe empty
+    ordering should have size 2
+    ordering.head.id shouldBe orderingTx.id
+    assertFeeReward(ordering.last, Seq(orderingTx))
+  }
+
+  property("an accepted input payment produces its fee reward with an empty new pool") {
+    val source = box(10)
+    val accepted = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq.empty,
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering should have size 1
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("an accepted input payment duplicated in the pool is skipped without invalidation") {
+    val source = box(11)
+    val accepted = payment(source)
+    val (input, ordering, invalid) = select(Seq(source), Seq(accepted),
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering should have size 1
+    ordering.map(_.id) should not contain accepted.id
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("a descendant of an accepted input payment uses the accepted prefix state") {
+    val source = box(12)
+    val accepted = payment(source)
+    val child = payment(accepted.outputs.head)
+    val (input, ordering, invalid) = select(Seq(source), Seq(child),
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input.map(_.id) shouldBe Seq(child.id)
+    invalid shouldBe empty
+    ordering should have size 1
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("new input fees remain excluded while accepted input fees are collected") {
+    val acceptedSource = box(13)
+    val newSource = box(14)
+    val accepted = payment(acceptedSource)
+    val fresh = payment(newSource)
+    val (input, ordering, invalid) = select(Seq(acceptedSource, newSource), Seq(fresh),
+      Header.Interpreter60Version, prefix = Seq(accepted))
+    input.map(_.id) shouldBe Seq(fresh.id)
+    invalid shouldBe empty
+    ordering should have size 1
+    assertFeeReward(ordering.head, Seq(accepted))
+  }
+
+  property("an ordering payment is not admitted when its fee reward exceeds the size budget") {
+    val source = box(15, orderingTree)
+    val tx = payment(source)
+    val (_, complete, _) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    complete should have size 2
+    val budget = sectionSize(Seq(tx))
+    sectionSize(complete) should be > budget
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version,
+      maxSize = budget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("an ordering payment is not admitted when its fee reward exceeds the cost budget") {
+    val source = box(16, orderingTree)
+    val tx = payment(source)
+    val (_, complete, _) = select(Seq(source), Seq(tx), Header.Interpreter60Version)
+    complete should have size 2
+    val budget = transactionCost(Seq(source), tx)
+    budget should be > 0
+    transactionCost(Seq(source), complete.last, Seq(tx)) should be > 0
+    val (input, ordering, invalid) = select(Seq(source), Seq(tx), Header.Interpreter60Version,
+      maxCost = budget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  Seq("size", "cost").foreach { limit =>
+    property(s"an accepted prefix remains valid with its fee unspent when the reward exceeds the $limit budget") {
+      val source = box(17)
+      val accepted = payment(source)
+      val (_, complete, _) = select(Seq(source), Seq.empty, Header.Interpreter60Version,
+        prefix = Seq(accepted))
+      complete should have size 1
+      val prefixSize = sectionSize(Seq(accepted))
+      sectionSize(Seq(accepted) ++ complete) should be > prefixSize
+      val prefixCost = transactionCost(Seq(source), accepted)
+      transactionCost(Seq(source), complete.head, Seq(accepted)) should be > 0
+      val (input, ordering, invalid) = select(Seq(source), Seq.empty, Header.Interpreter60Version,
+        prefix = Seq(accepted),
+        maxCost = if (limit == "cost") prefixCost else parameters.maxBlockCost,
+        maxSize = if (limit == "size") prefixSize else parameters.maxBlockSize)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe empty
+      val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(Seq(accepted) ++ ordering)
+      unspent.map(b => bytesToId(b.id)) should contain(bytesToId(accepted.outputs.last.id))
+    }
+  }
+
+  Seq(true, false).foreach { fits =>
+    property(s"new input growth is ${if (fits) "accepted" else "deferred"} according to the cumulative conservative cost allowance") {
+      val sources = Seq(box(18), box(19))
+      val txs = sources.map { source =>
+        ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+          IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+      }
+      val costs = txs.map(tx => transactionCost(sources, tx))
+      costs.foreach(_ should be > 0)
+      val total = costs.sum
+      total should be < parameters.maxBlockCost
+      val allowance = if (fits) total + 100 else costs.max + (total - costs.max) / 2
+      allowance should be > costs.max
+      allowance should be < parameters.maxBlockCost
+      if (fits) total should be <= allowance else total should be > allowance
+      val (input, ordering, invalid) = select(sources, Seq(txs.last),
+        Header.Interpreter60Version, prefix = Seq(txs.head), maxCost = allowance)
+      input.map(_.id) shouldBe (if (fits) Seq(txs.last.id) else Seq.empty)
+      ordering shouldBe empty
+      invalid shouldBe empty
+    }
+  }
+
+  property("a mandatory prefix above the conservative allowance is retained without additional input growth") {
+    val sources = Seq(box(22), box(23), box(24))
+    val txs = sources.map { source =>
+      ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+    }
+    val costs = txs.map(tx => transactionCost(sources, tx))
+    costs.foreach(_ should be > 0)
+    val prefixCost = costs.take(2).sum
+    val allowance = costs.max + (prefixCost - costs.max) / 2
+    allowance should be > costs.max
+    prefixCost should be > allowance
+    costs.sum should be < parameters.maxBlockCost
+    val (input, ordering, invalid) = select(sources, Seq(txs.last),
+      Header.Interpreter60Version, prefix = txs.take(2), maxCost = allowance)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+    val retained = org.ergoplatform.nodeView.state.ErgoState.newBoxes(txs.take(2) ++ ordering)
+    retained.map(b => bytesToId(b.id)).toSet shouldBe
+      txs.take(2).flatMap(_.outputs).map(b => bytesToId(b.id)).toSet
+  }
+
+  property("a new input payment is deferred when its accepted prefix fills the ordering size budget") {
+    val acceptedSource = box(20)
+    val newSource = box(21)
+    val accepted = payment(acceptedSource)
+    val fresh = payment(newSource)
+    val budget = math.max(sectionSize(Seq(accepted)), sectionSize(Seq(fresh)))
+    sectionSize(Seq(accepted, fresh)) should be > budget
+    val (input, ordering, invalid) = select(Seq(acceptedSource, newSource), Seq(fresh),
+      Header.Interpreter60Version, prefix = Seq(accepted), maxSize = budget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+    val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(Seq(accepted) ++ ordering)
+    unspent.map(b => bytesToId(b.id)) should contain(bytesToId(accepted.outputs.last.id))
+  }
+
+  for {
+    version <- Seq(Header.InitialVersion, Header.Interpreter50Version, Header.Interpreter60Version)
+    count <- Seq(127, 128)
+  } {
+    property(s"version $version matches serialized section capacity for $count transactions") {
+      val sources = (0 until count).map(i => box(i.toByte, orderingTree))
+      val transactions = sources.map { source =>
+        ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+          IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+      }
+      def serializedSize(txs: Seq[ErgoTransaction]): Int =
+        BlockTransactions(bytesToId(Array.fill[Byte](32)(0)), version, txs).size
+      val totalCost = payloadCost(sources, transactions, version)
+      totalCost should be > parameters.maxBlockCost
+      val testProtocolCost = totalCost + 100000
+      testProtocolCost should be > totalCost
+      val exactSize = serializedSize(transactions)
+      val (input, ordering, invalid) = select(sources, transactions, version, maxSize = exactSize,
+        maxCost = testProtocolCost, protocolCost = testProtocolCost)
+      input shouldBe empty
+      invalid shouldBe empty
+      ordering.map(_.id) shouldBe transactions.map(_.id)
+      serializedSize(ordering) shouldBe exactSize
+
+      val (shortInput, shortOrdering, shortInvalid) =
+        select(sources, transactions, version, maxSize = exactSize - 1,
+          maxCost = testProtocolCost, protocolCost = testProtocolCost)
+      shortInput shouldBe empty
+      shortInvalid shouldBe empty
+      shortOrdering.map(_.id) shouldBe transactions.dropRight(1).map(_.id)
+      serializedSize(shortOrdering) should be <= (exactSize - 1)
+    }
+  }
+
+  property("cumulative prefix and new input cost cannot exceed the consensus ordering budget") {
+    val sources = Seq(box(30), box(31))
+    val txs = sources.map { source =>
+      ErgoTransaction(IndexedSeq(Input(source.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(source.value, TrueTree, 1)))
+    }
+    val individualCosts = txs.map(tx => payloadCost(sources, Seq(tx), Header.Interpreter60Version))
+    individualCosts.foreach(_ should be > 0)
+    // Exact measured cost leaves only a rounded JIT allowance after initialization.
+    // Give each script headroom while keeping the combined payload over budget.
+    val consensusBudget = individualCosts.max + (individualCosts.sum - individualCosts.max) / 2
+    consensusBudget should be > individualCosts.max
+    individualCosts.sum should be > consensusBudget
+    val restrictedState = state(sources, consensusBudget)
+    val restrictedContext = restrictedState.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, Header.Interpreter60Version)
+    val verifier = org.ergoplatform.wallet.interpreter.ErgoInterpreter(restrictedContext.currentParameters)
+    val prefixState = restrictedState.withTransactions(Seq(txs.head))
+    val restrictedCosts = txs.map { tx =>
+      val validated = prefixState.validateWithCost(tx, restrictedContext, consensusBudget,
+        Some(verifier), softFieldsAllowed = true)
+      withClue("Each transaction must validate individually under the restricted consensus context: ") {
+        validated.isSuccess shouldBe true
+      }
+      validated.get
+    }
+    restrictedCosts.foreach(_ should be <= consensusBudget)
+    restrictedCosts.sum should be > consensusBudget
+    val (input, ordering, invalid) = select(sources, Seq(txs.last), Header.Interpreter60Version,
+      prefix = Seq(txs.head), maxCost = consensusBudget, protocolCost = consensusBudget)
+    input shouldBe empty
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("an accepted prefix collects only the optional fee chunk that fits") {
+    val sources = (0 to 100).map(i => box(i.toByte))
+    val accepted = sources.map(payment)
+    val testProtocolCost = 10000000
+    val (_, rewards, _) = select(sources, Seq.empty, Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost)
+    rewards should have size 2
+    val budget = sectionSize(accepted ++ rewards.take(1))
+    sectionSize(accepted ++ rewards) should be > budget
+    val (input, ordering, invalid) = select(sources, Seq.empty, Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost, maxSize = budget)
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering.map(_.id) shouldBe rewards.take(1).map(_.id)
+    val collectedIds = ordering.flatMap(_.inputs).map(in => bytesToId(in.boxId)).toSet
+    assertFeeReward(ordering.head, accepted.filter(tx => collectedIds.contains(bytesToId(tx.outputs.last.id))))
+    val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(accepted ++ ordering)
+      .filter(b => b.propositionBytes.toSeq == feeTree.bytes.toSeq)
+    unspent.map(b => bytesToId(b.id)).toSet shouldBe
+      accepted.map(tx => bytesToId(tx.outputs.last.id)).toSet.diff(collectedIds)
+    unspent should not be empty
+  }
+
+  property("a new ordering payment retains its required fee chunk ahead of optional prefix fees") {
+    val prefixSources = (0 until 100).map(i => box(i.toByte))
+    val newSource = box((-1).toByte, orderingTree)
+    val sources = prefixSources :+ newSource
+    val accepted = prefixSources.map(payment)
+    val fresh = payment(newSource)
+    val testProtocolCost = 10000000
+    val (_, complete, _) = select(sources, Seq(fresh), Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost)
+    complete.head.id shouldBe fresh.id
+    val rewards = complete.tail
+    rewards should have size 2
+    val (required, optional) = rewards.partition(_.inputs.exists(in =>
+      bytesToId(in.boxId) == bytesToId(fresh.outputs.last.id)))
+    required should have size 1
+    optional should have size 1
+    val budget = sectionSize(accepted ++ Seq(fresh) ++ required)
+    sectionSize(accepted ++ complete) should be > budget
+    val (input, ordering, invalid) = select(sources, Seq(fresh), Header.Interpreter60Version,
+      prefix = accepted, maxCost = testProtocolCost, protocolCost = testProtocolCost, maxSize = budget)
+    input shouldBe empty
+    invalid shouldBe empty
+    ordering.map(_.id) shouldBe (Seq(fresh) ++ required).map(_.id)
+    val collectedIds = required.head.inputs.map(in => bytesToId(in.boxId)).toSet
+    assertFeeReward(required.head, (accepted :+ fresh).filter(tx => collectedIds.contains(bytesToId(tx.outputs.last.id))))
+    val unspent = org.ergoplatform.nodeView.state.ErgoState.newBoxes(accepted ++ ordering)
+      .filter(b => b.propositionBytes.toSeq == feeTree.bytes.toSeq)
+    unspent.map(b => bytesToId(b.id)).toSet shouldBe
+      accepted.map(tx => bytesToId(tx.outputs.last.id)).toSet.diff(collectedIds)
+    unspent should not be empty
+  }
+
+  property("fee reward batches consume all fee boxes when there are more than one hundred") {
+    val batchSize = 100
+    val sources = (0 to batchSize).map(i => box(i.toByte))
+    val payments = sources.map(payment)
+    val us = state(sources)
+    val context = us.stateContext.upcoming(defaultMinerPk.value, 1L,
+      settings.chainSettings.initialNBits, Array.emptyByteArray, emptyVSUpdate, Header.InitialVersion)
+    val rewards = CandidateGenerator.collectRewards(None, us.stateContext.currentHeight,
+      payments, defaultMinerPk, context)
+    rewards should have size 2
+    val consumed = rewards.flatMap(_.inputs).map(in => bytesToId(in.boxId))
+    consumed should contain theSameElementsAs payments.map(tx => bytesToId(tx.outputs.last.id))
+    consumed.distinct.size shouldBe payments.size
+    rewards.foreach { reward =>
+      reward.inputs should not be empty
+      reward.inputs.size should be <= batchSize
+      val consumedIds = reward.inputs.map(in => bytesToId(in.boxId)).toSet
+      assertFeeReward(reward, payments.filter(tx => consumedIds.contains(bytesToId(tx.outputs.last.id))))
+    }
+    rewards.flatMap(_.outputs).map(_.value).sum shouldBe payments.size.toLong * fee
+    us.proofsForTransactions(payments ++ rewards).isSuccess shouldBe true
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.mining
+
+import com.google.common.io.Files.createTempDir
+import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, Input}
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.nodeView.state.{BoxHolder, UtxoState}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.{ErgoCompilerHelpers, ErgoCorePropertyTest}
+import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultMinerPk, emptyVSUpdate, parameters}
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import scorex.util.bytesToId
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.interpreter.ProverResult
+
+class MatrixTransactionSelectionSpec extends ErgoCorePropertyTest with ErgoCompilerHelpers {
+  private val orderingTree = compileSourceV5("CONTEXT.minerPubKey.size >= 0", 0)
+
+  private def box(index: Byte, tree: ErgoTree = TrueTree): ErgoBox = new ErgoBox(
+    value = 1000000000L, ergoTree = tree, creationHeight = 0,
+    additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+    transactionId = bytesToId(Array.fill(32)(index)), index = 0
+  )
+
+  private def spend(input: ErgoBox, outputTree: ErgoTree = TrueTree,
+                    dataInputs: IndexedSeq[DataInput] = IndexedSeq.empty): ErgoTransaction =
+    ErgoTransaction(IndexedSeq(Input(input.id, ProverResult.empty)), dataInputs,
+      IndexedSeq(new ErgoBoxCandidate(input.value, outputTree, 1)))
+
+  private def select(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction]) = {
+    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, parameters)
+    val context = state.stateContext.upcoming(defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
+      Array.emptyByteArray, emptyVSUpdate, 4.toByte)
+    val result = CandidateGenerator.collectTxs(defaultMinerPk, parameters.maxBlockCost,
+      parameters.maxBlockSize, state, context, txs)
+    // Both selected payloads must have a UTXO proof independently of the other new payload.
+    Seq(result._1, result._2).filter(_.nonEmpty).foreach { payload =>
+      state.proofsForTransactions(payload).isSuccess shouldBe true
+    }
+    result
+  }
+
+  property("ordinary and soft-field transactions enter their respective partitions") {
+    val inputBox = box(1)
+    val orderingBox = box(2, orderingTree)
+    val inputTx = spend(inputBox)
+    val orderingTx = spend(orderingBox)
+    val (input, ordering, invalid) = select(Seq(inputBox, orderingBox), Seq(inputTx, orderingTx))
+    input shouldBe Seq(inputTx)
+    ordering shouldBe Seq(orderingTx)
+    invalid shouldBe empty
+  }
+
+  property("input-only dependency chains remain in the input payload") {
+    val initial = box(3)
+    val parent = spend(initial)
+    val child = spend(parent.outputs.head)
+    val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child))
+    input shouldBe Seq(parent, child)
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+
+  property("ordering-only dependency chains remain in the ordering payload") {
+    val initial = box(4, orderingTree)
+    val parent = spend(initial, orderingTree)
+    val child = spend(parent.outputs.head)
+    val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child))
+    input shouldBe empty
+    ordering shouldBe Seq(parent, child)
+    invalid shouldBe empty
+  }
+
+  property("cross-partition spending dependencies and descendants are deferred without elimination") {
+    Seq(false, true).foreach { orderingParent =>
+      val initial = box(5, if (orderingParent) orderingTree else TrueTree)
+      val parent = spend(initial, if (orderingParent) TrueTree else orderingTree)
+      val child = spend(parent.outputs.head)
+      val grandchild = spend(child.outputs.head)
+      val independentBox = box(10)
+      val independent = spend(independentBox)
+      val (input, ordering, invalid) = select(Seq(initial, independentBox), Seq(parent, child, grandchild, independent))
+      (input ++ ordering) should contain theSameElementsAs Seq(parent, independent)
+      invalid shouldBe empty
+    }
+  }
+
+  property("cross-partition data dependencies are deferred in either direction") {
+    Seq(false, true).foreach { orderingParent =>
+      val first = box(6, if (orderingParent) orderingTree else TrueTree)
+      val second = box(7, if (orderingParent) TrueTree else orderingTree)
+      val parent = spend(first)
+      val child = spend(second, dataInputs = IndexedSeq(DataInput(parent.outputs.head.id)))
+      val (input, ordering, invalid) = select(Seq(first, second), Seq(parent, child))
+      (input ++ ordering) shouldBe Seq(parent)
+      invalid shouldBe empty
+    }
+  }
+
+  property("same-partition data dependencies remain selectable") {
+    val first = box(8)
+    val second = box(9)
+    val parent = spend(first)
+    val child = spend(second, dataInputs = IndexedSeq(DataInput(parent.outputs.head.id)))
+    val (input, ordering, invalid) = select(Seq(first, second), Seq(parent, child))
+    input shouldBe Seq(parent, child)
+    ordering shouldBe empty
+    invalid shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/llm_generated/MatrixTransactionSelectionSpec.scala
@@ -3,8 +3,10 @@ package org.ergoplatform.mining
 import com.google.common.io.Files.createTempDir
 import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, Input}
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.state.{BoxHolder, UtxoState}
-import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.settings.Parameters
+import org.ergoplatform.settings.Constants.{FalseTree, TrueTree}
 import org.ergoplatform.utils.{ErgoCompilerHelpers, ErgoCorePropertyTest}
 import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultMinerPk, emptyVSUpdate, parameters}
 import org.ergoplatform.utils.ErgoNodeTestConstants.settings
@@ -27,17 +29,88 @@ class MatrixTransactionSelectionSpec extends ErgoCorePropertyTest with ErgoCompi
     ErgoTransaction(IndexedSeq(Input(input.id, ProverResult.empty)), dataInputs,
       IndexedSeq(new ErgoBoxCandidate(input.value, outputTree, 1)))
 
-  private def select(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction]) = {
-    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, parameters)
+  private def select(boxes: Seq[ErgoBox], txs: Seq[ErgoTransaction],
+                     version: Byte = Header.Interpreter60Version,
+                     currentVersion: Byte = Header.InitialVersion,
+                     maxCost: Int = parameters.maxBlockCost,
+                     maxSize: Int = parameters.maxBlockSize) = {
+    val currentParameters = Parameters(parameters.height,
+      parameters.parametersTable.updated(Parameters.BlockVersion, currentVersion.toInt), parameters.proposedUpdate)
+    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir(), settings, currentParameters)
     val context = state.stateContext.upcoming(defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
-      Array.emptyByteArray, emptyVSUpdate, 4.toByte)
-    val result = CandidateGenerator.collectTxs(defaultMinerPk, parameters.maxBlockCost,
-      parameters.maxBlockSize, state, context, txs)
+      Array.emptyByteArray, emptyVSUpdate, version)
+    val result = CandidateGenerator.collectTxs(defaultMinerPk, maxCost,
+      maxSize, state, context, txs)
     // Both selected payloads must have a UTXO proof independently of the other new payload.
     Seq(result._1, result._2).filter(_.nonEmpty).foreach { payload =>
       state.proofsForTransactions(payload).isSuccess shouldBe true
     }
     result
+  }
+
+  Seq(Header.InitialVersion, Header.HardeningVersion, Header.Interpreter50Version).foreach { version =>
+    property(s"version $version includes ordinary transactions and their descendants in ordering blocks") {
+      val initial = box(11)
+      val parent = spend(initial)
+      val child = spend(parent.outputs.head)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child), version)
+      input shouldBe empty
+      ordering shouldBe Seq(parent, child)
+      invalid shouldBe empty
+    }
+  }
+
+  property("the first version 4 candidate partitions transactions while current parameters are version 3") {
+    val inputBox = box(12)
+    val orderingBox = box(13, orderingTree)
+    val inputTx = spend(inputBox)
+    val orderingTx = spend(orderingBox)
+    val (input, ordering, invalid) = select(Seq(inputBox, orderingBox), Seq(inputTx, orderingTx),
+      Header.Interpreter60Version, Header.Interpreter50Version)
+    input shouldBe Seq(inputTx)
+    ordering shouldBe Seq(orderingTx)
+    invalid shouldBe empty
+  }
+
+  property("legacy candidates keep dependencies between ordinary and context-dependent transactions") {
+    Seq(false, true).foreach { contextDependentParent =>
+      val initial = box(14, if (contextDependentParent) orderingTree else TrueTree)
+      val parent = spend(initial, if (contextDependentParent) TrueTree else orderingTree)
+      val child = spend(parent.outputs.head)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(parent, child), Header.Interpreter50Version)
+      input shouldBe empty
+      ordering shouldBe Seq(parent, child)
+      invalid shouldBe empty
+    }
+  }
+
+  Seq(Header.Interpreter50Version, Header.Interpreter60Version).foreach { version =>
+    property(s"version $version rejects an unsatisfied script") {
+      val initial = box(15, FalseTree)
+      val tx = spend(initial)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(tx), version)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe Seq(tx.id)
+    }
+
+    property(s"version $version rejects a transaction exceeding the validation cost budget") {
+      val initial = box(16)
+      val tx = spend(initial)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(tx), version, maxCost = 1)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe Seq(tx.id)
+    }
+
+    property(s"version $version leaves a valid transaction unselected when the payload is full") {
+      val initial = box(17)
+      val tx = spend(initial)
+      val (input, ordering, invalid) = select(Seq(initial), Seq(tx), version, maxSize = 1)
+      input shouldBe empty
+      ordering shouldBe empty
+      invalid shouldBe empty
+    }
   }
 
   property("ordinary and soft-field transactions enter their respective partitions") {

--- a/src/test/scala/org/ergoplatform/network/llm_generated/MatrixInputTipSyncSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/llm_generated/MatrixInputTipSyncSpec.scala
@@ -1,0 +1,384 @@
+package org.ergoplatform.network.llm_generated
+
+import akka.actor.{ActorRef, Props}
+import akka.testkit.{TestActorRef, TestProbe}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
+import org.ergoplatform.consensus.{Equal, Nonsense, PeerChainStatus, Unknown}
+import org.ergoplatform.mining.InputBlockFields
+import org.ergoplatform.modifiers.mempool.ErgoTransaction
+import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ErgoSyncTracker, ModePeerFeature, Version}
+import org.ergoplatform.network.message.Message
+import org.ergoplatform.network.message.inputblocks.InputBlockMessageSpec
+import org.ergoplatform.network.peer.PeerInfo
+import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoSyncInfo, ErgoSyncInfoMessageSpec}
+import org.ergoplatform.nodeView.state.{BoxHolder, StateType, UtxoState}
+import org.ergoplatform.settings.{Algos, ErgoSettings}
+import org.ergoplatform.subblocks.InputBlockAnnouncement
+import org.ergoplatform.wallet.utils.FileUtils
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
+import scorex.core.network.{ConnectedPeer, DeliveryTracker, SendToPeer}
+import scorex.testkit.utils.AkkaFixture
+import scorex.crypto.authds.LeafData
+import scorex.util.{bytesToId, idToBytes}
+import sigma.Colls
+import sigma.ast.ErgoTree
+import sigma.data.TrivialProp.TrueProp
+import sigma.interpreter.ProverResult
+
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+/** Replay is exercised through ordinary sync entry points, without locally mined block events. */
+class MatrixInputTipSyncSpec extends AnyPropSpec with Matchers with FileUtils {
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+  import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+  import org.ergoplatform.utils.generators.ConnectedPeerGenerators._
+  import org.ergoplatform.utils.generators.ChainGenerator._
+
+  private class Synchronizer(nc: ActorRef, vh: ActorRef, cfg: ErgoSettings,
+                             val statuses: ErgoSyncTracker)(implicit ec: ExecutionContext)
+    extends ErgoNodeViewSynchronizer(nc, vh, ErgoSyncInfoMessageSpec, cfg,
+      statuses, DeliveryTracker.empty(cfg)) {
+    def outbound(history: ErgoHistory): Unit = sendSync(history)
+    def inboundV2(history: ErgoHistory, peer: ConnectedPeer): Unit =
+      processSyncV2(history, history.syncInfoV2(full = true), peer)
+    def inboundV1(history: ErgoHistory, peer: ConnectedPeer): Unit =
+      processSyncV1(history, history.syncInfoV1, peer)
+  }
+
+  private class Fixture(initialHeight: Int) extends AkkaFixture {
+    implicit val ec: ExecutionContext = system.dispatcher
+    lazy val nc: TestProbe = TestProbe()
+    lazy val vh: TestProbe = TestProbe()
+    val cfg: ErgoSettings = settings.copy(directory = createTempDir.getAbsolutePath)
+    val boxes: Seq[ErgoBox] = (0 until 4).map { index =>
+      new ErgoBox(value = 1000000000L, ergoTree = ErgoTree.fromProposition(TrueProp), creationHeight = 0,
+        additionalTokens = Colls.emptyColl, additionalRegisters = Map.empty,
+        transactionId = bytesToId(Algos.hash(s"matrix-input-tip-sync-box-$index")), index = index.toShort)
+    }
+    var state: UtxoState = _
+    var history: ErgoHistory = _
+    val tracker: ErgoSyncTracker = ErgoSyncTracker(cfg.scorexSettings.network)
+    var sync: Synchronizer = _
+
+    def initialize(): Unit = {
+      state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir, cfg, parameters)
+      history = ErgoHistory.readOrGenerate(cfg)(null)
+      applyChain(history, genChain(height = initialHeight, history = history, stateOpt = Some(state)))
+      history.fullBlockHeight shouldBe initialHeight
+      val ref: TestActorRef[Synchronizer] = TestActorRef(Props(new Synchronizer(nc.ref, vh.ref, cfg, tracker)))
+      sync = ref.underlyingActor
+    }
+
+    def peer(version: Version = Version.SubblocksVersion,
+             mode: Option[StateType] = Some(StateType.Utxo)): ConnectedPeer = {
+      val spec = defaultPeerSpec.copy(protocolVersion = version,
+        features = mode.toSeq.map(t => ModePeerFeature(t, true, None, -1)))
+      ConnectedPeer(connectionIdGen.sample.get, TestProbe().ref,
+        Some(PeerInfo(spec, System.currentTimeMillis())))
+    }
+
+    def transactions(count: Int): Seq[ErgoTransaction] = boxes.take(count).map { box =>
+      new ErgoTransaction(IndexedSeq(Input(box.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(box.value, box.ergoTree, 0, box.additionalTokens, Map.empty)))
+    }
+
+    def announcement(parent: Option[InputBlockAnnouncement] = None,
+                     transactions: Seq[ErgoTransaction] = Seq.empty): InputBlockAnnouncement = {
+      val empty = InputBlockFields.empty
+      val fields = new InputBlockFields(parent.map(a => idToBytes(a.id)),
+        Algos.merkleTreeRoot(transactions.map(tx => LeafData @@ tx.serializedId)),
+        empty.prevTransactionsDigest, empty.inputBlockFieldsProof)
+      val weakIds = if (transactions.isEmpty) None else Some(transactions.map(_.weakId))
+      InputBlockAnnouncement(1.toByte, genChain(1, history).last.header, fields, weakIds)
+    }
+
+    def processedTip(transactions: Seq[ErgoTransaction] = Seq.empty): InputBlockAnnouncement = {
+      val tip = announcement(transactions = transactions)
+      history.applyInputBlock(tip) shouldBe None
+      history.applyInputBlockTransactions(tip.id, transactions, state)._1 shouldBe Seq(tip.id)
+      history.bestBlocks._2.map(_.id) shouldBe Some(tip.id)
+      history.bestInputBlocksChain() shouldBe Seq(tip.id)
+      tip
+    }
+
+    def eligible(peer: ConnectedPeer, offset: Int = 0, status: PeerChainStatus = Equal): Unit = {
+      tracker.updateStatus(peer, status, Some(history.fullBlockHeight + offset))
+      // A normal periodic sync opportunity, without wall-clock sleeping.
+      val old = tracker.statuses(peer)
+      tracker.statuses.update(peer, old.copy(lastSyncSentTime = Some(System.currentTimeMillis() - 61000L)))
+    }
+
+    def messages(): Seq[SendToNetwork] = nc.receiveWhile(300.millis, 30.millis) { case m => m }
+      .collect { case m: SendToNetwork => m }
+
+    def announcements(messages: Seq[SendToNetwork]): Seq[(InputBlockAnnouncement, SendToNetwork)] =
+      messages.collect {
+        case m @ SendToNetwork(Message(spec, Right(a: InputBlockAnnouncement), _), _) =>
+          spec shouldBe InputBlockMessageSpec
+          a -> m
+      }
+
+    def requireSync(messages: Seq[SendToNetwork]): Unit =
+      messages.exists {
+        case SendToNetwork(Message(_, Right(_: ErgoSyncInfo), _), _) => true
+        case _ => false
+      } shouldBe true
+
+    def requireReplay(messages: Seq[SendToNetwork], tip: InputBlockAnnouncement, remote: ConnectedPeer): Unit = {
+      val replays = announcements(messages)
+      replays should have size 1
+      InputBlockAnnouncement.serializer.toBytes(replays.head._1) shouldBe InputBlockAnnouncement.serializer.toBytes(tip)
+      replays.head._2.sendingStrategy shouldBe SendToPeer(remote)
+    }
+  }
+
+  private def withFixture(test: Fixture => Unit): Unit = withFixtureAtHeight(4)(test)
+
+  private def withFixtureAtHeight(height: Int)(test: Fixture => Unit): Unit = {
+    val fixture = new Fixture(height)
+    try {
+      fixture.initialize()
+      test(fixture)
+    }
+    finally {
+      try Await.result(fixture.system.terminate(), 10.seconds)
+      finally {
+        try {
+          if (fixture.history != null) fixture.history.closeStorage()
+        } finally {
+          if (fixture.state != null) fixture.state.closeStorage()
+        }
+      }
+    }
+  }
+
+  property("an Unknown peer learns the equal V2 height and receives the already processed tip") {
+    withFixture { f =>
+      val tip = f.processedTip()
+      val peer = f.peer()
+      f.tracker.updateStatus(peer, Unknown, None)
+      f.sync.inboundV2(f.history, peer)
+      f.tracker.getStatus(peer) shouldBe Some(Equal)
+      f.tracker.fullInfo().find(_.peer == peer).map(_.height) shouldBe Some(f.history.fullBlockHeight)
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.requireReplay(messages, tip, peer)
+    }
+  }
+
+  property("outbound periodic sync replays the tip even though it refreshes the send timestamp") {
+    withFixture { f =>
+      val tip = f.processedTip()
+      val peer = f.peer()
+      f.eligible(peer)
+      f.sync.outbound(f.history)
+      f.tracker.notSyncedOrOutdated(peer) shouldBe false
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.requireReplay(messages, tip, peer)
+      // Equal simultaneous sync responses need no reply; discovery must already have happened above.
+      f.sync.inboundV2(f.history, peer)
+      f.messages() shouldBe empty
+    }
+  }
+
+  property("an announced but unprocessed child does not replace the replayed processed tip") {
+    withFixture { f =>
+      val tip = f.processedTip()
+      val child = f.announcement(Some(tip))
+      f.history.applyInputBlock(child) shouldBe None
+      f.history.getInputBlock(child.id).isDefined shouldBe true
+      f.history.bestBlocks._2.map(_.id) shouldBe Some(child.id)
+      f.history.bestInputBlocksChain() shouldBe Seq(tip.id)
+      val peer = f.peer()
+      f.eligible(peer)
+      f.sync.outbound(f.history)
+      f.requireReplay(f.messages(), tip, peer)
+    }
+  }
+
+  property("an empty processed input chain preserves normal sync without an announcement") {
+    withFixture { f =>
+      val unprocessed = f.announcement()
+      f.history.applyInputBlock(unprocessed)
+      f.history.bestBlocks._2 shouldBe None
+      f.history.bestInputBlocksChain() shouldBe empty
+      val peer = f.peer()
+      f.eligible(peer)
+      f.sync.outbound(f.history)
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.announcements(messages) shouldBe empty
+    }
+  }
+
+  property("V1 can reuse an established V2 height for a sync response replay") {
+    withFixture { f =>
+      val tip = f.processedTip()
+      val peer = f.peer()
+      f.eligible(peer)
+      f.sync.inboundV1(f.history, peer)
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.requireReplay(messages, tip, peer)
+    }
+  }
+
+  property("fresh V1 sync without an established height does not replay an input tip") {
+    withFixture { f =>
+      f.processedTip()
+      val peer = f.peer()
+      f.sync.inboundV1(f.history, peer)
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.announcements(messages) shouldBe empty
+    }
+  }
+
+  for (offset <- Seq(-3, -2, 2, 3)) {
+    property(s"outbound tip replay observes the two-block height window at offset $offset") {
+      withFixture { f =>
+        val tip = f.processedTip()
+        val peer = f.peer()
+        f.eligible(peer, offset)
+        f.sync.outbound(f.history)
+        val messages = f.messages()
+        f.requireSync(messages)
+        if (math.abs(offset) <= 2) f.requireReplay(messages, tip, peer)
+        else f.announcements(messages) shouldBe empty
+      }
+    }
+  }
+
+  for ((label, version, mode) <- Seq(
+    ("older version", Version(6, 4, 0), Some(StateType.Utxo)),
+    ("digest mode", Version.SubblocksVersion, Some(StateType.Digest)),
+    ("absent mode", Version.SubblocksVersion, None))) {
+    property(s"outbound ordinary sync does not send an input tip to $label") {
+      withFixture { f =>
+        f.processedTip()
+        val peer = f.peer(version, mode)
+        f.eligible(peer)
+        f.sync.outbound(f.history)
+        val messages = f.messages()
+        f.requireSync(messages)
+        f.announcements(messages) shouldBe empty
+      }
+    }
+  }
+
+  for (status <- Seq(Unknown, Nonsense)) {
+    property(s"outbound ordinary sync does not replay a tip for unusable status $status") {
+      withFixture { f =>
+        f.processedTip()
+        val peer = f.peer()
+        f.eligible(peer, status = status)
+        f.sync.outbound(f.history)
+        val messages = f.messages()
+        f.requireSync(messages)
+        f.announcements(messages) shouldBe empty
+      }
+    }
+  }
+
+  for (count <- Seq(3, 4)) {
+    property(s"sync replay preserves the existing weak-ID payload rule for $count processed transactions") {
+      withFixture { f =>
+        val transactions = f.transactions(count)
+        transactions.size shouldBe count
+        val tip = f.processedTip(transactions)
+        tip.weakTxIds.map(_.size) shouldBe Some(count)
+        f.history.getInputBlockTransactions(tip.id).map(_.map(_.id)) shouldBe Some(transactions.map(_.id))
+        val peer = f.peer()
+        f.eligible(peer)
+        f.sync.outbound(f.history)
+        val expected = if (count <= 3) tip else tip.copy(weakTxIds = None)
+        f.requireReplay(f.messages(), expected, peer)
+        // Replay must not rewrite the stored announcement used by later body retrieval.
+        f.history.getInputBlock(tip.id).get.weakTxIds.map(_.map(_.toSeq)) shouldBe
+          tip.weakTxIds.map(_.map(_.toSeq))
+      }
+    }
+  }
+
+  property("zero peer height is not established eligibility even within the two-block window") {
+    withFixtureAtHeight(2) { f =>
+      f.processedTip()
+      val peer = f.peer()
+      f.eligible(peer, offset = -2)
+      f.tracker.fullInfo().find(_.peer == peer).map(_.height) shouldBe Some(0)
+      f.sync.outbound(f.history)
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.announcements(messages) shouldBe empty
+    }
+  }
+
+  property("without a local full ordering block ordinary sync has no input tip to replay") {
+    withFixtureAtHeight(0) { f =>
+      f.history.bestInputBlocksChain() shouldBe empty
+      val peer = f.peer()
+      f.eligible(peer, offset = 1)
+      f.sync.outbound(f.history)
+      val messages = f.messages()
+      f.requireSync(messages)
+      f.announcements(messages) shouldBe empty
+    }
+  }
+
+  property("outbound sync replays only to its selected eligible destinations") {
+    withFixture { f =>
+      val tip = f.processedTip()
+      val first = f.peer()
+      val second = f.peer()
+      val digest = f.peer(mode = Some(StateType.Digest))
+      val recentlySynced = f.peer()
+      Seq(first, second, digest, recentlySynced).foreach(f.eligible(_))
+      f.tracker.updateLastSyncSentTime(recentlySynced)
+      f.sync.outbound(f.history)
+      val messages = f.messages()
+      f.requireSync(messages)
+      val announcements = f.announcements(messages)
+      announcements should have size 2
+      announcements.map(_._2.sendingStrategy).toSet shouldBe Set(SendToPeer(first), SendToPeer(second))
+      announcements.foreach { case (announcement, _) =>
+        InputBlockAnnouncement.serializer.toBytes(announcement) shouldBe InputBlockAnnouncement.serializer.toBytes(tip)
+      }
+    }
+  }
+
+  for ((label, version, mode) <- Seq(
+    ("older version", Version(6, 4, 0), Some(StateType.Utxo)),
+    ("digest mode", Version.SubblocksVersion, Some(StateType.Digest)),
+    ("absent mode", Version.SubblocksVersion, None)); useV2 <- Seq(false, true)) {
+    property(s"V${if (useV2) 2 else 1} response retains ordinary sync but excludes $label from tip replay") {
+      withFixture { f =>
+        f.processedTip()
+        val peer = f.peer(version, mode)
+        f.eligible(peer)
+        if (useV2) f.sync.inboundV2(f.history, peer) else f.sync.inboundV1(f.history, peer)
+        val messages = f.messages()
+        f.requireSync(messages)
+        f.announcements(messages) shouldBe empty
+      }
+    }
+  }
+
+  for (offset <- Seq(-3, -2, 2, 3)) {
+    property(s"V1 response uses the established peer height at offset $offset") {
+      withFixture { f =>
+        val tip = f.processedTip()
+        val peer = f.peer()
+        f.eligible(peer, offset)
+        f.sync.inboundV1(f.history, peer)
+        val messages = f.messages()
+        f.requireSync(messages)
+        if (math.abs(offset) <= 2) f.requireReplay(messages, tip, peer)
+        else f.announcements(messages) shouldBe empty
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/MempoolBlockClearingSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/MempoolBlockClearingSpec.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.nodeView.mempool
 
-import org.ergoplatform.{ErgoBox, Input}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
 import org.ergoplatform.mining.InputBlockFields
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
@@ -79,24 +79,22 @@ class MempoolBlockClearingSpec extends AnyFlatSpec
   private def emptyInputBlockFields: InputBlockFields = InputBlockFields.empty
 
   it should "remove transactions from mempool when block containing them is applied" in {
-    // Setup initial state with genesis block
-    val (us, bh) = createUtxoState(settings)
-    val genesis = validFullBlock(None, us, bh)
-    val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-
-    // Create valid transactions from available boxes and add them to mempool
-    val boxes = wus.takeBoxes(3)
-    val limit = 10000
-    val txs = validTransactionsFromBoxes(limit, boxes, new RandomWrapper)._1
-    info(s"Generated ${txs.length} transactions")
-    txs.length should be >= 1
+    val boxes = Seq(testBox1, testBox2, testBox3)
+    val state = UtxoState.fromBoxHolder(BoxHolder(boxes), None, createTempDir, settings, parameters)
+    val txs = boxes.map { box =>
+      ErgoTransaction(IndexedSeq(Input(box.id, ProverResult.empty)), IndexedSeq.empty,
+        IndexedSeq(new ErgoBoxCandidate(box.value, box.ergoTree, box.creationHeight)))
+    }
+    txs.length shouldBe 3
     val unconfirmedTxs = txs.map(tx => UnconfirmedTransaction(tx, None))
     var pool = ErgoMemPool.empty(settings)
 
     // Add all transactions to mempool
     unconfirmedTxs.foreach { utx =>
-      val (_newPool, outcome) = pool.process(utx, wus)
-      outcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+      val (_newPool, outcome) = pool.process(utx, state)
+      withClue(s"Admission of ${utx.transaction.id}: $outcome: ") {
+        outcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
+      }
       pool = _newPool
     }
 

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
Replay the processed input tip during periodic sync and sync replies so peers reconnecting at the same ordering height can discover that input chain while mining is idle. Replay retains the existing version, UTXO, height-proximity and compact weak-ID rules, and excludes an announced descendant whose transactions are still pending. [#2500](https://github.com/ergoplatform/ergo/pull/2500) and [#2503](https://github.com/ergoplatform/ergo/pull/2503) retain the adjacent request-admission and connection-state scopes.

Head `0d7b983061780bf7720e762b09d1b603328d02f6` targets `weak-blocks` at `c216c5b6e3310911d5f3822b40c5e57eee6fc45a`. The [new increment](https://github.com/a-shannon/ergo/compare/89bb84847223d57e0234e590384c19650408b084...0d7b983061780bf7720e762b09d1b603328d02f6) preserves this PR's replay production and tests. It reuses selection [E](https://github.com/a-shannon/ergo/commit/e77f77c2130521b0b9ddd7594d9d11aa5c51a56b), owned by [#2504](https://github.com/ergoplatform/ergo/pull/2504); typed-solution forwarding [F](https://github.com/a-shannon/ergo/commit/13d79b04a9e1d9ca7dbe57b4f701158a35b3b06d), owned by [#2505](https://github.com/ergoplatform/ergo/pull/2505); and mining fixtures [b43](https://github.com/a-shannon/ergo/commit/b43a21c49b827f7df11448767d28c2b3c42ab5c9), owned by [#2501](https://github.com/ergoplatform/ergo/pull/2501). The [focused fixture closure](https://github.com/a-shannon/ergo/commit/29e6b6c641c6b2f8e179a9a596fc566c494a8a7d) combines exact #2500 ordering-proof support with #2501 mempool-admission and funded-box support. Review these shared commits with their owners before this consumer; their whole branches are not prerequisites.

The final composition passed normal node compilation and **16/16 focused checks**: two deterministic funding regressions, the actual large-mempool property, and all thirteen mempool cases. Its five core proof checks passed on unchanged core inputs. Earlier in this update, five owner replay cases and a DevNet mining case passed, covering equal-height discovery, outbound timestamps, processed-tip selection and both compact-payload boundaries. Those earlier node sessions used the previous generator and are not presented as final-input results.

The prior native node job failed in old miner/candidate fixtures and mempool admission setup. The added funding prerequisite also addresses a subsequently reproduced underfunded-box premise in the shared large-mempool test. Assertions still require valid PoW, transaction admission, removal, rollback, value conservation and token preservation. Independent source review found no composition blocker. These focused results do not establish one cause for every historical failure or replace new-head native CI.

Existing [H/K observer support](https://github.com/a-shannon/ergo/compare/612c7eadf7698f8aaba6ce78a63433c046704ed2...89bb84847223d57e0234e590384c19650408b084), owned by #2535/#2511, is unchanged, including fixed targets, progress latches and the fifteen-minute fork deadline. Its earlier actual composition passed normal IT compilation and 37/37 observer/diagnostic cases. At `612c7ead`, native IT passed twelve cases with one fork timeout and one ignored case; a separate core failure occurred during tool download before project tests. Local observer checks did not run the Docker scenario.

The earlier [S/C increment](https://github.com/a-shannon/ergo/compare/89cc88cedb0f3280feb74136da6d2853f0b20473...612c7eadf7698f8aaba6ce78a63433c046704ed2), owned by #2501, preserves the declared Sigma coordinate, verified source and codec expressions. Shared bootstrap evidence includes seventeen shell contracts, both pinned sources on Scala 2.12.20, the older source on 2.11.12, and three codec cases on each relevant old/new composition.

Historical owner evidence includes thirty direct actor properties and [combined Linux node CI](https://github.com/a-shannon/ergo/actions/runs/34001725870): 1,146 tests across 105 suites, with two ignored. [Final lifecycle CI](https://github.com/a-shannon/ergo/actions/runs/34010622069) passed eight scenarios, including idle reconnection, a nonproducing relay, pending-input restart and offline catch-up, before further mining and with full serialized-body comparisons. Runtime sources matched node validation; idle reconnection failed twice on the baseline. These results apply to the combined #2505 harness/#2501 bootstrap stack. Separate Windows runs had a fork timeout and a native JVM error. The [test-only follow-up](https://github.com/a-shannon/ergo/commit/c8680dda90d0583fd6d90e2450befb1501eb3389) retains the Linux-validated test files and cancels dependent scenarios after the first failure. Current individual-PR CI and integration remain tracked in [#2533](https://github.com/ergoplatform/ergo/issues/2533).
