### PR TITLE
Propagate wallet unlock migration failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18, 2.12.20, 2.11.12]
-        java: [adopt@1.8]
+        java: ['8']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -30,10 +30,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
+      - name: Setup Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
+          overwrite-settings: false
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
+        with:
+          sbt-runner-version: '1.11.1'
+          disk-cache: false
 
       - name: Cache sbt
         uses: actions/cache@v4
@@ -65,7 +73,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18, 2.12.20, 2.11.12]
-        java: [adopt@1.8]
+        java: ['8']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -73,10 +81,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
+      - name: Setup Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
+          overwrite-settings: false
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
+        with:
+          sbt-runner-version: '1.11.1'
+          disk-cache: false
 
       - name: Cache sbt
         uses: actions/cache@v4
@@ -106,7 +122,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.20]
-        java: [adopt@1.8]
+        java: ['8']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -114,10 +130,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v10
+      - name: Setup Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
+          overwrite-settings: false
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
+        with:
+          sbt-runner-version: '1.11.1'
+          disk-cache: false
 
       - name: Cache sbt
         uses: actions/cache@v4
@@ -140,7 +164,7 @@ jobs:
        matrix:
          os: [ ubuntu-latest ]
          scala: [ 2.12.20 ]
-         java: [ adopt@1.8 ]
+         java: [ '8' ]
      runs-on: ${{ matrix.os }}
      steps:
        - name: Checkout current branch (full)
@@ -149,10 +173,18 @@ jobs:
            path: it
            fetch-depth: 0
 
-       - name: Setup Java and Scala
-         uses: olafurpg/setup-scala@v10
+       - name: Setup Java
+         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
          with:
+           distribution: temurin
            java-version: ${{ matrix.java }}
