### PR TITLE
Cancel network periodic tasks with their owning actors

### DIFF
--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -63,6 +63,7 @@ class NetworkController(ergoSettings: ErgoSettings,
 
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]
   private var unconfirmedConnections = Set.empty[InetSocketAddress]
+  private var periodicTasks = Vector.empty[Cancellable]
 
   private val mySessionIdFeature = SessionIdPeerFeature(networkSettings.magicBytes)
   /**
@@ -98,6 +99,8 @@ class NetworkController(ergoSettings: ErgoSettings,
   }
 
   override def postStop(): Unit = {
+    periodicTasks.foreach(_.cancel())
+    periodicTasks = Vector.empty
     log.warn("Network controller stopped")
     super.postStop()
   }
@@ -106,9 +109,11 @@ class NetworkController(ergoSettings: ErgoSettings,
   private def bindingLogic: Receive = {
     case Bound(_) =>
       log.info("Successfully bound to the port " + networkSettings.bindAddress.getPort)
-      scheduleConnectionToPeer()
-      scheduleDroppingDeadConnections()
-      scheduleEvictRandomConnections()
+      if (periodicTasks.isEmpty) {
+        scheduleConnectionToPeer()
+        scheduleDroppingDeadConnections()
+        scheduleEvictRandomConnections()
+      }
 
     case CommandFailed(_: Bind) =>
       log.error("Network port " + networkSettings.bindAddress.getPort + " already in use!")
@@ -266,7 +271,7 @@ class NetworkController(ergoSettings: ErgoSettings,
     * Schedule a periodic connection to a random known peer
     */
   private def scheduleConnectionToPeer(): Unit = {
-    context.system.scheduler.scheduleWithFixedDelay(5.seconds, 5.seconds) {
+    periodicTasks :+= context.system.scheduler.scheduleWithFixedDelay(5.seconds, 5.seconds) {
       () => if (connections.size < networkSettings.maxConnections) {
         log.debug(s"Looking for a new random connection")
         val randomPeerF = peerManagerRef ? RandomPeerExcluding(connections.values.flatMap(_.peerInfo).toSeq)
@@ -288,7 +293,7 @@ class NetworkController(ergoSettings: ErgoSettings,
     */
   private def scheduleEvictRandomConnections(): Unit = {
    val evictionThreshold = 5
-   context.system.scheduler.scheduleWithFixedDelay(networkSettings.peerEvictionInterval, networkSettings.peerEvictionInterval) {
+   periodicTasks :+= context.system.scheduler.scheduleWithFixedDelay(networkSettings.peerEvictionInterval, networkSettings.peerEvictionInterval) {
      () =>
        val connectedPeers = connections.values.filter(_.peerInfo.nonEmpty).toSeq
        if (connectedPeers.length >= evictionThreshold) {
@@ -305,7 +310,7 @@ class NetworkController(ergoSettings: ErgoSettings,
     * Schedule a periodic dropping of connections which seem to be inactive
     */
   private def scheduleDroppingDeadConnections(): Unit = {
-    context.system.scheduler.scheduleWithFixedDelay(60.seconds, 60.seconds) {
+    periodicTasks :+= context.system.scheduler.scheduleWithFixedDelay(60.seconds, 60.seconds) {
       () => {
         // Drop connections with peers if they seem to be inactive
         val now = time()

--- a/src/main/scala/scorex/core/network/PeerSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/PeerSynchronizer.scala
@@ -1,7 +1,7 @@
 package scorex.core.network
 
 import akka.actor.SupervisorStrategy.{Restart, Stop}
-import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorSystem, DeathPactException, OneForOneStrategy, Props}
+import akka.actor.{Actor, ActorInitializationException, ActorKilledException, ActorRef, ActorSystem, Cancellable, DeathPactException, OneForOneStrategy, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import org.ergoplatform.network.PeerSpec
@@ -39,6 +39,7 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
   }
 
   private val peersSpec = new PeersSpec(settings.maxPeerSpecObjects)
+  private var peerDiscoveryTask: Option[Cancellable] = None
 
   private val msgHandlers: PartialFunction[(MessageSpec[_], _, ConnectedPeer), Unit] = {
     case (_: PeersSpec, peers: Seq[PeerSpec]@unchecked, _) if peers.cast[Seq[PeerSpec]].isDefined =>
@@ -53,7 +54,14 @@ class PeerSynchronizer(val networkControllerRef: ActorRef,
 
     val msg = Message[Unit](GetPeersSpec, Right(Unit), None)
     val stn = SendToNetwork(msg, SendToRandom)
-    context.system.scheduler.scheduleWithFixedDelay(2.seconds, settings.getPeersInterval, networkControllerRef, stn)
+    peerDiscoveryTask = Some(
+      context.system.scheduler.scheduleWithFixedDelay(2.seconds, settings.getPeersInterval, networkControllerRef, stn))
+  }
+
+  override def postStop(): Unit = {
+    peerDiscoveryTask.foreach(_.cancel())
+    peerDiscoveryTask = None
+    super.postStop()
   }
 
   override def receive: Receive = {

--- a/src/test/scala/scorex/core/network/PeriodicTaskLifecycleSpec.scala
+++ b/src/test/scala/scorex/core/network/PeriodicTaskLifecycleSpec.scala
@@ -1,0 +1,164 @@
+package scorex.core.network
+
+import akka.actor.{ActorRef, ActorSystem, Cancellable}
+import akka.event.LoggingAdapter
+import akka.io.Tcp
+import akka.testkit.{ExplicitlyTriggeredScheduler, TestActorRef, TestProbe}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.ergoplatform.network.message.MessageConstants.MessageCode
+import org.ergoplatform.network.peer.PeerManager.ReceivableMessages.RandomPeerExcluding
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.core.app.ScorexContext
+import scorex.core.network.NetworkController.ReceivableMessages.SendToNetwork
+
+import java.util.concurrent.ThreadFactory
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+final class RecordingPeriodicTaskScheduler(config: Config, log: LoggingAdapter, threadFactory: ThreadFactory)
+  extends ExplicitlyTriggeredScheduler(config, log, threadFactory) {
+
+  private val recorded = ArrayBuffer.empty[(FiniteDuration, FiniteDuration, Cancellable)]
+
+  def tasks: Vector[(FiniteDuration, FiniteDuration, Cancellable)] = recorded.synchronized(recorded.toVector)
+
+  override def scheduleWithFixedDelay(initialDelay: FiniteDuration, delay: FiniteDuration)(runnable: Runnable)
+                                     (implicit executor: ExecutionContext): Cancellable = {
+    val task = super.scheduleWithFixedDelay(initialDelay, delay)(runnable)
+    recorded.synchronized(recorded += ((initialDelay, delay, task)))
+    task
+  }
+}
+
+class PeriodicTaskLifecycleSpec extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+
+  private class Fixture {
+    private val config = ConfigFactory.parseString(
+      "akka.scheduler.implementation = \"scorex.core.network.RecordingPeriodicTaskScheduler\"")
+      .withFallback(ConfigFactory.load())
+    implicit val system: ActorSystem = ActorSystem("periodic-task-lifecycle", config)
+    implicit val ec: ExecutionContext = system.dispatcher
+    val scheduler: RecordingPeriodicTaskScheduler = system.scheduler.asInstanceOf[RecordingPeriodicTaskScheduler]
+    val peerManager: TestProbe = TestProbe()
+    val tcpManager: TestProbe = TestProbe()
+    val controllerProbe: TestProbe = TestProbe()
+
+    def controller(): TestActorRef[NetworkController] = {
+      val actor = TestActorRef(new NetworkController(settings, peerManager.ref,
+        ScorexContext(Seq.empty, None, None), tcpManager.ref, _ => Map.empty[MessageCode, ActorRef]))
+      tcpManager.expectMsgType[Tcp.Bind]
+      actor
+    }
+
+    def bind(actor: ActorRef): Unit = actor ! Tcp.Bound(settings.scorexSettings.network.bindAddress)
+
+    def synchronizer(): TestActorRef[PeerSynchronizer] =
+      TestActorRef(new PeerSynchronizer(controllerProbe.ref, peerManager.ref, settings.scorexSettings.network))
+
+    def stop(actor: ActorRef): Unit = {
+      val lifecycle = TestProbe()
+      lifecycle.watch(actor)
+      system.stop(actor)
+      lifecycle.expectTerminated(actor)
+      system.whenTerminated.isCompleted shouldBe false
+    }
+  }
+
+  private def withFixture(test: Fixture => Unit): Unit = {
+    val fixture = new Fixture
+    try test(fixture)
+    finally Await.result(fixture.system.terminate(), 10.seconds)
+  }
+
+  property("controller repeats stay active until its individual stop") {
+    withFixture { f =>
+      val controller = f.controller()
+      f.scheduler.tasks shouldBe empty
+      f.bind(controller)
+      val tasks = f.scheduler.tasks
+      tasks.map(t => t._1 -> t._2).toSet shouldBe Set(
+        5.seconds -> 5.seconds,
+        60.seconds -> 60.seconds,
+        settings.scorexSettings.network.peerEvictionInterval -> settings.scorexSettings.network.peerEvictionInterval)
+      tasks.size shouldBe 3
+      tasks.forall(!_._3.isCancelled) shouldBe true
+      f.scheduler.timePasses(5.seconds)
+      f.peerManager.expectMsgType[RandomPeerExcluding]
+      f.peerManager.reply(None)
+      f.stop(controller)
+      tasks.forall(_._3.isCancelled) shouldBe true
+      f.scheduler.timePasses(65.seconds)
+      f.peerManager.expectNoMessage(100.millis)
+    }
+  }
+
+  property("a repeated Bound does not duplicate controller maintenance") {
+    withFixture { f =>
+      val controller = f.controller()
+      f.bind(controller)
+      f.bind(controller)
+      f.scheduler.tasks.size shouldBe 3
+      f.stop(controller)
+      f.scheduler.tasks.forall(_._3.isCancelled) shouldBe true
+    }
+  }
+
+  property("controller restart cancels the old instance and schedules only after rebinding") {
+    withFixture { f =>
+      val controller = f.controller()
+      f.bind(controller)
+      val oldActor = controller.underlyingActor
+      val oldTasks = f.scheduler.tasks
+      controller.suspend()
+      controller.restart(new IllegalStateException("controlled lifecycle restart"))
+      f.tcpManager.expectMsgType[Tcp.Bind]
+      controller.underlyingActor should not be theSameInstanceAs(oldActor)
+      oldTasks.forall(_._3.isCancelled) shouldBe true
+      f.scheduler.tasks.size shouldBe 3
+      f.bind(controller)
+      val replacementTasks = f.scheduler.tasks.drop(3)
+      replacementTasks.size shouldBe 3
+      replacementTasks.forall(!_._3.isCancelled) shouldBe true
+      f.stop(controller)
+      replacementTasks.forall(_._3.isCancelled) shouldBe true
+    }
+  }
+
+  property("peer discovery stops when its owner stops while the controller remains alive") {
+    withFixture { f =>
+      val synchronizer = f.synchronizer()
+      val task = f.scheduler.tasks.head
+      f.scheduler.tasks.size shouldBe 1
+      task._1 shouldBe 2.seconds
+      task._2 shouldBe settings.scorexSettings.network.getPeersInterval
+      task._3.isCancelled shouldBe false
+      f.scheduler.timePasses(2.seconds)
+      f.controllerProbe.expectMsgType[SendToNetwork]
+      f.stop(synchronizer)
+      task._3.isCancelled shouldBe true
+      f.scheduler.timePasses(settings.scorexSettings.network.getPeersInterval)
+      f.controllerProbe.expectNoMessage(100.millis)
+    }
+  }
+
+  property("peer discovery restart cancels the old repeat and starts one replacement") {
+    withFixture { f =>
+      val synchronizer = f.synchronizer()
+      val oldActor = synchronizer.underlyingActor
+      val oldTask = f.scheduler.tasks.head._3
+      synchronizer.suspend()
+      synchronizer.restart(new IllegalStateException("controlled lifecycle restart"))
+      synchronizer.underlyingActor should not be theSameInstanceAs(oldActor)
+      oldTask.isCancelled shouldBe true
+      f.scheduler.tasks.size shouldBe 2
+      f.scheduler.tasks.last._3.isCancelled shouldBe false
+      f.scheduler.timePasses(2.seconds)
+      f.controllerProbe.expectMsgType[SendToNetwork]
+      f.controllerProbe.expectNoMessage(100.millis)
+      f.stop(synchronizer)
+      f.scheduler.tasks.forall(_._3.isCancelled) shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
NetworkController and PeerSynchronizer now retain and cancel their periodic scheduling handles when the owning actor stops or restarts. Repeated Bound notifications also avoid creating duplicate controller schedules. Active intervals and callback behavior remain unchanged.

Validation: JDK 8, Scala 2.12.20; 18 tests pass across controller and lifecycle suites. Five new regressions fail against the original actors. Local scheduler fixtures exercise active handles, stop cancellation, restart replacement and duplicate Bound handling. Independent source and test review completed.

Cancellation prevents future scheduled invocations; it does not retract an already executing callback or an in-flight request. This is separate from the database-close correction in [#2449](https://github.com/ergoplatform/ergo/pull/2449).

All eight checks pass on the current head: [CI results](https://github.com/ergoplatform/ergo/actions/runs/34066262265).
