### PR TITLE
Publish wallet state context after successful persistence

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
@@ -101,8 +101,9 @@ final class WalletStorage(store: LDBKVStore, settings: ErgoSettings) extends Sco
     * @param ctx - state context
     */
   def updateStateContext(ctx: ErgoStateContext): Try[Unit] = {
-    cachedStateContext = Some(ctx)
-    store.insert(StateContextKey, ctx.bytes)
+    store.insert(StateContextKey, ctx.bytes).map { _ =>
+      cachedStateContext = Some(ctx)
+    }
   }
 
   /**

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorageSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.nodeView.wallet.persistence
 
 import com.google.common.primitives.Ints
 import org.ergoplatform.db.DBSpec
+import org.ergoplatform.nodeView.state.ErgoStateContext
 import org.ergoplatform.nodeView.wallet.persistence.WalletStorage.SecretPathsKey
 import org.ergoplatform.nodeView.wallet.scanning.{ScanRequest, ScanWalletInteraction}
 import org.ergoplatform.sdk.wallet.secrets.{DerivationPath, DerivationPathSerializer}
@@ -11,6 +12,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scorex.db.LDBKVStore
 
+import scala.util.{Failure, Try}
+
 class WalletStorageSpec
   extends AnyFlatSpec
     with Matchers
@@ -19,6 +22,49 @@ class WalletStorageSpec
   import org.ergoplatform.utils.ErgoNodeTestConstants._
   import org.ergoplatform.utils.generators.ErgoNodeWalletGenerators._
   import org.ergoplatform.wallet.utils.WalletGenerators._
+
+  private class ControlledStore(delegate: LDBKVStore) extends LDBKVStore(null) {
+    var writeFailure: Option[Throwable] = None
+    var beforeWrite: () => Unit = () => ()
+
+    override def get(key: K): Option[V] = delegate.get(key)
+
+    override def insert(key: K, value: V): Try[Unit] = {
+      beforeWrite()
+      writeFailure.fold(delegate.insert(key, value))(Failure(_))
+    }
+  }
+
+  Seq(false, true).foreach { warmCache =>
+    it should s"publish state context only after persistence with warm cache $warmCache" in {
+      withStore { store =>
+        val oldContext = ErgoStateContext.empty(settings.chainSettings,
+          org.ergoplatform.utils.ErgoCoreTestConstants.parameters)
+        val newContext = ErgoStateContext.empty(settings.chainSettings, extendedParameters)
+        oldContext.bytes.toSeq should not be newContext.bytes.toSeq
+        new WalletStorage(store, settings).updateStateContext(oldContext).get
+        val controlled = new ControlledStore(store)
+        val storage = new WalletStorage(controlled, settings)
+        if (warmCache) {
+          storage.getStateContext(extendedParameters).bytes.toSeq shouldBe oldContext.bytes.toSeq
+        }
+
+        val failure = new IllegalStateException("state context write rejected")
+        controlled.writeFailure = Some(failure)
+        storage.updateStateContext(newContext) shouldBe Failure(failure)
+        storage.getStateContext(extendedParameters).bytes.toSeq shouldBe oldContext.bytes.toSeq
+        new WalletStorage(store, settings).getStateContext(extendedParameters).bytes.toSeq shouldBe oldContext.bytes.toSeq
+
+        controlled.writeFailure = None
+        controlled.beforeWrite = () => {
+          storage.getStateContext(extendedParameters).bytes.toSeq shouldBe oldContext.bytes.toSeq
+        }
+        storage.updateStateContext(newContext).get
+        storage.getStateContext(extendedParameters) should be theSameInstanceAs newContext
+        new WalletStorage(store, settings).getStateContext(extendedParameters).bytes.toSeq shouldBe newContext.bytes.toSeq
+      }
+    }
+  }
 
   it should "add and read derivation paths" in {
     def addPath(store: LDBKVStore, storedPaths: Seq[DerivationPath], derivationPath: DerivationPath): Unit = {


### PR DESCRIPTION
Wallet state context is now cached only after its database write succeeds. A rejected write leaves readers on the previous persisted context, matching the actor's existing decision to retain its previous state reader and parameters after failure.

Validation: JDK 8, Scala 2.12.20; all six WalletStorageSpec tests pass. The two new regressions cover warm and cold caches, rejected-write identity, fresh persisted readers, successful retry, and visibility before the write completes. Both fail against the original setter. Independent source and test review completed, including the unchanged ChangedState consumer.

All eight [CI checks](https://github.com/ergoplatform/ergo/actions/runs/34062582285) pass at `f059ec4ecb3c6021dea966fc52a8d1c98d837b0b`.