+           overwrite-settings: false
+
+       - name: Setup sbt
+         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
+         with:
+           sbt-runner-version: '1.11.1'
+           disk-cache: false
 
        - name: Cache sbt
          uses: actions/cache@v4

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -354,6 +354,7 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
     if (state.walletVars.proverOpt.isEmpty) {
       state.secretStorageOpt match {
         case Some(secretStorage) =>
+          val wasLocked = secretStorage.isLocked
           secretStorage.unlock(walletPass).flatMap { _ =>
             secretStorage.secret match {
               case None =>
@@ -361,6 +362,9 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
               case Some(masterKey) =>
                 processUnlock(state, masterKey, usePreEip3Derivation)
             }
+          }.recoverWith { case error =>
+            if (wasLocked) secretStorage.lock()
+            Failure(error)
           }
         case None =>
           Failure(new Exception("Wallet not initialized"))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -160,19 +160,26 @@ trait ErgoWalletSupport extends ScorexLogging {
           }
         }
       } else {
-        if (pubKeys.size == 1 &&
+        val updateChangeAddress = if (pubKeys.size == 1 &&
               pubKeys.head.path == sdk.wallet.Constants.eip3DerivationPath.toPublicBranch &&
               state.storage.readChangeAddress.isEmpty) {
           val changeAddress = P2PKAddress(pubKeys.head.key)(addressEncoder)
           log.info(s"Update change address to $changeAddress")
           state.storage.updateChangeAddress(changeAddress)
+        } else {
+          Success(())
         }
-        // Add master key's public key to the storage to track payments to it when the wallet is locked
-        if (!state.storage.containsPublicKey(masterKey.path.toPublicBranch)) {
-          state.storage.addPublicKey(masterKey.publicKey)
+        updateChangeAddress.flatMap { _ =>
+          // Add master key's public key to the storage to track payments to it when the wallet is locked
+          if (!state.storage.containsPublicKey(masterKey.path.toPublicBranch)) {
+            state.storage.addPublicKey(masterKey.publicKey)
+          } else {
+            Success(())
+          }
+        }.map { _ =>
+          log.info("Wallet unlock finished using existing keys in storage")
+          updatePublicKeys(state, masterKey, pubKeys)
         }
-        log.info("Wallet unlock finished using existing keys in storage")
-        Try(updatePublicKeys(state, masterKey, pubKeys))
       }
     }
   }

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletUnlockMigrationSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletUnlockMigrationSpec.scala
@@ -1,0 +1,144 @@
+package org.ergoplatform.nodeView.wallet
+
+import org.ergoplatform.P2PKAddress
+import org.ergoplatform.db.DBSpec
+import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
+import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.wallet.secrets.{ExtendedPublicKey, ExtendedSecretKey}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.ergoplatform.wallet.secrets.JsonSecretStorage
+import org.iq80.leveldb.DB
+import scorex.db.LDBKVStore
+
+import scala.util.{Failure, Try}
+
+class ErgoWalletUnlockMigrationSpec extends ErgoCorePropertyTest with DBSpec {
+  private val service = new ErgoWalletServiceImpl(settings)
+  private val masterKey = ExtendedSecretKey.deriveMasterKey(Array.fill(32)(1.toByte), usePre1627KeyDerivation = false)
+  private val firstKey = masterKey.derive(org.ergoplatform.sdk.wallet.Constants.eip3DerivationPath).publicKey
+  private val changeAddress = P2PKAddress(firstKey.key)(settings.chainSettings.addressEncoder)
+
+  private class MigrationStore(db: DB) extends LDBKVStore(db) {
+    var failure: Option[(Array[Byte], Throwable)] = None
+    var writes: Vector[Vector[Byte]] = Vector.empty
+
+    override def insert(id: Array[Byte], value: Array[Byte]): Try[Unit] = {
+      writes :+= id.toVector
+      failure match {
+        case Some((key, error)) if key.sameElements(id) => Failure(error)
+        case _ => super.insert(id, value)
+      }
+    }
+  }
+
+  private def withWallet(keys: Seq[ExtendedPublicKey], withChange: Boolean = false)
+                        (test: (ErgoWalletState, MigrationStore) => Unit): Unit = {
+    withVersionedStore(2) { versionedStore =>
+      withDb { db =>
+        val store = new MigrationStore(db)
+        val storage = new WalletStorage(store, settings)
+        keys.foreach(key => storage.addPublicKey(key).get)
+        if (withChange) storage.updateChangeAddress(changeAddress).get
+        store.writes = Vector.empty
+        val secretStorage = JsonSecretStorage.init(
+          Array.fill(32)(1.toByte), SecretString.create("migration-test"), usePre1627KeyDerivation = false
+        )(settings.walletSettings.secretStorage.copy(secretDir = createTempDir.getPath))
+        val state = ErgoWalletState(
+          storage, Some(secretStorage), new WalletRegistry(versionedStore)(settings.walletSettings),
+          OffChainRegistry.empty, None, WalletVars(None, Seq.empty, None)(settings),
+          None, None, None, parameters, maxInputsToUse = 1000, rescanInProgress = false
+        )
+        try test(state, store) finally secretStorage.lock()
+      }
+    }
+  }
+
+  private def unlock(state: ErgoWalletState): Try[ErgoWalletState] =
+    service.unlockWallet(state, SecretString.create("migration-test"), usePreEip3Derivation = false)
+
+  property("unlock propagates change-address migration failure and retries before adding the master key") {
+    withWallet(Seq(firstKey)) { (state, store) =>
+      val error = new IllegalStateException("change-address migration write failed")
+      store.failure = Some(WalletStorage.ChangeAddressKey -> error)
+
+      unlock(state).failed.get should be theSameInstanceAs error
+      state.walletVars.proverOpt shouldBe empty
+      state.secretStorageOpt.get.isLocked shouldBe true
+      state.storage.readChangeAddress shouldBe empty
+      state.storage.containsPublicKey(masterKey.publicKey.path) shouldBe false
+      store.writes shouldBe Vector(WalletStorage.ChangeAddressKey.toVector)
+
+      store.failure = None
+      store.writes = Vector.empty
+      val unlocked = unlock(state).get
+      unlocked.walletVars.proverOpt shouldNot be(empty)
+      unlocked.secretStorageOpt.get.isLocked shouldBe false
+      unlocked.storage.readChangeAddress shouldBe Some(changeAddress)
+      unlocked.storage.readAllKeys().toSet shouldBe Set(firstKey, masterKey.publicKey)
+      store.writes shouldBe Vector(WalletStorage.ChangeAddressKey.toVector, WalletStorage.pubKeyPrefixKey(masterKey.publicKey).toVector)
+    }
+  }
+
+  property("unlock propagates master-key migration failure and retries after the change-address write") {
+    withWallet(Seq(firstKey)) { (state, store) =>
+      val error = new IllegalStateException("master-key migration write failed")
+      store.failure = Some(WalletStorage.pubKeyPrefixKey(masterKey.publicKey) -> error)
+
+      unlock(state).failed.get should be theSameInstanceAs error
+      state.walletVars.proverOpt shouldBe empty
+      state.secretStorageOpt.get.isLocked shouldBe true
+      state.storage.readChangeAddress shouldBe Some(changeAddress)
+      state.storage.containsPublicKey(masterKey.publicKey.path) shouldBe false
+      store.writes shouldBe Vector(WalletStorage.ChangeAddressKey.toVector, WalletStorage.pubKeyPrefixKey(masterKey.publicKey).toVector)
+
+      store.failure = None
+      store.writes = Vector.empty
+      val unlocked = unlock(state).get
+      unlocked.walletVars.proverOpt shouldNot be(empty)
+      unlocked.storage.readChangeAddress shouldBe Some(changeAddress)
+      unlocked.storage.readAllKeys().toSet shouldBe Set(firstKey, masterKey.publicKey)
+      store.writes shouldBe Vector(WalletStorage.pubKeyPrefixKey(masterKey.publicKey).toVector)
+    }
+  }
+
+  property("unlock performs no writes when existing keys and change address are complete") {
+    withWallet(Seq(firstKey, masterKey.publicKey), withChange = true) { (state, store) =>
+      val unlocked = unlock(state).get
+      unlocked.walletVars.proverOpt shouldNot be(empty)
+      unlocked.storage.readChangeAddress shouldBe Some(changeAddress)
+      store.writes shouldBe empty
+    }
+  }
+
+  property("unlock leaves a master-only wallet without a change address") {
+    withWallet(Seq(masterKey.publicKey)) { (state, store) =>
+      unlock(state).get.walletVars.proverOpt shouldNot be(empty)
+      state.storage.readChangeAddress shouldBe empty
+      store.writes shouldBe empty
+    }
+  }
+
+  property("unlock adds the master key without setting change for non-EIP3 or multiple existing keys") {
+    Seq(Seq(masterKey.child(1).publicKey), Seq(firstKey, masterKey.child(1).publicKey)).foreach { keys =>
+      withWallet(keys) { (state, store) =>
+        unlock(state).get.walletVars.proverOpt shouldNot be(empty)
+        state.storage.readChangeAddress shouldBe empty
+        state.storage.readAllKeys().toSet shouldBe (keys :+ masterKey.publicKey).toSet
+        store.writes shouldBe Vector(WalletStorage.pubKeyPrefixKey(masterKey.publicKey).toVector)
+      }
+    }
+  }
+
+  property("failed unlock preserves secret storage that was already unlocked before the attempt") {
+    withWallet(Seq(firstKey)) { (state, store) =>
+      state.secretStorageOpt.get.unlock(SecretString.create("migration-test")).get
+      val error = new IllegalStateException("existing unlocked storage migration write failed")
+      store.failure = Some(WalletStorage.ChangeAddressKey -> error)
+      unlock(state).failed.get should be theSameInstanceAs error
+      state.walletVars.proverOpt shouldBe empty
+      state.secretStorageOpt.get.isLocked shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
Wallet unlock now waits for required migration writes to succeed before returning the unlocked state. Failures while storing the missing change address or master public key are propagated, and a retry resumes from the rows already persisted.

If that attempt newly unlocked the secret storage, failure locks it again. Storage that was already unlocked retains that prior lock state. The actor's existing success/failure response and state-installation paths consume the corrected result.

Validation: JDK 8, Scala 2.12.20; 51 tests pass across migration, wallet service, wallet and storage suites. Separate failures cover each required write, retry, no-write conditions and newly unlocked versus already unlocked storage. The baseline and intermediate implementation fail the intended assertions. Independent source and test review completed.

Related wallet work in [#2507](https://github.com/ergoplatform/ergo/pull/2507), [#2508](https://github.com/ergoplatform/ergo/pull/2508) and [#2518](https://github.com/ergoplatform/ergo/pull/2518) addresses separate conditions. This patch preserves the existing derivation and serialization rules.

A separate CI commit replaces the failed Jabba bootstrap with pinned official Java and sbt setup actions. It selects Temurin Java 8 and an explicit sbt 1.11.1 runner, preserving all eight matrix jobs, Scala versions, test commands and publication conditions. Static validation and independent workflow review pass. All eight [CI checks](https://github.com/ergoplatform/ergo/actions/runs/34068136034) pass at `b95b7072edb4ec1efc5411c907ab7983be1a3a96`.
