### PR TITLE
Budget complete serialized transaction sections during candidate assembly

### DIFF
--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
@@ -15,7 +15,8 @@ import org.ergoplatform.serialization.ErgoSerializer
 import scorex.crypto.authds.LeafData
 import scorex.crypto.authds.merkle.{Leaf, MerkleProof, MerkleTree}
 import scorex.crypto.hash.Digest32
-import scorex.util.serialization.{Reader, Writer}
+import scorex.util.ByteArrayBuilder
+import scorex.util.serialization.{Reader, VLQByteBufferWriter, Writer}
 import scorex.util.{ModifierId, bytesToId, idToBytes}
 import scorex.util.Extensions._
 import sigma.VersionContext
@@ -141,23 +142,42 @@ object BlockTransactionsSerializer extends ErgoSerializer[BlockTransactions] {
 
   override def serialize(bt: BlockTransactions, w: Writer): Unit = {
     w.putBytes(idToBytes(bt.headerId))
-    val blockVersion = bt.blockVersion
+    serializeMetadata(bt.blockVersion, bt.txs.size, w)
+    bt.txs.foreach(tx => serializeTransaction(tx, bt.blockVersion, w))
+  }
+
+  private def serializeMetadata(blockVersion: Version, transactionCount: Int, w: Writer): Unit = {
     if (blockVersion > 1) {
       // see comments in parse()
-      w.putUInt(MaxTransactionsInBlock.toLong + bt.blockVersion)
+      w.putUInt(MaxTransactionsInBlock.toLong + blockVersion)
     }
-    w.putUInt(bt.txs.size.toLong)
-    bt.txs.foreach { tx =>
-      if (blockVersion >= VersionContext.V6SoftForkVersion) {
-        // since 6.0 we use versioned serializers
-        VersionContext.withVersions(blockVersion, blockVersion) {
-          ErgoTransactionSerializer.serialize(tx, w)
-        }
-      } else {
-        // before 6.0 activation, VersionContext is not used
+    w.putUInt(transactionCount.toLong)
+  }
+
+  private def serializeTransaction(tx: ErgoTransaction, blockVersion: Version, w: Writer): Unit = {
+    if (blockVersion >= VersionContext.V6SoftForkVersion) {
+      // since 6.0 we use versioned serializers
+      VersionContext.withVersions(blockVersion, blockVersion) {
         ErgoTransactionSerializer.serialize(tx, w)
       }
+    } else {
+      // before 6.0 activation, VersionContext is not used
+      ErgoTransactionSerializer.serialize(tx, w)
     }
+  }
+
+  /** Size of a transaction in the section's serialization context, independent of its cached standalone size. */
+  def transactionSize(tx: ErgoTransaction, blockVersion: Version): Int = {
+    val w = new VLQByteBufferWriter(new ByteArrayBuilder())
+    serializeTransaction(tx, blockVersion, w)
+    w.result().toBytes.length
+  }
+
+  /** Full section size from the already measured transaction payloads. */
+  def sectionSize(blockVersion: Version, transactionCount: Int, payloadSize: Long): Long = {
+    val w = new VLQByteBufferWriter(new ByteArrayBuilder())
+    serializeMetadata(blockVersion, transactionCount, w)
+    Constants.ModifierIdSize.toLong + w.result().toBytes.length + payloadSize
   }
 
   override def parse(r: Reader): BlockTransactions = {

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala
@@ -101,6 +101,10 @@ object BlockTransactions extends ApiCodecs {
 
   val modifierTypeId: NetworkObjectTypeId.Value = BlockTransactionsTypeId.value
 
+  /** Complete wire size, measured by the section writer in its existing block-version context. */
+  def sizeOf(txs: Seq[ErgoTransaction], blockVersion: Version): Int =
+    BlockTransactions(Header.GenesisParentId, blockVersion, txs).bytes.length
+
   // Used in the miner when a BlockTransaction instance is not generated yet (because a header is not known)
   def transactionsRoot(txs: Seq[ErgoTransaction], blockVersion: Version): Digest32 = {
     if (blockVersion == Header.InitialVersion) {
@@ -166,15 +170,14 @@ object BlockTransactionsSerializer extends ErgoSerializer[BlockTransactions] {
     }
   }
 
-  /** Size of a transaction in the section's serialization context, independent of its cached standalone size. */
-  def transactionSize(tx: ErgoTransaction, blockVersion: Version): Int = {
+  // Internal incremental accounting uses the same writer and version rules as sizeOf.
+  private[ergoplatform] def transactionSize(tx: ErgoTransaction, blockVersion: Version): Int = {
     val w = new VLQByteBufferWriter(new ByteArrayBuilder())
     serializeTransaction(tx, blockVersion, w)
     w.result().toBytes.length
   }
 
-  /** Full section size from the already measured transaction payloads. */
-  def sectionSize(blockVersion: Version, transactionCount: Int, payloadSize: Long): Long = {
+  private[ergoplatform] def sectionSize(blockVersion: Version, transactionCount: Int, payloadSize: Long): Long = {
     val w = new VLQByteBufferWriter(new ByteArrayBuilder())
     serializeMetadata(blockVersion, transactionCount, w)
     Constants.ModifierIdSize.toLong + w.result().toBytes.length + payloadSize

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -1,6 +1,15 @@
 package org.ergoplatform.modifiers.history
 
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, Input}
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.mempool.{ErgoTransaction, ErgoTransactionSerializer}
+import scorex.util.{ByteArrayBuilder, idToBytes}
+import scorex.util.serialization.VLQByteBufferWriter
+import sigma.VersionContext
+import sigma.ast.{Constant, ErgoTree, SInt, SOption}
+import sigma.data.TrivialProp.TrueProp
+import sigma.interpreter.ProverResult
 
 class BlockTransactionsSpec extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.generators.CoreObjectGenerators._
@@ -13,6 +22,63 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
 
       // no proof should be generated for a transaction which is not there
       bt.proofFor(absentTx).isDefined shouldBe false
+    }
+  }
+
+  // Original section writer, retained as a byte-level oracle for the factoring used by mining size accounting.
+  private def originalBytes(bt: BlockTransactions): Array[Byte] = {
+    val w = new VLQByteBufferWriter(new ByteArrayBuilder())
+    w.putBytes(idToBytes(bt.headerId))
+    val blockVersion = bt.blockVersion
+    if (blockVersion > 1) {
+      w.putUInt(10000000L + bt.blockVersion)
+    }
+    w.putUInt(bt.txs.size.toLong)
+    bt.txs.foreach { tx =>
+      if (blockVersion >= VersionContext.V6SoftForkVersion) {
+        VersionContext.withVersions(blockVersion, blockVersion) {
+          ErgoTransactionSerializer.serialize(tx, w)
+        }
+      } else {
+        ErgoTransactionSerializer.serialize(tx, w)
+      }
+    }
+    w.result().toBytes
+  }
+
+  private def transaction(index: Int, versionedRegister: Boolean): ErgoTransaction = {
+    val registers: ErgoBox.AdditionalRegisters = if (versionedRegister) {
+      Map(ErgoBox.R4 -> Constant[SOption[SInt.type]](Some(index), SOption(SInt)))
+    } else {
+      Map(ErgoBox.R4 -> Constant[SInt.type](index, SInt))
+    }
+    val box = new ErgoBoxCandidate(10000000L, ErgoTree.fromSigmaBoolean(TrueProp), index)
+      .toBox(Header.GenesisParentId, 0.toShort)
+    ErgoTransaction(IndexedSeq(Input(box.id, ProverResult.empty)), IndexedSeq.empty,
+      IndexedSeq(new ErgoBoxCandidate(box.value, box.ergoTree, index, additionalRegisters = registers)))
+  }
+
+  property("section sizing preserves original bytes across versions and count framing") {
+    for (version <- Seq[Byte](1, 2, 3, 4); count <- Seq(1, 127, 128)) {
+      val txs = (0 until count).map(i => transaction(i, versionedRegister = false))
+      val section = BlockTransactions(Header.GenesisParentId, version, txs)
+      val original = originalBytes(section)
+      section.bytes shouldBe original
+      val payloadSize = txs.map(BlockTransactionsSerializer.transactionSize(_, version).toLong).sum
+      BlockTransactionsSerializer.sectionSize(version, count, payloadSize) shouldBe original.length.toLong
+    }
+  }
+
+  property("section sizing uses the embedded version context for register values") {
+    val tx = VersionContext.withVersions(3, 3) {
+      transaction(1, versionedRegister = true)
+    }
+    for (version <- Seq[Byte](3, 4)) {
+      val section = BlockTransactions(Header.GenesisParentId, version, Seq(tx))
+      val original = originalBytes(section)
+      section.bytes shouldBe original
+      val payloadSize = BlockTransactionsSerializer.transactionSize(tx, version)
+      BlockTransactionsSerializer.sectionSize(version, 1, payloadSize) shouldBe original.length.toLong
     }
   }
 

--- a/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/modifiers/history/BlockTransactionsSpec.scala
@@ -46,13 +46,14 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
     w.result().toBytes
   }
 
-  private def transaction(index: Int, versionedRegister: Boolean): ErgoTransaction = {
+  private def transaction(index: Int, versionedRegister: Boolean, treeVersion: Byte = 0): ErgoTransaction = {
     val registers: ErgoBox.AdditionalRegisters = if (versionedRegister) {
       Map(ErgoBox.R4 -> Constant[SOption[SInt.type]](Some(index), SOption(SInt)))
     } else {
       Map(ErgoBox.R4 -> Constant[SInt.type](index, SInt))
     }
-    val box = new ErgoBoxCandidate(10000000L, ErgoTree.fromSigmaBoolean(TrueProp), index)
+    val tree = ErgoTree.fromSigmaBoolean(ErgoTree.defaultHeaderWithVersion(treeVersion), TrueProp)
+    val box = new ErgoBoxCandidate(10000000L, tree, index)
       .toBox(Header.GenesisParentId, 0.toShort)
     ErgoTransaction(IndexedSeq(Input(box.id, ProverResult.empty)), IndexedSeq.empty,
       IndexedSeq(new ErgoBoxCandidate(box.value, box.ergoTree, index, additionalRegisters = registers)))
@@ -66,6 +67,11 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
       section.bytes shouldBe original
       val payloadSize = txs.map(BlockTransactionsSerializer.transactionSize(_, version).toLong).sum
       BlockTransactionsSerializer.sectionSize(version, count, payloadSize) shouldBe original.length.toLong
+      BlockTransactions.sizeOf(txs, version) shouldBe original.length
+      val parsed = BlockTransactionsSerializer.parseBytesTry(original).get
+      parsed.blockVersion shouldBe version
+      parsed.txs.map(_.id) shouldBe txs.map(_.id)
+      parsed.bytes shouldBe original
     }
   }
 
@@ -79,7 +85,30 @@ class BlockTransactionsSpec extends ErgoCorePropertyTest {
       section.bytes shouldBe original
       val payloadSize = BlockTransactionsSerializer.transactionSize(tx, version)
       BlockTransactionsSerializer.sectionSize(version, 1, payloadSize) shouldBe original.length.toLong
+      BlockTransactions.sizeOf(Seq(tx), version) shouldBe original.length
     }
+  }
+
+  property("version four tree and register values round trip through the activated parser") {
+    val tx = VersionContext.withVersions(3, 3) { transaction(1, versionedRegister = false, treeVersion = 3) }
+    val section = BlockTransactions(Header.GenesisParentId, 4.toByte, Seq(tx))
+    val parsed = BlockTransactionsSerializer.parseBytesTry(section.bytes).get
+    parsed.blockVersion shouldBe 4.toByte
+    parsed.txs.head.outputCandidates.head.additionalRegisters shouldBe tx.outputCandidates.head.additionalRegisters
+    parsed.bytes shouldBe section.bytes
+  }
+
+  property("version four still rejects V6-only types in registers") {
+    val tx = VersionContext.withVersions(3, 3) { transaction(1, versionedRegister = true, treeVersion = 3) }
+    val section = BlockTransactions(Header.GenesisParentId, 4.toByte, Seq(tx))
+    BlockTransactionsSerializer.parseBytesTry(section.bytes).isFailure shouldBe true
+  }
+
+  property("section sizing does not force an uncached standalone size in the default version context") {
+    val tx = VersionContext.withVersions(3, 3) { transaction(2, versionedRegister = true) }
+    scala.util.Try(tx.size).isFailure shouldBe true
+    BlockTransactions.sizeOf(Seq(tx), 4.toByte) shouldBe originalBytes(
+      BlockTransactions(Header.GenesisParentId, 4.toByte, Seq(tx))).length
   }
 
 }

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -705,6 +705,7 @@ object CandidateGenerator extends ScorexLogging {
       }
 
       def deriveWorkMessage(block: CandidateBlock) = {
+        ensureCandidateSize(block, state.stateContext.currentParameters.maxBlockSize)
         ergoSettings.chainSettings.powScheme.deriveExternalCandidate(
           block,
           minerPk,
@@ -917,15 +918,20 @@ object CandidateGenerator extends ScorexLogging {
     Seq(emissionTxOpt, feeTxOpt).flatten
   }
 
-  /**
-    * Helper function which decides whether transactions can fit into a block with given cost and size limits
-    */
-  def correctLimits(
+  /** Check the complete serialized section before returning work, including the emission-only fallback. */
+  private[mining] def ensureCandidateSize(candidate: CandidateBlock, maxBlockSize: Int): Unit = {
+    val section = BlockTransactions(Header.GenesisParentId, candidate.version, candidate.transactions)
+    require(section.bytes.length <= maxBlockSize, "Candidate transaction section exceeds the block size limit")
+  }
+
+  /** Decide whether transactions fit the cost limit and the full serialized section size limit. */
+  private def correctLimits(
     blockTxs: Seq[CostedTransaction],
     maxBlockCost: Long,
-    maxBlockSize: Long
+    maxBlockSize: Long,
+    sectionSize: Long
   ): Boolean = {
-    blockTxs.map(_._2).sum < maxBlockCost && blockTxs.map(_._1.size).sum < maxBlockSize
+    blockTxs.map(_._2).sum < maxBlockCost && sectionSize <= maxBlockSize
   }
 
   /**
@@ -948,6 +954,7 @@ object CandidateGenerator extends ScorexLogging {
 
     val currentHeight = us.stateContext.currentHeight
     val nextHeight = upcomingContext.currentHeight
+    val blockVersion = upcomingContext.sigmaPreHeader.version
 
     log.info(
       s"Assembling a block candidate for block #$nextHeight from ${transactions.length} transactions available"
@@ -959,6 +966,7 @@ object CandidateGenerator extends ScorexLogging {
     def loop(
               mempoolTxs: Iterable[ErgoTransaction],
               acc: Seq[CostedTransaction],
+              accSize: Long,
               lastFeeTx: Option[CostedTransaction],
               invalidTxs: Seq[ModifierId]
             ): (Seq[ErgoTransaction], Seq[ModifierId]) = {
@@ -974,7 +982,7 @@ object CandidateGenerator extends ScorexLogging {
             //mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
             //do these checks before validating the scripts to save time
             log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
-            loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
+            loop(mempoolTxs.tail, acc, accSize, lastFeeTx, invalidTxs :+ tx.id)
           } else {
             // check validity and calculate transaction cost
             stateWithTxs.validateWithCost(
@@ -985,6 +993,7 @@ object CandidateGenerator extends ScorexLogging {
             ) match {
               case Success(costConsumed) =>
                 val newTxs = acc :+ (tx -> costConsumed)
+                val newSize = accSize + BlockTransactionsSerializer.transactionSize(tx, blockVersion)
                 val newBoxes = newTxs.flatMap(_._1.outputs)
 
                 collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
@@ -995,8 +1004,10 @@ object CandidateGenerator extends ScorexLogging {
                     feeTx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier) match {
                       case Success(cost) =>
                         val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
-                        if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                          loop(mempoolTxs.tail, newTxs, Some(feeTx -> cost), invalidTxs)
+                        val sectionSize = BlockTransactionsSerializer.sectionSize(blockVersion, blockTxs.size,
+                          newSize + BlockTransactionsSerializer.transactionSize(feeTx, blockVersion))
+                        if (correctLimits(blockTxs, maxBlockCost, maxBlockSize, sectionSize)) {
+                          loop(mempoolTxs.tail, newTxs, newSize, Some(feeTx -> cost), invalidTxs)
                         } else {
                           log.debug(s"Finishing block assembly on limits overflow, " +
                                     s"cost is ${currentCosted.map(_._2).sum}, cost limit: $maxBlockCost")
@@ -1012,15 +1023,18 @@ object CandidateGenerator extends ScorexLogging {
                   case None =>
                     log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
                     val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
-                    if (correctLimits(blockTxs, maxBlockCost, maxBlockSize)) {
-                      loop(mempoolTxs.tail, blockTxs, lastFeeTx, invalidTxs)
+                    val blockPayloadSize = newSize + lastFeeTx.map(t =>
+                      BlockTransactionsSerializer.transactionSize(t._1, blockVersion)).getOrElse(0)
+                    val sectionSize = BlockTransactionsSerializer.sectionSize(blockVersion, blockTxs.size, blockPayloadSize)
+                    if (correctLimits(blockTxs, maxBlockCost, maxBlockSize, sectionSize)) {
+                      loop(mempoolTxs.tail, blockTxs, blockPayloadSize, lastFeeTx, invalidTxs)
                     } else {
                       current -> invalidTxs
                     }
                 }
               case Failure(e) =>
                 log.info(s"Not included transaction ${tx.id} due to ${e.getMessage}: ", e)
-                loop(mempoolTxs.tail, acc, lastFeeTx, invalidTxs :+ tx.id)
+                loop(mempoolTxs.tail, acc, accSize, lastFeeTx, invalidTxs :+ tx.id)
             }
           }
         case None => // mempool is empty
@@ -1028,7 +1042,7 @@ object CandidateGenerator extends ScorexLogging {
       }
     }
 
-    val res = loop(transactions, Seq.empty, None, Seq.empty)
+    val res = loop(transactions, Seq.empty, 0L, None, Seq.empty)
     log.debug(
       s"Collected ${res._1.length} transactions for block #$currentHeight, " +
         s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")

--- a/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
+++ b/src/main/scala/org/ergoplatform/mining/CandidateGenerator.scala
@@ -616,6 +616,8 @@ object CandidateGenerator extends ScorexLogging {
         Math.max(System.currentTimeMillis(), bestHeaderOpt.map(_.timestamp + 1).getOrElse(0L))
 
       val stateContext = state.stateContext
+      val maxBlockSize = stateContext.currentParameters.maxBlockSize
+      val maxBlockCost = stateContext.currentParameters.maxBlockCost
 
       // Calculate required difficulty for the new block
       val nBits: Long = bestHeaderOpt
@@ -665,7 +667,7 @@ object CandidateGenerator extends ScorexLogging {
           (interlinksExtension, Array(0: Byte, 0: Byte, 0: Byte), Header.InitialVersion)
         )
 
-      val upcomingContext = state.stateContext.upcoming(
+      val upcomingContext = stateContext.upcoming(
         minerPk.value,
         timestamp,
         nBits,
@@ -679,9 +681,9 @@ object CandidateGenerator extends ScorexLogging {
       // todo: remove in 5.0
       // we allow for some gap, to avoid possible problems when different interpreter version can estimate cost
       // differently due to bugs in AOT costing
-      val safeGap = if (state.stateContext.currentParameters.maxBlockCost < 1000000) {
+      val safeGap = if (maxBlockCost < 1000000) {
         0
-      } else if (state.stateContext.currentParameters.maxBlockCost < 5000000) {
+      } else if (maxBlockCost < 5000000) {
         150000
       } else {
         500000
@@ -689,8 +691,8 @@ object CandidateGenerator extends ScorexLogging {
 
       val (txs, toEliminate) = collectTxs(
         minerPk,
-        state.stateContext.currentParameters.maxBlockCost - safeGap,
-        state.stateContext.currentParameters.maxBlockSize,
+        maxBlockCost - safeGap,
+        maxBlockSize,
         state,
         upcomingContext,
         emissionTxs ++ prioritizedTransactions ++ poolTxs.map(_.transaction)
@@ -705,7 +707,6 @@ object CandidateGenerator extends ScorexLogging {
       }
 
       def deriveWorkMessage(block: CandidateBlock) = {
-        ensureCandidateSize(block, state.stateContext.currentParameters.maxBlockSize)
         ergoSettings.chainSettings.powScheme.deriveExternalCandidate(
           block,
           minerPk,
@@ -745,7 +746,10 @@ object CandidateGenerator extends ScorexLogging {
                 t
               )
               val fallbackTxs = Seq(emissionTx)
-              state.proofsForTransactions(fallbackTxs).map {
+              candidateSizeWithinLimit(fallbackTxs, version, maxBlockSize).flatMap {
+                case true => state.proofsForTransactions(fallbackTxs)
+                case false => Failure(new IllegalArgumentException("Emission transaction section exceeds the block size limit"))
+              }.map {
                 case (adProof, adDigest) =>
                   val candidate = CandidateBlock(
                     bestHeaderOpt,
@@ -918,10 +922,26 @@ object CandidateGenerator extends ScorexLogging {
     Seq(emissionTxOpt, feeTxOpt).flatten
   }
 
-  /** Check the complete serialized section before returning work, including the emission-only fallback. */
-  private[mining] def ensureCandidateSize(candidate: CandidateBlock, maxBlockSize: Int): Unit = {
-    val section = BlockTransactions(Header.GenesisParentId, candidate.version, candidate.transactions)
-    require(section.bytes.length <= maxBlockSize, "Candidate transaction section exceeds the block size limit")
+  private[mining] def candidateSizeWithinLimit(
+    txs: Seq[ErgoTransaction], blockVersion: Byte, maxBlockSize: Int
+  ): Try[Boolean] = Try(BlockTransactions.sizeOf(txs, blockVersion) <= maxBlockSize)
+
+  /** Check the actual writer once on the normal path; on failure restore an earlier prefix and its fee transaction. */
+  @tailrec
+  private[mining] def checkedCandidate(
+    candidates: Iterator[(Seq[ErgoTransaction], Seq[ModifierId])], blockVersion: Byte, maxBlockSize: Int
+  ): (Seq[ErgoTransaction], Seq[ModifierId]) = {
+    if (!candidates.hasNext) Seq.empty -> Seq.empty
+    else {
+      val candidate = candidates.next()
+      val txs = candidate._1
+      (if (txs.isEmpty) Success(true) else candidateSizeWithinLimit(txs, blockVersion, maxBlockSize)) match {
+        case Success(true) => candidate
+        case result =>
+          log.warn(s"Cannot return transaction section ($result); restoring the previous accepted prefix")
+          checkedCandidate(candidates, blockVersion, maxBlockSize)
+      }
+    }
   }
 
   /** Decide whether transactions fit the cost limit and the full serialized section size limit. */
@@ -929,9 +949,13 @@ object CandidateGenerator extends ScorexLogging {
     blockTxs: Seq[CostedTransaction],
     maxBlockCost: Long,
     maxBlockSize: Long,
-    sectionSize: Long
+    sectionSize: => Long
   ): Boolean = {
-    blockTxs.map(_._2).sum < maxBlockCost && sectionSize <= maxBlockSize
+    Try(blockTxs.map(_._2).sum < maxBlockCost && sectionSize <= maxBlockSize).recover {
+      case e =>
+        log.warn("Cannot measure tentative transaction section; retaining the accepted candidate", e)
+        false
+    }.get
   }
 
   /**
@@ -968,11 +992,16 @@ object CandidateGenerator extends ScorexLogging {
               acc: Seq[CostedTransaction],
               accSize: Long,
               lastFeeTx: Option[CostedTransaction],
-              invalidTxs: Seq[ModifierId]
+              invalidTxs: Seq[ModifierId],
+              previousCandidates: List[(Seq[CostedTransaction], Seq[ModifierId])]
             ): (Seq[ErgoTransaction], Seq[ModifierId]) = {
       // transactions from mempool and fee txs from the previous step
       val currentCosted = acc ++ lastFeeTx
       def current: Seq[ErgoTransaction] = currentCosted.map(_._1)
+      def finish: (Seq[ErgoTransaction], Seq[ModifierId]) =
+        checkedCandidate(((currentCosted -> invalidTxs) :: previousCandidates).iterator.map {
+          case (txs, invalid) => txs.map(_._1) -> invalid
+        }, blockVersion, maxBlockSize)
 
       val stateWithTxs = us.withTransactions(current)
 
@@ -982,7 +1011,7 @@ object CandidateGenerator extends ScorexLogging {
             //mark transaction as invalid if it tries to do double-spending or trying to spend outputs not present
             //do these checks before validating the scripts to save time
             log.debug(s"Transaction ${tx.id} double-spending or spending non-existing inputs")
-            loop(mempoolTxs.tail, acc, accSize, lastFeeTx, invalidTxs :+ tx.id)
+            loop(mempoolTxs.tail, acc, accSize, lastFeeTx, invalidTxs :+ tx.id, previousCandidates)
           } else {
             // check validity and calculate transaction cost
             stateWithTxs.validateWithCost(
@@ -992,57 +1021,65 @@ object CandidateGenerator extends ScorexLogging {
               Some(verifier)
             ) match {
               case Success(costConsumed) =>
-                val newTxs = acc :+ (tx -> costConsumed)
-                val newSize = accSize + BlockTransactionsSerializer.transactionSize(tx, blockVersion)
-                val newBoxes = newTxs.flatMap(_._1.outputs)
+                Try(accSize + BlockTransactionsSerializer.transactionSize(tx, blockVersion)) match {
+                  case Failure(e) =>
+                    log.warn("Cannot measure tentative transaction; retaining the accepted candidate", e)
+                    finish
+                  case Success(newSize) =>
+                    val newTxs = acc :+ (tx -> costConsumed)
+                    val newBoxes = newTxs.flatMap(_._1.outputs)
 
-                collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
-                  case Some(feeTx) =>
-                    val boxesToSpend = feeTx.inputs.flatMap(i =>
-                      newBoxes.find(b => java.util.Arrays.equals(b.id, i.boxId))
-                    )
-                    feeTx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier) match {
-                      case Success(cost) =>
-                        val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
-                        val sectionSize = BlockTransactionsSerializer.sectionSize(blockVersion, blockTxs.size,
-                          newSize + BlockTransactionsSerializer.transactionSize(feeTx, blockVersion))
-                        if (correctLimits(blockTxs, maxBlockCost, maxBlockSize, sectionSize)) {
-                          loop(mempoolTxs.tail, newTxs, newSize, Some(feeTx -> cost), invalidTxs)
-                        } else {
-                          log.debug(s"Finishing block assembly on limits overflow, " +
-                                    s"cost is ${currentCosted.map(_._2).sum}, cost limit: $maxBlockCost")
-                          current -> invalidTxs
-                        }
-                      case Failure(e) =>
-                        log.warn(
-                          s"Fee collecting tx is invalid, not including it, " +
-                            s"details: ${e.getMessage} from ${stateWithTxs.stateContext}"
+                    collectFees(currentHeight, newTxs.map(_._1), minerPk, upcomingContext) match {
+                      case Some(feeTx) =>
+                        val boxesToSpend = feeTx.inputs.flatMap(i =>
+                          newBoxes.find(b => java.util.Arrays.equals(b.id, i.boxId))
                         )
-                        current -> invalidTxs
-                    }
-                  case None =>
-                    log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
-                    val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
-                    val blockPayloadSize = newSize + lastFeeTx.map(t =>
-                      BlockTransactionsSerializer.transactionSize(t._1, blockVersion)).getOrElse(0)
-                    val sectionSize = BlockTransactionsSerializer.sectionSize(blockVersion, blockTxs.size, blockPayloadSize)
-                    if (correctLimits(blockTxs, maxBlockCost, maxBlockSize, sectionSize)) {
-                      loop(mempoolTxs.tail, blockTxs, blockPayloadSize, lastFeeTx, invalidTxs)
-                    } else {
-                      current -> invalidTxs
+                        feeTx.statefulValidity(boxesToSpend, IndexedSeq(), upcomingContext)(verifier) match {
+                          case Success(cost) =>
+                            val blockTxs: Seq[CostedTransaction] = (feeTx -> cost) +: newTxs
+                            def sectionSize: Long = BlockTransactionsSerializer.sectionSize(blockVersion, blockTxs.size,
+                              newSize + BlockTransactionsSerializer.transactionSize(feeTx, blockVersion))
+                            if (correctLimits(blockTxs, maxBlockCost, maxBlockSize, sectionSize)) {
+                              loop(mempoolTxs.tail, newTxs, newSize, Some(feeTx -> cost), invalidTxs,
+                                (currentCosted -> invalidTxs) :: previousCandidates)
+                            } else {
+                              log.debug(s"Finishing block assembly on limits overflow, " +
+                                        s"cost is ${currentCosted.map(_._2).sum}, cost limit: $maxBlockCost")
+                              finish
+                            }
+                          case Failure(e) =>
+                            log.warn(
+                              s"Fee collecting tx is invalid, not including it, " +
+                                s"details: ${e.getMessage} from ${stateWithTxs.stateContext}"
+                            )
+                            finish
+                        }
+                      case None =>
+                        log.info(s"No fee proposition found in txs ${newTxs.map(_._1.id)} ")
+                        val blockTxs: Seq[CostedTransaction] = newTxs ++ lastFeeTx.toSeq
+                        lazy val blockPayloadSize = newSize + lastFeeTx.map(t =>
+                          BlockTransactionsSerializer.transactionSize(t._1, blockVersion)).getOrElse(0)
+                        def sectionSize: Long = BlockTransactionsSerializer.sectionSize(blockVersion, blockTxs.size, blockPayloadSize)
+                        if (correctLimits(blockTxs, maxBlockCost, maxBlockSize, sectionSize)) {
+                          loop(mempoolTxs.tail, blockTxs, blockPayloadSize, lastFeeTx, invalidTxs,
+                            (currentCosted -> invalidTxs) :: previousCandidates)
+                        } else {
+                          finish
+                        }
                     }
                 }
               case Failure(e) =>
                 log.info(s"Not included transaction ${tx.id} due to ${e.getMessage}: ", e)
-                loop(mempoolTxs.tail, acc, accSize, lastFeeTx, invalidTxs :+ tx.id)
+                loop(mempoolTxs.tail, acc, accSize, lastFeeTx, invalidTxs :+ tx.id, previousCandidates)
             }
           }
         case None => // mempool is empty
-          current -> invalidTxs
+          finish
       }
     }
 
-    val res = loop(transactions, Seq.empty, 0L, None, Seq.empty)
+    // Vector prefixes share their storage; retaining fallback snapshots must not retain quadratic copies.
+    val res = loop(transactions, Vector.empty, 0L, None, Seq.empty, Nil)
     log.debug(
       s"Collected ${res._1.length} transactions for block #$currentHeight, " +
         s"invalid transaction ids (total:${res._2.length}) for block #$currentHeight : ${res._2}")

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -1,17 +1,20 @@
 package org.ergoplatform.mining
 
 import org.ergoplatform.ErgoTreePredef
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
-import org.ergoplatform.nodeView.state.ErgoStateContext
-import org.ergoplatform.settings.MonetarySettings
-import org.ergoplatform.utils.{BoxUtils, ErgoCorePropertyTest, RandomWrapper}
+import org.ergoplatform.nodeView.state.{ErgoStateContext, StateType, UtxoState}
+import org.ergoplatform.settings.{MonetarySettings, Parameters}
+import org.ergoplatform.utils.{BoxUtils, ErgoCorePropertyTest, HistoryTestHelpers, RandomWrapper}
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.scalacheck.Gen
 import scorex.util.{ModifierId, bytesToId}
+import scorex.crypto.authds.{ADDigest, SerializedAdProof}
 import sigma.data.ProveDlog
 
 import scala.concurrent.duration._
+import scala.util.{Failure, Try}
 
 class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
@@ -183,7 +186,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
       }
 
       fromBigMempool.length should be > 2
-      fromBigMempool.map(_.size).sum should be < maxSize
+      BlockTransactions(h.id, h.version, fromBigMempool).bytes.length should be <= maxSize
       costs.sum should be < maxCost
       if (!withTokens) fromBigMempool.size should be < txsWithFees.size
     }
@@ -197,6 +200,121 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
     // miner collects correct transactions from mempool even if they have tokens
     checkCollectTxs(Int.MaxValue, Int.MaxValue, withTokens = true)
 
+  }
+
+  property("transaction section size includes framing at the collection boundary") {
+    val bh = boxesHolderGen.sample.get
+    val us = createUtxoState(bh, parameters)
+    val input = bh.boxes.values.find(_.value >= BoxUtils.sufficientAmount(parameters) * 2).get
+    val headerId = bytesToId(Array.fill(32)(0.toByte))
+
+    for (version <- Seq[Byte](1, 2, 3, 4); withFees <- Seq(false, true)) {
+      val tx = validTransactionFromBoxes(
+        IndexedSeq(input),
+        outputsProposition = if (withFees) feeProp else sigma.ast.ErgoTree.fromSigmaBoolean(sigma.data.TrivialProp.TrueProp)
+      )
+      val context = us.stateContext.upcoming(
+        defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
+        Array.fill(3)(0.toByte), emptyVSUpdate, version
+      )
+      def collect(limit: Int): Seq[ErgoTransaction] = {
+        val (collected, invalid) = CandidateGenerator.collectTxs(
+          defaultMinerPk, Int.MaxValue, limit, us, context, Seq(tx)
+        )
+        invalid shouldBe empty
+        collected
+      }
+      val unconstrained = collect(Int.MaxValue)
+      unconstrained should contain(tx)
+      unconstrained.size shouldBe (if (withFees) 2 else 1)
+      val sectionSize = BlockTransactions(headerId, version, unconstrained).bytes.length
+      collect(sectionSize) shouldBe unconstrained
+      collect(sectionSize - 1) shouldBe empty
+    }
+  }
+
+  property("transaction section size is checked before normal and fallback work is returned") {
+    for (fallback <- Seq(false, true)) {
+      val base = createUtxoState(settings)._1
+      val history = HistoryTestHelpers.generateHistory(true, StateType.Utxo, false, -1)
+      var proofCalls = 0
+      val state = new UtxoState(base.persistentProver, base.version, base.store, settings) {
+        override def proofsForTransactions(txs: Seq[ErgoTransaction]): Try[(SerializedAdProof, ADDigest)] = {
+          proofCalls += 1
+          if (fallback && proofCalls == 1) Failure(new IllegalStateException("Proof generation unavailable"))
+          else super.proofsForTransactions(txs)
+        }
+      }
+      try {
+        val emissionTx = CandidateGenerator.collectEmission(state, defaultMinerPk, emptyStateContext)
+        val (result, _) = CandidateGenerator.createCandidate(
+          defaultMinerPk, history, emptyVSUpdate, state, Seq.empty, emissionTx, Seq.empty, settings
+        ).get
+        proofCalls shouldBe (if (fallback) 2 else 1)
+        result.candidateBlock.transactions shouldBe emissionTx.toSeq
+        val section = BlockTransactions(bytesToId(Array.fill(32)(0.toByte)),
+          result.candidateBlock.version, result.candidateBlock.transactions)
+        val limit = section.bytes.length
+        CandidateGenerator.ensureCandidateSize(result.candidateBlock, limit)
+        val error = intercept[IllegalArgumentException] {
+          CandidateGenerator.ensureCandidateSize(result.candidateBlock, limit - 1)
+        }
+        error.getMessage should include("Candidate transaction section exceeds the block size limit")
+      } finally {
+        history.closeStorage()
+        base.store.close()
+      }
+    }
+  }
+
+  for (fallback <- Seq(false, true)) {
+    val branch = if (fallback) "fallback" else "normal"
+    property(s"transaction section size guard is connected to $branch candidate creation") {
+      for (budgetReduction <- Seq(0, 1)) {
+        val base = createUtxoState(settings)._1
+        val history = HistoryTestHelpers.generateHistory(true, StateType.Utxo, false, -1)
+        val originalContext = base.stateContext
+        var testContext = originalContext
+        var proofCalls = 0
+        val state = new UtxoState(base.persistentProver, base.version, base.store, settings) {
+          override def stateContext: ErgoStateContext = testContext
+
+          override def proofsForTransactions(txs: Seq[ErgoTransaction]): Try[(SerializedAdProof, ADDigest)] = {
+            proofCalls += 1
+            if (fallback && proofCalls == 1) Failure(new IllegalStateException("Proof generation unavailable"))
+            else super.proofsForTransactions(txs).map { proof =>
+              // Change only the local size budget after selection, so the final work guard decides this boundary.
+              val sectionSize = BlockTransactions(bytesToId(Array.fill(32)(0.toByte)), 1.toByte, txs).bytes.length
+              val params = originalContext.currentParameters
+              val finalParameters = new Parameters(params.height,
+                params.parametersTable.updated(Parameters.MaxBlockSizeIncrease, sectionSize - budgetReduction),
+                params.proposedUpdate)
+              testContext = new ErgoStateContext(originalContext.lastHeaders, originalContext.lastExtensionOpt,
+                originalContext.genesisStateDigest, finalParameters, originalContext.validationSettings,
+                originalContext.votingData)(originalContext.chainSettings)
+              proof
+            }
+          }
+        }
+        try {
+          val emissionTx = CandidateGenerator.collectEmission(state, defaultMinerPk, emptyStateContext)
+          val result = CandidateGenerator.createCandidate(
+            defaultMinerPk, history, emptyVSUpdate, state, Seq.empty, emissionTx, Seq.empty, settings
+          )
+          proofCalls shouldBe (if (fallback) 2 else 1)
+          if (budgetReduction == 0) {
+            result.get._1.candidateBlock.transactions shouldBe emissionTx.toSeq
+          } else {
+            result.isFailure shouldBe true
+            result.failed.get shouldBe a[IllegalArgumentException]
+            result.failed.get.getMessage should include("Candidate transaction section exceeds the block size limit")
+          }
+        } finally {
+          history.closeStorage()
+          base.store.close()
+        }
+      }
+    }
   }
 
   property("should not be able to spend recent fee boxes") {

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorPropSpec.scala
@@ -1,6 +1,6 @@
 package org.ergoplatform.mining
 
-import org.ergoplatform.ErgoTreePredef
+import org.ergoplatform.{ErgoBoxCandidate, ErgoTreePredef}
 import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
@@ -10,7 +10,7 @@ import org.ergoplatform.utils.{BoxUtils, ErgoCorePropertyTest, HistoryTestHelper
 import org.ergoplatform.wallet.interpreter.ErgoInterpreter
 import org.scalacheck.Gen
 import scorex.util.{ModifierId, bytesToId}
-import scorex.crypto.authds.{ADDigest, SerializedAdProof}
+import scorex.crypto.authds.{ADDigest, ADKey, SerializedAdProof}
 import sigma.data.ProveDlog
 
 import scala.concurrent.duration._
@@ -255,11 +255,10 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
         val section = BlockTransactions(bytesToId(Array.fill(32)(0.toByte)),
           result.candidateBlock.version, result.candidateBlock.transactions)
         val limit = section.bytes.length
-        CandidateGenerator.ensureCandidateSize(result.candidateBlock, limit)
-        val error = intercept[IllegalArgumentException] {
-          CandidateGenerator.ensureCandidateSize(result.candidateBlock, limit - 1)
-        }
-        error.getMessage should include("Candidate transaction section exceeds the block size limit")
+        CandidateGenerator.candidateSizeWithinLimit(result.candidateBlock.transactions,
+          result.candidateBlock.version, limit).get shouldBe true
+        CandidateGenerator.candidateSizeWithinLimit(result.candidateBlock.transactions,
+          result.candidateBlock.version, limit - 1).get shouldBe false
       } finally {
         history.closeStorage()
         base.store.close()
@@ -269,7 +268,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
 
   for (fallback <- Seq(false, true)) {
     val branch = if (fallback) "fallback" else "normal"
-    property(s"transaction section size guard is connected to $branch candidate creation") {
+    property(s"$branch candidate creation retains the size budget captured before proof generation") {
       for (budgetReduction <- Seq(0, 1)) {
         val base = createUtxoState(settings)._1
         val history = HistoryTestHelpers.generateHistory(true, StateType.Utxo, false, -1)
@@ -283,7 +282,7 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
             proofCalls += 1
             if (fallback && proofCalls == 1) Failure(new IllegalStateException("Proof generation unavailable"))
             else super.proofsForTransactions(txs).map { proof =>
-              // Change only the local size budget after selection, so the final work guard decides this boundary.
+              // A later store observation must not replace the budget used to select this candidate.
               val sectionSize = BlockTransactions(bytesToId(Array.fill(32)(0.toByte)), 1.toByte, txs).bytes.length
               val params = originalContext.currentParameters
               val finalParameters = new Parameters(params.height,
@@ -302,18 +301,91 @@ class CandidateGeneratorPropSpec extends ErgoCorePropertyTest {
             defaultMinerPk, history, emptyVSUpdate, state, Seq.empty, emissionTx, Seq.empty, settings
           )
           proofCalls shouldBe (if (fallback) 2 else 1)
-          if (budgetReduction == 0) {
-            result.get._1.candidateBlock.transactions shouldBe emissionTx.toSeq
-          } else {
-            result.isFailure shouldBe true
-            result.failed.get shouldBe a[IllegalArgumentException]
-            result.failed.get.getMessage should include("Candidate transaction section exceeds the block size limit")
-          }
+          result.get._1.candidateBlock.transactions shouldBe emissionTx.toSeq
+          BlockTransactions.sizeOf(result.get._1.candidateBlock.transactions, 1.toByte) should be <=
+            originalContext.currentParameters.maxBlockSize
         } finally {
           history.closeStorage()
           base.store.close()
         }
       }
+    }
+  }
+
+  property("a final size discrepancy restores the accepted prefix with its matching fee transaction") {
+    val bh = boxesHolderGen.sample.get
+    val us = createUtxoState(bh, parameters)
+    try {
+      val inputs = bh.boxes.values.filter(_.value >= BoxUtils.sufficientAmount(parameters) * 2).take(2).toIndexedSeq
+      inputs.size shouldBe 2
+      val txs = inputs.map(input => validTransactionFromBoxes(IndexedSeq(input), outputsProposition = feeProp))
+      val context = us.stateContext.upcoming(defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
+        Array.fill(3)(0.toByte), emptyVSUpdate, 1.toByte)
+      def selected(input: Seq[ErgoTransaction]): Seq[ErgoTransaction] =
+        CandidateGenerator.collectTxs(defaultMinerPk, Int.MaxValue, Int.MaxValue, us, context, input)._1
+      val prefix = selected(txs.take(1))
+      val complete = selected(txs)
+      val limit = BlockTransactions.sizeOf(prefix, 1.toByte)
+      BlockTransactions.sizeOf(complete, 1.toByte) should be > limit
+      val discardedConflict = txs.last.id
+      val restoredResult = CandidateGenerator.checkedCandidate(
+        Iterator(complete -> Seq(discardedConflict), prefix -> Seq.empty), 1.toByte, limit)
+      val restored = restoredResult._1
+      restoredResult._2 shouldBe empty
+      restored shouldBe prefix
+      restored.last shouldBe CandidateGenerator.collectFees(us.stateContext.currentHeight,
+        txs.take(1), defaultMinerPk, context).get
+      CandidateGenerator.checkedCandidate(Iterator(complete -> Seq.empty, prefix -> Seq.empty),
+        1.toByte, limit - 1)._1 shouldBe empty
+    } finally us.store.close()
+  }
+
+  property("collection restores the prior fee prefix when incremental or final writing fails") {
+    for (incrementalFailure <- Seq(true, false)) {
+      val bh = boxesHolderGen.sample.get
+      val base = createUtxoState(bh, parameters)
+      var failSerialization = false
+      try {
+        val inputs = bh.boxes.values.filter(_.value >= BoxUtils.sufficientAmount(parameters) * 2).take(2).toIndexedSeq
+        inputs.size shouldBe 2
+        val first = validTransactionFromBoxes(IndexedSeq(inputs.head), outputsProposition = feeProp)
+        val original = validTransactionFromBoxes(IndexedSeq(inputs.last), outputsProposition = feeProp)
+        val guardedOutputs = new IndexedSeq[ErgoBoxCandidate] {
+          override def length: Int = original.outputCandidates.length
+          override def apply(index: Int): ErgoBoxCandidate = {
+            if (failSerialization) throw new IllegalStateException("Final section writer unavailable")
+            original.outputCandidates(index)
+          }
+        }
+        val last = ErgoTransaction(original.inputs, original.dataInputs, guardedOutputs)
+        val missing = validErgoTransactionGen.sample.get._2
+        missing.inputs.foreach(input => base.boxById(input.boxId) shouldBe empty)
+        val state = new UtxoState(base.persistentProver, base.version, base.store, settings) {
+          override def withTransactions(txs: Seq[ErgoTransaction]): UtxoState = {
+            val withTxs = super.withTransactions(txs)
+            val result = new UtxoState(base.persistentProver, base.version, base.store, settings) {
+              override def boxById(id: ADKey): Option[org.ergoplatform.ErgoBox] = withTxs.boxById(id)
+              override def validateWithCost(tx: ErgoTransaction, context: ErgoStateContext,
+                                            costLimit: Int, interpreterOpt: Option[ErgoInterpreter]): Try[Int] = {
+                val validated = super.validateWithCost(tx, context, costLimit, interpreterOpt)
+                if (incrementalFailure && (tx eq last) && validated.isSuccess) failSerialization = true
+                validated
+              }
+            }
+            // Both incremental measurements completed. Fail only the final complete-section serialization.
+            if (!incrementalFailure && txs.exists(_ eq last)) failSerialization = true
+            result
+          }
+        }
+        val context = base.stateContext.upcoming(defaultMinerPk.value, 1L, settings.chainSettings.initialNBits,
+          Array.fill(3)(0.toByte), emptyVSUpdate, 1.toByte)
+        val (selected, eliminated) = CandidateGenerator.collectTxs(defaultMinerPk, Int.MaxValue, Int.MaxValue,
+          state, context, Seq(first, last, missing))
+        failSerialization shouldBe true
+        selected shouldBe Seq(first, CandidateGenerator.collectFees(base.stateContext.currentHeight,
+          Seq(first), defaultMinerPk, context).get)
+        eliminated shouldBe empty
+      } finally base.store.close()
     }
   }
 


### PR DESCRIPTION
Candidate assembly budgets the complete serialized transaction section: header ID, version marker, transaction count and payloads. Measurement uses the section writer's version context, including fee replacement. Exact size fits remain eligible; the existing strict cost limit is unchanged.

The budget is captured once for selection and emission-only fallback. Before returning collected transactions, the actual section writer checks the result. An oversized result or writer failure restores an earlier accepted prefix with its matching fee and invalid-transaction snapshot. If no nonempty candidate fits, construction fails without issuing work. The emission-only proof fallback has its own size check.

### September 13 review follow-up

Review the [three-file increment](https://github.com/a-shannon/ergo/compare/d904fd1da9697ce6d5471e4416570c7bd0cf8ced...c9ddcaaa5207d5373a720a4399ea27489faa6a9e). Current head: `c9ddcaaa5207d5373a720a4399ea27489faa6a9e`.

- `BlockTransactions.sizeOf` now documents its existing nonempty-transaction precondition.
- Expected oversize recovery logs at DEBUG; reconstruction or measurement failures log at WARN.
- The requested memory measurement found that shared Vector nodes still retained every historical fee transaction. Each fee transaction grows with the accepted prefix. Snapshots now retain shared costed prefixes and reconstruct historical fees only when fallback needs them. Ordinary selection, limits, fee construction and no-fee accumulator transitions are unchanged. A failed reconstruction continues to an earlier snapshot.

The measurement invoked the compiled recipe factory and verified that each closure retains the original prefix by identity, without eagerly copying it. With 256 synthetic fee-producing transactions, retained input objects fell from 33,152 to 512, including ordinary inputs. For a 524,166-byte synthetic section with 2,864 ordinary transactions, the new strategy retained 2,865 transaction objects, 5,728 inputs and about 4.13 MB of traversed structure and payload. This measures retained objects for that fixture, not peak heap, transient allocation, execution complexity or a state/cost-valid full block. Fees already embedded in accepted candidate content are preserved.

### Validation

- Current JDK 8 / Scala 2.12.20 execution: `CandidateGeneratorPropSpec` 19/19, with no failures or skips. Cases include exact fit, one-byte-under budgets, frozen limits and actual incremental/final writer failure with and without fees.
- Recovery checks preserve exact section bytes and the corresponding invalid-ID snapshot, skip failed reconstruction, terminate on exhaustion, and perform no historical reconstruction when the current candidate succeeds.
- The new reconstruction regression fails against the preceding production code: the exception escapes the old `checkedCandidate`. It passes with this increment.
- Independent review of all three changed files found no blocking issue. The retained-object measurement and focused tests bind the source above.
- Current-head GitHub CI passed [8/8](https://github.com/ergoplatform/ergo/actions/runs/34784284996), with the test-execution step successful in each job. The preceding approved `d904fd1da` head passed [all eight jobs](https://github.com/ergoplatform/ergo/actions/runs/34721554177). Its approval and CI remain historical evidence.

Earlier serializer evidence, unchanged by this follow-up, covers writer-byte comparisons and parser round trips for versions 1 through 4 and counts 1, 127 and 128 (6/6). The earlier actor suite initially passed 19/20; its forced-cache case passed separately on both baseline and corrected code. That original failed result is retained. Standalone sizing does not imply acceptance of SOption registers: the pinned parser still rejects V6-only register types.

### Integration

The requested full-section assertions are now published on [#2479](https://github.com/ergoplatform/ergo/pull/2479) itself at [`f75bda15c`](https://github.com/a-shannon/ergo/commit/f75bda15cb1b859a505a264c5b5a5b167d2c9809), with 16/16 tests. They use the existing writer and preserve its `v6.0.7` target.

For a common release line, integrate this sizing correction before adapting #2479's deferral changes. The [earlier combined revision](https://github.com/a-shannon/ergo/commit/5f171a53a65e6b22615780647aeceb2386f87858) passed 48/48 at its pinned inputs; it predates this retention increment and is not validation of the new combination. If [#2462](https://github.com/ergoplatform/ergo/pull/2462) is combined later, accounting must include every fee chunk. Current review increments and integration order are tracked in [#2533](https://github.com/ergoplatform/ergo/issues/2533).
