### PR TITLE
Release snapshot acquisition locks and preserve cleanup errors

### DIFF
--- a/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
+++ b/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
@@ -11,6 +11,7 @@ import scorex.crypto.hash.Blake2b256
 import scorex.db.LDBVersionedStore.SnapshotReadInterface
 import scorex.util.ScorexLogging
 
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 
@@ -424,20 +425,34 @@ class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
     val ro = new ReadOptions()
     try {
       lock.writeLock().lock()
-      ro.snapshot(db.getSnapshot)
-      lock.writeLock().unlock()
-
-      object readInterface extends SnapshotReadInterface {
-        def get(key: Array[Byte]): Array[Byte] = db.get(key, ro)
+      val snapshot = try {
+        db.getSnapshot
+      } finally {
+        lock.writeLock().unlock()
       }
-      Success(logic(readInterface))
+      var processingFailure: Throwable = null
+      try {
+        ro.snapshot(snapshot)
+        object readInterface extends SnapshotReadInterface {
+          def get(key: Array[Byte]): Array[Byte] = db.get(key, ro)
+        }
+        Success(logic(readInterface))
+      } catch {
+        case t: Throwable =>
+          processingFailure = t
+          throw t
+      } finally {
+        try {
+          snapshot.close()
+        } catch {
+          case NonFatal(t) if processingFailure != null =>
+            if (t ne processingFailure) processingFailure.addSuppressed(t)
+        }
+      }
     } catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         log.info("Error during snapshot processing: ", t)
         Failure(t)
-    } finally {
-      // Close the snapshot to avoid resource leaks
-      ro.snapshot().close()
     }
   }
 

