### PR TITLE
Preserve valid box selections across optional consolidation

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelector.scala
@@ -100,7 +100,10 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
     val dust = tail.sortBy(_.value).take(diff).filter(b => !bsr.inputBoxes.contains(b))
 
     val boxes = bsr.inputBoxes ++ dust
-    calcChange(boxes, targetBalance, targetAssets).mapRight(changeBoxes => selectionResultWithEip27Output(boxes, changeBoxes))
+    calcChange(boxes, targetBalance, targetAssets).fold(
+      _ => Right(bsr),
+      changeBoxes => Right(selectionResultWithEip27Output(boxes, changeBoxes))
+    )
   }
 
   protected[boxes] def compress[T <: ErgoBoxAssets](bsr: BoxSelectionResult[T],
@@ -114,7 +117,7 @@ class ReplaceCompactCollectBoxSelector(maxInputs: Int,
       boxes.filter(!_.tokens.keySet.exists(tid => targetAssetsKeys.contains(tid)))
         .sortBy(b => BoxSelector.valueOf(b, reemissionDataOpt))
 
-    if (diff >= BoxSelector.valueOf(sortedBoxesToThrowAway.head, reemissionDataOpt)) {
+    if (sortedBoxesToThrowAway.headOption.exists(b => diff >= BoxSelector.valueOf(b, reemissionDataOpt))) {
       var thrownValue = 0L
       val thrownBoxes = sortedBoxesToThrowAway.takeWhile { b =>
         thrownValue = thrownValue + BoxSelector.valueOf(b, reemissionDataOpt)

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/boxes/ReplaceCompactCollectBoxSelectorSpec.scala
@@ -1,8 +1,11 @@
 package org.ergoplatform.wallet.boxes
 
 import org.ergoplatform.wallet.Constants.PaymentsScanId
-import org.ergoplatform.ErgoLikeTransaction
+import org.ergoplatform.{ErgoBoxAssetsHolder, ErgoLikeTransaction}
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
+import org.ergoplatform.wallet.boxes.DefaultBoxSelector.NotEnoughCoinsForChangeBoxesError
+import org.ergoplatform.wallet.boxes.ReplaceCompactCollectBoxSelector.MaxInputsExceededError
+import scorex.util.bytesToId
 import sigmastate.helpers.TestingHelpers._
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
@@ -18,6 +21,51 @@ class ReplaceCompactCollectBoxSelectorSpec extends AnyPropSpec with Matchers wit
 
   def box(value:Long) = testBox(value, ErgoTree.fromProposition(TrueLeaf.toSigmaProp), 0)
   def trackedBox(value:Long) = TrackedBox(parentTx, 0, None, box(value), Set(PaymentsScanId))
+
+  property("optional token dust cannot replace a valid selection with insufficient change") {
+    val token = bytesToId(Array.fill[Byte](32)(1))
+    val funding = ErgoBoxAssetsHolder(BoxSelector.MinBoxValue)
+    val dust = ErgoBoxAssetsHolder(1L, Map(token -> 1L))
+    val inputs = Seq(funding, dust)
+    val accept: ErgoBoxAssetsHolder => Boolean = _ => true
+    val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)
+    val initial = new DefaultBoxSelector(None).select(inputs.iterator, accept, funding.value, Map.empty).right.value
+    initial.inputBoxes shouldBe Seq(funding)
+    selector.calcChange(inputs, funding.value, Map.empty).left.value shouldBe a[NotEnoughCoinsForChangeBoxesError]
+    val result = selector.select(inputs.iterator, accept, funding.value, Map.empty).right.value
+    result.inputBoxes shouldBe initial.inputBoxes
+    result.changeBoxes shouldBe initial.changeBoxes
+    result.payToReemissionBox shouldBe initial.payToReemissionBox
+    selector.collectDust(initial, Seq(dust), funding.value, Map.empty).right.value should be theSameInstanceAs initial
+  }
+
+  property("optional token dust is collected when its change is funded") {
+    val token = bytesToId(Array.fill[Byte](32)(2))
+    val funding = ErgoBoxAssetsHolder(BoxSelector.MinBoxValue)
+    val dust = ErgoBoxAssetsHolder(BoxSelector.MinBoxValue, Map(token -> 1L))
+    val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)
+    val accept: ErgoBoxAssetsHolder => Boolean = _ => true
+    val result = selector.select(Seq(funding, dust).iterator, accept, funding.value, Map.empty).right.value
+    result.inputBoxes shouldBe Seq(funding, dust)
+    result.changeBoxes shouldBe Seq(dust)
+    result.payToReemissionBox shouldBe None
+  }
+
+  property("required token inputs above the limit return the typed maximum input error") {
+    val token = bytesToId(Array.fill[Byte](32)(3))
+    val inputs = (1 to 3).map(n => ErgoBoxAssetsHolder(BoxSelector.MinBoxValue * n, Map(token -> 1L)))
+    val target = inputs.map(_.value).sum
+    val accept: ErgoBoxAssetsHolder => Boolean = _ => true
+    new DefaultBoxSelector(None).select(inputs.iterator, accept, target, Map(token -> 3L)).isRight shouldBe true
+    val selector = new ReplaceCompactCollectBoxSelector(2, 2, None)
+    selector.select(inputs.iterator, accept, target, Map(token -> 3L)).left.value shouldBe a[MaxInputsExceededError]
+  }
+
+  property("compression preserves a selection with no removable inputs") {
+    val selector = new ReplaceCompactCollectBoxSelector(2, 2, None)
+    val empty = new BoxSelectionResult[ErgoBoxAssetsHolder](Seq.empty, Seq.empty, None)
+    selector.compress(empty, 0L, Map.empty).right.value shouldBe empty
+  }
 
   property("compress() done properly") {
     val selector = new ReplaceCompactCollectBoxSelector(3, 2, None)


### PR DESCRIPTION
Optional dust consolidation now preserves an already valid box selection when the additional inputs cannot fund their change. Successful consolidation keeps its existing behavior. Compression with no removable inputs now reaches the existing typed input-limit decision instead of throwing on an empty collection.

Validation: JDK 8, Scala 2.12.20; 18 tests pass across the replacement/compaction and default selector suites. Three regressions fail against the original implementation. The cases verify preserved inputs, change and re-emission output, funded token-dust consolidation, mandatory token inputs above the limit, and empty compression. Independent source and test review completed.

A local combination with [#2510](https://github.com/ergoplatform/ergo/pull/2510) and [#2518](https://github.com/ergoplatform/ergo/pull/2518) passes 46 targeted tests and independent review. The combination preserves the selected-input burn policy, applies consolidation checks within its policy-aware helpers, and binds issuance identity after final selection. This validates the named local combination; it is not a merged upstream CI result.

All eight checks pass on the current head: [CI results](https://github.com/ergoplatform/ergo/actions/runs/34065264429).
