### PR TITLE
Unlock wallets with their persisted cipher parameters

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
@@ -67,7 +67,8 @@ final class JsonSecretStorage(val secretFile: File, encryptionSettings: Encrypti
             )
           )
           .flatMap { case (cipherText, salt, iv, tag, usePre1627KeyDerivation) => {
-              val res = crypto.AES.decrypt(cipherText, pass.getData(), salt, iv, tag)(encryptionSettings)
+              // Existing files retain their KDF parameters when the current configuration changes.
+              val res = crypto.AES.decrypt(cipherText, pass.getData(), salt, iv, tag)(encryptedSecret.cipherParams)
               res
                 .map(seed => unlockedSecret = Some(ExtendedSecretKey.deriveMasterKey(seed, usePre1627KeyDerivation.getOrElse(true))))
             }

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/JsonSecretStorageSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/JsonSecretStorageSpec.scala
@@ -1,6 +1,9 @@
 package org.ergoplatform.wallet.secrets
 
+import io.circe.parser.decode
+import io.circe.syntax._
 import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.wallet.secrets.ExtendedSecretKey
 import org.ergoplatform.sdk.wallet.settings.EncryptionSettings
 import org.ergoplatform.wallet.settings.SecretStorageSettings
 import org.ergoplatform.wallet.utils.FileUtils
@@ -10,6 +13,8 @@ import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.io.{File, PrintWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.UUID
 
 class JsonSecretStorageSpec
@@ -36,6 +41,79 @@ class JsonSecretStorageSpec
 
       // wallet should use explicitly specified BIP32 key derivation
       storage.secret.get.usePre1627KeyDerivation shouldBe usePre1627KeyDerivation
+    }
+  }
+
+  private val originalEncryption = EncryptionSettings("HmacSHA1", 7, 256)
+  private val changedEncryptionSettings = Seq(
+    "prf" -> originalEncryption.copy(prf = "HmacSHA256"),
+    "c" -> originalEncryption.copy(c = 11),
+    "dkLen" -> originalEncryption.copy(dkLen = 128)
+  )
+
+  changedEncryptionSettings.foreach { case (field, currentEncryption) =>
+    property(s"reopening uses stored $field after configuration changes") {
+      Seq(false, true).foreach { usePre1627KeyDerivation =>
+        val dir = createTempDir
+        try {
+          val seed = Array.tabulate[Byte](32)(_.toByte)
+          val expected = ExtendedSecretKey.deriveMasterKey(seed, usePre1627KeyDerivation)
+          val pass = "synthetic-wallet-password"
+          val settings = SecretStorageSettings(dir.getAbsolutePath, originalEncryption)
+          val created = JsonSecretStorage.init(seed, SecretString.create(pass), usePre1627KeyDerivation)(settings)
+          val originalBytes = Files.readAllBytes(created.secretFile.toPath)
+          val reopened = JsonSecretStorage.readFile(settings.copy(encryption = currentEncryption)).get
+
+          reopened.unlock(SecretString.create(pass)) shouldBe 'success
+          reopened.secret.get shouldBe expected
+          reopened.secret.get.usePre1627KeyDerivation shouldBe usePre1627KeyDerivation
+          Files.readAllBytes(created.secretFile.toPath).toSeq shouldBe originalBytes.toSeq
+          reopened.lock()
+        } finally deleteRecursive(dir)
+      }
+    }
+
+    property(s"initialization persists the current $field setting") {
+      val dir = createTempDir
+      try {
+        val seed = Array.tabulate[Byte](32)(_.toByte)
+        val pass = "synthetic-wallet-password"
+        val settings = SecretStorageSettings(dir.getAbsolutePath, currentEncryption)
+        val created = JsonSecretStorage.init(seed, SecretString.create(pass), usePre1627KeyDerivation = false)(settings)
+        val raw = new String(Files.readAllBytes(created.secretFile.toPath), StandardCharsets.UTF_8)
+
+        decode[EncryptedSecret](raw).right.get.cipherParams shouldBe currentEncryption
+        created.unlock(SecretString.create(pass)) shouldBe 'success
+        created.lock()
+      } finally deleteRecursive(dir)
+    }
+  }
+
+  Seq(
+    "unsupported PRF" -> originalEncryption.copy(prf = "Unsupported"),
+    "zero iterations" -> originalEncryption.copy(c = 0),
+    "negative iterations" -> originalEncryption.copy(c = -1),
+    "zero key length" -> originalEncryption.copy(dkLen = 0),
+    "negative key length" -> originalEncryption.copy(dkLen = -1),
+    "unsupported AES key length" -> originalEncryption.copy(dkLen = 120)
+  ).foreach { case (description, invalidEncryption) =>
+    property(s"invalid stored parameters return failure: $description") {
+      val dir = createTempDir
+      try {
+        val pass = "synthetic-wallet-password"
+        val settings = SecretStorageSettings(dir.getAbsolutePath, originalEncryption)
+        val created = JsonSecretStorage.init(Array.fill[Byte](32)(1), SecretString.create(pass),
+          usePre1627KeyDerivation = false)(settings)
+        val raw = new String(Files.readAllBytes(created.secretFile.toPath), StandardCharsets.UTF_8)
+        val encrypted = decode[EncryptedSecret](raw).right.get
+        Files.write(created.secretFile.toPath,
+          encrypted.copy(cipherParams = invalidEncryption).asJson.noSpaces.getBytes(StandardCharsets.UTF_8))
+        val reopened = JsonSecretStorage.readFile(settings).get
+
+        reopened.unlock(SecretString.create(pass)) shouldBe 'failure
+        reopened.isLocked shouldBe true
+        reopened.secret shouldBe None
+      } finally deleteRecursive(dir)
     }
   }
 