--- a/avldb/src/test/scala/scorex/db/LDBVersionedStoreSnapshotSpec.scala
+++ b/avldb/src/test/scala/scorex/db/LDBVersionedStoreSnapshotSpec.scala
@@ -1,0 +1,196 @@
+package scorex.db
+
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.nio.file.Files
+
+import org.iq80.leveldb.{DB, DBException, ReadOptions, Snapshot}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import scala.util.control.ControlThrowable
+import scala.util.{Failure, Try}
+
+class LDBVersionedStoreSnapshotSpec extends AnyPropSpec with Matchers {
+
+  private class SnapshotCalls {
+    var acquisitionFailure: Option[Throwable] = None
+    var closeFailure: Option[Throwable] = None
+    var acquisitions = 0
+    var closes = 0
+  }
+
+  private def withStore(test: (LDBVersionedStore, SnapshotCalls) => Unit): Unit = {
+    val dir = Files.createTempDirectory("snapshot-lifecycle").toFile
+    val store = new LDBVersionedStore(dir, 2)
+    val original = store.db
+    val calls = new SnapshotCalls
+    var acquired: Snapshot = null
+    var exposedSnapshot: Snapshot = null
+    val proxy = Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+      override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+        if (method.getName == "getSnapshot") {
+          store.lock.isWriteLockedByCurrentThread shouldBe true
+          calls.acquisitions += 1
+          calls.acquisitionFailure.foreach(throw _)
+          acquired = original.getSnapshot
+          exposedSnapshot = new Snapshot {
+            override def close(): Unit = {
+              calls.closes += 1
+              acquired.close()
+              calls.closeFailure.foreach(throw _)
+            }
+          }
+          exposedSnapshot
+        } else if (method.getName == "get" && args.length == 2) {
+          val options = args(1).asInstanceOf[ReadOptions]
+          options.snapshot() should be theSameInstanceAs exposedSnapshot
+          original.get(args(0).asInstanceOf[Array[Byte]], new ReadOptions().snapshot(acquired))
+        } else {
+          try {
+            method.invoke(original, Option(args).getOrElse(Array.empty[AnyRef]): _*)
+          } catch {
+            case e: InvocationTargetException => throw e.getCause
+          }
+        }
+      }
+    }).asInstanceOf[DB]
+    // Replace only the dependency after the real store has finished initialization.
+    val dbField = classOf[LDBVersionedStore].getDeclaredField("db")
+    dbField.setAccessible(true)
+    dbField.set(store, proxy)
+    try {
+      test(store, calls)
+    } finally {
+      // Permit cleanup even when checking an implementation that retains the lock.
+      while (store.lock.isWriteLockedByCurrentThread) store.lock.writeLock().unlock()
+      store.close()
+      LDBFactory.factory.destroy(new java.io.File(dir, "ldb_main"), new org.iq80.leveldb.Options())
+      LDBFactory.factory.destroy(new java.io.File(dir, "ldb_undo"), new org.iq80.leveldb.Options())
+      dir.delete()
+    }
+  }
+
+  property("snapshot acquisition failure releases the write lock") {
+    withStore { (store, calls) =>
+      calls.acquisitionFailure = Some(new DBException("snapshot acquisition failed"))
+      Try(store.processSnapshot(_ => ()))
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+
+  property("snapshot acquisition failure is returned without processing or closing an absent snapshot") {
+    withStore { (store, calls) =>
+      val failure = new DBException("snapshot acquisition failed")
+      calls.acquisitionFailure = Some(failure)
+      var processed = false
+      Try(store.processSnapshot(_ => processed = true)).flatten shouldBe Failure(failure)
+      processed shouldBe false
+      calls.acquisitions shouldBe 1
+      calls.closes shouldBe 0
+    }
+  }
+
+  property("snapshot processing failure closes the snapshot once") {
+    withStore { (store, calls) =>
+      val failure = new IllegalStateException("processing failed")
+      store.processSnapshot(_ => throw failure) shouldBe Failure(failure)
+      calls.closes shouldBe 1
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+
+  property("snapshot close failure is returned as a Failure") {
+    withStore { (store, calls) =>
+      val failure = new java.io.IOException("snapshot close failed")
+      calls.closeFailure = Some(failure)
+      val result = store.processSnapshot(_ => 42)
+      result shouldBe Failure(failure)
+      calls.closes shouldBe 1
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+
+  property("snapshot processing failure remains primary when closing also fails") {
+    withStore { (store, calls) =>
+      val primary = new IllegalStateException("processing failed")
+      val secondary = new java.io.IOException("snapshot close failed")
+      calls.closeFailure = Some(secondary)
+      Try(store.processSnapshot(_ => throw primary)).flatten shouldBe Failure(primary)
+      primary.getSuppressed.toSeq shouldBe Seq(secondary)
+      calls.closes shouldBe 1
+    }
+  }
+
+  property("the same processing and close failure does not cause self-suppression") {
+    withStore { (store, calls) =>
+      val failure = new IllegalStateException("shared failure")
+      calls.closeFailure = Some(failure)
+      val result = store.processSnapshot(_ => throw failure)
+      result shouldBe Failure(failure)
+      failure.getSuppressed shouldBe empty
+      calls.closes shouldBe 1
+    }
+  }
+
+  private val propagatingFailures: Seq[(String, () => Throwable)] = Seq(
+    "control throwable" -> (() => new ControlThrowable {}),
+    "interrupted exception" -> (() => new InterruptedException("interruption sentinel"))
+  )
+
+  for ((name, newFailure) <- propagatingFailures; processingFails <- Seq(false, true)) {
+    property(s"close $name propagates when ordinary processing failure is $processingFails") {
+      withStore { (store, calls) =>
+        val sentinel = newFailure()
+        val processingFailure = new IllegalStateException("processing failed")
+        calls.closeFailure = Some(sentinel)
+        val thrown = intercept[Throwable] {
+          store.processSnapshot { _ =>
+            if (processingFails) throw processingFailure
+            42
+          }
+        }
+        thrown should be theSameInstanceAs sentinel
+        processingFailure.getSuppressed shouldBe empty
+        calls.closes shouldBe 1
+        store.lock.isWriteLocked shouldBe false
+      }
+    }
+  }
+
+  for ((name, newFailure) <- propagatingFailures; closingFails <- Seq(false, true)) {
+    property(s"processing $name propagates when ordinary close failure is $closingFails") {
+      withStore { (store, calls) =>
+        val sentinel = newFailure()
+        val closingFailure = new java.io.IOException("snapshot close failed")
+        if (closingFails) calls.closeFailure = Some(closingFailure)
+        val thrown = intercept[Throwable] {
+          store.processSnapshot(_ => throw sentinel)
+        }
+        thrown should be theSameInstanceAs sentinel
+        sentinel.getSuppressed.toSeq shouldBe (if (closingFails) Seq(closingFailure) else Seq.empty)
+        calls.closes shouldBe 1
+        store.lock.isWriteLocked shouldBe false
+      }
+    }
+  }
+
+  property("snapshot reads stay stable while processing writes with the lock released") {
+    withStore { (store, calls) =>
+      val key = Array[Byte](1)
+      val before = Array[Byte](2)
+      val after = Array[Byte](3)
+      store.update(Array[Byte](4), Seq.empty, Seq(key -> before)).get
+      val result = store.processSnapshot { reader =>
+        store.lock.isWriteLocked shouldBe false
+        reader.get(key).toSeq shouldBe before.toSeq
+        store.update(Array[Byte](5), Seq.empty, Seq(key -> after)).get
+        reader.get(key).toSeq
+      }
+      result.get shouldBe before.toSeq
+      store.get(key).get.toSeq shouldBe after.toSeq
+      calls.acquisitions shouldBe 1
+      calls.closes shouldBe 1
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
Snapshot acquisition now releases the store write lock even if acquisition fails. An acquired snapshot is closed once after processing, while ordinary processing errors retain their identity and any distinct ordinary close error is suppressed onto them.

The callback runs after the acquisition lock is released. Control and interruption exceptions propagate through cleanup rather than becoming ordinary `Failure` results. Snapshot encoding and retention are unchanged.

Validation: JDK 8, Scala 2.12.20; all 34 `avldb` tests pass using the Java backend, including the existing snapshot-dump consumer. The 15 focused cases call the actual store owner and cover acquisition failure, callback and close errors, suppression, control/interruption propagation, lock release and a stable snapshot view across a store update. Regression assertions fail against the preceding implementations. Independent source and test review completed.

The additional snapshot consumers in [#2072](https://github.com/ergoplatform/ergo/pull/2072) and [#2343](https://github.com/ergoplatform/ergo/pull/2343) remain separate work.

CI: all eight checks passed on `f3b7630771ec2a274510291e048cc709a5a7797e`, including node integration tests. [CI run](https://github.com/ergoplatform/ergo/actions/runs/34061384138).
