### PR TITLE
Apply automatic token burning to selected input surplus

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/BoxSelector.scala
@@ -3,7 +3,7 @@ package org.ergoplatform.wallet.boxes
 import org.ergoplatform.sdk.wallet.TokensMap
 import org.ergoplatform.wallet.boxes.BoxSelector.{BoxSelectionError, BoxSelectionResult}
 import org.ergoplatform.{ErgoBoxAssets, ErgoBoxAssetsHolder}
-import scorex.util.ScorexLogging
+import scorex.util.{ModifierId, ScorexLogging}
 import sigma.data.SigmaConstants.MaxBoxSize
 
 
@@ -42,6 +42,18 @@ trait BoxSelector extends ScorexLogging {
     targetAssets: TokensMap
   ): Either[BoxSelectionError, BoxSelectionResult[T]] =
     select(inputBoxes, _ => true, targetBalance, targetAssets)
+
+  /** Select with a policy for retaining surplus tokens in change. Target assets are
+    * still required in full, independently of this policy. Implementations must
+    * apply it to change sizing as well as the final selected inputs. Selectors
+    * without policy support fail explicitly rather than silently retaining tokens.
+    */
+  def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                filterFn: T => Boolean,
+                                targetBalance: Long,
+                                targetAssets: TokensMap,
+                                keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    Left(BoxSelector.UnsupportedChangeTokenPolicy())
 
   /**
     * Helper method to get total amount of re-emission tokens stored in input `boxes`.
@@ -105,6 +117,10 @@ object BoxSelector {
 
   trait BoxSelectionError {
     def message: String
+  }
+
+  final case class UnsupportedChangeTokenPolicy() extends BoxSelectionError {
+    val message: String = "This box selector does not support a change token policy"
   }
 
 }

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelector.scala
@@ -23,9 +23,11 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
   import DefaultBoxSelector._
 
   // helper function which returns count of assets in `initialMap` not fully spent in `subtractor`
-  private def diffCount(initialMap: mutable.Map[ModifierId, Long], subtractor: TokensMap): Int = {
+  private def diffCount(initialMap: mutable.Map[ModifierId, Long],
+                        subtractor: TokensMap,
+                        keepChangeToken: ModifierId => Boolean): Int = {
     initialMap.foldLeft(0){case (cnt, (tokenId, tokenAmt)) =>
-      if (tokenAmt - subtractor.getOrElse(tokenId, 0L) > 0) {
+      if (keepChangeToken(tokenId) && tokenAmt - subtractor.getOrElse(tokenId, 0L) > 0) {
         cnt + 1
       } else {
         cnt
@@ -36,7 +38,22 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
   override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
                                           externalFilter: T => Boolean,
                                           targetBalance: Long,
-                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    selectDefault(inputBoxes, externalFilter, targetBalance, targetAssets, None)
+
+  override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                          externalFilter: T => Boolean,
+                                          targetBalance: Long,
+                                          targetAssets: TokensMap,
+                                          keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    selectDefault(inputBoxes, externalFilter, targetBalance, targetAssets, Some(keepChangeToken))
+
+  private def selectDefault[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                                externalFilter: T => Boolean,
+                                                targetBalance: Long,
+                                                targetAssets: TokensMap,
+                                                changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+    val keepChangeToken = changeTokenPolicy.getOrElse((_: ModifierId) => true)
     //mutable structures to collect results
     val res = mutable.Buffer[T]()
     var currentBalance = 0L
@@ -55,7 +72,7 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
       val diff = currentBalance - targetBalance
 
       // We estimate how many ERG needed for assets in change boxes
-      val assetsDiff = diffCount(currentAssets, targetAssets)
+      val assetsDiff = diffCount(currentAssets, targetAssets, keepChangeToken)
       val diffThreshold = if (assetsDiff <= 0) {
         0
       } else {
@@ -102,7 +119,12 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
           },
         assetsMet
       )) {
-        formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets).mapRight { changeBoxes =>
+        // Preserve legacy helper overrides when no policy was supplied.
+        val change = changeTokenPolicy match {
+          case Some(policy) => formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets, policy)
+          case None => formChangeBoxes(currentBalance, targetBalance, currentAssets, targetAssets)
+        }
+        change.mapRight { changeBoxes =>
           selectionResultWithEip27Output(res.toSeq, changeBoxes)
         }
       } else {
@@ -130,8 +152,23 @@ class DefaultBoxSelector(override val reemissionDataOpt: Option[ReemissionData])
   def formChangeBoxes(foundBalance: Long,
                       targetBalance: Long,
                       foundBoxAssets: mutable.Map[ModifierId, Long],
-                      targetBoxAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+                      targetBoxAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] =
+    formChangeBoxesImpl(foundBalance, targetBalance, foundBoxAssets, targetBoxAssets, _ => true)
+
+  def formChangeBoxes(foundBalance: Long,
+                      targetBalance: Long,
+                      foundBoxAssets: mutable.Map[ModifierId, Long],
+                      targetBoxAssets: TokensMap,
+                      keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, Seq[ErgoBoxAssets]] =
+    formChangeBoxesImpl(foundBalance, targetBalance, foundBoxAssets, targetBoxAssets, keepChangeToken)
+
+  private def formChangeBoxesImpl(foundBalance: Long,
+                                  targetBalance: Long,
+                                  foundBoxAssets: mutable.Map[ModifierId, Long],
+                                  targetBoxAssets: TokensMap,
+                                  keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
     AssetUtils.subtractAssetsMut(foundBoxAssets, targetBoxAssets)
+    foundBoxAssets.retain { (tokenId, _) => keepChangeToken(tokenId) }
     val changeBoxesAssets: Seq[mutable.Map[ModifierId, Long]] = foundBoxAssets.grouped(MaxAssetsPerBox).toIndexedSeq
     val changeBalance = foundBalance - targetBalance
     //at least a minimum amount of ERG should be assigned per a created box

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -47,14 +47,35 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
   override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
                                           filterFn: T => Boolean,
                                           targetBalance: Long,
-                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                          targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    selectCompact(inputBoxes, filterFn, targetBalance, targetAssets, None)
+
+  override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                          filterFn: T => Boolean,
+                                          targetBalance: Long,
+                                          targetAssets: TokensMap,
+                                          keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    selectCompact(inputBoxes, filterFn, targetBalance, targetAssets, Some(keepChangeToken))
+
+  private def selectCompact[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                                filterFn: T => Boolean,
+                                                targetBalance: Long,
+                                                targetAssets: TokensMap,
+                                                changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     // First picking up boxes in given order (1,2,3,4,...) by using DefaultBoxSelector
-    super.select(inputBoxes, filterFn, targetBalance, targetAssets).flatMapRight { initialSelection =>
+    val initial = changeTokenPolicy match {
+      case Some(policy) => super.select(inputBoxes, filterFn, targetBalance, targetAssets, policy)
+      case None => super.select(inputBoxes, filterFn, targetBalance, targetAssets)
+    }
+    initial.flatMapRight { initialSelection =>
       val tail = inputBoxes.take(maxInputs * BoxSelector.ScanDepthFactor).filter(filterFn).toSeq
       // if number of inputs exceeds the limit, the selector is sorting remaining boxes(actually, only 10*maximum
       // boxes) by value in descending order and replaces small-value boxes in the inputs by big-value from the tail (1,2,3,4 => 10)
       (if (initialSelection.inputBoxes.length > maxInputs) {
-        replace(initialSelection, tail, targetBalance, targetAssets)
+        changeTokenPolicy match {
+          case Some(policy) => replace(initialSelection, tail, targetBalance, targetAssets, policy)
+          case None => replace(initialSelection, tail, targetBalance, targetAssets)
+        }
       } else {
         Right(initialSelection)
       }).flatMapRight { afterReplacement =>
@@ -62,7 +83,10 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
         // E.g. if inputs are (100, 200, 1, 2, 1000), target value is 1300 and maximum number of inputs is 3,
         // the selector kicks out (1, 2)
         if (afterReplacement.inputBoxes.length > maxInputs) {
-          compress(afterReplacement, targetBalance, targetAssets)
+          changeTokenPolicy match {
+            case Some(policy) => compress(afterReplacement, targetBalance, targetAssets, policy)
+            case None => compress(afterReplacement, targetBalance, targetAssets)
+          }
         } else {
           Right(afterReplacement)
         }
@@ -72,7 +96,10 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
         if (afterCompaction.inputBoxes.length > maxInputs) {
           Left(MaxInputsExceededError(s"${afterCompaction.inputBoxes.length} boxes exceed max inputs in transaction ($maxInputs)"))
         } else if (afterCompaction.inputBoxes.length < optimalInputs) {
-          collectDust(afterCompaction, tail, targetBalance, targetAssets)
+          changeTokenPolicy match {
+            case Some(policy) => collectDust(afterCompaction, tail, targetBalance, targetAssets, policy)
+            case None => collectDust(afterCompaction, tail, targetBalance, targetAssets)
+          }
         } else {
           Right(afterCompaction)
         }
@@ -82,30 +109,82 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
 
   protected[boxes] def calcChange[T <: ErgoBoxAssets](boxes: Seq[T],
                                                       targetBalance: Long,
-                                                      targetAssets: TokensMap
-                                                     ): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+                                                      targetAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] =
+    calcChangeImpl(boxes, targetBalance, targetAssets, None)
+
+  protected[boxes] def calcChange[T <: ErgoBoxAssets](boxes: Seq[T],
+                                                      targetBalance: Long,
+                                                      targetAssets: TokensMap,
+                                                      keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, Seq[ErgoBoxAssets]] =
+    calcChangeImpl(boxes, targetBalance, targetAssets, Some(keepChangeToken))
+
+  private def calcChangeImpl[T <: ErgoBoxAssets](boxes: Seq[T],
+                                                targetBalance: Long,
+                                                targetAssets: TokensMap,
+                                                changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
     val compactedBalance = boxes.foldLeft(0L) { case (sum, b) => sum + BoxSelector.valueOf(b, reemissionDataOpt) }
     val compactedAssets = mutable.Map[ModifierId, Long]()
     AssetUtils.mergeAssetsMut(compactedAssets, boxes.map(_.tokens): _*)
-    super.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets)
+    changeTokenPolicy match {
+      case Some(policy) => super.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets, policy)
+      case None => super.formChangeBoxes(compactedBalance, targetBalance, compactedAssets, targetAssets)
+    }
+  }
+
+  // Use the original override points for legacy recalculation and the new ones for policy-aware calls.
+  private def calculateChange[T <: ErgoBoxAssets](boxes: Seq[T],
+                                                  targetBalance: Long,
+                                                  targetAssets: TokensMap,
+                                                  changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+    changeTokenPolicy match {
+      case Some(policy) => calcChange(boxes, targetBalance, targetAssets, policy)
+      case None => calcChange(boxes, targetBalance, targetAssets)
+    }
   }
 
   protected[boxes] def collectDust[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
                                                        tail: Seq[T],
                                                        targetBalance: Long,
-                                                       targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                                       targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    collectDustImpl(bsr, tail, targetBalance, targetAssets, None)
+
+  protected[boxes] def collectDust[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                       tail: Seq[T],
+                                                       targetBalance: Long,
+                                                       targetAssets: TokensMap,
+                                                       keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    collectDustImpl(bsr, tail, targetBalance, targetAssets, Some(keepChangeToken))
+
+  private def collectDustImpl[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                 tail: Seq[T],
+                                                 targetBalance: Long,
+                                                 targetAssets: TokensMap,
+                                                 changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     val diff = optimalInputs - bsr.inputBoxes.length
 
     // it is okay to not to consider reemission tokens here probably, so sorting is done by _.value just, not valueOf()
     val dust = tail.sortBy(_.value).take(diff).filter(b => !bsr.inputBoxes.contains(b))
 
     val boxes = bsr.inputBoxes ++ dust
-    calcChange(boxes, targetBalance, targetAssets).mapRight(changeBoxes => selectionResultWithEip27Output(boxes, changeBoxes))
+    calculateChange(boxes, targetBalance, targetAssets, changeTokenPolicy)
+      .mapRight(changeBoxes => selectionResultWithEip27Output(boxes, changeBoxes))
   }
 
   protected[boxes] def compress[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
                                                     targetBalance: Long,
-                                                    targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                                    targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    compressImpl(bsr, targetBalance, targetAssets, None)
+
+  protected[boxes] def compress[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                    targetBalance: Long,
+                                                    targetAssets: TokensMap,
+                                                    keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    compressImpl(bsr, targetBalance, targetAssets, Some(keepChangeToken))
+
+  private def compressImpl[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                              targetBalance: Long,
+                                              targetAssets: TokensMap,
+                                              changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     val boxes = bsr.inputBoxes
     val diff = boxes.foldLeft(0L) { case (sum, b) => sum + BoxSelector.valueOf(b, reemissionDataOpt) } - targetBalance
 
@@ -121,7 +200,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
         thrownValue <= diff
       }
       val compactedBoxes = boxes.filter(b => !thrownBoxes.contains(b))
-      calcChange(compactedBoxes, targetBalance, targetAssets)
+      calculateChange(compactedBoxes, targetBalance, targetAssets, changeTokenPolicy)
         .mapRight(changeBoxes => selectionResultWithEip27Output(compactedBoxes, changeBoxes))
     } else {
       Right(bsr)
@@ -131,7 +210,21 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
   protected[boxes] def replace[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
                                                    tail: Seq[T],
                                                    targetBalance: Long,
-                                                   targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+                                                   targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    replaceImpl(bsr, tail, targetBalance, targetAssets, None)
+
+  protected[boxes] def replace[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                   tail: Seq[T],
+                                                   targetBalance: Long,
+                                                   targetAssets: TokensMap,
+                                                   keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] =
+    replaceImpl(bsr, tail, targetBalance, targetAssets, Some(keepChangeToken))
+
+  private def replaceImpl[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                             tail: Seq[T],
+                                             targetBalance: Long,
+                                             targetAssets: TokensMap,
+                                             changeTokenPolicy: Option[ModifierId => Boolean]): Either[BoxSelectionError, BoxSelectionResult[T]] = {
     val bigBoxes = tail.sortBy(b => -BoxSelector.valueOf(b, reemissionDataOpt))
     val boxesToThrowAway = bsr.inputBoxes.filter(!_.tokens.keySet.exists(tid => targetAssets.keySet.contains(tid)))
     val sorted = boxesToThrowAway.sortBy(b => BoxSelector.valueOf(b, reemissionDataOpt))
@@ -163,7 +256,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
     replaceStep(bigBoxes, sorted)
     if (boxesToAdd.nonEmpty) {
       val compactedBoxes = bsr.inputBoxes.filter(b => !boxesToDrop.contains(b)) ++ boxesToAdd
-      calcChange(compactedBoxes, targetBalance, targetAssets)
+      calculateChange(compactedBoxes, targetBalance, targetAssets, changeTokenPolicy)
         .mapRight(changeBoxes => selectionResultWithEip27Output(compactedBoxes, changeBoxes))
     } else {
       Right(bsr)

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/transactions/TransactionBuilder.scala
@@ -146,7 +146,10 @@ object TransactionBuilder {
   }
 
   def collTokensToMap(tokens: Coll[(TokenId, Long)]): TokensMap =
-    tokens.toArray.map(t => t._1.toModifierId -> t._2).toMap
+    tokens.toArray.foldLeft(Map.empty[ModifierId, Long]) { case (amounts, (tokenId, amount)) =>
+      val id = tokenId.toModifierId
+      amounts.updated(id, java7.compat.Math.addExact(amounts.getOrElse(id, 0L), amount))
+    }
 
   def tokensMapToColl(tokens: TokensMap): Coll[(TokenId, Long)] =
     tokens.toArray.map {t => t._1.toTokenId -> t._2}.toColl

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/DefaultBoxSelectorSpec.scala
@@ -1,15 +1,17 @@
 package org.ergoplatform.wallet.boxes
 
 import org.ergoplatform.ErgoBox.TokenId
-import org.ergoplatform.ErgoLikeTransaction
+import org.ergoplatform.{ErgoBoxAssets, ErgoBoxAssetsHolder, ErgoLikeTransaction}
+import org.ergoplatform.sdk.wallet.TokensMap
 import org.ergoplatform.sdk.wallet.Constants.MaxAssetsPerBox
 import org.ergoplatform.wallet.Constants.PaymentsScanId
 import org.ergoplatform.wallet.boxes.DefaultBoxSelector.{NotEnoughErgsError, NotEnoughTokensError}
+import org.ergoplatform.wallet.boxes.BoxSelector.{BoxSelectionError, BoxSelectionResult, UnsupportedChangeTokenPolicy}
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import scorex.crypto.hash.Blake2b256
-import scorex.util.bytesToId
+import scorex.util.{ModifierId, bytesToId}
 import sigmastate.eval.Extensions._
 import sigmastate.helpers.TestingHelpers._
 import sigmastate.utils.Extensions._
@@ -19,6 +21,7 @@ import sigma.ast.syntax.SigmaPropValue
 import sigma.data.SigmaConstants.MaxBoxSize
 
 import scala.util.Random
+import scala.collection.mutable
 
 class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues {
   import BoxSelector.MinBoxValue
@@ -35,6 +38,126 @@ class DefaultBoxSelectorSpec extends AnyPropSpec with Matchers with EitherValues
   }
 
   private val selector = new DefaultBoxSelector(None)
+
+  property("legacy selection dispatches to the original change helper override") {
+    class LegacySelector extends DefaultBoxSelector(None) {
+      var changeCalls = 0
+      var policyCalls = 0
+
+      override def formChangeBoxes(foundBalance: Long,
+                                   targetBalance: Long,
+                                   foundBoxAssets: mutable.Map[ModifierId, Long],
+                                   targetBoxAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+        changeCalls += 1
+        super.formChangeBoxes(foundBalance, targetBalance, foundBoxAssets, targetBoxAssets)
+      }
+
+      override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                               filterFn: T => Boolean,
+                                               targetBalance: Long,
+                                               targetAssets: TokensMap,
+                                               keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+        policyCalls += 1
+        super.select(inputBoxes, filterFn, targetBalance, targetAssets, keepChangeToken)
+      }
+    }
+
+    val legacy = new LegacySelector
+    val input = ErgoBoxAssetsHolder(10000000L)
+    val result = legacy.select(Iterator(input), 5000000L, Map.empty).right.value
+    result.changeBoxes.map(_.value).sum shouldBe 5000000L
+    legacy.changeCalls shouldBe 1
+    legacy.policyCalls shouldBe 0
+  }
+
+  property("legacy custom selectors explicitly reject unsupported change policies") {
+    val custom = new BoxSelector {
+      override val reemissionDataOpt: Option[ReemissionData] = None
+
+      override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                               filterFn: T => Boolean,
+                                               targetBalance: Long,
+                                               targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] =
+        selector.select(inputBoxes, filterFn, targetBalance, targetAssets)
+    }
+    val input = ErgoBoxAssetsHolder(10000000L)
+    custom.select(Iterator(input), 5000000L, Map.empty).right.value.inputBoxes shouldBe Seq(input)
+    custom.select(Iterator(input), (_: ErgoBoxAssetsHolder) => true, 5000000L, Map.empty, _ => false)
+      .left.value shouldBe UnsupportedChangeTokenPolicy()
+  }
+
+  property("change token policy preserves EIP-27 and selected input accounting") {
+    val tokens = genTokens(3).map(_._1.toModifierId)
+    val reemission = ReemissionData(tokens(0), tokens(1))
+    val ordinary = tokens(2)
+    val input = ErgoBoxAssetsHolder(
+      10000000L, Map(reemission.reemissionTokenId -> 2000000L, ordinary -> 10L)
+    )
+    Seq(
+      new DefaultBoxSelector(Some(reemission)),
+      new ReplaceCompactCollectBoxSelector(10, 1, Some(reemission))
+    ).foreach { policySelector =>
+      val selected = policySelector.select(
+        Iterator(input), (_: ErgoBoxAssetsHolder) => true,
+        8000000L, Map(ordinary -> 4L), _ => false
+      ).right.value
+      selected.inputBoxes shouldBe Seq(input)
+      selected.changeBoxes shouldBe empty
+      selected.payToReemissionBox.get.value shouldBe 2000000L
+    }
+  }
+
+  property("change token policy is applied after dust collection") {
+    val token = genTokens(1).head._1.toModifierId
+    val first = ErgoBoxAssetsHolder(10000000L, Map(token -> 10L))
+    val dust = ErgoBoxAssetsHolder(2000000L, Map(token -> 3L))
+    val unused = ErgoBoxAssetsHolder(20000000L, Map(token -> 100L))
+    val policySelector = new ReplaceCompactCollectBoxSelector(10, 2, None)
+    val selected = policySelector.select(
+      Iterator(first, dust, unused), (_: ErgoBoxAssetsHolder) => true,
+      8000000L, Map(token -> 4L), _ => false
+    ).right.value
+    selected.inputBoxes shouldBe Seq(first, dust)
+    selected.changeBoxes.map(_.value).sum shouldBe 4000000L
+    selected.changeBoxes.flatMap(_.tokens) shouldBe empty
+  }
+
+  property("change token policy survives replacement and compaction") {
+    val token = genTokens(1).head._1.toModifierId
+    def assets(value: Long) = ErgoBoxAssetsHolder(value, Map(token -> 10L))
+    val policySelector = new ReplaceCompactCollectBoxSelector(2, 1, None)
+    val inputs = Seq(assets(2000000L), assets(3000000L), assets(4000000L))
+    val replacement = assets(10000000L)
+    val replaced = policySelector.select(
+      (inputs :+ replacement).iterator, (_: ErgoBoxAssetsHolder) => true,
+      8000000L, Map.empty, _ => false
+    ).right.value
+    replaced.inputBoxes shouldBe Seq(replacement)
+    replaced.changeBoxes.map(_.value).sum shouldBe 2000000L
+    replaced.changeBoxes.flatMap(_.tokens) shouldBe empty
+
+    val compactInputs = Seq(assets(2000000L), assets(3000000L), assets(10000000L))
+    val compacted = policySelector.select(
+      compactInputs.iterator, (_: ErgoBoxAssetsHolder) => true, 10000000L, Map.empty, _ => false
+    ).right.value
+    compacted.inputBoxes shouldBe compactInputs.takeRight(1)
+    compacted.changeBoxes shouldBe empty
+  }
+
+  property("change token policy preserves whitelisted surplus and requires all target assets") {
+    val tokens = genTokens(2).map(_._1.toModifierId)
+    val input = ErgoBoxAssetsHolder(10000000L, Map(tokens(0) -> 10L, tokens(1) -> 20L))
+    val result = selector.select(
+      Iterator(input), (_: ErgoBoxAssetsHolder) => true,
+      5000000L, Map(tokens(0) -> 4L, tokens(1) -> 3L), _ == tokens(1)
+    ).right.value
+    result.changeBoxes.map(_.value).sum shouldBe 5000000L
+    result.changeBoxes.flatMap(_.tokens).toMap shouldBe Map(tokens(1) -> 17L)
+    selector.select(
+      Iterator(input), (_: ErgoBoxAssetsHolder) => true,
+      5000000L, Map(tokens(0) -> 11L), _ => false
+    ).left.value shouldBe a[NotEnoughTokensError]
+  }
 
   property("returns error when it is impossible to select coins") {
     val box = testBox(1, TrueTree, creationHeight = StartHeight)

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
@@ -1,8 +1,11 @@
 package org.ergoplatform.wallet.boxes
 
 import org.ergoplatform.wallet.Constants.PaymentsScanId
-import org.ergoplatform.ErgoLikeTransaction
-import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
+import org.ergoplatform.{ErgoBoxAssets, ErgoBoxAssetsHolder, ErgoLikeTransaction}
+import org.ergoplatform.sdk.wallet.TokensMap
+import org.ergoplatform.wallet.boxes.BoxSelector.{BoxSelectionError, BoxSelectionResult}
+import scorex.util.ModifierId
+import scala.collection.mutable
 import sigmastate.helpers.TestingHelpers._
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
@@ -18,6 +21,75 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
 
   def box(value:Long) = testBox(value, ErgoTree.fromProposition(TrueLeaf.toSigmaProp), 0)
   def trackedBox(value:Long) = TrackedBox(parentTx, 0, None, box(value), Set(PaymentsScanId))
+
+  property("legacy selection and recalculation preserve original helper overrides") {
+    class LegacySelector(maxInputs: Int, optimalInputs: Int)
+      extends ReplaceCompactCollectBoxSelector(maxInputs, optimalInputs, None) {
+      val calls: mutable.Map[String, Int] = mutable.Map.empty.withDefaultValue(0)
+      private def record(name: String): Unit = calls.update(name, calls(name) + 1)
+
+      override def formChangeBoxes(foundBalance: Long,
+                                   targetBalance: Long,
+                                   foundBoxAssets: mutable.Map[ModifierId, Long],
+                                   targetBoxAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+        record("formChange")
+        super.formChangeBoxes(foundBalance, targetBalance, foundBoxAssets, targetBoxAssets)
+      }
+
+      override protected[boxes] def calcChange[T <: ErgoBoxAssets](boxes: Seq[T],
+                                                                   targetBalance: Long,
+                                                                   targetAssets: TokensMap): Either[BoxSelectionError, Seq[ErgoBoxAssets]] = {
+        record("calcChange")
+        super.calcChange(boxes, targetBalance, targetAssets)
+      }
+
+      override protected[boxes] def replace[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                                tail: Seq[T],
+                                                                targetBalance: Long,
+                                                                targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+        record("replace")
+        super.replace(bsr, tail, targetBalance, targetAssets)
+      }
+
+      override protected[boxes] def compress[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                                 targetBalance: Long,
+                                                                 targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+        record("compress")
+        super.compress(bsr, targetBalance, targetAssets)
+      }
+
+      override protected[boxes] def collectDust[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
+                                                                    tail: Seq[T],
+                                                                    targetBalance: Long,
+                                                                    targetAssets: TokensMap): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+        record("dust")
+        super.collectDust(bsr, tail, targetBalance, targetAssets)
+      }
+
+      override def select[T <: ErgoBoxAssets](inputBoxes: Iterator[T],
+                                               filterFn: T => Boolean,
+                                               targetBalance: Long,
+                                               targetAssets: TokensMap,
+                                               keepChangeToken: ModifierId => Boolean): Either[BoxSelectionError, BoxSelectionResult[T]] = {
+        record("policySelect")
+        super.select(inputBoxes, filterFn, targetBalance, targetAssets, keepChangeToken)
+      }
+    }
+
+    val cases = Seq(
+      (2, 1, Seq(2L, 3L, 4L, 10L), 8L, Seq(10L), Map("replace" -> 1)),
+      (2, 1, Seq(2L, 3L, 10L), 10L, Seq(10L), Map("replace" -> 1, "compress" -> 1)),
+      (10, 2, Seq(10L, 2L, 20L), 8L, Seq(10L, 2L), Map("dust" -> 1))
+    )
+    cases.foreach { case (max, optimal, values, target, expected, helperCalls) =>
+      val legacy = new LegacySelector(max, optimal)
+      val inputs = values.map(value => ErgoBoxAssetsHolder(value * 1000000L))
+      val result = legacy.select(inputs.iterator, target * 1000000L, Map.empty).right.value
+      result.inputBoxes.map(_.value) shouldBe expected.map(_ * 1000000L)
+      result.changeBoxes.map(_.value).sum shouldBe (expected.sum - target) * 1000000L
+      legacy.calls.toMap shouldBe (helperCalls ++ Map("formChange" -> 1, "calcChange" -> 1))
+    }
+  }
 
   property("compress() done properly") {
     val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/transactions/TransactionBuilderSpec.scala
@@ -104,6 +104,18 @@ class TransactionBuilderSpec extends WalletTestHelpers with Matchers {
     TransactionBuilder.collTokensToMap(out2.additionalTokens) shouldBe remainingTokens
   }
 
+  property("token quantities are aggregated by id") {
+    val tokens = Array(tid1.toTokenId -> 2L, tid2.toTokenId -> 5L, tid1.toTokenId -> 3L)
+    TransactionBuilder.collTokensToMap(tokens.toColl) shouldBe Map(tid1 -> 5L, tid2 -> 5L)
+    TransactionBuilder.collTokensToMap(tokens.reverse.toColl) shouldBe Map(tid1 -> 5L, tid2 -> 5L)
+    TransactionBuilder.collTokensToMap(Array.empty[(TokenId, Long)].toColl) shouldBe Map.empty
+  }
+
+  property("token quantity aggregation uses checked addition") {
+    val tokens = Array(tid1.toTokenId -> Long.MaxValue, tid1.toTokenId -> 1L)
+    an[ArithmeticException] should be thrownBy TransactionBuilder.collTokensToMap(tokens.toColl)
+  }
+
   property("no fees") {
     val inputBox = box(minBoxValue)
     val tokenId  = inputBox.id.toTokenId

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -10,7 +10,7 @@ import org.ergoplatform.nodeView.wallet.persistence.WalletStorage
 import org.ergoplatform.nodeView.wallet.requests._
 import org.ergoplatform.sdk.SecretString
 import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, ExtendedPublicKey, ExtendedSecretKey}
-import org.ergoplatform.sdk.wallet.{AssetUtils, TokensMap}
+import org.ergoplatform.sdk.wallet.AssetUtils
 import org.ergoplatform.settings.{ErgoSettings, Parameters}
 import org.ergoplatform.utils.BoxUtils
 import org.ergoplatform.wallet.Constants.PaymentsScanId
@@ -96,30 +96,6 @@ trait ErgoWalletSupport extends ScorexLogging {
       val oldPubKeys = oldDerivedSecrets.map(_.publicKey)
       oldPubKeys.foreach(storage.addPublicKey(_).get)
       storage.removePaths().get
-    }
-  }
-
-  // merge tokens from burn request with auto-burn mechanism
-  private def mergeBurnWhitelistTokens(state: ErgoWalletState,
-                                       inputBoxes: Array[TrackedBox],
-                                       burnTokensRequestMap: TokensMap): TokensMap = {
-    val input = inputBoxes.flatMap(_.tokens)
-    state.walletVars.settings.walletSettings.tokensWhitelist match {
-      case Some(x: Seq[String]) if x.isEmpty =>
-        AssetUtils.mergeAssets(
-          TransactionBuilder.collTokensToMap(
-            input.map { case (id, amt) => (IdUtils.decodedTokenId(id), amt) }.toColl
-          ),
-          burnTokensRequestMap)
-      case Some(x: Seq[String]) => AssetUtils.mergeAssets(
-        TransactionBuilder.collTokensToMap(
-          input
-            .filterNot(tMap => x.contains(tMap._1))
-            .map { case (id, amt) => (IdUtils.decodedTokenId(id), amt) }.toColl
-        ),
-        burnTokensRequestMap)
-      case None =>
-        burnTokensRequestMap
     }
   }
 
@@ -307,15 +283,12 @@ trait ErgoWalletSupport extends ScorexLogging {
 
     //filter burnTokens requests
     val (requestsWithBurnTokens, requestsWithoutBurnTokens) = requests.partition(_.isInstanceOf[BurnTokensRequest])
-    val burnTokensRequestMap = TransactionBuilder.collTokensToMap(
-      requestsWithBurnTokens
-        .toArray
-        .map(_.asInstanceOf[BurnTokensRequest])
-        .flatMap(_.assetsToBurn)
-        .toColl
-    )
-    //filter out tokens on whitelist from wallet and merge the rest with burnTokens from requests
-    val burnTokensMap = mergeBurnWhitelistTokens(state, inputBoxes.toArray, burnTokensRequestMap)
+    val requestedBurnTokens = requestsWithBurnTokens
+      .toArray
+      .map(_.asInstanceOf[BurnTokensRequest])
+      .flatMap(_.assetsToBurn)
+    require(requestedBurnTokens.forall(_._2 > 0), "Non-positive burn asset value")
+    val burnTokensRequestMap = TransactionBuilder.collTokensToMap(requestedBurnTokens.toColl)
 
     //We're getting id of the first input, it will be used in case of asset issuance (asset id == first input id)
     requestsToBoxCandidates(requestsWithoutBurnTokens, inputBoxes.head.box.id, state.fullHeight, state.parameters, state.walletVars.publicKeyAddresses)
@@ -334,9 +307,17 @@ trait ErgoWalletSupport extends ScorexLogging {
 
         //add burnTokens to target assets so that they are excluded from the change outputs
         //thus total outputs assets will be reduced which is interpreted as _token burning_
-        val targetAssetsWithBurn = AssetUtils.mergeAssets(targetAssets, burnTokensMap)
+        val targetAssetsWithBurn = AssetUtils.mergeAssets(targetAssets, burnTokensRequestMap)
 
-        val selectionOpt = boxSelector.select(inputBoxes.iterator, targetBalance, targetAssetsWithBurn)
+        // Automatic burning applies only to selected surplus, after output and explicit burn targets.
+        val selectionOpt = state.walletVars.settings.walletSettings.tokensWhitelist match {
+          case Some(whitelist) =>
+            val preservedTokens = whitelist.toSet
+            boxSelector.select(inputBoxes.iterator, (_: TrackedBox) => true,
+              targetBalance, targetAssetsWithBurn, tokenId => preservedTokens.contains(tokenId))
+          case None =>
+            boxSelector.select(inputBoxes.iterator, targetBalance, targetAssetsWithBurn)
+        }
         val dataInputs = ErgoWalletServiceUtils.stringsToBoxes(dataInputsRaw).toIndexedSeq
         selectionOpt.map { selectionResult =>
           val changeAddressOpt: Option[ProveDlog] = state.getChangeAddress(addressEncoder).map(_.pubkey)

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -18,7 +18,7 @@ import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.validErgo
 import org.ergoplatform.utils.{ErgoCorePropertyTest, MempoolTestHelpers, WalletTestOps}
 import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
-import org.ergoplatform.wallet.boxes.{ErgoBoxSerializer, ReplaceCompactCollectBoxSelector, TrackedBox}
+import org.ergoplatform.wallet.boxes.{DefaultBoxSelector, ErgoBoxSerializer, ReplaceCompactCollectBoxSelector, TrackedBox}
 import org.ergoplatform.wallet.crypto.ErgoSignature
 import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.wallet.mnemonic.Mnemonic
@@ -365,6 +365,83 @@ class ErgoWalletServiceSpec
             .sum
           selectedExistingAmount - outputExistingAmount shouldBe burnAmount
           selectedInputs.map(_.value).sum shouldBe tx.outputCandidates.map(_.value).sum
+        }
+      }
+    }
+  }
+
+  property("burn policy preserves payments and burns only selected surplus") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val baseState = initialState(store, versionedStore)
+        val tokenId = newAssetIdStub
+        val payment = PaymentRequest(pks.head, 10000000L, Array(tokenId -> 4L), Map.empty)
+        val burns = Seq(
+          BurnTokensRequest(Array(tokenId -> 1L, tokenId -> 2L)),
+          BurnTokensRequest(Array(tokenId -> 2L))
+        )
+        val boxes = Seq(
+          testBox(7000000L, TrueTree, 1, Seq(tokenId -> 10L)),
+          testBox(7000000L, TrueTree, 2, Seq(tokenId -> 10L)),
+          testBox(7000000L, TrueTree, 3, Seq(tokenId -> 100L))
+        )
+        val encoded = boxes.map(box => Base16.encode(ErgoBoxSerializer.toBytes(box)))
+        val policies = Seq(None, Some(Seq.empty[String]), Some(Seq(IdUtils.encodedTokenId(tokenId))))
+
+        policies.foreach { whitelist =>
+          val policySettings = settings.copy(walletSettings = settings.walletSettings.copy(tokensWhitelist = whitelist))
+          val state = baseState.copy(walletVars = baseState.walletVars.copy()(policySettings))
+          Seq(new DefaultBoxSelector(None), new ReplaceCompactCollectBoxSelector(10, 1, None)).foreach { selector =>
+            val (tx, selected, _) = generateUnsignedTransaction(
+              state, selector, payment +: burns, encoded, Seq.empty
+            ).get
+            selected shouldBe boxes.take(2)
+            tx.outputCandidates.head.additionalTokens.toArray should contain(tokenId -> 4L)
+            val outputAmount = tx.outputCandidates.flatMap(_.additionalTokens.toArray).map(_._2).sum
+            val automaticBurn = whitelist.contains(Seq.empty[String])
+            outputAmount shouldBe (if (automaticBurn) 4L else 15L)
+            tx.outputCandidates.map(_.value).sum shouldBe selected.map(_.value).sum
+          }
+        }
+      }
+    }
+  }
+
+  property("automatic burn permits an exact ERG payment without token change") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val baseState = initialState(store, versionedStore)
+        val policySettings = settings.copy(walletSettings = settings.walletSettings.copy(tokensWhitelist = Some(Seq.empty)))
+        val state = baseState.copy(walletVars = baseState.walletVars.copy()(policySettings))
+        val tokenId = newAssetIdStub
+        val input = testBox(10000000L, TrueTree, 1, Seq(tokenId -> 10L))
+        val payment = PaymentRequest(pks.head, input.value, Array(tokenId -> 4L), Map.empty)
+        val encoded = Seq(Base16.encode(ErgoBoxSerializer.toBytes(input)))
+        val (tx, selected, _) = generateUnsignedTransaction(
+          state, new ReplaceCompactCollectBoxSelector(10, 1, None), Seq(payment), encoded, Seq.empty
+        ).get
+        selected shouldBe Seq(input)
+        tx.outputCandidates should have size 1
+        tx.outputCandidates.head.value shouldBe input.value
+        tx.outputCandidates.head.additionalTokens.toArray should contain(tokenId -> 4L)
+      }
+    }
+  }
+
+  property("explicit burn quantities must each be positive") {
+    withVersionedStore(2) { versionedStore =>
+      withStore { store =>
+        val state = initialState(store, versionedStore)
+        val input = testBox(10000000L, TrueTree, 1, Seq(newAssetIdStub -> 10L))
+        val encoded = Seq(Base16.encode(ErgoBoxSerializer.toBytes(input)))
+        val payment = PaymentRequest(pks.head, 5000000L, Array.empty, Map.empty)
+        Seq(0L, -1L).foreach { amount =>
+          val burn = BurnTokensRequest(Array(newAssetIdStub -> amount, newAssetIdStub -> 2L))
+          val result = generateUnsignedTransaction(
+            state, new DefaultBoxSelector(None), Seq(payment, burn), encoded, Seq.empty
+          )
+          result.failed.get shouldBe a[IllegalArgumentException]
+          result.failed.get.getMessage should include("Non-positive burn asset value")
         }
       }
     }


### PR DESCRIPTION
Repeated token IDs in explicit burn requests are now aggregated with checked arithmetic. Automatic whitelist burning applies to surplus from the inputs actually selected, after accounting for requested outputs and explicit burns. It no longer treats all eligible wallet holdings as amounts that must be collected and burned.

The change-token policy is applied during selection and ERG sizing, and is retained through replacement, compaction and dust collection. Existing source-level selector entry points and the tested helper override dispatch retain their prior behavior. Selectors that do not implement the new policy return an explicit unsupported-policy result. Requested payments, token issuance and EIP-27 re-emission are preserved.

Validation: 29 wallet builder/selector tests and 17 wallet-service tests pass on JDK 8 / Scala 2.12.20. Coverage includes repeated amounts, whitelist variants, selected versus unused inputs, exact ERG spending, payment/burn overlap, re-emission and legacy overrides. The four combined corrections pass 126 tests: 89 wallet, 15 core projection/voting, and 22 wallet-service/state-context tests. Independent source review is complete.

[CI run 34027927343](https://github.com/ergoplatform/ergo/actions/runs/34027927343) passes all eight jobs at `0748f1a0939c03ad464ae5e9f1ee7165ae820966`: wallet/core tests on Scala 2.11.12, 2.12.20 and 2.13.18, plus full node and integration tests.

This complements [#2377](https://github.com/ergoplatform/ergo/pull/2377), which handles wallet amount validation and ERG arithmetic. The issuance/burn ordering correction already present in master is retained.

CI history: the [first run](https://github.com/ergoplatform/ergo/actions/runs/34026432661) passed seven jobs and 12 of 13 integration tests, then timed out waiting for convergence after deep rollback. That test performs mining and restarts without wallet transaction generation. The inspected source and log did not identify a connection to this correction; the shared token-map helper also serves wallet accounting, so complete source isolation is not claimed. The successful rerun uses identical source bytes. It does not establish the cause of the original timeout.
