### PR TITLE
Bind minted token identity to the final selected input

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -317,17 +317,14 @@ trait ErgoWalletSupport extends ScorexLogging {
     //filter out tokens on whitelist from wallet and merge the rest with burnTokens from requests
     val burnTokensMap = mergeBurnWhitelistTokens(state, inputBoxes.toArray, burnTokensRequestMap)
 
-    //We're getting id of the first input, it will be used in case of asset issuance (asset id == first input id)
+    // Use a provisional mint id for sizing; selection may replace or remove the first candidate input.
     requestsToBoxCandidates(requestsWithoutBurnTokens, inputBoxes.head.box.id, state.fullHeight, state.parameters, state.walletVars.publicKeyAddresses)
       .flatMap { outputs =>
         require(outputs.forall(c => c.value >= BoxUtils.minimalErgoAmountSimulated(c, state.parameters)), "Minimal ERG value not met")
         require(outputs.forall(_.additionalTokens.forall(_._2 > 0)), "Non-positive asset value")
 
-        val assetIssueBox = outputs
-          .zip(requestsWithoutBurnTokens)
-          .filter(_._2.isInstanceOf[AssetIssueRequest])
-          .map(_._1)
-          .headOption
+        val assetIssueIndex = requestsWithoutBurnTokens.indexWhere(_.isInstanceOf[AssetIssueRequest])
+        val assetIssueBox = outputs.lift(assetIssueIndex)
 
         val targetBalance = outputs.map(_.value).sum
         val targetAssets = TransactionBuilder.collectOutputTokens(outputs.filterNot(bx => assetIssueBox.contains(bx)))
@@ -339,8 +336,18 @@ trait ErgoWalletSupport extends ScorexLogging {
         val selectionOpt = boxSelector.select(inputBoxes.iterator, targetBalance, targetAssetsWithBurn)
         val dataInputs = ErgoWalletServiceUtils.stringsToBoxes(dataInputsRaw).toIndexedSeq
         selectionOpt.map { selectionResult =>
+          // Mint identity must match the first input of the final unsigned transaction.
+          val finalOutputs = assetIssueBox.fold(outputs) { issueBox =>
+            outputs.updated(assetIssueIndex, new ErgoBoxCandidate(
+              issueBox.value,
+              issueBox.ergoTree,
+              issueBox.creationHeight,
+              Colls.fromItems(selectionResult.inputBoxes.head.box.id.toTokenId -> issueBox.additionalTokens(0)._2),
+              issueBox.additionalRegisters
+            ))
+          }
           val changeAddressOpt: Option[ProveDlog] = state.getChangeAddress(addressEncoder).map(_.pubkey)
-          prepareUnsignedTransaction(outputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.inputBoxes
+          prepareUnsignedTransaction(finalOutputs, state.getWalletHeight, selectionResult, dataInputs, changeAddressOpt) -> selectionResult.inputBoxes
         } match {
           case Right((txTry, inputs)) => txTry.map(tx => (tx, inputs.map(_.box).toIndexedSeq, dataInputs))
           case Left(e) => Failure(

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,8 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    // The holder also contains protected genesis/emission boxes, ordered by random output IDs.
+    val box = wusAfterGenesis.versionedBoxHolder.boxes.values.find(_.ergoTree == TrueTree).get
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -275,6 +275,61 @@ class ErgoWalletServiceSpec
     }
   }
 
+  Seq(
+    ("replacement", Seq(6000000L, 6000000L, 20000000L), 2),
+    ("compression", Seq(2000000L, 10000000L), 1),
+    ("unchanged selection", Seq(20000000L, 6000000L), 0)
+  ).foreach { case (selection, values, selectedIndex) =>
+    Seq(true, false).foreach { explicitInputs =>
+      property(s"mint identity follows final $selection with explicit inputs $explicitInputs") {
+        withVersionedStore(2) { versionedStore =>
+          withStore { store =>
+            val boxes = values.zipWithIndex.map { case (value, index) => testBox(value, TrueTree, index) }
+            val tracked = boxes.map { box =>
+              TrackedBox(box.transactionId, box.index, None, None, None, box, Set(PaymentsScanId))
+            }
+            val wState = initialState(store, versionedStore).copy(
+              offChainRegistry = OffChainRegistry.empty.copy(offChainBoxes = tracked)
+            )
+            val encodedBoxes = if (explicitInputs) boxes.map(box => Base16.encode(ErgoBoxSerializer.toBytes(box))) else Seq.empty
+            val dataBox = testBox(1000000L, TrueTree, 10)
+            val payment = PaymentRequest(pks.head, 2000000L, Array.empty, Map.empty)
+            val issue = AssetIssueRequest(pks.head, Some(8000000L), 7L, "mint-name", "mint-description", 4,
+              Some(Map[NonMandatoryRegisterId, EvaluatedValue[_ <: SType]](
+                ErgoBox.R7 -> ByteArrayConstant(Array[Byte](1, 2)))))
+            val selector = new ReplaceCompactCollectBoxSelector(1, 1, None)
+            val (tx, inputs, dataInputs) = generateUnsignedTransaction(
+              wState, selector, Seq(payment, issue), encodedBoxes,
+              Seq(Base16.encode(ErgoBoxSerializer.toBytes(dataBox)))
+            ).get
+
+            inputs.map(_.id.toSeq) shouldBe Seq(boxes(selectedIndex).id.toSeq)
+            tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+            val minted = tx.outputCandidates(1)
+            minted.additionalTokens.toArray.toSeq shouldBe Seq(inputs.head.id.toTokenId -> 7L)
+            minted.value shouldBe 8000000L
+            minted.ergoTree shouldBe pks.head.script
+            minted.creationHeight shouldBe wState.fullHeight
+            minted.additionalRegisters shouldBe Map(
+              ErgoBox.R4 -> ByteArrayConstant("mint-name".getBytes("UTF-8")),
+              ErgoBox.R5 -> ByteArrayConstant("mint-description".getBytes("UTF-8")),
+              ErgoBox.R6 -> ByteArrayConstant("4".getBytes("UTF-8")),
+              ErgoBox.R7 -> ByteArrayConstant(Array[Byte](1, 2))
+            )
+            tx.outputCandidates.head.value shouldBe payment.value
+            tx.outputCandidates.head.additionalTokens.toArray shouldBe empty
+            tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+            tx.outputCandidates.drop(2).flatMap(_.additionalTokens.toArray) shouldBe empty
+            dataInputs.map(_.id.toSeq) shouldBe Seq(dataBox.id.toSeq)
+            tx.dataInputs.map(_.boxId.toSeq) shouldBe Seq(dataBox.id.toSeq)
+            generateUnsignedTransaction(wState, selector, Seq(issue, issue), encodedBoxes, Seq.empty)
+              .failed.get.getMessage shouldBe "requirement failed: Too many asset issuance requests"
+          }
+        }
+      }
+    }
+  }
+
   property("asset issuance should be independent of burn request order") {
     withVersionedStore(2) { versionedStore =>
       withStore { store =>


### PR DESCRIPTION
Asset issuance now binds the minted token ID to the first input returned by final box selection. Previously, replacement or compression could remove the provisional first box while the issuance output kept its ID, producing a transaction rejected by the ordinary asset validation rule.

The constructor sizes a provisional issuance output, then replaces its fixed-width token ID after successful selection. Amount, ERG value, script, creation height, registers and output order are preserved.

Validation: JDK 8, Scala 2.12.20; 61 distinct wallet and selector tests pass. Six constructor cases use the real replacement/compression selector with explicit inputs and wallet-discovered inputs. Four fail against the original implementation; the two unchanged-input controls pass. Assertions cover final inputs, issuance metadata, payments, change, data inputs and the existing single-issuance restriction. Independent source and test review completed.

Integration with [#2510](https://github.com/ergoplatform/ergo/pull/2510): preserve its burn-policy selection block and perform this issuance rebind after selection. The fixes have distinct invariants and share `ErgoWalletSupport`; the combined branch still requires validation.

The holder script-failure fixture now explicitly selects a TrueTree input when preparing its valid setup transaction. This removes dependence on randomly ordered genesis/emission boxes while preserving the later failing spend and transaction-ID assertion. All four holder configurations pass the focused fixture check.

All eight [CI checks](https://github.com/ergoplatform/ergo/actions/runs/34064154036) pass at `114add1cfa06a72a7cb1a3b0190d33fee29af6fa`.