@@ -84,7 +162,7 @@ class JsonSecretStorageSpec
     {"cipherText":"e134f488c52a87ccb0287fdd164bdb3b67f04c33ba94eab169e802df7a082addd434e1f36dccbf5362f97a9e57ef97879807bdc632072fb2b3ae9a9b08a6caf6","salt":"988e9d31c675bf6012c235e4c238f22649285140544b17600e2887f655b74ae7","iv":"dff8c6b120cdfaac4192e9c1","authTag":"de1c6443808263b749f4c29f146208ba","cipherParams":{"prf":"HmacSHA1","c":7,"dkLen":256}}
     """
     val pass = List("N", "m").toString()
-    val encryptionSettings = EncryptionSettings("HmacSHA1", 7, 256)
+    val encryptionSettings = EncryptionSettings("HmacSHA256", 11, 128)
 
     new File(dir.getAbsolutePath()).mkdirs()
     val uuid = UUID.randomUUID()
@@ -96,7 +174,7 @@ class JsonSecretStorageSpec
     val settings = SecretStorageSettings(dir.getAbsolutePath, encryptionSettings)
     val storage = JsonSecretStorage.readFile(settings).get
 
-    val _ = storage.unlock(SecretString.create(pass))
+    storage.unlock(SecretString.create(pass)) shouldBe 'success
 
     // loaded wallet should use pre 1627 key derivation
     storage.secret.get.usePre1627KeyDerivation shouldBe true

--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -3,7 +3,8 @@ package org.ergoplatform.it
 import java.io.File
 import java.util.concurrent.TimeoutException
 import com.typesafe.config.Config
-import org.ergoplatform.it.api.NodeApi.NodeInfo
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.{NodeInfo, nodeInfoDecoder}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
 import org.scalatest.freespec.AnyFreeSpec
@@ -45,6 +46,44 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(allowLocalConfig)
 
+  private def clearPeerDatabases(): Unit = {
+    Seq(localVolumeA -> remoteVolumeA, localVolumeB -> remoteVolumeB).foreach {
+      case (localVolume, remoteVolume) =>
+        docker.removeFromMountedVolume(localVolume, remoteVolume, "peers")
+    }
+  }
+
+  private case class NodeSnapshot(info: NodeInfo, summary: String)
+
+  @volatile private var lastObservation = "No node pair observed"
+
+  private def snapshot(node: Node): Future[NodeSnapshot] = {
+    node.status.zip(node.connectedPeers).map { case (status, peers) =>
+      val json = node.ergoJsonAnswerAs[Json](status.status)
+      val fields = Seq(
+        "headersHeight", "bestHeaderId", "fullHeight", "bestFullHeaderId",
+        "headersScore", "fullBlocksScore", "isMining"
+      ).map(name => name -> json.hcursor.downField(name).focus.getOrElse(Json.Null))
+      val summary = Json.obj((fields :+ ("connectedPeerCount" -> Json.fromInt(peers.size))): _*)
+      NodeSnapshot(node.ergoJsonAnswerAs[NodeInfo](status.status), summary.noSpaces)
+    }
+  }
+
+  private def observeNodes(
+    phase: String,
+    nodeA: Node,
+    nodeB: Node
+  ): Future[(NodeSnapshot, NodeSnapshot)] = {
+    snapshot(nodeA).zip(snapshot(nodeB)).map { case pair @ (a, b) =>
+      val observation = s"$phase A=${a.summary} B=${b.summary}"
+      if (observation != lastObservation) {
+        lastObservation = observation
+        log.info(observation)
+      }
+      pair
+    }
+  }
+
   private def waitForSameBestBlock(
     nodeA: Node,
     nodeB: Node,
@@ -67,12 +106,14 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       }.flatMap(_ => loop(deadline))
 
     def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
+      observeNodes("convergence", nodeA, nodeB).flatMap { case (a, b) =>
+        val (infoA, infoB) = (a.info, b.info)
         if (sameBestBlock(infoA, infoB)) {
           Future.successful((infoA, infoB))
         } else if (deadline.isOverdue()) {
           Future.failed(new TimeoutException(
-            s"Nodes did not converge to the same best full block at height >= $minHeight"
+            s"Nodes did not converge to the same best full block at height >= $minHeight; " +
+              s"last observation: $lastObservation"
           ))
         } else {
           retryAfterDelay(deadline)
@@ -107,10 +148,12 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       log.info("heightB: " + minerBGenBestHeight)
 
       genesisAGen shouldBe genesisBGen
+      Async.await(observeNodes("initial shared chain", minerAGen, minerBGen))
 
       // 2. Stop all nodes
       docker.stopNode(minerAGen.containerId)
       docker.stopNode(minerBGen.containerId)
+      clearPeerDatabases()
 
       val minerAIsolated: Node = docker.startDevNetNode(minerAConfig, isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeA, remoteVolumeA))).get
@@ -120,6 +163,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerBIsolated: Node = docker.startDevNetNode(minerBConfig, isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
+      Async.await(observeNodes("isolated miners started", minerAIsolated, minerBIsolated))
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
       Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
@@ -128,9 +172,11 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerABestHeight = Async.await(minerAIsolated.fullHeight)
       val minerBBestHeight = Async.await(minerBIsolated.fullHeight)
+      Async.await(observeNodes("isolated mining complete", minerAIsolated, minerBIsolated))
 
       docker.stopNode(minerAIsolated.containerId)
       docker.stopNode(minerBIsolated.containerId)
+      clearPeerDatabases()
 
       log.info("heightA: " + minerABestHeight)
       log.info("heightB: " + minerBBestHeight)
@@ -143,7 +189,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerB: Node = docker.startDevNetNode(minerBConfigNonGen,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
-
+      Async.await(observeNodes("restarted without mining", minerA, minerB))
 
       val isMiningAOpt = Async.await(minerA.info).isMining
       log.info("isminingA: " + isMiningAOpt)
@@ -162,7 +208,13 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
-    Await.result(result, 20.minutes)
+    try {
+      Await.result(result, 20.minutes)
+    } catch {
+      case error: TimeoutException =>
+        log.error(s"Deep rollback timed out; last observation: $lastObservation")
+        throw error
+    }
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -37,9 +37,16 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
       log.info(
         s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
       )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
     Await.result(result, 15.minutes)
   }

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -75,7 +75,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private var syncInfoV1CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV1)] = Option.empty
 
-  private var syncInfoV2CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV2)] = Option.empty
+  private val syncInfoV2Cache = new SyncInfoV2Cache
 
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 
@@ -315,14 +315,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   /** Get V2 sync info from cache or load it from history and add to cache */
   private def getV2SyncInfo(history: ErgoHistory, full: Boolean): ErgoSyncInfoV2 = {
-    val headersHeight = history.headersHeight
-    syncInfoV2CacheByHeadersHeight
-      .collect { case (height, syncInfo) if height == headersHeight => syncInfo }
-      .getOrElse {
-        val v2SyncInfo = history.syncInfoV2(full)
-        syncInfoV2CacheByHeadersHeight = Some(headersHeight -> v2SyncInfo)
-        v2SyncInfo
-      }
+    syncInfoV2Cache.getOrElseUpdate(history.bestHeaderIdOpt, full)(history.syncInfoV2(full))
   }
 
   /**
@@ -1658,6 +1651,22 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
+  /** Single-entry cache owned by the synchronizer actor. */
+  private[network] final class SyncInfoV2Cache {
+    private var cached: Option[(Option[ModifierId], Boolean, ErgoSyncInfoV2)] = None
+
+    def getOrElseUpdate(bestHeaderId: Option[ModifierId], full: Boolean)
+                       (build: => ErgoSyncInfoV2): ErgoSyncInfoV2 = {
+      cached.collect {
+        case (tip, mode, info) if tip == bestHeaderId && mode == full => info
+      }.getOrElse {
+        val info = build
+        cached = Some((bestHeaderId, full, info))
+        info
+      }
+    }
+  }
 
   private def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -403,8 +403,14 @@ trait ErgoHistoryReader
       }
 
       val headers = offsets.flatMap(offset => bestHeaderAtHeight(h - offset))
+      // Keep a shared starting point in full summaries when it is available locally.
+      val genesisAnchor = if (full) {
+        bestHeaderAtHeight(GenesisHeight).filterNot(genesis => headers.exists(_.id == genesis.id)).toSeq
+      } else {
+        Seq.empty
+      }
 
-      ErgoSyncInfoV2(headers)
+      ErgoSyncInfoV2(headers.toSeq ++ genesisAnchor)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -71,7 +71,7 @@ trait ToDownloadProcessor
             val toDownload = headersAtThisHeight.flatMap(requiredModifiersForHeader).filter { case (mtid, mid) => condition(mtid, mid) }
             // add new modifiers to download to accumulator
             val newAcc = toDownload.foldLeft(acc) { case (newAcc, (mType, mId)) => newAcc.adjust(mType)(_.fold(Vector(mId))(_ :+ mId)) }
-            continuation(height + 1, newAcc, maxHeight)
+            if (height == maxHeight) newAcc else continuation(height + 1, newAcc, maxHeight)
           } else {
             acc
           }
@@ -84,8 +84,20 @@ trait ToDownloadProcessor
         // do not download full blocks if no headers-chain synced yet or SPV mode
         Map.empty
       case Some(fb) if farAwayFromBeingSynced(fb) =>
-        // when far away from blockchain tip
-        continuation(fb.height + 1, Map.empty, fb.height + FullBlocksToDownloadAhead)
+        // A different best headers-chain may need block sections below the old full-chain tip.
+        val commonAncestor = if (isInBestChain(fb.id)) {
+          None
+        } else {
+          val parentSteps = Math.max(0L, nodeSettings.keepVersions.toLong)
+          val limit = Math.min(fb.height.toLong, parentSteps + 1L).toInt
+          headerChainBack(limit, fb.header, h => isInBestChain(h.id)).headOption
+            .filter(h => isInBestChain(h.id))
+        }
+        val fromHeight = commonAncestor
+          .map(h => Math.max(minimalFullBlockHeight, h.height + 1))
+          .getOrElse(fb.height + 1)
+        val maxHeight = Math.min(fromHeight.toLong + FullBlocksToDownloadAhead - 1L, Int.MaxValue.toLong).toInt
+        continuation(fromHeight, Map.empty, maxHeight)
       case Some(fb) =>
         // when blockchain is about to be synced,
         // download children blocks of last 100 full blocks applied to the best chain, to get block sections from forks

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -96,7 +96,8 @@ trait ToDownloadProcessor
         val fromHeight = commonAncestor
           .map(h => Math.max(minimalFullBlockHeight, h.height + 1))
           .getOrElse(fb.height + 1)
-        val maxHeight = Math.min(fromHeight.toLong + FullBlocksToDownloadAhead - 1L, Int.MaxValue.toLong).toInt
+        // Extending the scan backward must preserve forward progress beyond the existing full-chain tip.
+        val maxHeight = Math.min(fb.height.toLong + FullBlocksToDownloadAhead, Int.MaxValue.toLong).toInt
         continuation(fromHeight, Map.empty, maxHeight)
       case Some(fb) =>
         // when blockchain is about to be synced,

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -895,17 +895,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsForExplicitForcing: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            // Keep automatic refresh outside this test of explicit forcing.
+            .copy(blockCandidateGenerationInterval = 1.hour),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsForExplicitForcing)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -913,10 +914,10 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        settingsWithShortRegeneration
+        settingsForExplicitForcing
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    val powScheme = settingsForExplicitForcing.chainSettings.powScheme
 
     // First mine a block to establish chain (needed for avg mining time calculation)
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -927,16 +928,26 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
       .get
     candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
+    var ackSeen = false
+    var appliedSeen = false
     testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
+      case StatusReply.Success(()) =>
+        ackSeen = true
+        ackSeen && appliedSeen
+      case FullBlockApplied(header) if header.id == initBlock.header.id =>
+        appliedSeen = true
+        ackSeen && appliedSeen
       case _ => false
     }
 
     // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+    val candidate1 = eventually(timeout(candidateGenDelay), interval(50.millis)) {
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate.candidateBlock.parentOpt.map(_.id) shouldBe Some(initBlock.id)
+      candidate
     }
 
     // Request with forced = false should return cached candidate immediately

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -492,14 +492,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }
@@ -517,14 +519,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }

--- a/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.network
+
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.SyncInfoV2Cache
+import org.ergoplatform.nodeView.history.ErgoSyncInfoV2
+import org.ergoplatform.utils.generators.ChainGenerator.genHeaderChain
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class SyncInfoV2CacheSpec extends AnyPropSpec with Matchers {
+  private val headers = genHeaderChain(3, diffBitsOpt = None, useRealTs = false).headers
+  private val tip = headers.last
+  private val fullSummary = ErgoSyncInfoV2(Seq(tip, headers.head))
+  private val reducedSummary = ErgoSyncInfoV2(Seq(tip))
+
+  property("reuse a summary only for the same tip and requested mode") {
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+      cache.getOrElseUpdate(Some(tip.id), full) {
+        fail("An unchanged tip and mode should reuse the cached summary")
+      } shouldBe expected
+    }
+  }
+
+  property("alternating reduced and full requests preserves each requested summary") {
+    val cache = new SyncInfoV2Cache
+    Seq(false, true, false, true).foreach { full =>
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+    }
+  }
+
+  property("a different best header at the same height replaces the cached summary") {
+    val otherTip = genHeaderChain(1, prefixOpt = Some(headers(1)),
+      diffBitsOpt = None, useRealTs = false).last
+    otherTip.height shouldBe tip.height
+    otherTip.id should not be tip.id
+
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val original = if (full) fullSummary else reducedSummary
+      val replacement = ErgoSyncInfoV2(if (full) Seq(otherTip, headers.head) else Seq(otherTip))
+      cache.getOrElseUpdate(Some(tip.id), full)(original) shouldBe original
+      cache.getOrElseUpdate(Some(otherTip.id), full)(replacement) shouldBe replacement
+      cache.getOrElseUpdate(Some(otherTip.id), full) {
+        fail("The replacement tip should now be cached")
+      } shouldBe replacement
+    }
+  }
+
+  property("empty history and populated history do not share cached summaries") {
+    val cache = new SyncInfoV2Cache
+    val empty = ErgoSyncInfoV2(Nil)
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+    cache.getOrElseUpdate(None, full = true) {
+      fail("An unchanged empty history should reuse its summary")
+    } shouldBe empty
+    cache.getOrElseUpdate(Some(tip.id), full = true)(fullSummary) shouldBe fullSummary
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
@@ -1,0 +1,149 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NetworkObjectTypeId, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.{BlockTransactions, HeaderChain}
+import org.ergoplatform.modifiers.history.extension.Extension
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.initSettings
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import org.ergoplatform.utils.generators.ErgoCoreTransactionGenerators.invalidErgoTransactionGen
+import scorex.util.ModifierId
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
+
+  // These in-memory records exercise scheduling, not block or chain validation.
+  private val template = defaultHeaderGen.sample.get
+  private val transaction = invalidErgoTransactionGen.sample.get
+  private val maximumHeightHeader = template.copy(height = Int.MaxValue)
+  private val bestChain = (1 to 300).foldLeft(Vector.empty[Header]) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.lastOption.map(_.id).getOrElse(Header.GenesisParentId))
+  }
+  private val oldChain = (21 to 60).foldLeft(bestChain.take(20)) { (chain, height) =>
+    chain :+ template.copy(height = height, parentId = chain.last.id, timestamp = template.timestamp + 1)
+  }
+
+  private class SchedulingReader(fullHeader: Header,
+                                 retainedVersions: Int = 50,
+                                 minimumHeight: Int = 1,
+                                 synced: Boolean = true,
+                                 verify: Boolean = true,
+                                 tipHeight: Int = 300,
+                                 missingHeader: Option[ModifierId] = None) extends ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = initSettings.copy(nodeSettings = initSettings.nodeSettings.copy(
+      keepVersions = retainedVersions, verifyTransactions = verify, stateType = StateType.Utxo))
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Scheduling snapshots do not process sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Scheduling snapshots do not validate sections")
+
+    private val headersById = (bestChain ++ oldChain :+ maximumHeightHeader).map(h => h.id -> h).toMap
+    var traversals: Vector[(Int, ModifierId)] = Vector.empty
+    override def bestFullBlockOpt: Option[ErgoFullBlock] = Some(ErgoFullBlock(fullHeader,
+      BlockTransactions(fullHeader.id, fullHeader.version, Seq(transaction)), Extension(fullHeader.id, Seq.empty), None))
+    override def bestHeaderIdOpt: Option[ModifierId] = Some(bestChain(tipHeight - 1).id)
+    override def estimatedTip(): Option[Int] = Some(tipHeight)
+    override def minimalFullBlockHeight: Int = minimumHeight
+    override def isHeadersChainSynced: Boolean = synced
+    override def isInBestChain(id: ModifierId): Boolean = bestChain.exists(_.id == id)
+    override def headerIdsAtHeight(height: Int): Seq[ModifierId] =
+      (bestChain :+ maximumHeightHeader).find(_.height == height).map(_.id).toSeq
+    override def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T] =
+      headersById.get(id).filterNot(h => missingHeader.contains(h.id)).collect { case section: T => section }
+    override def headerChainBack(limit: Int, startHeader: Header, until: Header => Boolean): HeaderChain = {
+      traversals :+= limit -> startHeader.id
+      super.headerChainBack(limit, startHeader, until)
+    }
+  }
+
+  private def expected(reader: SchedulingReader, heights: Range): Map[NetworkObjectTypeId.Value, Seq[ModifierId]] =
+    heights.flatMap(h => reader.requiredModifiersForHeader(bestChain(h - 1)))
+      .groupBy(_._1).map { case (kind, sections) => kind -> sections.map(_._2) }
+
+  private val acceptAll: (NetworkObjectTypeId.Value, ModifierId) => Boolean = (_, _) => true
+
+  property("linear far-behind downloads retain the forward window without walking history") {
+    val reader = new SchedulingReader(bestChain(59))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe empty
+  }
+
+  property("far-behind downloads begin after a confirmed common ancestor within retention") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 40)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 212)
+    reader.traversals shouldBe Vector(41 -> oldChain.last.id)
+  }
+
+  property("a truncated traversal does not infer a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = 39)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(40 -> oldChain.last.id)
+  }
+
+  property("non-positive retention does not walk to a parent") {
+    Seq(0, -1, Int.MinValue).foreach { retained =>
+      val reader = new SchedulingReader(oldChain.last, retainedVersions = retained)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+      reader.traversals shouldBe Vector(1 -> oldChain.last.id)
+    }
+  }
+
+  property("a missing parent does not turn a partial traversal into a common ancestor") {
+    val reader = new SchedulingReader(oldChain.last, missingHeader = Some(oldChain(39).id))
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 61 to 252)
+    reader.traversals shouldBe Vector(51 -> oldChain.last.id)
+  }
+
+  property("ancestor scheduling respects the minimum retained full-block height") {
+    val reader = new SchedulingReader(oldChain.last, minimumHeight = 30)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 30 to 221)
+  }
+
+  property("maximum retention does not overflow the traversal bound") {
+    val reader = new SchedulingReader(oldChain.last, retainedVersions = Int.MaxValue)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 212)
+    reader.traversals shouldBe Vector(60 -> oldChain.last.id)
+  }
+
+  property("a download window ending at the maximum height terminates without wrapping") {
+    val reader = new SchedulingReader(oldChain.last, minimumHeight = Int.MaxValue)
+    val sections = reader.requiredModifiersForHeader(maximumHeightHeader)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe
+      sections.groupBy(_._1).map { case (kind, entries) => kind -> entries.map(_._2) }
+  }
+
+  property("ancestor scheduling preserves per-type caps and the section filter") {
+    val reader = new SchedulingReader(oldChain.last)
+    val firstSections = reader.requiredModifiersForHeader(bestChain(20))
+    val excluded = firstSections.head._2
+    val result = reader.nextModifiersToDownload(2, (_, id) => id != excluded)
+    val all = expected(reader, 21 to 22)
+    result shouldBe all.map { case (kind, ids) => kind -> ids.filterNot(_ == excluded) }
+    result.values.foreach(_.size should be <= 2)
+  }
+
+  property("unsynced and non-verifying readers do not schedule sections or walk history") {
+    Seq(new SchedulingReader(oldChain.last, synced = false), new SchedulingReader(oldChain.last, verify = false))
+      .foreach { reader =>
+        reader.nextModifiersToDownload(1000, acceptAll) shouldBe empty
+        reader.traversals shouldBe empty
+      }
+  }
+
+  property("near-tip scheduling retains its existing lookback without walking history") {
+    val reader = new SchedulingReader(oldChain.last, tipHeight = 100)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 1 to 300)
+    reader.traversals shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/BlockDownloadSchedulingSpecification.scala
@@ -50,6 +50,7 @@ class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
 
     private val headersById = (bestChain ++ oldChain :+ maximumHeightHeader).map(h => h.id -> h).toMap
     var traversals: Vector[(Int, ModifierId)] = Vector.empty
+    var heightLookups: Vector[Int] = Vector.empty
     override def bestFullBlockOpt: Option[ErgoFullBlock] = Some(ErgoFullBlock(fullHeader,
       BlockTransactions(fullHeader.id, fullHeader.version, Seq(transaction)), Extension(fullHeader.id, Seq.empty), None))
     override def bestHeaderIdOpt: Option[ModifierId] = Some(bestChain(tipHeight - 1).id)
@@ -57,8 +58,10 @@ class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
     override def minimalFullBlockHeight: Int = minimumHeight
     override def isHeadersChainSynced: Boolean = synced
     override def isInBestChain(id: ModifierId): Boolean = bestChain.exists(_.id == id)
-    override def headerIdsAtHeight(height: Int): Seq[ModifierId] =
+    override def headerIdsAtHeight(height: Int): Seq[ModifierId] = {
+      heightLookups :+= height
       (bestChain :+ maximumHeightHeader).find(_.height == height).map(_.id).toSeq
+    }
     override def typedModifierById[T <: BlockSection : ClassTag](id: ModifierId): Option[T] =
       headersById.get(id).filterNot(h => missingHeader.contains(h.id)).collect { case section: T => section }
     override def headerChainBack(limit: Int, startHeader: Header, until: Header => Boolean): HeaderChain = {
@@ -79,9 +82,9 @@ class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
     reader.traversals shouldBe empty
   }
 
-  property("far-behind downloads begin after a confirmed common ancestor within retention") {
+  property("ancestor scheduling extends backward without shortening the forward window") {
     val reader = new SchedulingReader(oldChain.last, retainedVersions = 40)
-    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 212)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
     reader.traversals shouldBe Vector(41 -> oldChain.last.id)
   }
 
@@ -106,21 +109,27 @@ class BlockDownloadSchedulingSpecification extends ErgoCorePropertyTest {
   }
 
   property("ancestor scheduling respects the minimum retained full-block height") {
-    val reader = new SchedulingReader(oldChain.last, minimumHeight = 30)
-    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 30 to 221)
+    Seq(30, 253).foreach { minimumHeight =>
+      val reader = new SchedulingReader(oldChain.last, minimumHeight = minimumHeight)
+      reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, minimumHeight to 252)
+    }
   }
 
   property("maximum retention does not overflow the traversal bound") {
     val reader = new SchedulingReader(oldChain.last, retainedVersions = Int.MaxValue)
-    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 212)
+    reader.nextModifiersToDownload(1000, acceptAll) shouldBe expected(reader, 21 to 252)
     reader.traversals shouldBe Vector(60 -> oldChain.last.id)
   }
 
   property("a download window ending at the maximum height terminates without wrapping") {
-    val reader = new SchedulingReader(oldChain.last, minimumHeight = Int.MaxValue)
+    val fullHeader = oldChain.last.copy(height = Int.MaxValue - 191)
+    val reader = new SchedulingReader(fullHeader, minimumHeight = Int.MaxValue) {
+      override def estimatedTip(): Option[Int] = Some(Int.MaxValue)
+    }
     val sections = reader.requiredModifiersForHeader(maximumHeightHeader)
     reader.nextModifiersToDownload(1000, acceptAll) shouldBe
       sections.groupBy(_._1).map { case (kind, entries) => kind -> entries.map(_._2) }
+    reader.heightLookups shouldBe Vector(Int.MaxValue)
   }
 
   property("ancestor scheduling preserves per-type caps and the section filter") {

--- a/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
@@ -1,0 +1,146 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.HeaderChain
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.HistoryTestHelpers.generateHistory
+import org.ergoplatform.utils.generators.ChainGenerator.{applyHeaderChain, genHeaderChain}
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+
+import scala.util.Try
+
+class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
+
+  private def newHistory(): ErgoHistory =
+    generateHistory(
+      verifyTransactions = false,
+      stateType = StateType.Digest,
+      PoPoWBootstrap = false,
+      blocksToKeep = 0,
+      epochLength = 1000
+    )
+
+  private def checkRoundtrip(summary: ErgoSyncInfoV2): Unit = {
+    val bytes = ErgoSyncInfoSerializer.toBytes(summary)
+    val decoded = ErgoSyncInfoSerializer.parseBytes(bytes).asInstanceOf[ErgoSyncInfoV2]
+    decoded.lastHeaders.map(_.id) shouldBe summary.lastHeaders.map(_.id)
+    decoded.height shouldBe summary.height
+    ErgoSyncInfoSerializer.toBytes(decoded).sameElements(bytes) shouldBe true
+  }
+
+  // These snapshots exercise summary selection, not header or chain validity.
+  private def snapshotReader(headers: Seq[Header]): ErgoHistoryReader = new ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = null
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Summary snapshots do not process block sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Summary snapshots do not validate block sections")
+    override def bestHeaderOpt: Option[Header] = headers.sortBy(_.height).lastOption
+    override def headersHeight: Int = bestHeaderOpt.map(_.height).getOrElse(0)
+    override def isEmpty: Boolean = headers.isEmpty
+    override def bestHeaderAtHeight(height: Int): Option[Header] = headers.find(_.height == height)
+  }
+
+  property("full and reduced sync summaries remain empty for empty history") {
+    val history = newHistory()
+    try {
+      Seq(true, false).foreach { full =>
+        val summary = history.syncInfoV2(full)
+        summary.lastHeaders shouldBe empty
+        summary.nonEmpty shouldBe false
+        summary.height shouldBe None
+        checkRoundtrip(summary)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("linear history summaries retain recent samples and exactly one genesis anchor") {
+    var history = newHistory()
+    try {
+      val chain = genHeaderChain(17, history, diffBitsOpt = None, useRealTs = false)
+      val expectedHeights = Seq(
+        1 -> Seq(1),
+        2 -> Seq(2, 1),
+        10 -> Seq(10, 1),
+        17 -> Seq(17, 1)
+      )
+      var appliedHeight = 0
+      expectedHeights.foreach { case (height, heights) =>
+        history = applyHeaderChain(history, HeaderChain(chain.headers.slice(appliedHeight, height)))
+        appliedHeight = height
+        history.headersHeight shouldBe height
+
+        val full = history.syncInfoV2(full = true)
+        val expectedIds = heights.map(h => chain.headers(h - 1).id)
+        full.lastHeaders.map(_.id) shouldBe expectedIds
+        full.lastHeaders.map(_.height) shouldBe heights
+        full.lastHeaders.head.id shouldBe history.bestHeaderOpt.get.id
+        full.lastHeaders.last.id shouldBe chain.head.id
+        full.lastHeaders.count(_.id == chain.head.id) shouldBe 1
+        full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+        full.lastHeaders.size should be <= 5
+        full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+        full.height shouldBe Some(height)
+        checkRoundtrip(full)
+
+        val reduced = history.syncInfoV2(full = false)
+        reduced.lastHeaders.map(_.id) shouldBe Seq(chain.headers(height - 1).id)
+        reduced.height shouldBe Some(height)
+        checkRoundtrip(reduced)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("full summary snapshots preserve sparse samples and deduplicate the genesis anchor") {
+    val template = defaultHeaderGen.sample.get
+    val cases = Seq(
+      Seq(129, 113, 1),
+      Seq(513, 497, 385, 1),
+      Seq(600, 584, 472, 88, 1)
+    )
+    cases.foreach { heights =>
+      val headers = heights.map(height => template.copy(height = height))
+      val reader = snapshotReader(headers)
+      val full = reader.syncInfoV2(full = true)
+      full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+      full.lastHeaders.map(_.height) shouldBe heights
+      full.lastHeaders.count(_.height == 1) shouldBe 1
+      full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+      full.lastHeaders.size should be <= 5
+      full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+      full.height shouldBe Some(heights.head)
+      checkRoundtrip(full)
+
+      val reduced = reader.syncInfoV2(full = false)
+      reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+      checkRoundtrip(reduced)
+    }
+  }
+
+  property("full summary preserves available samples when genesis is unavailable") {
+    val template = defaultHeaderGen.sample.get
+    val headers = Seq(600, 584, 472, 88).map(height => template.copy(height = height))
+    val reader = snapshotReader(headers)
+    reader.bestHeaderAtHeight(1) shouldBe None
+    val full = reader.syncInfoV2(full = true)
+    full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+    full.height shouldBe Some(600)
+    checkRoundtrip(full)
+    val reduced = reader.syncInfoV2(full = false)
+    reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+    checkRoundtrip(reduced)
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,9 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    val box = wusAfterGenesis.takeBoxes(wusAfterGenesis.size)
+      .find(_.ergoTree == TrueTree)
+      .getOrElse(fail("Expected an unspent TrueTree box after genesis"))
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))


### PR DESCRIPTION
Wallet unlock derives the key using the cipher parameters stored in the wallet file. Changing the node's current encryption configuration therefore no longer prevents an existing wallet from reopening with its original password. New wallet files use the current configuration; opening an existing file does not rewrite it.

Focused coverage includes legacy wallet compatibility, both derivation modes, independent PRF, iteration-count and key-length changes, and invalid-parameter handling. Unsupported or nonpositive parameters return the existing failure result through the cryptographic provider. The correction introduces no arbitrary iteration limit. Independent source review is complete.

[#2507](https://github.com/ergoplatform/ergo/pull/2507) adds checked persistence and atomic publication in the same file. The two corrections apply independently and have also been tested together. The unlock correction is isolated in commit `a785374f386ac2b1c02f41ae2cef61f9eeab0a91`.

The [published composition](https://github.com/a-shannon/ergo/commit/438df263256f1ff7a694d4bd6c0f4c61b902e83d) adds only that unlock correction to #2507's reviewed storage head `f17d145d62f4c0375401f7aea64915625d0fe1a8`. Review the [two-file increment](https://github.com/a-shannon/ergo/compare/f17d145d62f4c0375401f7aea64915625d0fe1a8...438df263256f1ff7a694d4bd6c0f4c61b902e83d): all 35 focused wallet tests passed on the combination. Its production patch matches the owning unlock commit, so the synchronization changes carried by this PR are not part of that composition.

This branch also carries the shared synchronization changes from [#2511](https://github.com/ergoplatform/ergo/pull/2511), which should be reviewed separately. Their scheduling correction extends backward to retained ancestors while preserving the forward ceiling anchored to the best full block, existing pruning and filtering, request-count logic and terminal-height handling. The port has independent composition review. This dependency is separate from wallet key derivation.

Included CI support retains Ergologica's contributions from [#2452](https://github.com/ergoplatform/ergo/pull/2452) and [#2455](https://github.com/ergoplatform/ergo/pull/2455), with authorship and provenance.

## Current CI

Commit [`8af2db9156003417b72d9a96e88330ea9ece667f`](https://github.com/ergoplatform/ergo/commit/8af2db9156003417b72d9a96e88330ea9ece667f): [workflow run 34144500555](https://github.com/ergoplatform/ergo/actions/runs/34144500555). All eight checks passed, including node and integration tests and wallet/core tests across the three Scala versions.
