### PR TITLE
Complete mempool cleanup jobs and discard stale results

### DIFF
--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -3,12 +3,14 @@ package org.ergoplatform.it
 import java.io.File
 import java.util.concurrent.TimeoutException
 import com.typesafe.config.Config
-import org.ergoplatform.it.api.NodeApi.NodeInfo
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.{NodeInfo, nodeInfoDecoder}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.freespec.AnyFreeSpec
 import scala.async.Async
-import scala.concurrent.{Await, Future, blocking}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
@@ -45,41 +47,78 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(allowLocalConfig)
 
+  private val observations = new ConvergenceObservations
+  private case class NodeSnapshot(info: Option[NodeInfo])
+  private val probes = scala.collection.mutable.Map.empty[
+    Node, (observations.Probe[NodeInfo], observations.Probe[Int])]
+
+  @volatile private var lastObservation = "No node pair observed"
+  private var recentObservations = Vector.empty[String]
+
+  private def remember(phase: String, label: String, endpoint: String, summary: String): Unit = synchronized {
+    val observation = s"$phase $label $endpoint sampledAt=${System.currentTimeMillis()} $summary"
+    recentObservations = (recentObservations :+ observation).takeRight(12)
+    lastObservation = recentObservations.mkString("; ")
+    log.info(observation)
+  }
+
+  private def snapshot(phase: String, label: String, node: Node, budget: FiniteDuration): Future[NodeSnapshot] = {
+    val (statusProbe, peerProbe) = probes.getOrElseUpdate(node, (
+      observations.probe(node.singleGet("/info", _.setRequestTimeout(5000))
+        .map { r =>
+          require(r.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[NodeInfo](r.getResponseBody)
+        }),
+      observations.probe(node.singleGet("/peers/connected", _.setRequestTimeout(5000)).map { r =>
+        require(r.getStatusCode == 200, "Unexpected observation status")
+        node.ergoJsonAnswerAs[Json](r.getResponseBody).asArray.getOrElse(
+          throw new IllegalArgumentException("Expected peer array")).size
+      })
+    ))
+    val status = statusProbe.sample(budget).map {
+      case Right(info) =>
+        val summary = Json.obj(
+          "headersHeight" -> info.bestHeaderHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "fullHeight" -> info.bestBlockHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "bestHeaderId" -> info.bestHeaderIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null),
+          "bestFullHeaderId" -> info.bestBlockIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null)
+        )
+        remember(phase, label, "status", summary.noSpaces)
+        Some(info)
+      case Left(error) =>
+        remember(phase, label, "status", s"errorClass=$error")
+        None
+    }
+    val peers = peerProbe.sample(budget).map { result =>
+      val summary = result.fold(error => s"errorClass=$error", count => s"connectedPeerCount=$count")
+      remember(phase, label, "peers", summary)
+    }
+    status.zip(peers).map { case (info, _) => NodeSnapshot(info) }
+  }
+
+  private def observeNodes(
+    phase: String,
+    nodeA: Node,
+    nodeB: Node,
+    budget: FiniteDuration = 5.seconds
+  ): Future[(NodeSnapshot, NodeSnapshot)] = {
+    snapshot(phase, "A", nodeA, budget).zip(snapshot(phase, "B", nodeB, budget))
+  }
+
   private def waitForSameBestBlock(
     nodeA: Node,
     nodeB: Node,
     minHeight: Int,
     timeout: FiniteDuration
   ): Future[(NodeInfo, NodeInfo)] = {
-    def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo): Boolean = {
-      val sameHeight =
-        infoA.bestBlockHeightOpt.nonEmpty &&
-          infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
-      val sameBlock =
-        infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
-      val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
-      sameHeight && sameBlock && highEnough
-    }
-
-    def retryAfterDelay(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      Future {
-        blocking(Thread.sleep(1000))
-      }.flatMap(_ => loop(deadline))
-
-    def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
-        if (sameBestBlock(infoA, infoB)) {
-          Future.successful((infoA, infoB))
-        } else if (deadline.isOverdue()) {
-          Future.failed(new TimeoutException(
-            s"Nodes did not converge to the same best full block at height >= $minHeight"
-          ))
-        } else {
-          retryAfterDelay(deadline)
-        }
-      }
-
-    loop(timeout.fromNow)
+    observations.until(timeout.fromNow, 1.second, 5.seconds)(
+      budget => observeNodes("convergence", nodeA, nodeB, budget)
+    ) { case (a, b) =>
+      a.info.exists(infoA => b.info.exists(infoB => ConvergenceObservations.sameBestBlock(infoA, infoB, minHeight)))
+    }(
+      s"Nodes did not converge to the same best full block at height >= $minHeight; " +
+        s"recent observations: $lastObservation"
+    ).map { case (a, b) => (a.info.get, b.info.get) }
   }
 
   "Deep rollback handling" in {
@@ -107,6 +146,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       log.info("heightB: " + minerBGenBestHeight)
 
       genesisAGen shouldBe genesisBGen
+      Async.await(observeNodes("initial shared chain", minerAGen, minerBGen))
 
       // 2. Stop all nodes
       docker.stopNode(minerAGen.containerId)
@@ -120,6 +160,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerBIsolated: Node = docker.startDevNetNode(minerBConfig, isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
+      Async.await(observeNodes("isolated miners started", minerAIsolated, minerBIsolated))
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
       Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
@@ -128,6 +169,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerABestHeight = Async.await(minerAIsolated.fullHeight)
       val minerBBestHeight = Async.await(minerBIsolated.fullHeight)
+      Async.await(observeNodes("isolated mining complete", minerAIsolated, minerBIsolated))
 
       docker.stopNode(minerAIsolated.containerId)
       docker.stopNode(minerBIsolated.containerId)
@@ -143,7 +185,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerB: Node = docker.startDevNetNode(minerBConfigNonGen,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
-
+      Async.await(observeNodes("restarted without mining", minerA, minerB))
 
       val isMiningAOpt = Async.await(minerA.info).isMining
       log.info("isminingA: " + isMiningAOpt)
@@ -162,7 +204,15 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
-    Await.result(result, 20.minutes)
+    try {
+      Await.result(result, 20.minutes)
+    } catch {
+      case error: TimeoutException =>
+        log.error(s"Deep rollback timed out; last observation: $lastObservation")
+        throw error
+    } finally {
+      observations.close()
+    }
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
+++ b/src/main/scala/org/ergoplatform/local/CleanupWorker.scala
@@ -1,13 +1,14 @@
 package org.ergoplatform.local
 
-import akka.actor.{Actor, ActorRef}
+import akka.actor.Actor
 import org.ergoplatform.local.CleanupWorker.RunCleanup
 import org.ergoplatform.local.MempoolAuditor.CleanupDone
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.RecheckMempool
 import org.ergoplatform.modifiers.mempool.UnconfirmedTransaction
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolReader
 import org.ergoplatform.nodeView.state.UtxoStateReader
 import org.ergoplatform.settings.NodeConfigurationSettings
-import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{EliminateTransactions, RecheckedTransactions}
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.RecheckedTransactions
 import scorex.util.{ModifierId, ScorexLogging}
 
 import scala.annotation.tailrec
@@ -15,13 +16,13 @@ import scala.collection.mutable
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.util.UUID
 
 /**
   * Performs mempool transactions re-validation. Called on a new block coming.
-  * Validation results sent directly to `NodeViewHolder`.
+  * Reports a terminal result to the auditor for every completed Future.
   */
-class CleanupWorker(nodeViewHolderRef: ActorRef,
-                    nodeSettings: NodeConfigurationSettings) extends Actor with ScorexLogging {
+class CleanupWorker(nodeSettings: NodeConfigurationSettings) extends Actor with ScorexLogging {
 
   // Limit for total cost of transactions to be re-checked. Hard-coded for now.
   private val CostLimit = 7000000
@@ -34,23 +35,14 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
   }
 
   override def receive: Receive = {
-    case RunCleanup(validator, mempool) =>
+    case RunCleanup(jobId, request) =>
       val s = sender()
-      validatePool(validator, mempool)
-        .map { case (validated, toEliminate) =>
-          log.debug(s"${validated.size} re-checked mempool transactions were ok, " +
-            s"${toEliminate.size} transactions were invalidated")
-
-          if (validated.nonEmpty) {
-            nodeViewHolderRef ! RecheckedTransactions(validated)
-          }
-          if (toEliminate.nonEmpty) {
-            nodeViewHolderRef ! EliminateTransactions(toEliminate)
-          }
-          s ! CleanupDone
-        }.andThen { case Failure(ex) =>
-          logger.error("Mempool validation failed", ex)
+      validatePool(request.state, request.mempool, request.stateRevision).onComplete { result =>
+        s ! CleanupDone(jobId, result)
+        result.failed.foreach { ex =>
+          log.error("Mempool validation failed", ex)
         }
+      }
 
     //Should not be here, if non-expected signal comes, check logic
     case a: Any => log.warn(s"Strange input: $a")
@@ -62,7 +54,8 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
     * @return - updated valid transactions and invalidated transaction ids
     */
   private def validatePool(validator: UtxoStateReader,
-                           mempool: ErgoMemPoolReader): Future[(Seq[UnconfirmedTransaction], Seq[ModifierId])] = Future {
+                           mempool: ErgoMemPoolReader,
+                           stateRevision: UUID): Future[RecheckedTransactions] = Future {
 
     val now = System.currentTimeMillis()
 
@@ -102,7 +95,7 @@ class CleanupWorker(nodeViewHolderRef: ActorRef,
     }
 
     val res = validationLoop(txsToValidate, mutable.ArrayBuilder.make(), mutable.ArrayBuilder.make(), 0L)
-    wrapRefArray(res._1.result()) -> wrapRefArray(res._2.result())
+    RecheckedTransactions(stateRevision, allPoolTxs, wrapRefArray(res._1.result()), wrapRefArray(res._2.result()))
   }
 
 }
@@ -113,9 +106,9 @@ object CleanupWorker {
     *
     * A command to run (partial) memory pool cleanup
     *
-    * @param validator - a state implementation which provides transaction validation
-    * @param mempool - mempool reader instance
+    * @param jobId - identifies this run independently of the state revision
+    * @param request - state, pool and owner-issued state revision to validate
     */
-  case class RunCleanup(validator: UtxoStateReader, mempool: ErgoMemPoolReader)
+  case class RunCleanup(jobId: UUID, request: RecheckMempool)
 
 }

--- a/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
+++ b/src/main/scala/org/ergoplatform/local/MempoolAuditor.scala
@@ -12,9 +12,12 @@ import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.RecheckMempool
 import org.ergoplatform.nodeView.state.{ErgoStateReader, UtxoStateReader}
 import org.ergoplatform.network.message.{InvData, InvSpec, Message}
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.RecheckedTransactions
 import scorex.util.ScorexLogging
 
+import java.util.UUID
 import scala.concurrent.duration._
+import scala.util.Try
 
 /**
   * Controls mempool cleanup workflow. Watches NodeView events and delegates
@@ -50,9 +53,10 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
 
   private var poolReaderOpt: Option[ErgoMemPoolReader] = None
   private var stateReaderOpt: Option[ErgoStateReader] = None
+  private var pending: Option[RecheckMempool] = None
 
   private val worker: ActorRef =
-    context.actorOf(Props(new CleanupWorker(nodeViewHolderRef, settings.nodeSettings)))
+    context.actorOf(Props(new CleanupWorker(settings.nodeSettings)))
 
   override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[RecheckMempool])
@@ -61,26 +65,30 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
   override def receive: Receive = awaiting
 
   private def awaiting: Receive = {
-    case RecheckMempool(st: UtxoStateReader, mp: ErgoMemPoolReader) =>
-      stateReaderOpt = Some(st)
-      poolReaderOpt = Some(mp)
-      initiateCleanup(st, mp)
+    case request: RecheckMempool => initiateCleanup(request)
+    case _: CleanupDone => // a completion from an obsolete worker run
   }
 
-  private def working: Receive = {
-    case CleanupDone =>
-      log.info("Cleanup done. Switching to awaiting mode")
-      //rebroadcast transactions
-      rebroadcastTransactions()
+  private def working(jobId: UUID): Receive = {
+    case CleanupDone(`jobId`, result) if sender() == worker =>
+      result.foreach(nodeViewHolderRef ! _)
       context become awaiting
-
-    case _ => // ignore other triggers until work is done
+      pending match {
+        case Some(request) => initiateCleanup(request)
+        case None => result.foreach { _ => rebroadcastTransactions() }
+      }
+    case request: RecheckMempool => pending = Some(request)
+    case _: CleanupDone => // a stale completion must not release the current job
   }
 
-  private def initiateCleanup(validator: UtxoStateReader, mempool: ErgoMemPoolReader): Unit = {
+  private def initiateCleanup(request: RecheckMempool): Unit = {
     log.info("Initiating mempool cleanup")
-    worker ! RunCleanup(validator, mempool)
-    context become working // ignore other triggers until work is done
+    stateReaderOpt = Some(request.state)
+    poolReaderOpt = Some(request.mempool)
+    pending = None
+    val jobId = UUID.randomUUID()
+    worker ! RunCleanup(jobId, request)
+    context become working(jobId)
   }
 
   private def broadcastTx(unconfirmedTx: UnconfirmedTransaction): Unit = {
@@ -119,7 +127,7 @@ class MempoolAuditor(nodeViewHolderRef: ActorRef,
 
 object MempoolAuditor {
 
-  case object CleanupDone
+  case class CleanupDone(jobId: UUID, result: Try[RecheckedTransactions])
 
 }
 

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerMessages.scala
@@ -156,7 +156,7 @@ object ErgoNodeViewSynchronizerMessages {
      * @param state   - up-to-date state to check transaction against
      * @param mempool - mempool to check
      */
-    case class RecheckMempool(state: UtxoStateReader, mempool: ErgoMemPoolReader)
+    case class RecheckMempool(state: UtxoStateReader, mempool: ErgoMemPoolReader, stateRevision: java.util.UUID)
 
     /**
      * Signal for a central node view holder component to initialize UTXO state from UTXO set snapshot

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -22,10 +22,11 @@ import org.ergoplatform.settings.{Algos, Constants, ErgoSettings, NetworkType, S
 import org.ergoplatform.utils.ScorexEncoding
 import org.ergoplatform.validation.{MalformedModifierError, RecoverableModifierError}
 import org.ergoplatform.wallet.utils.FileUtils
-import scorex.util.{ModifierId, ScorexLogging}
+import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import spire.syntax.all.cfor
 
 import java.io.File
+import java.util.UUID
 import org.ergoplatform.modifiers.history.extension.Extension
 
 import scala.annotation.tailrec
@@ -70,6 +71,10 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     */
   private var nodeView: NodeView = restoreState().getOrElse(genesisState)
 
+  // Readers share mutable storage. Invalidate in-flight checks before mutation,
+  // including attempts which fail or roll back to the same state version.
+  private var stateRevision: UUID = UUID.randomUUID()
+
   /** Tracking last modifier and header & block heights in time, being periodically checked for possible stuck */
   private var chainProgress: Option[ChainProgress] = None
 
@@ -106,6 +111,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                                updatedState: Option[State] = None,
                                updatedVault: Option[ErgoWallet] = None,
                                updatedMempool: Option[ErgoMemPool] = None): Unit = {
+    if (updatedState.nonEmpty) stateRevision = UUID.randomUUID()
     val newNodeView = (updatedHistory.getOrElse(history()),
       updatedState.getOrElse(minimalState()),
       updatedVault.getOrElse(vault()),
@@ -187,6 +193,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                                   progressInfo: ProgressInfo[BlockSection],
                                   suffixApplied: IndexedSeq[BlockSection],
                                   local: Boolean = false): (ErgoHistory, Try[State], Seq[BlockSection]) = {
+    stateRevision = UUID.randomUUID()
     requestDownloads(progressInfo)
 
     val (stateToApplyTry: Try[State], suffixTrimmed: IndexedSeq[BlockSection]) = if (progressInfo.chainSwitchingNeeded) {
@@ -298,6 +305,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
   def processStateSnapshot: Receive = {
     case InitStateFromSnapshot(height, blockId) =>
       if (!history().isUtxoSnapshotApplied) {
+        stateRevision = UUID.randomUUID()
         val store = minimalState().store
         history().createPersistentProver(store, history(), height, blockId) match {
           case Success(pp) =>
@@ -527,18 +535,19 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
                     blocksApplied.foreach(newVault.scanPersistent)
                   }
 
+                  updateNodeView(Some(newHistory), Some(newMinState), Some(newVault), Some(newMemPool))
+
                   // if blockchain is synced,
                   // send an order to clean mempool up from transactions possibly become invalid
                   // we can check mempool transactions only in "utxo" mode
                   newMinState match {
                     case utxoStateReader: UtxoStateReader if headersHeight == fullBlockHeight =>
-                      val recheckCommand = RecheckMempool(utxoStateReader, newMemPool)
+                      val recheckCommand = RecheckMempool(utxoStateReader, newMemPool, stateRevision)
                       context.system.eventStream.publish(recheckCommand)
                     case _ =>
                   }
 
                   log.info(s"Persistent modifier ${pmod.encodedId} applied successfully")
-                  updateNodeView(Some(newHistory), Some(newMinState), Some(newVault), Some(newMemPool))
                   chainProgress =
                     Some(ChainProgress(pmod, headersHeight, fullBlockHeight, System.currentTimeMillis()))
 
@@ -666,9 +675,27 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
       txModify(unconfirmedTx)
     case LocallyGeneratedTransaction(unconfirmedTx) =>
       sender() ! txModify(unconfirmedTx)
-    case RecheckedTransactions(unconfirmedTxs) =>
-      val updatedPool = memoryPool().put(unconfirmedTxs)
-      updateNodeView(updatedMempool = Some(updatedPool))
+    case RecheckedTransactions(revision, originals, unconfirmedTxs, invalidatedIds) if revision == stateRevision =>
+      val currentPool = memoryPool()
+      val originalOutputs = originals.iterator.flatMap(_.transaction.outputs).map(b => bytesToId(b.id)).toSet
+      val currentOutputs = currentPool.getAll.iterator.flatMap(_.transaction.outputs).map(b => bytesToId(b.id)).toSet
+      val eligibleIds = originals.iterator.filter { original =>
+        currentPool.getAll(Seq(original.id)).headOption.exists(_ eq original) && {
+          val tx = original.transaction
+          val dependencies = tx.inputs.iterator.map(i => bytesToId(i.boxId)) ++
+            tx.dataInputs.iterator.map(i => bytesToId(i.boxId))
+          dependencies.forall(id => originalOutputs.contains(id) == currentOutputs.contains(id))
+        }
+      }.map(_.id).toSet
+      val toEliminate = invalidatedIds.filter(eligibleIds.contains)
+      val refreshed = unconfirmedTxs.filter(tx => eligibleIds.contains(tx.id))
+      if (refreshed.nonEmpty || toEliminate.nonEmpty) {
+        val updatedPool = toEliminate.foldLeft(currentPool.put(refreshed)) { case (pool, id) => pool.invalidate(id) }
+        updateNodeView(updatedMempool = Some(updatedPool))
+        val e = new Exception("Became invalid")
+        toEliminate.foreach(id => context.system.eventStream.publish(FailedOnRecheckTransaction(id, e)))
+      }
+    case _: RecheckedTransactions => // state changed while validation was running
     case EliminateTransactions(ids) =>
       val updatedPool = ids.foldLeft(memoryPool()) { case (pool, txId) => pool.invalidate(txId) }
       updateNodeView(updatedMempool = Some(updatedPool))
@@ -749,7 +776,10 @@ object ErgoNodeViewHolder {
       * Wrapper for transactions which sit in mempool for long enough time, so `CleanWorker` is re-checking their
       * validity and then sending via this message to update the mempool
       */
-    case class RecheckedTransactions(unconfirmedTxs: Iterable[UnconfirmedTransaction])
+    case class RecheckedTransactions(stateRevision: UUID,
+                                     originals: Seq[UnconfirmedTransaction],
+                                     unconfirmedTxs: Seq[UnconfirmedTransaction],
+                                     invalidatedIds: Seq[ModifierId])
 
     case class EliminateTransactions(ids: Seq[ModifierId])
 

--- a/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolAuditorSpec.scala
@@ -116,7 +116,7 @@ class MempoolAuditorSpec extends AnyFlatSpec with NodeViewTestOps with ErgoTestH
     val auditor: ActorRef = TestActorRef(new MempoolAuditor(probe.ref, probe.ref, settingsToTest))
 
 
-    auditor ! RecheckMempool(us, new FakeMempool(txs))
+    auditor ! RecheckMempool(us, new FakeMempool(txs), java.util.UUID.randomUUID())
 
     probe.fishForMessage(3.seconds) {
       case _: SendToNetwork => true

--- a/src/test/scala/org/ergoplatform/local/MempoolCleanupSpec.scala
+++ b/src/test/scala/org/ergoplatform/local/MempoolCleanupSpec.scala
@@ -1,0 +1,427 @@
+package org.ergoplatform.local
+
+import akka.actor.{ActorIdentity, ActorRef, ActorSystem, Identify, Props}
+import akka.testkit.{TestActorRef, TestProbe}
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.core.versionToId
+import org.ergoplatform.local.CleanupWorker.RunCleanup
+import org.ergoplatform.local.MempoolAuditor.CleanupDone
+import org.ergoplatform.modifiers.mempool.UnconfirmedTransaction
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{InitStateFromSnapshot, RecheckMempool}
+import org.ergoplatform.nodeView.{ErgoNodeViewHolder, LocallyGeneratedModifier}
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{EliminateTransactions, LocallyGeneratedTransaction, RecheckedTransactions}
+import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.history.storage.modifierprocessors.EmptyBlockSectionProcessor
+import org.ergoplatform.nodeView.mempool.ErgoMemPool
+import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
+import org.ergoplatform.nodeView.state.{ErgoState, UtxoState}
+import org.ergoplatform.nodeView.wallet.ErgoWallet
+import org.ergoplatform.settings.{Algos, ErgoSettings}
+import org.ergoplatform.settings.Constants.TrueTree
+import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.ergoplatform.utils.fixtures.NodeViewFixture
+import org.ergoplatform.utils.{MempoolTestHelpers, NodeViewTestOps}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+import scorex.crypto.authds.avltree.batch.PersistentBatchAVLProver
+import scorex.crypto.hash.Digest32
+import scorex.db.LDBVersionedStore
+import scorex.util.ModifierId
+import java.util.UUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+class MempoolCleanupSpec extends AnyFlatSpec with Matchers with NodeViewTestOps with MempoolTestHelpers {
+  import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+  import org.ergoplatform.utils.generators.ValidBlocksGenerators._
+
+  it should "terminate a cleanup whose pool read fails and accept the next cleanup" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val probe = TestProbe()
+    val (state, _) = createUtxoState(settings)
+    val worker = system.actorOf(Props(new CleanupWorker(settings.nodeSettings)))
+    val failedPool = new FakeMempool(Seq.empty) {
+      override def getAllPrioritized: Seq[UnconfirmedTransaction] =
+        throw new IllegalStateException("bounded pool read failure")
+    }
+    try {
+      val failedJob = UUID.randomUUID()
+      probe.send(worker, RunCleanup(failedJob, RecheckMempool(state, failedPool, UUID.randomUUID())))
+      val failed = probe.expectMsgType[CleanupDone](3.seconds)
+      failed.jobId shouldBe failedJob
+      failed.result.failed.get.getMessage shouldBe "bounded pool read failure"
+      val nextJob = UUID.randomUUID()
+      probe.send(worker, RunCleanup(nextJob, RecheckMempool(state, new FakeMempool(Seq.empty), UUID.randomUUID())))
+      val completed = probe.expectMsgType[CleanupDone](3.seconds)
+      completed.jobId shouldBe nextJob
+      completed.result.isSuccess shouldBe true
+    } finally {
+      Await.result(system.terminate(), 10.seconds)
+      state.closeStorage()
+    }
+  }
+
+  private def withEntry(test: (NodeViewFixture, RecheckMempool, UnconfirmedTransaction, ErgoFullBlock) => Unit): Unit = {
+    new NodeViewFixture(settings, parameters).apply { fixture =>
+      import fixture._
+      val (state, boxes) = createUtxoState(fixture.settings)
+      val requests = TestProbe()(actorSystem)
+      actorSystem.eventStream.subscribe(requests.ref, classOf[RecheckMempool])
+      try {
+        val genesis = validFullBlock(None, state, boxes)
+        applyBlock(genesis).isSuccess shouldBe true
+        val request = requests.expectMsgType[RecheckMempool]
+        val spendable = ErgoState.newBoxes(genesis.transactions).filter(_.ergoTree == TrueTree).toIndexedSeq.sortBy(-_.value)
+        val tx = validTransactionFromBoxes(spendable.take(1))
+        nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(tx, None))
+        expectMsgType[ProcessingOutcome.Accepted]
+        val original = getCurrentView.pool.getAll.head
+        test(fixture, request.copy(mempool = getCurrentView.pool), original, genesis)
+      } finally {
+        Await.result(getCurrentView.vault.getWalletStatus, 10.seconds)
+        state.closeStorage()
+      }
+    }
+  }
+
+  private def checked(request: RecheckMempool, original: UnconfirmedTransaction, cost: Int = 1): RecheckedTransactions =
+    RecheckedTransactions(request.stateRevision, request.mempool.getAll, Seq(original.withCost(cost)), Seq.empty)
+
+  it should "leave an entry removed from the current pool absent after cleanup" in {
+    withEntry { (fixture, request, original, _) =>
+      import fixture._
+        nodeViewHolderRef ! EliminateTransactions(Seq(original.id))
+        getPoolSize shouldBe 0
+        nodeViewHolderRef ! checked(request, original)
+        getPoolSize shouldBe 0
+    }
+  }
+
+  it should "refresh a present entry even after an unrelated admission" in {
+    withEntry { (fixture, request, original, _) =>
+      import fixture._
+      val child = validTransactionFromBoxes(original.transaction.outputs.take(1))
+      nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(child, None))
+      expectMsgType[ProcessingOutcome.Accepted]
+      nodeViewHolderRef ! checked(request, original)
+      getCurrentView.pool.getAll(Seq(original.id)).head.lastCost shouldBe Some(1)
+      getPoolSize shouldBe 2
+    }
+  }
+
+  it should "retain a newer wrapper when an obsolete refresh or invalidation arrives" in {
+    withEntry { (fixture, request, original, _) =>
+      import fixture._
+      nodeViewHolderRef ! checked(request, original, 2)
+      getCurrentView.pool.getAll(Seq(original.id)).head.lastCost shouldBe Some(2)
+      nodeViewHolderRef ! checked(request, original, 1)
+      nodeViewHolderRef ! RecheckedTransactions(request.stateRevision, request.mempool.getAll, Seq.empty, Seq(original.id))
+      getCurrentView.pool.getAll(Seq(original.id)).head.lastCost shouldBe Some(2)
+    }
+  }
+
+  it should "invalidate a present eligible entry on a normal negative result" in {
+    withEntry { (fixture, request, original, _) =>
+      import fixture._
+      nodeViewHolderRef ! RecheckedTransactions(request.stateRevision, request.mempool.getAll, Seq.empty, Seq(original.id))
+      getPoolSize shouldBe 0
+    }
+  }
+
+  it should "discard both outcomes after the owner applies a new state" in {
+    withEntry { (fixture, request, original, genesis) =>
+      import fixture._
+      val unspent = ErgoState.newBoxes(genesis.transactions).filter { box =>
+        box.ergoTree == TrueTree && !original.transaction.inputs.exists(_.boxId.sameElements(box.id))
+      }.take(1).toIndexedSeq
+      val blockTx = validTransactionFromBoxes(unspent)
+      val block = validFullBlock(Some(genesis), getCurrentState.asInstanceOf[UtxoState], Seq(blockTx))
+      applyBlock(block).isSuccess shouldBe true
+      getCurrentView.pool.getAll(Seq(original.id)).head should be theSameInstanceAs original
+      nodeViewHolderRef ! checked(request, original)
+      nodeViewHolderRef ! RecheckedTransactions(request.stateRevision, request.mempool.getAll, Seq.empty, Seq(original.id))
+      getCurrentView.pool.getAll(Seq(original.id)).head should be theSameInstanceAs original
+    }
+  }
+
+  for (dataInput <- Seq(false, true)) {
+    it should s"discard both outcomes when a ${if (dataInput) "data" else "spending"} input leaves the pool" in {
+      withEntry { (fixture, request, parent, genesis) =>
+        import fixture._
+        val parentOutputs = parent.transaction.outputs
+        val prerequisite = validTransactionFromBoxes(parentOutputs.take(1))
+        nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(prerequisite, None))
+        expectMsgType[ProcessingOutcome.Accepted]
+        val target = if (dataInput) {
+          val confirmedInputs = ErgoState.newBoxes(genesis.transactions).filter { box =>
+            box.ergoTree == TrueTree && !parent.transaction.inputs.exists(_.boxId.sameElements(box.id))
+          }.take(1).toIndexedSeq
+          validTransactionFromBoxes(confirmedInputs, dataBoxes = prerequisite.outputs.take(1))
+        } else {
+          validTransactionFromBoxes(prerequisite.outputs.take(1))
+        }
+        nodeViewHolderRef ! LocallyGeneratedTransaction(UnconfirmedTransaction(target, None))
+        expectMsgType[ProcessingOutcome.Accepted]
+        val snapshot = getCurrentView.pool
+        val original = snapshot.getAll(Seq(target.id)).head
+        val targetRequest = request.copy(mempool = snapshot)
+        nodeViewHolderRef ! EliminateTransactions(Seq(prerequisite.id))
+        getCurrentView.pool.getAll(Seq(target.id)).head should be theSameInstanceAs original
+        nodeViewHolderRef ! checked(targetRequest, original)
+        nodeViewHolderRef ! RecheckedTransactions(request.stateRevision, snapshot.getAll, Seq.empty, Seq(target.id))
+        getCurrentView.pool.getAll(Seq(target.id)).head should be theSameInstanceAs original
+      }
+    }
+  }
+
+  it should "ignore obsolete completion and run the latest queued request after failure" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val holder = TestProbe()
+    val reads = TestProbe()
+    val (state, _) = createUtxoState(settings)
+    val release = new CountDownLatch(1)
+    val failingPool = new FakeMempool(Seq.empty) {
+      override def getAllPrioritized: Seq[UnconfirmedTransaction] = {
+        reads.ref ! "first"
+        require(release.await(10, TimeUnit.SECONDS), "bounded release timeout")
+        throw new IllegalStateException("bounded queued failure")
+      }
+    }
+    def pool(label: String): FakeMempool = new FakeMempool(Seq.empty) {
+      override def getAllPrioritized: Seq[UnconfirmedTransaction] = {
+        reads.ref ! label
+        Seq.empty
+      }
+    }
+    val auditor = system.actorOf(Props(new MempoolAuditor(holder.ref, holder.ref, settings)))
+    try {
+      holder.send(auditor, RecheckMempool(state, failingPool, UUID.randomUUID()))
+      reads.expectMsg("first")
+      system.actorSelection(auditor.path / "*").tell(Identify("worker"), holder.ref)
+      val worker = holder.expectMsgType[ActorIdentity].ref.get
+      val request = RecheckMempool(state, pool("latest"), UUID.randomUUID())
+      holder.send(auditor, request.copy(mempool = pool("superseded")))
+      holder.send(auditor, request)
+      auditor.tell(CleanupDone(UUID.randomUUID(), Success(RecheckedTransactions(UUID.randomUUID(), Seq.empty, Seq.empty, Seq.empty))), worker)
+      reads.expectNoMessage(100.millis)
+      release.countDown()
+      reads.expectMsg("latest")
+      holder.expectMsgType[RecheckedTransactions].stateRevision shouldBe request.stateRevision
+      holder.send(auditor, RecheckMempool(state, pool("next"), UUID.randomUUID()))
+      reads.expectMsg("next")
+      holder.expectMsgType[RecheckedTransactions]
+    } finally {
+      release.countDown()
+      Await.result(system.terminate(), 10.seconds)
+      state.closeStorage()
+    }
+  }
+
+  it should "reject a wrong sender and a completed job replay while preserving queued work" in {
+    implicit val system: ActorSystem = ActorSystem()
+    val holder = TestProbe()
+    val intercepted = TestProbe()
+    val reads = TestProbe()
+    val release = new CountDownLatch(1)
+    val (state, _) = createUtxoState(settings)
+    // Hold the actual terminal envelope, so the UUID is the real active job's
+    // identity; only its sender is changed in the negative case.
+    val auditor = TestActorRef(new MempoolAuditor(holder.ref, holder.ref, settings) {
+      private var holdFirstCompletion = true
+      override def aroundReceive(receive: Receive, message: Any): Unit = message match {
+        case done: CleanupDone if holdFirstCompletion =>
+          holdFirstCompletion = false
+          intercepted.ref ! (done -> sender())
+        case _ => super.aroundReceive(receive, message)
+      }
+    })
+    try {
+      holder.send(auditor, RecheckMempool(state, new FakeMempool(Seq.empty), UUID.randomUUID()))
+      val (done, worker) = intercepted.expectMsgType[(CleanupDone, ActorRef)]
+      val secondPool = new FakeMempool(Seq.empty) {
+        override def getAllPrioritized: Seq[UnconfirmedTransaction] = {
+          reads.ref ! "second"
+          require(release.await(10, TimeUnit.SECONDS), "bounded second-job release timeout")
+          Seq.empty
+        }
+      }
+      val secondRequest = RecheckMempool(state, secondPool, UUID.randomUUID())
+      holder.send(auditor, secondRequest)
+      holder.send(auditor, done)
+      holder.expectNoMessage(100.millis)
+      reads.expectNoMessage(100.millis)
+      auditor.tell(done, worker)
+      holder.expectMsg(done.result.get)
+      reads.expectMsg("second")
+      val thirdPool = new FakeMempool(Seq.empty) {
+        override def getAllPrioritized: Seq[UnconfirmedTransaction] = {
+          reads.ref ! "third"
+          Seq.empty
+        }
+      }
+      val thirdRequest = RecheckMempool(state, thirdPool, UUID.randomUUID())
+      holder.send(auditor, thirdRequest)
+      auditor.tell(done, worker)
+      holder.expectNoMessage(100.millis)
+      reads.expectNoMessage(100.millis)
+      release.countDown()
+      holder.expectMsgType[RecheckedTransactions].stateRevision shouldBe secondRequest.stateRevision
+      reads.expectMsg("third")
+      holder.expectMsgType[RecheckedTransactions].stateRevision shouldBe thirdRequest.stateRevision
+    } finally {
+      release.countDown()
+      Await.result(system.terminate(), 10.seconds)
+      state.closeStorage()
+    }
+  }
+
+  // These bounded seams script state outcomes and snapshot reconstruction.
+  // The real holder owns installation, epoch changes and cleanup consumption.
+  private class ScriptedState(base: UtxoState, nodeSettings: ErgoSettings)
+    extends UtxoState(base.persistentProver, base.version, base.store, nodeSettings) {
+    var rejectUpdate = false
+    var attempts = 0
+    override def applyModifier(mod: BlockSection, estimatedTip: Option[Int])
+                              (generate: LocallyGeneratedModifier => Unit): Try[UtxoState] = {
+      attempts += 1
+      if (rejectUpdate) Failure(new IllegalStateException("bounded state update failure"))
+      else Success(this)
+    }
+  }
+
+  private class ScriptedHistory(section: BlockSection, state: UtxoState,
+                                override protected val settings: ErgoSettings)
+    extends ErgoHistory with EmptyBlockSectionProcessor {
+    override val historyStorage: HistoryStorage = null
+    override val powScheme = settings.chainSettings.powScheme
+    var snapshotFails = false
+    var snapshotAttempts = 0
+    var snapshotInstalled = false
+    var invalidReports = 0
+    override def contains(id: ModifierId): Boolean = false
+    override def estimatedTip(): Option[Int] = None
+    override def headersHeight: Int = 1
+    override def fullBlockHeight: Int = 1
+    override def bestHeaderIdOpt: Option[ModifierId] = None
+    override def closeStorage(): Unit = ()
+    override def append(mod: BlockSection): Try[(ErgoHistory, ProgressInfo[BlockSection])] =
+      Success(this -> ProgressInfo(None, Seq.empty, Seq(section), Seq.empty))
+    override def reportModifierIsValid(mod: BlockSection): Try[ErgoHistory] = Success(this)
+    override def reportModifierIsInvalid(mod: BlockSection, progress: ProgressInfo[BlockSection])
+      : Try[(ErgoHistory, ProgressInfo[BlockSection])] = {
+      invalidReports += 1
+      Failure(new IllegalStateException("bounded state update report failure"))
+    }
+    override def isUtxoSnapshotApplied: Boolean = snapshotInstalled
+    override def onUtxoSnapshotApplied(height: Int): Unit = snapshotInstalled = true
+    override def createPersistentProver(store: LDBVersionedStore, history: ErgoHistoryReader,
+                                        height: Int, blockId: ModifierId)
+      : Try[PersistentBatchAVLProver[Digest32, Algos.HF]] = {
+      snapshotAttempts += 1
+      if (snapshotFails) Failure(new IllegalStateException("bounded snapshot reconstruction failure"))
+      else Success(state.persistentProver)
+    }
+  }
+
+  private class Holder(nodeSettings: ErgoSettings, initialView: (ErgoHistory, UtxoState, ErgoWallet, ErgoMemPool))
+    extends ErgoNodeViewHolder[UtxoState](nodeSettings) {
+    override def restoreState(): Option[NodeView] = Some(initialView)
+    def applySection(section: BlockSection): Unit = pmodModify(section, local = false)
+    def pool: ErgoMemPool = memoryPool()
+    def state: UtxoState = minimalState()
+    def installPool(pool: ErgoMemPool): Unit = updateNodeView(updatedMempool = Some(pool))
+  }
+
+  private def withOwner(test: (TestActorRef[Holder], ScriptedState, ScriptedHistory,
+                               RecheckMempool, ErgoFullBlock) => Unit): Unit = {
+    implicit val system: ActorSystem = ActorSystem()
+    val (base, boxes) = createUtxoState(settings)
+    val genesis = validFullBlock(None, base, boxes)
+    val updated = base.applyModifier(genesis, None)(_ => ()).get
+    val state = new ScriptedState(updated, settings)
+    val history = new ScriptedHistory(genesis.header, state, settings)
+    val scans = TestProbe()
+    val wallet = new ErgoWallet(history, settings, parameters) {
+      override val walletActor: ActorRef = scans.ref
+    }
+    val requests = TestProbe()
+    system.eventStream.subscribe(requests.ref, classOf[RecheckMempool])
+    val holder = TestActorRef(new Holder(settings, (history, state, wallet, ErgoMemPool.empty(settings))))
+    try {
+      holder.underlyingActor.applySection(genesis.header)
+      val request = requests.expectMsgType[RecheckMempool]
+      test(holder, state, history, request, genesis)
+    } finally Await.result(system.terminate(), 10.seconds)
+  }
+
+  private def installEntry(holder: TestActorRef[Holder], request: RecheckMempool,
+                           genesis: ErgoFullBlock): (RecheckMempool, UnconfirmedTransaction) = {
+    val boxes = ErgoState.newBoxes(genesis.transactions).filter(_.ergoTree == TrueTree).take(1).toIndexedSeq
+    val entry = UnconfirmedTransaction(validTransactionFromBoxes(boxes), None)
+    holder.underlyingActor.installPool(holder.underlyingActor.pool.put(entry))
+    holder ! checked(request.copy(mempool = holder.underlyingActor.pool), entry, 3)
+    val original = holder.underlyingActor.pool.getAll(Seq(entry.id)).head
+    original.lastCost shouldBe Some(3)
+    request.copy(mempool = holder.underlyingActor.pool) -> original
+  }
+
+  private def assertObsolete(holder: TestActorRef[Holder], request: RecheckMempool,
+                             original: UnconfirmedTransaction): Unit = {
+    holder ! checked(request, original)
+    holder.underlyingActor.pool.getAll(Seq(original.id)).head should be theSameInstanceAs original
+    holder ! RecheckedTransactions(request.stateRevision, request.mempool.getAll, Seq.empty, Seq(original.id))
+    holder.underlyingActor.pool.getAll(Seq(original.id)).head should be theSameInstanceAs original
+  }
+
+  it should "discard the old epoch after a failed state attempt without installing a new state" in {
+    withOwner { (holder, state, history, request, genesis) =>
+      val (snapshot, original) = installEntry(holder, request, genesis)
+      val installed = holder.underlyingActor.state
+      state.rejectUpdate = true
+      holder.underlyingActor.applySection(genesis.header)
+      state.attempts shouldBe 2
+      history.invalidReports shouldBe 1
+      holder.underlyingActor.state should be theSameInstanceAs installed
+      assertObsolete(holder, snapshot, original)
+    }
+  }
+
+  for (fails <- Seq(false, true)) {
+    it should s"discard the old epoch after ${if (fails) "failed" else "successful"} snapshot reconstruction" in {
+      withOwner { (holder, state, history, request, genesis) =>
+        val (snapshot, original) = installEntry(holder, request, genesis)
+        history.snapshotFails = fails
+        holder ! InitStateFromSnapshot(1, versionToId(state.version))
+        history.snapshotAttempts shouldBe 1
+        history.snapshotInstalled shouldBe !fails
+        if (fails) holder.underlyingActor.state should be theSameInstanceAs state
+        else holder.underlyingActor.state should not be theSameInstanceAs(state)
+        assertObsolete(holder, snapshot, original)
+      }
+    }
+  }
+
+  for (dataInput <- Seq(false, true)) {
+    it should s"discard both outcomes when a ${if (dataInput) "data" else "spending"} prerequisite enters the pool" in {
+      withOwner { (holder, _, _, request, genesis) =>
+        val boxes = ErgoState.newBoxes(genesis.transactions).filter(_.ergoTree == TrueTree).toIndexedSeq
+        val prerequisite = validTransactionFromBoxes(boxes.take(1))
+        val target = if (dataInput) {
+          validTransactionFromBoxes(boxes.slice(1, 2), dataBoxes = prerequisite.outputs.take(1))
+        } else validTransactionFromBoxes(prerequisite.outputs.take(1))
+        val original = UnconfirmedTransaction(target, None)
+        holder.underlyingActor.installPool(holder.underlyingActor.pool.put(original))
+        val snapshot = request.copy(mempool = holder.underlyingActor.pool)
+        holder.underlyingActor.installPool(holder.underlyingActor.pool.put(UnconfirmedTransaction(prerequisite, None)))
+        holder.underlyingActor.pool.getAll(Seq(original.id)).head should be theSameInstanceAs original
+        assertObsolete(holder, snapshot, original)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Mempool cleanup now reports completion after both successful validation and exceptional failure, allowing the auditor to continue with its latest queued request. Completion is matched to the active worker and job.

The holder applies cleanup results only while their state revision, original transaction entries and relevant spending/data-input dependencies remain current. State revisions change before mutation attempts and after installation. Removed or replaced entries cannot be restored by old results, while unrelated pool admissions still allow cleanup to progress. Refreshes and invalidations are consumed together.

Validation: JDK 8, Scala 2.12.20; all 17 tests in MempoolCleanupSpec and MempoolAuditorSpec pass. Coverage includes failure recovery, queued work, stale completion and wrong sender, removed/replaced entries, prerequisite changes in both directions, failed state updates, and snapshot outcomes. The original lifecycle and reinsertion assertions fail before the fix. Removing either pre-mutation revision change also fails its corresponding owner test. Independent source and test review completed.

This overlaps the cleanup refactor in [#2457](https://github.com/ergoplatform/ergo/pull/2457) and will need coordination when integrating its worker API.

A separate test-only follow-up, shared with [#2511](https://github.com/ergoplatform/ergo/pull/2511), polls selected-header agreement and records bounded rollback observations. Nine observation contracts pass and independent review is complete. [All eight CI checks](https://github.com/ergoplatform/ergo/actions/runs/34067602796) pass at `a6a3225e3bf236a7eb1052c8ab44b397c55029c8`, including the real integration scenarios.
