### PR TITLE
Restore durable ExtraIndexer checkpoint recovery

### DIFF
--- a/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/DeepRollBackSpec.scala
@@ -3,12 +3,14 @@ package org.ergoplatform.it
 import java.io.File
 import java.util.concurrent.TimeoutException
 import com.typesafe.config.Config
-import org.ergoplatform.it.api.NodeApi.NodeInfo
+import io.circe.Json
+import org.ergoplatform.it.api.NodeApi.{NodeInfo, nodeInfoDecoder}
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.freespec.AnyFreeSpec
 import scala.async.Async
-import scala.concurrent.{Await, Future, blocking}
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
@@ -45,41 +47,78 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
     .withFallback(nonGeneratingPeerConfig)
     .withFallback(allowLocalConfig)
 
+  private val observations = new ConvergenceObservations
+  private case class NodeSnapshot(info: Option[NodeInfo])
+  private val probes = scala.collection.mutable.Map.empty[
+    Node, (observations.Probe[NodeInfo], observations.Probe[Int])]
+
+  @volatile private var lastObservation = "No node pair observed"
+  private var recentObservations = Vector.empty[String]
+
+  private def remember(phase: String, label: String, endpoint: String, summary: String): Unit = synchronized {
+    val observation = s"$phase $label $endpoint sampledAt=${System.currentTimeMillis()} $summary"
+    recentObservations = (recentObservations :+ observation).takeRight(12)
+    lastObservation = recentObservations.mkString("; ")
+    log.info(observation)
+  }
+
+  private def snapshot(phase: String, label: String, node: Node, budget: FiniteDuration): Future[NodeSnapshot] = {
+    val (statusProbe, peerProbe) = probes.getOrElseUpdate(node, (
+      observations.probe(node.singleGet("/info", _.setRequestTimeout(5000))
+        .map { r =>
+          require(r.getStatusCode == 200, "Unexpected observation status")
+          node.ergoJsonAnswerAs[NodeInfo](r.getResponseBody)
+        }),
+      observations.probe(node.singleGet("/peers/connected", _.setRequestTimeout(5000)).map { r =>
+        require(r.getStatusCode == 200, "Unexpected observation status")
+        node.ergoJsonAnswerAs[Json](r.getResponseBody).asArray.getOrElse(
+          throw new IllegalArgumentException("Expected peer array")).size
+      })
+    ))
+    val status = statusProbe.sample(budget).map {
+      case Right(info) =>
+        val summary = Json.obj(
+          "headersHeight" -> info.bestHeaderHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "fullHeight" -> info.bestBlockHeightOpt.map(Json.fromInt).getOrElse(Json.Null),
+          "bestHeaderId" -> info.bestHeaderIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null),
+          "bestFullHeaderId" -> info.bestBlockIdOpt.map(ConvergenceObservations.headerId).map(Json.fromString).getOrElse(Json.Null)
+        )
+        remember(phase, label, "status", summary.noSpaces)
+        Some(info)
+      case Left(error) =>
+        remember(phase, label, "status", s"errorClass=$error")
+        None
+    }
+    val peers = peerProbe.sample(budget).map { result =>
+      val summary = result.fold(error => s"errorClass=$error", count => s"connectedPeerCount=$count")
+      remember(phase, label, "peers", summary)
+    }
+    status.zip(peers).map { case (info, _) => NodeSnapshot(info) }
+  }
+
+  private def observeNodes(
+    phase: String,
+    nodeA: Node,
+    nodeB: Node,
+    budget: FiniteDuration = 5.seconds
+  ): Future[(NodeSnapshot, NodeSnapshot)] = {
+    snapshot(phase, "A", nodeA, budget).zip(snapshot(phase, "B", nodeB, budget))
+  }
+
   private def waitForSameBestBlock(
     nodeA: Node,
     nodeB: Node,
     minHeight: Int,
     timeout: FiniteDuration
   ): Future[(NodeInfo, NodeInfo)] = {
-    def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo): Boolean = {
-      val sameHeight =
-        infoA.bestBlockHeightOpt.nonEmpty &&
-          infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
-      val sameBlock =
-        infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
-      val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
-      sameHeight && sameBlock && highEnough
-    }
-
-    def retryAfterDelay(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      Future {
-        blocking(Thread.sleep(1000))
-      }.flatMap(_ => loop(deadline))
-
-    def loop(deadline: Deadline): Future[(NodeInfo, NodeInfo)] =
-      nodeA.info.zip(nodeB.info).flatMap { case (infoA, infoB) =>
-        if (sameBestBlock(infoA, infoB)) {
-          Future.successful((infoA, infoB))
-        } else if (deadline.isOverdue()) {
-          Future.failed(new TimeoutException(
-            s"Nodes did not converge to the same best full block at height >= $minHeight"
-          ))
-        } else {
-          retryAfterDelay(deadline)
-        }
-      }
-
-    loop(timeout.fromNow)
+    observations.until(timeout.fromNow, 1.second, 5.seconds)(
+      budget => observeNodes("convergence", nodeA, nodeB, budget)
+    ) { case (a, b) =>
+      a.info.exists(infoA => b.info.exists(infoB => ConvergenceObservations.sameBestBlock(infoA, infoB, minHeight)))
+    }(
+      s"Nodes did not converge to the same best full block at height >= $minHeight; " +
+        s"recent observations: $lastObservation"
+    ).map { case (a, b) => (a.info.get, b.info.get) }
   }
 
   "Deep rollback handling" in {
@@ -107,6 +146,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       log.info("heightB: " + minerBGenBestHeight)
 
       genesisAGen shouldBe genesisBGen
+      Async.await(observeNodes("initial shared chain", minerAGen, minerBGen))
 
       // 2. Stop all nodes
       docker.stopNode(minerAGen.containerId)
@@ -120,6 +160,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerBIsolated: Node = docker.startDevNetNode(minerBConfig, isolatedPeersConfig,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
+      Async.await(observeNodes("isolated miners started", minerAIsolated, minerBIsolated))
 
       // 2. Let nodeB mine `chainLength` blocks in isolation
       Async.await(minerBIsolated.waitForHeight(chainLength, 100.millis))
@@ -128,6 +169,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerABestHeight = Async.await(minerAIsolated.fullHeight)
       val minerBBestHeight = Async.await(minerBIsolated.fullHeight)
+      Async.await(observeNodes("isolated mining complete", minerAIsolated, minerBIsolated))
 
       docker.stopNode(minerAIsolated.containerId)
       docker.stopNode(minerBIsolated.containerId)
@@ -143,7 +185,7 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
 
       val minerB: Node = docker.startDevNetNode(minerBConfigNonGen,
         specialVolumeOpt = Some((localVolumeB, remoteVolumeB))).get
-
+      Async.await(observeNodes("restarted without mining", minerA, minerB))
 
       val isMiningAOpt = Async.await(minerA.info).isMining
       log.info("isminingA: " + isMiningAOpt)
@@ -162,7 +204,15 @@ class DeepRollBackSpec extends AnyFreeSpec with IntegrationSuite {
       minerBInfo.bestBlockIdOpt shouldEqual minerAInfo.bestBlockIdOpt
     }
 
-    Await.result(result, 20.minutes)
+    try {
+      Await.result(result, 20.minutes)
+    } catch {
+      case error: TimeoutException =>
+        log.error(s"Deep rollback timed out; last observation: $lastObservation")
+        throw error
+    } finally {
+      observations.close()
+    }
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -75,7 +75,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   private var syncInfoV1CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV1)] = Option.empty
 
-  private var syncInfoV2CacheByHeadersHeight: Option[(Int, ErgoSyncInfoV2)] = Option.empty
+  private val syncInfoV2Cache = new SyncInfoV2Cache
 
   private val networkSettings: NetworkSettings = settings.scorexSettings.network
 
@@ -315,14 +315,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 
   /** Get V2 sync info from cache or load it from history and add to cache */
   private def getV2SyncInfo(history: ErgoHistory, full: Boolean): ErgoSyncInfoV2 = {
-    val headersHeight = history.headersHeight
-    syncInfoV2CacheByHeadersHeight
-      .collect { case (height, syncInfo) if height == headersHeight => syncInfo }
-      .getOrElse {
-        val v2SyncInfo = history.syncInfoV2(full)
-        syncInfoV2CacheByHeadersHeight = Some(headersHeight -> v2SyncInfo)
-        v2SyncInfo
-      }
+    syncInfoV2Cache.getOrElseUpdate(history.bestHeaderIdOpt, full)(history.syncInfoV2(full))
   }
 
   /**
@@ -1658,6 +1651,22 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
 }
 
 object ErgoNodeViewSynchronizer {
+
+  /** Single-entry cache owned by the synchronizer actor. */
+  private[network] final class SyncInfoV2Cache {
+    private var cached: Option[(Option[ModifierId], Boolean, ErgoSyncInfoV2)] = None
+
+    def getOrElseUpdate(bestHeaderId: Option[ModifierId], full: Boolean)
+                       (build: => ErgoSyncInfoV2): ErgoSyncInfoV2 = {
+      cached.collect {
+        case (tip, mode, info) if tip == bestHeaderId && mode == full => info
+      }.getOrElse {
+        val info = build
+        cached = Some((bestHeaderId, full, info))
+        info
+      }
+    }
+  }
 
   private def props(networkControllerRef: ActorRef,
             viewHolderRef: ActorRef,

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistory.scala
@@ -4,18 +4,23 @@ import akka.actor.ActorContext
 import org.ergoplatform.consensus.ProgressInfo
 
 import java.io.File
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.charset.StandardCharsets
 import org.ergoplatform.mining.AutolykosPowScheme
 import org.ergoplatform.modifiers.history._
 import org.ergoplatform.modifiers.history.header.{Header, PreGenesisHeader}
-import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock, ErgoNodeViewModifier, NonHeaderBlockSection}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.StartExtraIndexer
-import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{IndexedHeightKey, NewestVersion, NewestVersionBytes, SchemaVersionKey, getIndex}
+import org.ergoplatform.nodeView.history.extra.ExtraIndexer.{GlobalBoxIndexKey, GlobalTxIndexKey, IndexedHeaderIdKey,
+  IndexedHeightKey, NewestVersion, NewestVersionBytes, RollbackToKey, SchemaVersionKey}
+import org.ergoplatform.nodeView.history.extra.{IndexedErgoBox, IndexedErgoTransaction, NumericBoxIndex, NumericTxIndex}
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.history.storage.modifierprocessors._
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{Algos, ErgoSettings}
 import org.ergoplatform.utils.LoggingUtil
 import org.ergoplatform.validation.RecoverableModifierError
-import scorex.util.{ModifierId, ScorexLogging, idToBytes}
+import scorex.db.ByteArrayWrapper
+import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 
 import scala.util.{Failure, Success, Try}
 
@@ -265,12 +270,113 @@ object ErgoHistory extends ScorexLogging {
     var db = HistoryStorage(ergoSettings)
 
     // ExtraIndexer db check
-    if(ergoSettings.nodeSettings.extraIndex) { // check db schema
-      val schemaVersion: Int = getIndex(SchemaVersionKey, db).getInt
-      if (schemaVersion != NewestVersion) {
-        if(getIndex(IndexedHeightKey, db).getInt > 0)
-          db = db.deleteExtraDB(ergoSettings) // older schema -> delete and reopen db
-        db.insertExtra(Array((SchemaVersionKey, NewestVersionBytes)), Array.empty) // update version key
+    if(ergoSettings.nodeSettings.extraIndex) { // check db schema and checkpoint provenance
+      def storedBytes(key: Array[Byte]): Option[Array[Byte]] = db.modifierBytesById(bytesToId(key))
+      def intValue(bytesOpt: Option[Array[Byte]]): Option[Int] = bytesOpt
+        .filter(_.length == Integer.BYTES)
+        .map(bytes => ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getInt)
+      def longValue(bytesOpt: Option[Array[Byte]]): Option[Long] = bytesOpt
+        .filter(_.length == java.lang.Long.BYTES)
+        .map(bytes => ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getLong)
+
+      val schemaVersionBytesOpt = storedBytes(SchemaVersionKey)
+      val indexedHeightBytesOpt = storedBytes(IndexedHeightKey)
+      val globalTxIndexBytesOpt = storedBytes(GlobalTxIndexKey)
+      val globalBoxIndexBytesOpt = storedBytes(GlobalBoxIndexKey)
+      val rollbackToBytesOpt = storedBytes(RollbackToKey)
+      val schemaVersionOpt = intValue(schemaVersionBytesOpt)
+      val indexedHeightOpt = intValue(indexedHeightBytesOpt)
+      val globalTxIndexOpt = longValue(globalTxIndexBytesOpt)
+      val globalBoxIndexOpt = longValue(globalBoxIndexBytesOpt)
+      val rollbackToOpt = intValue(rollbackToBytesOpt)
+      val indexedHeight = indexedHeightOpt.getOrElse(0)
+      val globalTxIndex = globalTxIndexOpt.getOrElse(0L)
+      val globalBoxIndex = globalBoxIndexOpt.getOrElse(0L)
+      val rollbackTo = rollbackToOpt.getOrElse(0)
+      val indexedHeaderIdBytesOpt = db.modifierBytesById(bytesToId(IndexedHeaderIdKey))
+      val indexedHeaderOpt = indexedHeaderIdBytesOpt
+        .filter(_.length == ErgoNodeViewModifier.ModifierIdSize)
+        .flatMap { idBytes =>
+        val id = bytesToId(idBytes)
+        val validityKey = ByteArrayWrapper(Algos.hash("validity".getBytes(StandardCharsets.UTF_8) ++ idToBytes(id)))
+        val isValid = db.getIndex(validityKey).exists(_.sameElements(Array(1.toByte)))
+        if (isValid) db.modifierById(id).collect {
+          case header: Header if header.height == indexedHeight && header.id == id => header
+        } else None
+      }
+      val terminalRowsMatchCheckpoint = indexedHeaderOpt.exists { header =>
+        if (globalTxIndex <= 0 || globalBoxIndex <= 0) {
+          false
+        } else {
+          db.modifierById(header.transactionsId).collect {
+            case transactions: BlockTransactions if transactions.headerId == header.id =>
+              val lastTx = transactions.txs.last
+              val lastTxIndex = globalTxIndex - 1
+              val firstTxBoxIndex = globalBoxIndex - lastTx.outputs.size
+              val expectedOutputNums = Array.tabulate(lastTx.outputs.size)(i => firstTxBoxIndex + i)
+              val expectedInputNumsOpt = if (header.height <= 1) {
+                Some(Array.fill[Long](lastTx.inputs.size)(0L))
+              } else {
+                val inputNums = lastTx.inputs.map { input =>
+                  val inputId = bytesToId(input.boxId)
+                  db.getExtraIndex(inputId).collect {
+                    case box: IndexedErgoBox
+                      if box.id == inputId && box.spendingTxIdOpt.contains(lastTx.id) &&
+                        box.spendingHeightOpt.contains(header.height) => box.globalIndex
+                  }
+                }
+                if (inputNums.forall(_.isDefined)) Some(inputNums.flatten.toArray) else None
+              }
+              val numericTxMatches = db.getExtraIndex(bytesToId(NumericTxIndex.indexToBytes(lastTxIndex))).exists {
+                case NumericTxIndex(index, id) => index == lastTxIndex && id == lastTx.id
+                case _ => false
+              }
+              val indexedTxMatches = db.getExtraIndex(lastTx.id).exists {
+                case tx: IndexedErgoTransaction =>
+                  tx.txid == lastTx.id && tx.globalIndex == lastTxIndex && tx.height == header.height &&
+                    tx.index == transactions.txs.size - 1 && tx.size == lastTx.size &&
+                    expectedInputNumsOpt.exists(expected => tx.inputNums.sameElements(expected)) &&
+                    tx.outputNums.sameElements(expectedOutputNums) && tx.dataInputs.sameElements(lastTx.dataInputs)
+                case _ => false
+              }
+              val outputRowsMatch = expectedOutputNums.zip(lastTx.outputs).forall { case (boxIndex, output) =>
+                val boxId = bytesToId(output.id)
+                val numericBoxMatches = db.getExtraIndex(bytesToId(NumericBoxIndex.indexToBytes(boxIndex))).exists {
+                  case NumericBoxIndex(index, id) => index == boxIndex && id == boxId
+                  case _ => false
+                }
+                val indexedBoxMatches = db.getExtraIndex(boxId).exists {
+                  case box: IndexedErgoBox =>
+                    box.globalIndex == boxIndex && box.inclusionHeight == header.height && box.id == boxId &&
+                      box.spendingTxIdOpt.isEmpty && box.spendingHeightOpt.isEmpty && box.spendingProofOpt.isEmpty
+                  case _ => false
+                }
+                numericBoxMatches && indexedBoxMatches
+              }
+              numericTxMatches && indexedTxMatches && outputRowsMatch
+          }.contains(true)
+        }
+      }
+      val numericValuesAreWellFormed = Seq(
+        indexedHeightBytesOpt.forall(_.length == Integer.BYTES),
+        globalTxIndexBytesOpt.forall(_.length == java.lang.Long.BYTES),
+        globalBoxIndexBytesOpt.forall(_.length == java.lang.Long.BYTES),
+        rollbackToBytesOpt.forall(_.length == Integer.BYTES)
+      ).forall(identity)
+      val valuesAreNonNegative = indexedHeight >= 0 && globalTxIndex >= 0 && globalBoxIndex >= 0 && rollbackTo >= 0
+      val emptyCheckpoint = indexedHeight == 0 && globalTxIndex == 0 && globalBoxIndex == 0 &&
+        rollbackTo == 0 && indexedHeaderIdBytesOpt.isEmpty
+      val nonEmptyCheckpoint = indexedHeight > 0 && Seq(indexedHeightOpt, globalTxIndexOpt, globalBoxIndexOpt, rollbackToOpt)
+        .forall(_.isDefined) && rollbackTo == 0 && terminalRowsMatchCheckpoint
+      val checkpointIsValid = schemaVersionOpt.contains(NewestVersion) && numericValuesAreWellFormed &&
+        valuesAreNonNegative && (emptyCheckpoint || nonEmptyCheckpoint)
+      if (!checkpointIsValid) {
+        val freshDb = db.deleteExtraDBTry(ergoSettings).get
+        freshDb.insertExtraTry(Array((SchemaVersionKey, NewestVersionBytes)), Array.empty).recoverWith { case error =>
+          Try(freshDb.close()).failed.foreach(error.addSuppressed)
+          Failure(error)
+        }.get
+        db = freshDb
       }
     }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/ErgoHistoryReader.scala
@@ -403,8 +403,14 @@ trait ErgoHistoryReader
       }
 
       val headers = offsets.flatMap(offset => bestHeaderAtHeight(h - offset))
+      // Keep a shared starting point in full summaries when it is available locally.
+      val genesisAnchor = if (full) {
+        bestHeaderAtHeight(GenesisHeight).filterNot(genesis => headers.exists(_.id == genesis.id)).toSeq
+      } else {
+        Seq.empty
+      }
 
-      ErgoSyncInfoV2(headers)
+      ErgoSyncInfoV2(headers.toSeq ++ genesisAnchor)
     }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
@@ -1,7 +1,8 @@
 package org.ergoplatform.nodeView.history.extra
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash}
+import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash, Timers}
 import org.ergoplatform.{ErgoAddress, ErgoAddressEncoder, GlobalConstants, Pay2SAddress}
+import org.ergoplatform.consensus.ModifierSemanticValidity
 import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
@@ -13,6 +14,7 @@ import org.ergoplatform.nodeView.history.extra.IndexedContractTemplateSerializer
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
 import org.ergoplatform.nodeView.history.extra.IndexedTokenSerializer.uniqueId
 import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.history.storage.modifierprocessors.FullBlockProcessor
 import org.ergoplatform.settings.{Algos, CacheSettings, ChainSettings}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import sigma.ast.ErgoTree
@@ -27,19 +29,27 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable
 import scala.collection.concurrent
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
 
 /**
   * Base trait for extra indexer actor and its test.
   */
-trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
+trait ExtraIndexerBase extends Actor with Stash with Timers with ScorexLogging {
+
+  private case class RetryIndex(generation: Long)
+  private case object RetryIndexTimerKey
+  private case class RollbackToHeader(header: Header, resume: Boolean)
+  private var retryGeneration: Long = 0L
+  private var persistencePending: Boolean = false
 
   private implicit val ec: ExecutionContextExecutor = context.dispatcher
 
   /**
     * Max buffer size (determined by config)
     */
-  protected val saveLimit: Int
+  protected def saveLimit: Int
 
   /**
     * Number of transaction/box numeric indexes object segments contain
@@ -62,16 +72,56 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
 
   protected def historyStorage: HistoryStorage = _history.historyStorage
 
+  protected def fullChainHeaderAtHeight(height: Int): Option[Header] = {
+    _history.headerIdsAtHeight(height)
+      .find { id =>
+        FullBlockProcessor.isInBestFullChain(historyStorage, id) &&
+          _history.isSemanticallyValid(id) == ModifierSemanticValidity.Valid
+      }
+      .flatMap(id => _history.typedModifierById[Header](id))
+  }
+
+  protected def blockTransactionsForHeader(header: Header): Option[BlockTransactions] = {
+    history.typedModifierById[BlockTransactions](header.transactionsId)
+  }
+
+  protected def retryDelay: FiniteDuration = 1.second
+
+  private def scheduleRetry(): Unit = {
+    if (!timers.isTimerActive(RetryIndexTimerKey)) {
+      retryGeneration += 1
+      timers.startSingleTimer(RetryIndexTimerKey, RetryIndex(retryGeneration), retryDelay)
+    }
+  }
+
+  private def cancelRetry(): Unit = {
+    retryGeneration += 1
+    timers.cancel(RetryIndexTimerKey)
+  }
+
+  protected def resetTransientState(): Unit = {
+    cancelRetry()
+    blockCache.clear()
+    readingUpTo = 0
+  }
+
   /**
    * Used in tests to indicate the indexer has caught up to the chain
    */
   protected def caughtUpHook(height: Int = 0): Unit = {}
 
+  protected def continueCatchUpAfterIndex(state: IndexerState): Boolean = true
+
+  protected def stopIndexer(): Unit = context.stop(self)
+
+  protected def removeRollbackIndexes(ids: Array[ModifierId]): Try[Unit] =
+    historyStorage.removeExtraTry(ids)
+
   /**
    * Used in tests to get block for rollback, maybe orphan
    */
   protected def getLastTxForHeight(height: Int): ErgoTransaction = {
-    history.bestBlockTransactionsAt(height).get.txs.last
+    fullChainHeaderAtHeight(height).flatMap(blockTransactionsForHeader).get.txs.last
   }
 
   // fast access buffers
@@ -91,6 +141,13 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
     * Holds upcoming blocks to be indexed, and when empty, it is filled back from multiple threads
     */
   private val blockCache: concurrent.Map[Int, BlockTransactions] = new ConcurrentHashMap[Int, BlockTransactions]().asScala
+
+  private[extra] final def putBlockTransactionsInCache(
+    height: Int,
+    transactions: BlockTransactions
+  ): Unit =
+    blockCache.put(height, transactions)
+
   private var readingUpTo: Int = 0
 
   /**
@@ -100,8 +157,11 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
     * @param height - blockheight to get transations from
     * @return transactions at height
     */
-  private def getBlockTransactionsAt(height: Int): Option[BlockTransactions] = {
-    blockCache.remove(height).orElse(history.bestBlockTransactionsAt(height)).map { txs =>
+  private def getBlockTransactionsAt(height: Int, header: Header): Option[BlockTransactions] = {
+    val cached = blockCache.remove(height)
+    val txsOpt = cached.filter(_.headerId == header.id).orElse(blockTransactionsForHeader(header))
+
+    txsOpt.map { txs =>
       if (height % 1000 == 0) blockCache.keySet.filter(_ < height).map(blockCache.remove)
       if (readingUpTo - height < 300 && chainHeight - height > 1000) {
         readingUpTo = math.min(height + 1001, chainHeight)
@@ -111,7 +171,9 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
           blockNums.zip(blockNums.tail).map { range => // ranges of 250 blocks for each thread to read
             Future {
               (range._1 until range._2).foreach { blockNum =>
-                history.bestBlockTransactionsAt(blockNum).map(blockCache.put(blockNum, _))
+                fullChainHeaderAtHeight(blockNum)
+                  .flatMap(blockTransactionsForHeader)
+                  .map(putBlockTransactionsInCache(blockNum, _))
               }
             }
           }
@@ -119,7 +181,9 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
           val blockNums = height + 1 to readingUpTo
           Future {
             blockNums.foreach { blockNum =>
-              history.bestBlockTransactionsAt(blockNum).map(blockCache.put(blockNum, _))
+              fullChainHeaderAtHeight(blockNum)
+                .flatMap(blockTransactionsForHeader)
+                .map(putBlockTransactionsInCache(blockNum, _))
             }
           }
         }
@@ -240,64 +304,67 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
   /**
     * Write buffered indexes to database and clear buffers.
     */
-  private def saveProgress(state: IndexerState): Unit = {
-
+  private def saveProgress(state: IndexerState): Try[Unit] = Try {
+    persistencePending = true
     val start: Long = System.currentTimeMillis
 
-    // perform segmentation on big addresses and save their internal segment buffer
     trees.values.foreach { tree =>
       tree.buffer.values.foreach(seg => segments.put(seg.id, seg))
       tree.splitToSegments.foreach(seg => segments.put(seg.id, seg))
     }
-
     templates.values.foreach { template =>
       template.buffer.values.foreach(seg => segments.put(seg.id, seg))
       template.splitToSegments.foreach(seg => segments.put(seg.id, seg))
     }
-
-    // perform segmentation on big tokens and save their internal segment buffer
     tokens.values.foreach { token =>
       token.buffer.values.foreach(seg => segments.put(seg.id, seg))
       token.splitToSegments.foreach(seg => segments.put(seg.id, seg))
     }
 
-    // insert modifiers and progress info to db
-    historyStorage.insertExtra(
+    val indexedHeaderEntry = state.indexedHeaderId.map { id =>
+      IndexedHeaderIdKey -> fastIdToBytes(id)
+    }.toArray
+    val objects = (general.iterator ++ boxes.valuesIterator ++ trees.valuesIterator ++
+      templates.valuesIterator ++ tokens.valuesIterator ++ segments.valuesIterator).toArray
+    historyStorage.insertExtraTry(
       Array(
         (IndexedHeightKey, ByteBuffer.allocate(4).putInt(state.indexedHeight).array),
         (GlobalTxIndexKey, ByteBuffer.allocate(8).putLong(state.globalTxIndex).array),
         (GlobalBoxIndexKey, ByteBuffer.allocate(8).putLong(state.globalBoxIndex).array),
         (RollbackToKey, ByteBuffer.allocate(4).putInt(state.rollbackTo).array)
-      ),
-      (((((general ++= boxes.values) ++= trees.values) ++= templates.values) ++= tokens.values) ++= segments.values).toArray
-    )
+      ) ++ indexedHeaderEntry,
+      objects
+    ).recoverWith { case error =>
+      historyStorage.invalidateExtraCache(objects.iterator.map(_.id).toSeq)
+      Failure(error)
+    }.get
 
     log.debug(s"Processed ${trees.size} ErgoTrees with ${boxes.size} boxes and inserted them to database in ${System.currentTimeMillis - start}ms")
-
-    // clear buffers for next batch
     general.clear()
     boxes.clear()
     trees.clear()
     templates.clear()
     tokens.clear()
     segments.clear()
+    persistencePending = false
   }
 
   /**
     * Process a batch of BlockTransactions into memory and occasionally write them to database.
     *
     * @param state     - current indexer state
-    * @param headerOpt - header to index block transactions of (used after caught up with chain)
+    * @param header       - exact full-chain header to index
+    * @param targetHeight - full-chain height captured for this catch-up pass
     */
-  protected def index(state: IndexerState, headerOpt: Option[Header] = None): IndexerState = {
-    val btOpt = headerOpt.flatMap { header =>
-      history.typedModifierById[BlockTransactions](header.transactionsId)
-    }.orElse(getBlockTransactionsAt(state.indexedHeight))
-    val height = headerOpt.map(_.height).getOrElse(state.indexedHeight)
+  protected def index(state: IndexerState,
+                      header: Header,
+                      targetHeight: Int): Option[IndexerState] = {
+    val height = header.height
+    val btOpt = getBlockTransactionsAt(height, header)
 
     if (btOpt.isEmpty) {
       log.error(s"Could not read block $height / $chainHeight from database, waiting for new block until retrying")
-      return state.decrementIndexedHeight.copy(caughtUp = true)
+      return None
     }
 
     val txs: Seq[ErgoTransaction] = btOpt.get.txs
@@ -375,11 +442,10 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
 
     log.info(s"Buffered block $height / $chainHeight [txs: ${txs.length}, boxes: $boxCount] (buffer: $modCount / $saveLimit)")
 
-    val maxHeight = headerOpt.map(_.height).getOrElse(chainHeight)
-    newState.copy(
-      caughtUp = newState.indexedHeight == maxHeight,
-      indexedHeaderId = headerOpt.map(_.id).orElse(history.bestHeaderIdAtHeight(height))
-    )
+    Some(newState.copy(
+      caughtUp = newState.indexedHeight == targetHeight,
+      indexedHeaderId = Some(header.id)
+    ))
   }
 
   /**
@@ -388,15 +454,15 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
     * @param state  - current state of indexer
     * @param height - forking height (height of last common block)
     */
-  private def removeAfter(state: IndexerState, height: Int): IndexerState = {
+  private def removeAfter(state: IndexerState, targetHeader: Header): Try[IndexerState] = Try {
 
     var newState: IndexerState = state
+    val height = targetHeader.height
 
-    saveProgress(newState)
+    saveProgress(newState).get
     log.info(s"Rolling back indexes from ${state.indexedHeight} to $height")
 
-    try {
-      val lastTxToKeep: ErgoTransaction = getLastTxForHeight(height)
+      val lastTxToKeep: ErgoTransaction = blockTransactionsForHeader(targetHeader).get.txs.last
       val txTarget: Long = history.typedExtraIndexById[IndexedErgoTransaction](lastTxToKeep.id).get.globalIndex
       val boxTarget: Long = history.typedExtraIndexById[IndexedErgoBox](bytesToId(lastTxToKeep.outputs.last.id)).get.globalIndex
       val toRemove: ArrayBuffer[ModifierId] = ArrayBuffer.empty[ModifierId]
@@ -417,12 +483,12 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
           val template = history.typedExtraIndexById[IndexedContractTemplate](hashTreeTemplate(iEb.box.ergoTree)).get
           template.findAndModBox(iEb.globalIndex, history)
 
-          historyStorage.insertExtra(Array.empty, Array[ExtraIndex](iEb, address, template) ++ address.buffer.values ++ template.buffer.values)
+          historyStorage.insertExtraTry(Array.empty, Array[ExtraIndex](iEb, address, template) ++ address.buffer.values ++ template.buffer.values).get
 
           cfor(0)(_ < iEb.box.additionalTokens.length, _ + 1) { i =>
             history.typedExtraIndexById[IndexedToken](IndexedToken.fromBox(iEb, i).id).map { token =>
               token.findAndModBox(iEb.globalIndex, history)
-              historyStorage.insertExtra(Array.empty, Array[ExtraIndex](token) ++ token.buffer.values)
+              historyStorage.insertExtraTry(Array.empty, Array[ExtraIndex](token) ++ token.buffer.values).get
             }
           }
         }
@@ -460,61 +526,144 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
       newState = newState.incrementBoxIndex
 
       // Save changes
-      newState = newState.copy(
+      val completedState = newState.copy(
         indexedHeight = height,
         rollbackTo = 0,
-        caughtUp = state.caughtUp,
-        indexedHeaderId = history.bestHeaderIdAtHeight(height)
+        caughtUp = height == chainHeight && fullChainHeaderAtHeight(height).exists(_.id == targetHeader.id),
+        indexedHeaderId = Some(targetHeader.id)
       )
-      historyStorage.removeExtra(toRemove.toArray)
-      saveProgress(newState)
-    } catch {
-      case t: Throwable => log.error(s"removeAfter during rollback failed due to: ${t.getMessage}", t)
-    }
+      removeRollbackIndexes(toRemove.toArray).get
+      saveProgress(completedState).get
+      completedState
+  }
 
-    newState
+  private def indexedTipIsOnBestFullChain(state: IndexerState): Boolean = {
+    state.indexedHeight == 0 ||
+      (chainHeight >= state.indexedHeight &&
+        state.indexedHeaderId == fullChainHeaderAtHeight(state.indexedHeight).map(_.id))
+  }
+
+  private def reconcileIndexedTip(state: IndexerState): Boolean = {
+    val rollbackHeaderOpt = for {
+      indexedHeaderId <- state.indexedHeaderId
+      indexedHeader <- history.typedModifierById[Header](indexedHeaderId)
+      bestFullBlock <- history.bestFullBlockOpt
+      branchPointId <- history.chainToHeader(Some(indexedHeader), bestFullBlock.header)._1
+      branchHeader <- history.typedModifierById[Header](branchPointId)
+      if branchHeader.height < state.indexedHeight
+    } yield branchHeader
+
+    rollbackHeaderOpt.exists { branchHeader =>
+      beginRollback(state, branchHeader)
+      true
+    }
+  }
+
+  private def validatedRollbackHeader(state: IndexerState, branchPoint: ModifierId): Option[Header] = {
+    history.typedModifierById[Header](branchPoint).filter { header =>
+      header.height < state.indexedHeight &&
+        fullChainHeaderAtHeight(header.height).exists(_.id == header.id)
+    }
+  }
+
+  protected def beginRollback(state: IndexerState, targetHeader: Header, resume: Boolean = true): Unit = {
+    resetTransientState()
+    context.become(receive.orElse(loaded(state.copy(caughtUp = false, rollbackTo = targetHeader.height))))
+    self ! RollbackToHeader(targetHeader, resume)
+  }
+
+  private def persistBuffered(state: IndexerState): Boolean = {
+    saveProgress(state) match {
+      case Success(_) => true
+      case Failure(error) =>
+        log.error(s"Failed to persist extra indexes at height ${state.indexedHeight}; retrying", error)
+        scheduleRetry()
+        false
+    }
   }
 
   protected def loaded(state: IndexerState): Receive = {
 
+    // Segmentation mutates parent references before persistence. Flush those rows
+    // before either event-driven or self-driven indexing can consume them.
+    case Index() | _: FullBlockApplied if persistencePending && !state.rollbackInProgress =>
+      cancelRetry()
+      context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
+      if (persistBuffered(state)) self ! Index()
+
     case Index() if !state.caughtUp && !state.rollbackInProgress =>
-      val nextHeaderOpt = history.bestHeaderAtHeight(state.indexedHeight + 1)
-      val extendsIndexedTip = nextHeaderOpt.forall { header =>
-        state.indexedHeight == 0 || state.indexedHeaderId.contains(header.parentId)
-      }
-      if (extendsIndexedTip) {
-        val newState = index(state.incrementIndexedHeight)
-        if (modCount >= saveLimit) saveProgress(newState)
-        context.become(receive.orElse(loaded(newState)))
-        self ! Index()
-      } else {
-        log.info("Deferring catch-up because the next header does not extend the indexed tip")
+      cancelRetry()
+      if (modCount < saveLimit || persistBuffered(state)) {
+        if (state.indexedHeight == chainHeight && indexedTipIsOnBestFullChain(state)) {
+          val newState = state.copy(caughtUp = true)
+          context.become(receive.orElse(loaded(newState)))
+          self ! Index()
+        } else {
+          val nextHeaderOpt = fullChainHeaderAtHeight(state.indexedHeight + 1)
+          val extendsIndexedTip = nextHeaderOpt.forall { header =>
+            state.indexedHeight == 0 || state.indexedHeaderId.contains(header.parentId)
+          }
+          if (extendsIndexedTip && nextHeaderOpt.isDefined) {
+            index(state.incrementIndexedHeight, nextHeaderOpt.get, chainHeight) match {
+              case Some(newState) =>
+                context.become(receive.orElse(loaded(newState)))
+                if (continueCatchUpAfterIndex(newState)) self ! Index()
+              case None =>
+                scheduleRetry()
+            }
+          } else if (!reconcileIndexedTip(state)) {
+            log.info("Deferring catch-up because the next full-chain header does not extend the indexed tip")
+            scheduleRetry()
+          }
+        }
       }
 
-    case Index() if state.caughtUp =>
-      if (modCount > 0) saveProgress(state)
-      blockCache.clear()
-      caughtUpHook()
-      log.info("Indexer caught up with chain")
+    case Index() if state.caughtUp && !state.rollbackInProgress && !indexedTipIsOnBestFullChain(state) =>
+      if (!reconcileIndexedTip(state)) {
+        val newState = state.copy(caughtUp = false)
+        context.become(receive.orElse(loaded(newState)))
+        scheduleRetry()
+      }
+
+    case Index() if state.caughtUp && !state.rollbackInProgress =>
+      cancelRetry()
+      if (modCount == 0 || persistBuffered(state)) {
+        blockCache.clear()
+        caughtUpHook()
+        log.info("Indexer caught up with chain")
+      }
+
+    case Index() if state.rollbackInProgress =>
 
     // after the indexer caught up with the chain, stay up to date
     case FullBlockApplied(header: Header) if state.caughtUp && !state.rollbackInProgress =>
-      val indexedTipStillBest = state.indexedHeight == 0 ||
-        (chainHeight >= state.indexedHeight && state.indexedHeaderId.exists { indexedHeaderId =>
-          history.bestHeaderIdAtHeight(state.indexedHeight).contains(indexedHeaderId)
-        })
+      val indexedTipStillBest = indexedTipIsOnBestFullChain(state)
       val isDirectSuccessor = header.height == state.indexedHeight + 1 &&
         (state.indexedHeight == 0 || state.indexedHeaderId.contains(header.parentId)) &&
-        history.bestHeaderIdAtHeight(header.height).contains(header.id)
+        fullChainHeaderAtHeight(header.height).exists(_.id == header.id)
 
       if (isDirectSuccessor) {
-        val newState: IndexerState = index(state.incrementIndexedHeight, Some(header))
-        saveProgress(newState)
-        context.become(receive.orElse(loaded(newState)))
-        caughtUpHook(header.height)
+        cancelRetry()
+        val targetHeight = chainHeight
+        index(state.incrementIndexedHeight, header, targetHeight) match {
+          case Some(newState) =>
+            context.become(receive.orElse(loaded(newState)))
+            if (newState.caughtUp) {
+              if (persistBuffered(newState)) caughtUpHook(header.height)
+            } else {
+              self ! Index()
+            }
+          case None =>
+            val newState = state.copy(caughtUp = false)
+            context.become(receive.orElse(loaded(newState)))
+            scheduleRetry()
+        }
       } else if (!indexedTipStillBest) {
-        log.info(s"Deferring block ${header.id} at height ${header.height} until rollback")
-        context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
+        log.info(s"Reconciling indexed tip before applying block ${header.id} at height ${header.height}")
+        if (!reconcileIndexedTip(state)) {
+          context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
+          scheduleRetry()
+        }
       } else if (header.height > state.indexedHeight + 1) {
         context.become(receive.orElse(loaded(state.copy(caughtUp = false))))
         self ! Index()
@@ -522,47 +671,56 @@ trait ExtraIndexerBase extends Actor with Stash with ScorexLogging {
         log.warn(s"Skipping block ${header.id} applied at height ${header.height}, indexed height is ${state.indexedHeight}")
       }
 
-    case _: FullBlockApplied if state.rollbackInProgress => stash()
-
-    // Resume catch-up when a block is applied while the indexer is behind.
-    // Without this the indexer can stall after logging "Deferring catch-up",
-    // because no Index() message is scheduled and further FullBlockApplied events
-    // are dropped while caughtUp = false.
-    case _: FullBlockApplied if !state.caughtUp && !state.rollbackInProgress =>
+    case _: FullBlockApplied if !state.rollbackInProgress =>
       self ! Index()
 
+    case _: FullBlockApplied if state.rollbackInProgress => stash()
+
     case Rollback(branchPoint: ModifierId) =>
+      cancelRetry()
       if (state.rollbackInProgress) {
         log.warn(s"Rollback already in progress")
         stash()
+      } else if (indexedTipIsOnBestFullChain(state)) {
+        log.info(s"Ignoring rollback to $branchPoint because the indexed tip is already on the best full chain")
+        if (!state.caughtUp) self ! Index()
       } else {
-        history.heightOf(branchPoint) match {
-          case Some(branchHeight) =>
-            if (branchHeight < state.indexedHeight) {
-              context.become(receive.orElse(loaded(state.copy(rollbackTo = branchHeight))))
-              self ! RemoveAfter(branchHeight)
-            } else if (!state.caughtUp) {
-              blockCache.clear()
-              readingUpTo = 0
-              self ! Index()
-            }
-          case None =>
-            log.error(s"No rollback height found for $branchPoint")
-            val newState = state.copy(rollbackTo = 0)
+        validatedRollbackHeader(state, branchPoint) match {
+          case Some(header) => beginRollback(state, header)
+          case None if !reconcileIndexedTip(state) =>
+            log.info(s"Deferring rollback to $branchPoint until the indexed tip can be reconciled with the best full chain")
+            val newState = state.copy(caughtUp = false, rollbackTo = 0)
             context.become(receive.orElse(loaded(newState)))
-            unstashAll()
+            scheduleRetry()
+          case None =>
         }
       }
 
-    case RemoveAfter(branchHeight: Int) if state.rollbackInProgress =>
+    case RollbackToHeader(targetHeader, resume)
+      if state.rollbackInProgress && state.rollbackTo == targetHeader.height =>
       blockCache.clear()
       readingUpTo = 0
-      val newState = removeAfter(state, branchHeight)
-      context.become(receive.orElse(loaded(newState)))
-      if (!newState.caughtUp && !newState.rollbackInProgress) self ! Index()
-      caughtUpHook()
-      log.info(s"Successfully rolled back indexes to $branchHeight")
-      unstashAll()
+      removeAfter(state, targetHeader) match {
+        case Success(newState) =>
+          context.become(receive.orElse(loaded(newState)))
+          if (resume && !newState.caughtUp) self ! Index()
+          caughtUpHook()
+          log.info(s"Successfully rolled back indexes to ${targetHeader.height}")
+          unstashAll()
+        case Failure(error) =>
+          log.error(s"Failed to roll back extra indexes to ${targetHeader.height}; stopping extra indexer until node restart", error)
+          stopIndexer()
+      }
+
+    case RollbackToHeader(_, _) =>
+
+    case RetryIndex(generation) if generation == retryGeneration && !state.rollbackInProgress =>
+      self ! Index()
+
+    case RetryIndex(_) =>
+
+    case RemoveAfter(branchHeight) =>
+      log.warn(s"Ignoring unsupported direct extra-index rollback request to height $branchHeight")
 
     case GetSegmentThreshold =>
       sender ! segmentThreshold
@@ -685,13 +843,14 @@ object ExtraIndexer {
   /**
     * Current newest database schema version. Used to force extra database resync.
     */
-  val NewestVersion: Int = 6
+  val NewestVersion: Int = 7
   val NewestVersionBytes: Array[Byte] = ByteBuffer.allocate(4).putInt(NewestVersion).array
 
   val IndexedHeightKey: Array[Byte] = Algos.hash("indexed height")
   val GlobalTxIndexKey: Array[Byte] = Algos.hash("txns height")
   val GlobalBoxIndexKey: Array[Byte] = Algos.hash("boxes height")
   val RollbackToKey: Array[Byte] = Algos.hash("rollback to")
+  val IndexedHeaderIdKey: Array[Byte] = Algos.hash("indexed header id")
   val SchemaVersionKey: Array[Byte] = Algos.hash("schema version")
 
   def getIndex(key: Array[Byte], history: HistoryStorage): ByteBuffer =

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedContractTemplate.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedContractTemplate.scala
@@ -27,7 +27,7 @@ case class IndexedContractTemplate(templateHash: ModifierId,
     if (boxCount == 0)
       toRemove += templateHash
     else
-      history.historyStorage.insertExtra(Array.empty, Array(this))
+      history.historyStorage.insertExtraTry(Array.empty, Array(this)).get
 
     toRemove.toArray
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedErgoAddress.scala
@@ -88,7 +88,7 @@ case class IndexedErgoAddress(treeHash: ModifierId,
     if (txCount == 0 && boxCount == 0)
       toRemove += treeHash // all segments empty after rollback, delete parent
     else
-      history.historyStorage.insertExtra(Array.empty, Array(this)) // save the changes made to this address
+      history.historyStorage.insertExtraTry(Array.empty, Array(this)).get // save the changes made to this address
 
     toRemove.toArray
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedToken.scala
@@ -53,7 +53,7 @@ case class IndexedToken(tokenId: ModifierId,
       toRemove += id // all segments empty after rollback, delete parent
       log.info(s"Removing token $tokenId because no more boxes are associated with it")
     } else
-      history.historyStorage.insertExtra(Array.empty, Array(this)) // save the changes made to this address
+      history.historyStorage.insertExtraTry(Array.empty, Array(this)).get // save the changes made to this address
 
     toRemove.toArray
   }

--- a/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexerState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexerState.scala
@@ -2,7 +2,9 @@ package org.ergoplatform.nodeView.history.extra
 
 import org.ergoplatform.nodeView.history.ErgoHistory
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer._
-import scorex.util.ModifierId
+import org.ergoplatform.modifiers.ErgoNodeViewModifier
+import org.ergoplatform.modifiers.history.header.Header
+import scorex.util.{ModifierId, bytesToId}
 
 /**
  * An immutable state for extra indexer
@@ -40,13 +42,19 @@ object IndexerState {
     val globalTxIndex = getIndex(GlobalTxIndexKey, history).getLong
     val globalBoxIndex = getIndex(GlobalBoxIndexKey, history).getLong
     val rollbackTo = getIndex(RollbackToKey, history).getInt
+    val indexedHeaderId = history.historyStorage
+      .modifierBytesById(bytesToId(IndexedHeaderIdKey))
+      .filter(_.length == ErgoNodeViewModifier.ModifierIdSize)
+      .map(bytesToId)
+      .filter(id => history.typedModifierById[Header](id).exists(_.height == indexedHeight))
     IndexerState(
       indexedHeight,
       globalTxIndex,
       globalBoxIndex,
       rollbackTo,
-      caughtUp = indexedHeight == history.fullBlockHeight,
-      indexedHeaderId = history.bestHeaderIdAtHeight(indexedHeight)
+      caughtUp = indexedHeight == history.fullBlockHeight &&
+        (indexedHeight == 0 || indexedHeaderId.isDefined),
+      indexedHeaderId = indexedHeaderId
     )
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
@@ -14,7 +14,8 @@ import scala.util.{Failure, Success, Try}
 import spire.syntax.all.cfor
 
 import java.io.File
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import scala.jdk.CollectionConverters.asScalaIteratorConverter
 
 /**
@@ -50,6 +51,20 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     Caffeine.newBuilder()
       .maximumSize(config.history.indexesCacheSize)
       .build[ByteArrayWrapper, Array[Byte]]
+
+  private val extraCacheLock = new ReentrantReadWriteLock()
+
+  private def withExtraCacheReadLock[A](body: => A): A = {
+    extraCacheLock.readLock().lock()
+    try body
+    finally extraCacheLock.readLock().unlock()
+  }
+
+  private def withExtraCacheWriteLock[A](body: => A): A = {
+    extraCacheLock.writeLock().lock()
+    try body
+    finally extraCacheLock.writeLock().unlock()
+  }
 
   private def cacheModifier(mod: BlockSection): Unit = mod.modifierTypeId match {
     case Header.modifierTypeId => headersCache.put(mod.id, mod)
@@ -89,7 +104,7 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
       }
     }
 
-  def getExtraIndex(id: ModifierId): Option[ExtraIndex] = {
+  def getExtraIndex(id: ModifierId): Option[ExtraIndex] = withExtraCacheReadLock {
     Option(extraCache.getIfPresent(id)) orElse extraStore.get(idToBytes(id)).flatMap { bytes =>
       ExtraIndexSerializer.parseBytesTry(bytes) match {
         case Success(pm) =>
@@ -150,16 +165,46 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
 
   def insertExtra(indexesToInsert: Array[(Array[Byte], Array[Byte])],
                   objectsToInsert: Array[ExtraIndex]): Unit = {
-    extraStore.insert(
-      objectsToInsert.map(mod => mod.serializedId),
-      objectsToInsert.map(mod => ExtraIndexSerializer.toBytes(mod))
-    )
-    cfor(0)(_ < indexesToInsert.length, _ + 1) { i => extraStore.insert(indexesToInsert(i)._1, indexesToInsert(i)._2)}
+    insertExtraTry(indexesToInsert, objectsToInsert).failed.foreach { error =>
+      log.error("Failed to insert extra indexes", error)
+    }
+  }
+
+  private[history] def invalidateExtraCache(ids: Iterable[ModifierId]): Unit = withExtraCacheWriteLock {
+    ids.foreach(extraCache.invalidate)
+  }
+
+  def insertExtraTry(indexesToInsert: Array[(Array[Byte], Array[Byte])],
+                     objectsToInsert: Array[ExtraIndex]): Try[Unit] = {
+    val objectIds = objectsToInsert.iterator.flatMap(obj => Try(obj.id).toOption).toArray
+    Try {
+      val keys = objectsToInsert.map(_.serializedId) ++ indexesToInsert.map(_._1)
+      val values = objectsToInsert.map(ExtraIndexSerializer.toBytes) ++ indexesToInsert.map(_._2)
+      keys -> values
+    }.flatMap { case (keys, values) =>
+      withExtraCacheWriteLock {
+        extraStore.insert(keys, values).map { _ =>
+          objectIds.foreach(extraCache.invalidate)
+        }
+      }
+    }.recoverWith { case error =>
+      invalidateExtraCache(objectIds)
+      Failure(error)
+    }
   }
 
   def removeExtra(indexesToRemove: Array[ModifierId]) : Unit = {
-    extraStore.remove(indexesToRemove.map(idToBytes))
-    cfor(0)(_ < indexesToRemove.length, _ + 1) { i => removeModifier(indexesToRemove(i)) }
+    removeExtraTry(indexesToRemove).failed.foreach { error =>
+      log.error("Failed to remove extra indexes", error)
+    }
+  }
+
+  def removeExtraTry(indexesToRemove: Array[ModifierId]): Try[Unit] = {
+    withExtraCacheWriteLock {
+      extraStore.remove(indexesToRemove.map(idToBytes)).map { _ =>
+        cfor(0)(_ < indexesToRemove.length, _ + 1) { i => removeModifier(indexesToRemove(i)) }
+      }
+    }
   }
 
   /**
@@ -205,26 +250,37 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     * Delete the extra index database and reopen it.
     *
     * @param ergoSettings - settings to use
-    * @return new HistoryStorage instance with empty extra database, or this instance in case of failure
+    * @return new HistoryStorage instance with an empty extra database
     */
-  def deleteExtraDB(ergoSettings: ErgoSettings): HistoryStorage = {
+  def deleteExtraDB(ergoSettings: ErgoSettings): HistoryStorage =
+    deleteExtraDBTry(ergoSettings).get
+
+  /**
+    * Delete the extra index database and reopen it, preserving deletion failures.
+    */
+  def deleteExtraDBTry(ergoSettings: ErgoSettings): Try[HistoryStorage] = {
     log.warn(s"Removing extra index database due to old schema.")
-    close()
-    // org.ergoplatform.wallet.utils.FileUtils
     val root = new File(s"${ergoSettings.directory}/history/extra")
-    if (root.exists()) {
-      Files.walk(root.toPath).iterator().asScala.toSeq.reverse.foreach(path => Try(Files.delete(path)))
-    }else {
-      log.error(s"Could not delete ${root.toString}")
-      return this
+    Try(close()).flatMap { _ =>
+      HistoryStorage.deleteRecursively(root.toPath, Files.delete)
+    }.map { _ =>
+      log.info(s"Deleted ${root.toString}")
+      HistoryStorage.apply(ergoSettings)
     }
-    log.info(s"Deleted ${root.toString}")
-    HistoryStorage.apply(ergoSettings)
   }
 
 }
 
 object HistoryStorage {
+  private[storage] def deleteRecursively(root: Path, deletePath: Path => Unit): Try[Unit] = Try {
+    if (Files.exists(root)) {
+      val paths = Files.walk(root)
+      try paths.iterator().asScala.toSeq.reverse.foreach(deletePath)
+      finally paths.close()
+    }
+    require(!Files.exists(root), s"Could not delete $root")
+  }
+
   def apply(ergoSettings: ErgoSettings): HistoryStorage = {
     val indexStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/index")
     val objectsStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/objects")

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -6,6 +6,7 @@ import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.modifiers.{BlockSection, ErgoFullBlock}
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.settings.Algos
 import scorex.db.ByteArrayWrapper
 import scorex.util.{ModifierId, bytesToId, idToBytes}
@@ -24,9 +25,8 @@ trait FullBlockProcessor extends HeadersProcessor {
 
   private var nonBestChainsCache = FullBlockProcessor.emptyCache
 
-  def isInBestFullChain(id: ModifierId): Boolean = historyStorage.getIndex(chainStatusKey(id))
-    .map(ByteArrayWrapper.apply)
-    .contains(ByteArrayWrapper(FullBlockProcessor.BestChainMarker))
+  def isInBestFullChain(id: ModifierId): Boolean =
+    FullBlockProcessor.isInBestFullChain(historyStorage, id)
 
   /**
     * Id of header that contains transactions and proofs
@@ -287,5 +287,13 @@ object FullBlockProcessor {
 
   def chainStatusKey(id: ModifierId): ByteArrayWrapper =
     ByteArrayWrapper(Algos.hash("main_chain".getBytes(CharsetName) ++ idToBytes(id)))
+
+  private[history] def isInBestFullChain(
+    historyStorage: HistoryStorage,
+    id: ModifierId
+  ): Boolean =
+    historyStorage.getIndex(chainStatusKey(id))
+      .map(ByteArrayWrapper.apply)
+      .contains(ByteArrayWrapper(BestChainMarker))
 
 }

--- a/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/network/ErgoNodeViewSynchronizerSpecification.scala
@@ -492,14 +492,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }
@@ -517,14 +519,16 @@ class ErgoNodeViewSynchronizerSpecification extends AnyPropSpec
 
       // we check that in case of neighbour with older history (it has more blocks),
       // sync message will be sent by our node (to get invs from the neighbour),
-      // sync message will consist of 4 headers
+      // sync message will contain the sampled headers followed by genesis
       synchronizer ! Message(ErgoSyncInfoMessageSpec, Left(msgBytes), Some(peer))
       ncProbe.fishForMessage(3 seconds) { case m =>
         m match {
           case stn: SendToNetwork =>
             val msg = stn.message
             val headers = msg.data.get.asInstanceOf[ErgoSyncInfoV2].lastHeaders
-            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode && headers.length == 4
+            msg.spec.messageCode == ErgoSyncInfoMessageSpec.messageCode &&
+              headers.map(_.id) == (Seq(0, 16, 128, 512)
+                .map(offset => localChain(localChain.size - offset - 1).id) :+ localChain.head.id)
           case _ => false
         }
       }

--- a/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/network/SyncInfoV2CacheSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.network
+
+import org.ergoplatform.network.ErgoNodeViewSynchronizer.SyncInfoV2Cache
+import org.ergoplatform.nodeView.history.ErgoSyncInfoV2
+import org.ergoplatform.utils.generators.ChainGenerator.genHeaderChain
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+class SyncInfoV2CacheSpec extends AnyPropSpec with Matchers {
+  private val headers = genHeaderChain(3, diffBitsOpt = None, useRealTs = false).headers
+  private val tip = headers.last
+  private val fullSummary = ErgoSyncInfoV2(Seq(tip, headers.head))
+  private val reducedSummary = ErgoSyncInfoV2(Seq(tip))
+
+  property("reuse a summary only for the same tip and requested mode") {
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+      cache.getOrElseUpdate(Some(tip.id), full) {
+        fail("An unchanged tip and mode should reuse the cached summary")
+      } shouldBe expected
+    }
+  }
+
+  property("alternating reduced and full requests preserves each requested summary") {
+    val cache = new SyncInfoV2Cache
+    Seq(false, true, false, true).foreach { full =>
+      val expected = if (full) fullSummary else reducedSummary
+      cache.getOrElseUpdate(Some(tip.id), full)(expected) shouldBe expected
+    }
+  }
+
+  property("a different best header at the same height replaces the cached summary") {
+    val otherTip = genHeaderChain(1, prefixOpt = Some(headers(1)),
+      diffBitsOpt = None, useRealTs = false).last
+    otherTip.height shouldBe tip.height
+    otherTip.id should not be tip.id
+
+    Seq(false, true).foreach { full =>
+      val cache = new SyncInfoV2Cache
+      val original = if (full) fullSummary else reducedSummary
+      val replacement = ErgoSyncInfoV2(if (full) Seq(otherTip, headers.head) else Seq(otherTip))
+      cache.getOrElseUpdate(Some(tip.id), full)(original) shouldBe original
+      cache.getOrElseUpdate(Some(otherTip.id), full)(replacement) shouldBe replacement
+      cache.getOrElseUpdate(Some(otherTip.id), full) {
+        fail("The replacement tip should now be cached")
+      } shouldBe replacement
+    }
+  }
+
+  property("empty history and populated history do not share cached summaries") {
+    val cache = new SyncInfoV2Cache
+    val empty = ErgoSyncInfoV2(Nil)
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+    cache.getOrElseUpdate(None, full = true) {
+      fail("An unchanged empty history should reuse its summary")
+    } shouldBe empty
+    cache.getOrElseUpdate(Some(tip.id), full = true)(fullSummary) shouldBe fullSummary
+    cache.getOrElseUpdate(None, full = true)(empty) shouldBe empty
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/SyncInfoV2HistorySpecification.scala
@@ -1,0 +1,146 @@
+package org.ergoplatform.nodeView.history
+
+import org.ergoplatform.consensus.ProgressInfo
+import org.ergoplatform.mining.AutolykosPowScheme
+import org.ergoplatform.modifiers.{BlockSection, NonHeaderBlockSection}
+import org.ergoplatform.modifiers.history.HeaderChain
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.HistoryTestHelpers.generateHistory
+import org.ergoplatform.utils.generators.ChainGenerator.{applyHeaderChain, genHeaderChain}
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+
+import scala.util.Try
+
+class SyncInfoV2HistorySpecification extends ErgoCorePropertyTest {
+
+  private def newHistory(): ErgoHistory =
+    generateHistory(
+      verifyTransactions = false,
+      stateType = StateType.Digest,
+      PoPoWBootstrap = false,
+      blocksToKeep = 0,
+      epochLength = 1000
+    )
+
+  private def checkRoundtrip(summary: ErgoSyncInfoV2): Unit = {
+    val bytes = ErgoSyncInfoSerializer.toBytes(summary)
+    val decoded = ErgoSyncInfoSerializer.parseBytes(bytes).asInstanceOf[ErgoSyncInfoV2]
+    decoded.lastHeaders.map(_.id) shouldBe summary.lastHeaders.map(_.id)
+    decoded.height shouldBe summary.height
+    ErgoSyncInfoSerializer.toBytes(decoded).sameElements(bytes) shouldBe true
+  }
+
+  // These snapshots exercise summary selection, not header or chain validity.
+  private def snapshotReader(headers: Seq[Header]): ErgoHistoryReader = new ErgoHistoryReader {
+    override protected[history] val historyStorage: HistoryStorage = null
+    override protected val settings: ErgoSettings = null
+    override val powScheme: AutolykosPowScheme = null
+    override protected def requireProofs: Boolean = false
+    override protected def process(m: NonHeaderBlockSection): Try[ProgressInfo[BlockSection]] =
+      fail("Summary snapshots do not process block sections")
+    override protected def validate(m: NonHeaderBlockSection): Try[Unit] =
+      fail("Summary snapshots do not validate block sections")
+    override def bestHeaderOpt: Option[Header] = headers.sortBy(_.height).lastOption
+    override def headersHeight: Int = bestHeaderOpt.map(_.height).getOrElse(0)
+    override def isEmpty: Boolean = headers.isEmpty
+    override def bestHeaderAtHeight(height: Int): Option[Header] = headers.find(_.height == height)
+  }
+
+  property("full and reduced sync summaries remain empty for empty history") {
+    val history = newHistory()
+    try {
+      Seq(true, false).foreach { full =>
+        val summary = history.syncInfoV2(full)
+        summary.lastHeaders shouldBe empty
+        summary.nonEmpty shouldBe false
+        summary.height shouldBe None
+        checkRoundtrip(summary)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("linear history summaries retain recent samples and exactly one genesis anchor") {
+    var history = newHistory()
+    try {
+      val chain = genHeaderChain(17, history, diffBitsOpt = None, useRealTs = false)
+      val expectedHeights = Seq(
+        1 -> Seq(1),
+        2 -> Seq(2, 1),
+        10 -> Seq(10, 1),
+        17 -> Seq(17, 1)
+      )
+      var appliedHeight = 0
+      expectedHeights.foreach { case (height, heights) =>
+        history = applyHeaderChain(history, HeaderChain(chain.headers.slice(appliedHeight, height)))
+        appliedHeight = height
+        history.headersHeight shouldBe height
+
+        val full = history.syncInfoV2(full = true)
+        val expectedIds = heights.map(h => chain.headers(h - 1).id)
+        full.lastHeaders.map(_.id) shouldBe expectedIds
+        full.lastHeaders.map(_.height) shouldBe heights
+        full.lastHeaders.head.id shouldBe history.bestHeaderOpt.get.id
+        full.lastHeaders.last.id shouldBe chain.head.id
+        full.lastHeaders.count(_.id == chain.head.id) shouldBe 1
+        full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+        full.lastHeaders.size should be <= 5
+        full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+        full.height shouldBe Some(height)
+        checkRoundtrip(full)
+
+        val reduced = history.syncInfoV2(full = false)
+        reduced.lastHeaders.map(_.id) shouldBe Seq(chain.headers(height - 1).id)
+        reduced.height shouldBe Some(height)
+        checkRoundtrip(reduced)
+      }
+    } finally {
+      history.closeStorage()
+    }
+  }
+
+  property("full summary snapshots preserve sparse samples and deduplicate the genesis anchor") {
+    val template = defaultHeaderGen.sample.get
+    val cases = Seq(
+      Seq(129, 113, 1),
+      Seq(513, 497, 385, 1),
+      Seq(600, 584, 472, 88, 1)
+    )
+    cases.foreach { heights =>
+      val headers = heights.map(height => template.copy(height = height))
+      val reader = snapshotReader(headers)
+      val full = reader.syncInfoV2(full = true)
+      full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+      full.lastHeaders.map(_.height) shouldBe heights
+      full.lastHeaders.count(_.height == 1) shouldBe 1
+      full.lastHeaders.map(_.id).distinct.size shouldBe full.lastHeaders.size
+      full.lastHeaders.size should be <= 5
+      full.lastHeaders.size should be <= ErgoSyncInfoSerializer.MaxHeadersAllowed
+      full.height shouldBe Some(heights.head)
+      checkRoundtrip(full)
+
+      val reduced = reader.syncInfoV2(full = false)
+      reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+      checkRoundtrip(reduced)
+    }
+  }
+
+  property("full summary preserves available samples when genesis is unavailable") {
+    val template = defaultHeaderGen.sample.get
+    val headers = Seq(600, 584, 472, 88).map(height => template.copy(height = height))
+    val reader = snapshotReader(headers)
+    reader.bestHeaderAtHeight(1) shouldBe None
+    val full = reader.syncInfoV2(full = true)
+    full.lastHeaders.map(_.id) shouldBe headers.map(_.id)
+    full.height shouldBe Some(600)
+    checkRoundtrip(full)
+    val reduced = reader.syncInfoV2(full = false)
+    reduced.lastHeaders.map(_.id) shouldBe Seq(headers.head.id)
+    checkRoundtrip(reduced)
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ChainGenerator.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ChainGenerator.scala
@@ -108,7 +108,9 @@ object ChainGenerator extends ErgoTestHelpers with Matchers {
       log.info(
         s"Block ${block.id} with ${block.transactions.size} transactions at height ${block.header.height} generated")
 
-      loop(state.applyModifier(block, None)(_ => ()).get, outToPassNext, Some(block.header), acc :+ block.id)(history)
+      val newState = state.applyModifier(block, None)(_ => ()).get
+      history.reportModifierIsValid(block).get
+      loop(newState, outToPassNext, Some(block.header), acc :+ block.id)(history)
     } else {
       acc
     }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerSpecification.scala
@@ -1,8 +1,10 @@
 package org.ergoplatform.nodeView.history.extra
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{Actor, ActorIdentity, ActorRef, ActorSystem, Identify, Props}
+import akka.testkit.TestProbe
 import org.ergoplatform.ErgoAddressEncoder
 import org.ergoplatform.http.api.SortDirection
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{RemoteBlockApplied, Rollback}
 import org.ergoplatform.nodeView.history.extra.ExtraIndexer.ReceivableMessages.Index
@@ -10,13 +12,17 @@ import org.ergoplatform.nodeView.history.extra.IndexedContractTemplateSerializer
 import org.ergoplatform.nodeView.history.extra.IndexedErgoAddressSerializer.hashErgoTree
 import org.ergoplatform.nodeView.history.extra.SegmentSerializer.{boxSegmentId, txSegmentId}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
-import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.settings.{ErgoSettings, NetworkType}
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import scorex.util.{ModifierId, bytesToId}
+import scorex.db.ByteArrayWrapper
 import spire.implicits.cfor
 
 import java.util.concurrent.locks.{Condition, ReentrantLock}
+import java.nio.ByteBuffer
+import java.nio.file.Files
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.reflect.ClassTag
@@ -31,6 +37,18 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   case class Reset()
   case class GenerateBetterChainTip()
   case class SetCaughtUp(caughtUp: Boolean)
+  case class CacheBlockTransactions(height: Int, transactions: BlockTransactions)
+  case class DeferNextHeaderOnce(height: Int)
+  case class DeferBlockTransactionsOnce(height: Int)
+  case class Reload()
+  case class ForceRollback(height: Int)
+  case class GetLoadedState()
+  case class FailNextRollbackRemoval(probe: ActorRef)
+  case class PauseBufferedCatchUpAt(height: Int, saveLimit: Int, probe: ActorRef)
+  case class ConfigureWriteFailure(phase: String, probe: ActorRef)
+  case class AllowWrites()
+  case class ReopenCheckpoint()
+  case class CheckpointSettings()
 
   type ID_LL = mutable.HashMap[ModifierId,(Long,Long)]
 
@@ -43,6 +61,19 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
 
   var _history: ErgoHistory = _
   def history: ErgoHistoryReader = _history.getReader
+
+  def fullChainHeaderAt(height: Int): Header = {
+    val bestFullBlock = history.bestFullBlockOpt.get
+    history.headerChainBack(bestFullBlock.height - height + 1, bestFullBlock.header, _.height == height)
+      .headers
+      .find(_.height == height)
+      .get
+  }
+
+  def fullChainTransactionsAt(height: Int): BlockTransactions = {
+    val header = fullChainHeaderAt(height)
+    history.typedModifierById[BlockTransactions](header.transactionsId).get
+  }
 
   val lock: ReentrantLock = new ReentrantLock()
   val done: Condition = lock.newCondition()
@@ -65,8 +96,8 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     val templates: ID_LL = mutable.HashMap[ModifierId, (Long, Long)]()
     val indexedTokens: ID_LL = mutable.HashMap[ModifierId, (Long, Long)]()
     cfor(1)(_ <= limit, _ + 1) { i =>
-      val header = history.headerIdsAtHeight(i).last
-      val block = history.getFullBlock(history.typedModifierById[Header](header).get)
+      val header = fullChainHeaderAt(i)
+      val block = history.getFullBlock(header)
       block.get.transactions.foreach { tx =>
         txsIndexed += 1
         if (i != 1) {
@@ -175,9 +206,8 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
       val (addresses, templates, indexedTokens, txsIndexed, boxesIndexed) = manualIndex(n)
 
       // perform rollback
-      indexer ! Rollback(history.bestHeaderIdAtHeight(n).get)
-      lock.lock()
-      done.await()
+      indexer ! ForceRollback(n)
+      awaitCondition(done)
       state = IndexerState.fromHistory(_history)
 
       // address balances
@@ -221,8 +251,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
       println(s"Generate to $n")
       indexer ! CreateDB(n)
       indexer ! Index()
-      lock.lock()
-      done.await()
+      awaitCondition(done)
 
       val (addresses, _, _, _, _) = manualIndex(n)
 
@@ -275,11 +304,438 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     indexer ! Reset()
   }
 
+  property("catches up past a direct block event when history is already ahead") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+
+    indexer ! ExtendDB(HEIGHT + 2)
+    awaitCondition(created)
+    val firstHeader = fullChainHeaderAt(HEIGHT + 1)
+    indexer ! RemoteBlockApplied(firstHeader, history.getFullBlock(firstHeader).get.transactions.map(_.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 2
+      state.indexedHeaderId shouldBe Some(fullChainHeaderAt(HEIGHT + 2).id)
+    }
+    indexer ! Reset()
+  }
+
+  property("restores the exact persisted indexed header after the best header changes") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+
+    val persistedState = IndexerState.fromHistory(_history)
+    persistedState.indexedHeaderId shouldBe history.bestHeaderIdAtHeight(HEIGHT)
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! CreateDB(HEIGHT + 1)
+    awaitCondition(created)
+    history.bestHeaderIdAtHeight(HEIGHT) should not be persistedState.indexedHeaderId
+
+    IndexerState.fromHistory(_history).indexedHeaderId shouldBe persistedState.indexedHeaderId
+    indexer ! Reset()
+  }
+
+  property("rebuilds legacy, malformed, and interrupted checkpoints") {
+    def intBytes(value: Int): Array[Byte] = ByteBuffer.allocate(4).putInt(value).array
+    def longBytes(value: Long): Array[Byte] = ByteBuffer.allocate(8).putLong(value).array
+    val schema = ExtraIndexer.SchemaVersionKey -> intBytes(ExtraIndexer.NewestVersion)
+    val emptyMetadata = Array(
+      ExtraIndexer.IndexedHeightKey -> intBytes(0),
+      ExtraIndexer.GlobalTxIndexKey -> longBytes(0),
+      ExtraIndexer.GlobalBoxIndexKey -> longBytes(0),
+      ExtraIndexer.RollbackToKey -> intBytes(0)
+    )
+    val invalidCheckpoints = Seq[(String, Array[(Array[Byte], Array[Byte])])](
+      "legacy non-empty" -> Array(
+        ExtraIndexer.SchemaVersionKey -> intBytes(6),
+        ExtraIndexer.IndexedHeightKey -> intBytes(1),
+        ExtraIndexer.GlobalTxIndexKey -> longBytes(0),
+        ExtraIndexer.GlobalBoxIndexKey -> longBytes(0),
+        ExtraIndexer.RollbackToKey -> intBytes(0)
+      ),
+      "legacy height zero with stale counters" -> Array(
+        ExtraIndexer.SchemaVersionKey -> intBytes(6),
+        ExtraIndexer.IndexedHeightKey -> intBytes(0),
+        ExtraIndexer.GlobalTxIndexKey -> longBytes(7),
+        ExtraIndexer.GlobalBoxIndexKey -> longBytes(9),
+        ExtraIndexer.RollbackToKey -> intBytes(0)
+      ),
+      "missing header id" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> intBytes(1))),
+      "short header id" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> intBytes(1)) ++
+        Array(ExtraIndexer.IndexedHeaderIdKey -> Array[Byte](1, 2, 3))),
+      "unknown header id" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> intBytes(1)) ++
+        Array(ExtraIndexer.IndexedHeaderIdKey -> Array.fill[Byte](32)(1))),
+      "interrupted rollback" -> (Array(schema) ++ emptyMetadata.updated(3, ExtraIndexer.RollbackToKey -> intBytes(1))),
+      "short indexed height" -> (Array(schema) ++ emptyMetadata.updated(0, ExtraIndexer.IndexedHeightKey -> Array[Byte](1))),
+      "long transaction index" -> (Array(schema) ++ emptyMetadata.updated(1, ExtraIndexer.GlobalTxIndexKey -> Array.fill[Byte](9)(1))),
+      "short box index" -> (Array(schema) ++ emptyMetadata.updated(2, ExtraIndexer.GlobalBoxIndexKey -> Array[Byte](1))),
+      "short rollback target" -> (Array(schema) ++ emptyMetadata.updated(3, ExtraIndexer.RollbackToKey -> Array[Byte](1))),
+      "current schema height zero with stale transaction counter" ->
+        (Array(schema) ++ emptyMetadata.updated(1, ExtraIndexer.GlobalTxIndexKey -> longBytes(1))),
+      "current schema height zero with stale box counter" ->
+        (Array(schema) ++ emptyMetadata.updated(2, ExtraIndexer.GlobalBoxIndexKey -> longBytes(1))),
+      "negative box index" -> (Array(schema) ++ emptyMetadata.updated(2, ExtraIndexer.GlobalBoxIndexKey -> longBytes(-1)))
+    )
+
+    invalidCheckpoints.foreach { case (name, entries) =>
+      val dbDir = Files.createTempDirectory("extra-indexer-checkpoint").toFile
+      val dbSettings = initSettings.copy(
+        directory = dbDir.getAbsolutePath,
+        nodeSettings = initSettings.nodeSettings.copy(extraIndex = true)
+      )
+      val db = HistoryStorage(dbSettings)
+      db.insertExtraTry(entries, Array.empty).get
+      db.close()
+
+      val probe = TestProbe()(system)
+      system.actorOf(Props(new Actor {
+        override def preStart(): Unit = {
+          val reloaded = ErgoHistory.readOrGenerate(dbSettings)(context)
+          probe.ref ! ((
+            ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, reloaded).getInt,
+            ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, reloaded).getLong,
+            ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, reloaded).getLong,
+            ExtraIndexer.getIndex(ExtraIndexer.RollbackToKey, reloaded).getInt,
+            reloaded.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+          ))
+          reloaded.closeStorage()
+          context.stop(self)
+        }
+
+        override def receive: Receive = Actor.emptyBehavior
+      }))
+      withClue(name) {
+        probe.expectMsg((0, 0L, 0L, 0, None))
+      }
+    }
+  }
+
+  property("preserves a valid non-empty checkpoint across storage reopen") {
+    val dbDir = Files.createTempDirectory("extra-indexer-valid-checkpoint").toFile
+    val dbSettings = initSettings.copy(
+      directory = dbDir.getAbsolutePath,
+      networkType = NetworkType.TestNet,
+      nodeSettings = initSettings.nodeSettings.copy(extraIndex = true, headerChainDiff = 5000)
+    )
+    val generationSettings = dbSettings.copy(
+      nodeSettings = dbSettings.nodeSettings.copy(extraIndex = false)
+    )
+    val probe = TestProbe()(system)
+    system.actorOf(Props(new Actor {
+      override def preStart(): Unit = {
+        val generatedHistory = ErgoHistory.readOrGenerate(generationSettings)(context)
+        ChainGenerator.generate(1, dbDir, generatedHistory, None)
+        generatedHistory.closeStorage()
+
+        val indexedHistory = ErgoHistory.readOrGenerate(dbSettings)(context)
+        val header = indexedHistory.bestFullBlockOpt.get.header
+        val blockTransactions = indexedHistory.typedModifierById[BlockTransactions](header.transactionsId).get
+        val txCount = blockTransactions.txs.size.toLong
+        val boxCount = blockTransactions.txs.map(_.outputs.size.toLong).sum
+        val lastTx = blockTransactions.txs.last
+        val lastTxIndex = txCount - 1
+        val lastBoxIndex = boxCount - 1
+        val outputIndexes = Array.tabulate(lastTx.outputs.size) { i =>
+          boxCount - lastTx.outputs.size.toLong + i.toLong
+        }
+        val indexedTx = IndexedErgoTransaction.fromTx(
+          lastTx,
+          blockTransactions.txs.size - 1,
+          header.height,
+          lastTxIndex,
+          Array.fill(lastTx.inputs.size)(0L),
+          outputIndexes
+        )
+        val indexedBoxes = lastTx.outputs.zip(outputIndexes).map { case (output, outputIndex) =>
+          new IndexedErgoBox(
+            header.height,
+            None,
+            None,
+            None,
+            output,
+            outputIndex
+          )
+        }.toArray
+        val numericBoxes = indexedBoxes.map(box => NumericBoxIndex(box.globalIndex, box.id))
+        val lastBox = indexedBoxes.last
+        val numericTx = NumericTxIndex(lastTxIndex, lastTx.id)
+        val numericBox = numericBoxes.last
+        val checkpointMetadata = Array(
+          ExtraIndexer.SchemaVersionKey -> ByteBuffer.allocate(4).putInt(ExtraIndexer.NewestVersion).array,
+          ExtraIndexer.IndexedHeightKey -> ByteBuffer.allocate(4).putInt(header.height).array,
+          ExtraIndexer.GlobalTxIndexKey -> ByteBuffer.allocate(8).putLong(txCount).array,
+          ExtraIndexer.GlobalBoxIndexKey -> ByteBuffer.allocate(8).putLong(boxCount).array,
+          ExtraIndexer.RollbackToKey -> ByteBuffer.allocate(4).putInt(0).array,
+          ExtraIndexer.IndexedHeaderIdKey -> ExtraIndexer.fastIdToBytes(header.id)
+        )
+        val checkpointObjects = Array[ExtraIndex](numericTx, indexedTx) ++ numericBoxes ++ indexedBoxes
+        indexedHistory.historyStorage.insertExtraTry(
+          checkpointMetadata,
+          checkpointObjects
+        ).get
+        indexedHistory.closeStorage()
+
+        val reloaded = ErgoHistory.readOrGenerate(dbSettings)(context)
+        val state = IndexerState.fromHistory(reloaded)
+        val terminalRowsPreserved =
+          reloaded.typedExtraIndexById[NumericTxIndex](numericTx.id).contains(numericTx) &&
+            reloaded.typedExtraIndexById[IndexedErgoTransaction](indexedTx.id).exists { tx =>
+              tx.txid == indexedTx.txid && tx.globalIndex == indexedTx.globalIndex &&
+                tx.height == indexedTx.height && tx.outputNums.sameElements(indexedTx.outputNums)
+            } &&
+            reloaded.typedExtraIndexById[NumericBoxIndex](numericBox.id).contains(numericBox) &&
+            reloaded.typedExtraIndexById[IndexedErgoBox](lastBox.id).exists(_.globalIndex == lastBoxIndex)
+        probe.ref ! state
+        probe.ref ! terminalRowsPreserved
+        reloaded.closeStorage()
+
+        val interrupted = HistoryStorage(dbSettings)
+        interrupted.insertExtraTry(
+          Array(ExtraIndexer.RollbackToKey -> ByteBuffer.allocate(4).putInt(header.height).array),
+          Array.empty
+        ).get
+        interrupted.close()
+
+        val rebuiltAfterInterruptedRollback = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterInterruptedRollback).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterInterruptedRollback).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterInterruptedRollback).getLong,
+          rebuiltAfterInterruptedRollback.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterInterruptedRollback.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterInterruptedRollback.closeStorage()
+
+        val wrongSchema = HistoryStorage(dbSettings)
+        wrongSchema.insertExtraTry(
+          Array(ExtraIndexer.SchemaVersionKey -> ByteBuffer.allocate(4).putInt(ExtraIndexer.NewestVersion - 1).array),
+          Array.empty
+        ).get
+        wrongSchema.close()
+
+        val rebuiltAfterSchemaMismatch = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterSchemaMismatch).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterSchemaMismatch).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterSchemaMismatch).getLong,
+          rebuiltAfterSchemaMismatch.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterSchemaMismatch.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterSchemaMismatch.closeStorage()
+
+        val malformed = HistoryStorage(dbSettings)
+        val malformedTx = indexedTx.copy(outputNums = indexedTx.outputNums ++ Array(lastBoxIndex))
+        malformed.insertExtraTry(Array.empty, Array(malformedTx)).get
+        malformed.close()
+
+        val rebuiltAfterMalformedTx = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterMalformedTx).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterMalformedTx).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterMalformedTx).getLong,
+          rebuiltAfterMalformedTx.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterMalformedTx.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterMalformedTx.closeStorage()
+
+        val malformedInputs = HistoryStorage(dbSettings)
+        val malformedInputTx = indexedTx.copy(inputNums = indexedTx.inputNums.map(_ + 1L))
+        malformedInputs.insertExtraTry(Array.empty, Array(malformedInputTx)).get
+        malformedInputs.close()
+
+        val rebuiltAfterMalformedInputs = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterMalformedInputs).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterMalformedInputs).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterMalformedInputs).getLong,
+          rebuiltAfterMalformedInputs.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterMalformedInputs.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterMalformedInputs.closeStorage()
+
+        val malformedSpentOutput = HistoryStorage(dbSettings)
+        val spentTerminalBox = new IndexedErgoBox(
+          header.height,
+          Some(lastTx.id),
+          Some(header.height + 1),
+          None,
+          lastTx.outputs.last,
+          lastBoxIndex
+        )
+        malformedSpentOutput.insertExtraTry(Array.empty, Array(spentTerminalBox)).get
+        malformedSpentOutput.close()
+
+        val rebuiltAfterSpentOutput = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterSpentOutput).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterSpentOutput).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterSpentOutput).getLong,
+          rebuiltAfterSpentOutput.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterSpentOutput.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        rebuiltAfterSpentOutput.closeStorage()
+
+        val corrupted = HistoryStorage(dbSettings)
+        corrupted.removeExtraTry(Array(numericBox.id)).get
+        corrupted.close()
+
+        val rebuilt = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuilt).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuilt).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuilt).getLong,
+          rebuilt.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuilt.closeStorage()
+
+        val invalidatedHeaderHistory = ErgoHistory.readOrGenerate(dbSettings)(context)
+        invalidatedHeaderHistory.historyStorage.insertExtraTry(checkpointMetadata, checkpointObjects).get
+        invalidatedHeaderHistory.historyStorage.insert(
+          Array(invalidatedHeaderHistory.validityKey(header.id) -> Array(0.toByte)),
+          org.ergoplatform.modifiers.BlockSection.emptyArray
+        ).get
+        invalidatedHeaderHistory.closeStorage()
+
+        val rebuiltAfterInvalidatedHeader = ErgoHistory.readOrGenerate(dbSettings)(context)
+        probe.ref ! ((
+          ExtraIndexer.getIndex(ExtraIndexer.IndexedHeightKey, rebuiltAfterInvalidatedHeader).getInt,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalTxIndexKey, rebuiltAfterInvalidatedHeader).getLong,
+          ExtraIndexer.getIndex(ExtraIndexer.GlobalBoxIndexKey, rebuiltAfterInvalidatedHeader).getLong,
+          rebuiltAfterInvalidatedHeader.historyStorage.modifierBytesById(bytesToId(ExtraIndexer.IndexedHeaderIdKey))
+        ))
+        rebuiltAfterInvalidatedHeader.closeStorage()
+        context.stop(self)
+      }
+
+      override def receive: Receive = Actor.emptyBehavior
+    }))
+    val preserved = probe.expectMsgType[IndexerState]
+    preserved.indexedHeight shouldBe 1
+    preserved.indexedHeaderId should not be empty
+    preserved.globalTxIndex should be > 0L
+    preserved.globalBoxIndex should be > 0L
+    probe.expectMsg(true)
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+    probe.expectMsg((0, 0L, 0L, None))
+  }
+
+  property("binds cached transactions to the selected header") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+    val originalTransactions = history.bestBlockTransactionsAt(HEIGHT).get
+    val staleTransactions = originalTransactions.copy(
+      txs = history.bestBlockTransactionsAt(HEIGHT - 1).get.txs
+    )
+
+    indexer ! ForceRollback(HEIGHT - 1)
+    awaitCondition(done)
+    val branchState = IndexerState.fromHistory(_history)
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! CreateDB(HEIGHT + 1)
+    awaitCondition(created)
+    val selectedTransactions = history.bestBlockTransactionsAt(HEIGHT).get
+    selectedTransactions.headerId should not be originalTransactions.headerId
+    selectedTransactions.txs.head.id should not be staleTransactions.txs.head.id
+
+    indexer ! CacheBlockTransactions(HEIGHT, staleTransactions)
+    awaitCondition(created)
+    indexer ! Index()
+    awaitCondition(done)
+
+    NumericTxIndex.getTxByNumber(history, branchState.globalTxIndex).map(_.id) shouldBe
+      Some(selectedTransactions.txs.head.id)
+    indexer ! Reset()
+  }
+
+  property("retries catch-up after a transient non-extending header") {
+    indexer ! CreateDB(HEIGHT)
+    awaitCondition(created)
+    indexer ! DeferNextHeaderOnce(2)
+    awaitCondition(created)
+    indexer ! Index()
+
+    org.ergoplatform.utils.untilTimeout(3.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT
+      state.indexedHeaderId shouldBe history.bestHeaderIdAtHeight(HEIGHT)
+    }
+    indexer ! Reset()
+  }
+
+  property("retries catch-up when the selected block transactions are temporarily unavailable") {
+    indexer ! CreateDB(HEIGHT)
+    awaitCondition(created)
+    indexer ! DeferBlockTransactionsOnce(2)
+    awaitCondition(created)
+    indexer ! Index()
+
+    org.ergoplatform.utils.untilTimeout(3.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT
+      state.indexedHeaderId shouldBe Some(fullChainHeaderAt(HEIGHT).id)
+    }
+    indexer ! Reset()
+  }
+
+  property("the production actor starts catch-up from the event stream") {
+    val dbDir = Files.createTempDirectory("extra-indexer-production-start").toFile
+    val dbSettings = initSettings.copy(
+      directory = dbDir.getAbsolutePath,
+      networkType = NetworkType.TestNet,
+      nodeSettings = initSettings.nodeSettings.copy(extraIndex = true, headerChainDiff = 5000)
+    )
+    val setupProbe = TestProbe()(system)
+    system.actorOf(Props(new Actor {
+      override def preStart(): Unit = {
+        val generatedHistory = ErgoHistory.readOrGenerate(dbSettings)(context)
+        ChainGenerator.generate(5, dbDir, generatedHistory, None)
+        setupProbe.ref ! generatedHistory
+        context.stop(self)
+      }
+
+      override def receive: Receive = Actor.emptyBehavior
+    }))
+    val history = setupProbe.expectMsgType[ErgoHistory](30.seconds)
+    IndexerState.fromHistory(history).indexedHeight shouldBe 0
+
+    val productionIndexer = system.actorOf(Props(new ExtraIndexer(
+      dbSettings.cacheSettings,
+      dbSettings.chainSettings.addressEncoder
+    )))
+    val probe = TestProbe()(system)
+    probe.send(productionIndexer, Identify("started"))
+    probe.expectMsg(ActorIdentity("started", Some(productionIndexer)))
+    system.eventStream.publish(ExtraIndexer.ReceivableMessages.StartExtraIndexer(history))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(history)
+      state.indexedHeight shouldBe history.fullBlockHeight
+      state.indexedHeaderId shouldBe Some(history.bestFullBlockOpt.get.header.id)
+    }
+
+    probe.watch(productionIndexer)
+    system.stop(productionIndexer)
+    probe.expectTerminated(productionIndexer)
+    history.closeStorage()
+  }
+
   property("transactions") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val state = IndexerState.fromHistory(_history)
     cfor(0)(_ < state.globalTxIndex, _ + 1) { n =>
       val id = history.typedExtraIndexById[NumericTxIndex](bytesToId(NumericTxIndex.indexToBytes(n)))
@@ -292,8 +748,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("boxes") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val state = IndexerState.fromHistory(_history)
     cfor(0)(_ < state.globalBoxIndex, _ + 1) { n =>
       val id = history.typedExtraIndexById[NumericBoxIndex](bytesToId(NumericBoxIndex.indexToBytes(n)))
@@ -306,8 +761,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("addresses") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val (addresses, _, _, _, _) = manualIndex(HEIGHT)
     checkAddresses(addresses) shouldBe 0
     indexer ! Reset()
@@ -316,8 +770,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("templates") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val (_, templates, _, _, _) = manualIndex(HEIGHT)
     checkTemplates(templates) shouldBe 0
     indexer ! Reset()
@@ -326,8 +779,7 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
   property("tokens") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
-    lock.lock()
-    done.await()
+    awaitCondition(done)
     val (_, _, indexedTokens, _, _) = manualIndex(HEIGHT)
     checkTokens(indexedTokens) shouldBe 0
     indexer ! Reset()
@@ -353,27 +805,275 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
     rollbackWithPattern("G-5;G-15;R-5;G-20;G-25;R-15;G-30;R-10;G-50;R-25")
   }
 
-  property("indexes replacement blocks after rolling back an orphan block") {
+  property("uses the production rollback point when the indexed tip becomes invalid") {
     indexer ! CreateDB(HEIGHT)
     indexer ! Index()
     awaitCondition(done)
+    val originalTipId = IndexerState.fromHistory(_history).indexedHeaderId.get
+
     indexer ! GenerateBetterChainTip()
-    lock.lock()
-    created.await()
-    val newBestHeaderOpt = history.typedModifierById[Header](history.headerIdsAtHeight(history.fullBlockHeight).last)
-    indexer ! RemoteBlockApplied(newBestHeaderOpt.get, Seq.empty) // will be ignored
-    indexer ! CreateDB(HEIGHT + 1)
-    lock.lock()
-    created.await()
+    awaitCondition(created)
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+    val branchPoint = fullChainHeaderAt(HEIGHT - 1)
+    val replacementHeader = fullChainHeaderAt(HEIGHT)
+    val replacementTip = fullChainHeaderAt(HEIGHT + 1)
+
+    _history.historyStorage.insert(
+      Array(_history.validityKey(originalTipId) -> Array(0.toByte)),
+      org.ergoplatform.modifiers.BlockSection.emptyArray
+    ).get
+    val eventProbe = TestProbe()(system)
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementHeader,
+      history.getFullBlock(replacementHeader).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementTip,
+      history.getFullBlock(replacementTip).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, Rollback(branchPoint.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.indexedHeaderId shouldBe Some(replacementTip.id)
+    }
+    indexer ! Reset()
+  }
+
+  property("persists buffered catch-up rows before processing a reorg") {
+    indexer ! CreateDB(HEIGHT)
+    awaitCondition(created)
+    val pauseProbe = TestProbe()(system)
+    pauseProbe.send(indexer, PauseBufferedCatchUpAt(HEIGHT, Int.MaxValue, pauseProbe.ref))
+    pauseProbe.expectMsg("configured")
     indexer ! Index()
-    lock.lock()
-    done.await()
-    indexer ! Rollback(history.bestHeaderIdAtHeight(HEIGHT).get)
-    lock.lock()
-    done.await()
-    val (_, _, indexedTokens, _, _) = manualIndex(HEIGHT)
+
+    val bufferedState = pauseProbe.expectMsgType[IndexerState](10.seconds)
+    bufferedState.indexedHeight shouldBe HEIGHT
+    IndexerState.fromHistory(_history).indexedHeight shouldBe 0
+    val originalTipId = bufferedState.indexedHeaderId.get
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+    val branchPoint = fullChainHeaderAt(HEIGHT - 1)
+    val replacementHeader = fullChainHeaderAt(HEIGHT)
+    val replacementTip = fullChainHeaderAt(HEIGHT + 1)
+    replacementHeader.id should not be originalTipId
+
+    val eventProbe = TestProbe()(system)
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementHeader,
+      history.getFullBlock(replacementHeader).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, RemoteBlockApplied(
+      replacementTip,
+      history.getFullBlock(replacementTip).get.transactions.map(_.id)
+    ))
+    eventProbe.send(indexer, Rollback(branchPoint.id))
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.indexedHeaderId shouldBe Some(replacementTip.id)
+    }
+
+    val expectedTransactions = (1 to HEIGHT + 1).flatMap(fullChainTransactionsAt(_).txs)
+    val expectedBoxes = expectedTransactions.flatMap(_.outputs)
+    val state = IndexerState.fromHistory(_history)
+    state.globalTxIndex shouldBe expectedTransactions.size
+    state.globalBoxIndex shouldBe expectedBoxes.size
+    expectedTransactions.zipWithIndex.foreach { case (tx, index) =>
+      NumericTxIndex.getTxByNumber(history, index).map(_.id) shouldBe Some(tx.id)
+    }
+    expectedBoxes.zipWithIndex.foreach { case (box, index) =>
+      NumericBoxIndex.getBoxByNumber(history, index).map(_.id) shouldBe Some(bytesToId(box.id))
+    }
+    val (addresses, templates, indexedTokens, _, _) = manualIndex(HEIGHT + 1)
+    checkAddresses(addresses) shouldBe 0
+    checkTemplates(templates) shouldBe 0
     checkTokens(indexedTokens) shouldBe 0
     indexer ! Reset()
+  }
+
+  property("requests only extra indexer stop when final removal fails after partial rollback writes") {
+    val failingIndexer = system.actorOf(Props.create(classOf[ExtraIndexerTestActor], this))
+    val lifecycleProbe = TestProbe()(system)
+    lifecycleProbe.watch(failingIndexer)
+
+    failingIndexer ! CreateDB(HEIGHT)
+    failingIndexer ! Index()
+    awaitCondition(done)
+    val spentInputId = bytesToId(fullChainTransactionsAt(HEIGHT).txs.flatMap(_.inputs).head.boxId)
+    history.typedExtraIndexById[IndexedErgoBox](spentInputId).exists(_.isSpent) shouldBe true
+
+    val probe = TestProbe()(system)
+    failingIndexer ! FailNextRollbackRemoval(probe.ref)
+    awaitCondition(created)
+    failingIndexer ! ForceRollback(HEIGHT - 1)
+
+    probe.expectMsg("indexer-stop-requested")
+    lifecycleProbe.expectTerminated(failingIndexer)
+    system.whenTerminated.isCompleted shouldBe false
+    ExtraIndexer.getIndex(ExtraIndexer.RollbackToKey, _history).getInt shouldBe HEIGHT - 1
+    _history.historyStorage.invalidateExtraCache(Seq(spentInputId))
+    history.typedExtraIndexById[IndexedErgoBox](spentInputId).exists(_.isSpent) shouldBe false
+  }
+
+  property("blocks every indexing entry while a segmented checkpoint write is pending") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+    val probe = TestProbe()(system)
+    probe.send(indexer, ConfigureWriteFailure("forward", probe.ref))
+    probe.expectMsg("configured")
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+    val first = fullChainHeaderAt(HEIGHT + 1)
+    probe.send(indexer, RemoteBlockApplied(first, fullChainTransactionsAt(HEIGHT + 1).txs.map(_.id)))
+    val pendingIds = probe.expectMsgType[Seq[ModifierId]]
+    pendingIds should not be empty
+    pendingIds.foreach(id => history.typedExtraIndexById[ExtraIndex](id) shouldBe None)
+    indexer ! ExtendDB(HEIGHT + 2)
+    awaitCondition(created)
+    val second = fullChainHeaderAt(HEIGHT + 2)
+    probe.send(indexer, RemoteBlockApplied(second, fullChainTransactionsAt(HEIGHT + 2).txs.map(_.id)))
+    probe.send(indexer, GetLoadedState())
+    probe.expectMsgType[IndexerState].indexedHeight shouldBe HEIGHT + 1
+    probe.send(indexer, SetCaughtUp(caughtUp = false))
+    probe.send(indexer, Index())
+    probe.send(indexer, GetLoadedState())
+    probe.expectMsgType[IndexerState].indexedHeight shouldBe HEIGHT + 1
+    IndexerState.fromHistory(_history).indexedHeight shouldBe HEIGHT
+    probe.send(indexer, AllowWrites())
+    probe.expectMsg("writes-allowed")
+    probe.send(indexer, Index())
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      IndexerState.fromHistory(_history).indexedHeight shouldBe HEIGHT + 2
+    }
+    pendingIds.foreach(id => history.typedExtraIndexById[ExtraIndex](id).isDefined shouldBe true)
+    val (addresses, templates, indexedTokens, txCount, boxCount) = manualIndex(HEIGHT + 2)
+    checkAddresses(addresses) shouldBe 0
+    checkTemplates(templates) shouldBe 0
+    checkTokens(indexedTokens) shouldBe 0
+    IndexerState.fromHistory(_history).globalTxIndex shouldBe txCount
+    IndexerState.fromHistory(_history).globalBoxIndex shouldBe boxCount
+    indexer ! Reset()
+  }
+
+  property("reopens a produced non-genesis checkpoint and rejects a changed terminal input mapping") {
+    indexer ! CreateDB(6)
+    indexer ! Index()
+    awaitCondition(done)
+    val expected = IndexerState.fromHistory(_history)
+    expected.indexedHeight shouldBe 6
+    val lastTx = fullChainTransactionsAt(6).txs.last
+    val indexedTx = history.typedExtraIndexById[IndexedErgoTransaction](lastTx.id).get
+    indexedTx.inputNums should not be empty
+    val probe = TestProbe()(system)
+    probe.send(indexer, ReopenCheckpoint())
+    probe.expectMsg(expected)
+    history.typedExtraIndexById[IndexedErgoTransaction](lastTx.id).isDefined shouldBe true
+
+    _history.historyStorage.insertExtraTry(Array.empty,
+      Array(indexedTx.copy(inputNums = indexedTx.inputNums.map(_ + 1L)))).get
+    probe.send(indexer, ReopenCheckpoint())
+    val rebuilt = probe.expectMsgType[IndexerState]
+    rebuilt.indexedHeight shouldBe 0
+    rebuilt.globalTxIndex shouldBe 0
+    rebuilt.globalBoxIndex shouldBe 0
+    rebuilt.indexedHeaderId shouldBe None
+    history.typedExtraIndexById[IndexedErgoTransaction](lastTx.id) shouldBe None
+    indexer ! Reset()
+  }
+
+  property("indexes the selected full chain while a competing header is first at its height") {
+    indexer ! CreateDB(6)
+    awaitCondition(created)
+    val selected = fullChainHeaderAt(3)
+    val competing = selected.copy(timestamp = selected.timestamp + 1)
+    val heightKey = ByteArrayWrapper(org.ergoplatform.settings.Algos.hash(ByteBuffer.allocate(4).putInt(3).array))
+    val ids = ExtraIndexer.fastIdToBytes(competing.id) ++ ExtraIndexer.fastIdToBytes(selected.id)
+    _history.historyStorage.insert(Array(heightKey -> ids, _history.validityKey(competing.id) -> Array[Byte](1)),
+      Array[org.ergoplatform.modifiers.BlockSection](competing)).get
+    history.bestHeaderIdAtHeight(3) shouldBe Some(competing.id)
+    fullChainHeaderAt(3).id shouldBe selected.id
+    indexer ! Index()
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      IndexerState.fromHistory(_history).indexedHeight shouldBe 6
+    }
+    val expectedTxs = (1 to 6).flatMap(fullChainTransactionsAt(_).txs)
+    expectedTxs.zipWithIndex.foreach { case (tx, num) =>
+      NumericTxIndex.getTxByNumber(history, num).map(_.id) shouldBe Some(tx.id)
+    }
+    IndexerState.fromHistory(_history).globalTxIndex shouldBe expectedTxs.size
+    indexer ! Reset()
+  }
+
+  Seq("initial", "intermediate", "final").foreach { phase =>
+    property(s"preserves recovery at the $phase rollback write failure") {
+      val failingIndexer = system.actorOf(Props.create(classOf[ExtraIndexerTestActor], this))
+      val probe = TestProbe()(system)
+      probe.watch(failingIndexer)
+      failingIndexer ! CreateDB(HEIGHT)
+      failingIndexer ! Index()
+      awaitCondition(done)
+      val expected = IndexerState.fromHistory(_history)
+      val sentinelId = fullChainTransactionsAt(1).txs.head.id
+      val spentId = bytesToId(fullChainTransactionsAt(HEIGHT).txs.flatMap(_.inputs).head.boxId)
+      val originalSpentBytes = _history.historyStorage.get(spentId).get.toSeq
+      probe.send(failingIndexer, CheckpointSettings())
+      val dbSettings = probe.expectMsgType[ErgoSettings]
+      probe.send(failingIndexer, ConfigureWriteFailure(phase, probe.ref))
+      probe.expectMsg("configured")
+      probe.send(failingIndexer, ForceRollback(HEIGHT - 1))
+      probe.expectMsgType[Seq[ModifierId]]
+      val completedWrites = probe.expectMsgType[Vector[String]]
+      phase match {
+        case "initial" => completedWrites shouldBe empty
+        case "intermediate" => completedWrites shouldBe Vector("marked")
+        case "final" =>
+          completedWrites.head shouldBe "marked"
+          completedWrites should contain("rows")
+          completedWrites.last shouldBe "remove"
+          completedWrites should not contain "unmarked"
+      }
+      probe.expectTerminated(failingIndexer)
+      system.whenTerminated.isCompleted shouldBe false
+      ExtraIndexer.getIndex(ExtraIndexer.RollbackToKey, _history).getInt shouldBe
+        (if (phase == "initial") 0 else HEIGHT - 1)
+      if (phase == "initial") {
+        IndexerState.fromHistory(_history) shouldBe expected
+        _history.historyStorage.get(spentId).get.toSeq shouldBe originalSpentBytes
+      }
+      _history.historyStorage.getExtraIndex(sentinelId).isDefined shouldBe true
+      _history.closeStorage()
+      system.actorOf(Props(new Actor {
+        override def preStart(): Unit = {
+          val reopened = ErgoHistory.readOrGenerate(dbSettings.copy(
+            nodeSettings = dbSettings.nodeSettings.copy(extraIndex = true)))(context)
+          probe.ref ! ((IndexerState.fromHistory(reopened), reopened.historyStorage.getExtraIndex(sentinelId).isDefined))
+          reopened.closeStorage()
+          context.stop(self)
+        }
+        override def receive: Receive = Actor.emptyBehavior
+      }))
+      val (reopened, retained) = probe.expectMsgType[(IndexerState, Boolean)]
+      if (phase == "initial") {
+        reopened shouldBe expected
+        retained shouldBe true
+      } else {
+        reopened.indexedHeight shouldBe 0
+        reopened.globalTxIndex shouldBe 0
+        reopened.globalBoxIndex shouldBe 0
+        reopened.rollbackTo shouldBe 0
+        reopened.indexedHeaderId shouldBe None
+        retained shouldBe false
+      }
+    }
   }
 
   property("resumes catch-up from a deferred state on FullBlockApplied") {
@@ -383,14 +1083,8 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
 
     indexer ! ExtendDB(HEIGHT + 1)
     awaitCondition(created)
-    val nextHeader = history.typedModifierById[Header](history.bestHeaderIdAtHeight(HEIGHT + 1).get).get
-
-    // Simulate the state after a headers-only fork briefly became the best chain
-    // and then lost: caughtUp=false, but the indexed tip is still on the main chain.
+    val nextHeader = fullChainHeaderAt(HEIGHT + 1)
     indexer ! SetCaughtUp(caughtUp = false)
-
-    // Without the FullBlockApplied handler for !caughtUp, this event would be
-    // dropped and the indexer would stay stalled.
     indexer ! RemoteBlockApplied(nextHeader, history.getFullBlock(nextHeader).get.transactions.map(_.id))
 
     org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
@@ -398,6 +1092,58 @@ class ExtraIndexerSpecification extends ErgoCorePropertyTest {
       state.indexedHeight shouldBe HEIGHT + 1
       state.caughtUp shouldBe true
     }
+    indexer ! Reset()
+  }
+
+  property("recovers a reloaded checkpoint without waiting for block or rollback events") {
+    indexer ! CreateDB(HEIGHT)
+    indexer ! Index()
+    awaitCondition(done)
+    val originalTipId = IndexerState.fromHistory(_history).indexedHeaderId
+    val branchPointId = fullChainHeaderAt(HEIGHT - 1).id
+
+    indexer ! GenerateBetterChainTip()
+    awaitCondition(created)
+    indexer ! ExtendDB(HEIGHT + 1)
+    awaitCondition(created)
+
+    val replacementHeader = fullChainHeaderAt(HEIGHT)
+    val replacementChild = fullChainHeaderAt(HEIGHT + 1)
+    replacementHeader.id should not be originalTipId.get
+
+    indexer ! Reload()
+    awaitCondition(created)
+
+    org.ergoplatform.utils.untilTimeout(10.seconds, 50.millis) {
+      val state = IndexerState.fromHistory(_history)
+      state.indexedHeight shouldBe HEIGHT + 1
+      state.indexedHeaderId shouldBe Some(replacementChild.id)
+    }
+
+    val expectedTransactions = (1 to HEIGHT + 1).flatMap(fullChainTransactionsAt(_).txs)
+    val expectedBoxes = expectedTransactions.flatMap(_.outputs)
+    val state = IndexerState.fromHistory(_history)
+    state.globalTxIndex shouldBe expectedTransactions.size
+    state.globalBoxIndex shouldBe expectedBoxes.size
+    expectedTransactions.zipWithIndex.foreach { case (tx, index) =>
+      NumericTxIndex.getTxByNumber(history, index).map(_.id) shouldBe Some(tx.id)
+    }
+    expectedBoxes.zipWithIndex.foreach { case (box, index) =>
+      NumericBoxIndex.getBoxByNumber(history, index).map(_.id) shouldBe Some(bytesToId(box.id))
+    }
+
+    val (addresses, templates, indexedTokens, _, _) = manualIndex(HEIGHT + 1)
+    checkAddresses(addresses) shouldBe 0
+    checkTemplates(templates) shouldBe 0
+    checkTokens(indexedTokens) shouldBe 0
+
+    val probe = TestProbe()(system)
+    probe.send(indexer, Rollback(branchPointId))
+    probe.send(indexer, GetLoadedState())
+    val stateAfterLateRollback = probe.expectMsgType[IndexerState]
+    stateAfterLateRollback.indexedHeight shouldBe HEIGHT + 1
+    stateAfterLateRollback.indexedHeaderId shouldBe Some(replacementChild.id)
+    IndexerState.fromHistory(_history) shouldBe stateAfterLateRollback
     indexer ! Reset()
   }
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexerTestActor.scala
@@ -1,18 +1,25 @@
 package org.ergoplatform.nodeView.history.extra
 
+import akka.actor.ActorRef
 import org.ergoplatform._
 import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.modifiers.history.BlockTransactions
 import org.ergoplatform.modifiers.mempool.ErgoTransaction
 import org.ergoplatform.nodeView.history.ErgoHistory
+import org.ergoplatform.nodeView.history.storage.HistoryStorage
+import org.ergoplatform.nodeView.history.storage.modifierprocessors.FullBlockSectionProcessor
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.SortingOption
 import org.ergoplatform.nodeView.state._
 import org.ergoplatform.settings._
 import org.ergoplatform.wallet.utils.FileUtils
-import scorex.util.ModifierId
+import scorex.util.{ModifierId, bytesToId}
+import scorex.db.LDBFactory
 
 import java.io.File
+import java.nio.ByteBuffer
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Try}
 
 class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexerBase with FileUtils {
 
@@ -21,13 +28,38 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
     case test.ExtendDB(blockCount: Int) => extendDB(blockCount)
     case test.Reset() => reset()
     case test.GenerateBetterChainTip() => GenerateBetterChainTip()
+    case test.CacheBlockTransactions(height, transactions) => cacheBlockTransactions(height, transactions)
+    case test.DeferNextHeaderOnce(height) => deferNextHeaderOnce(height)
+    case test.DeferBlockTransactionsOnce(height) => deferBlockTransactionsOnce(height)
+    case test.Reload() => reload()
+    case test.FailNextRollbackRemoval(probe) => failNextRollbackRemoval(probe)
+    case test.PauseBufferedCatchUpAt(height, limit, probe) => pauseBufferedCatchUpAt(height, limit, probe)
+    case test.ConfigureWriteFailure(phase, probe) =>
+      writeFailurePhase = phase
+      writeFailureProbe = Some(probe)
+      writeFailureObserved = false
+      completedWriteKinds.clear()
+      configuredSaveLimit = Int.MaxValue
+      probe ! "configured"
+    case test.AllowWrites() =>
+      writeFailurePhase = ""
+      sender ! "writes-allowed"
+    case test.ReopenCheckpoint() =>
+      resetTransientState()
+      _history.closeStorage()
+      _history = ErgoHistory.readOrGenerate(dbSettings.copy(nodeSettings = nodeSettings.copy(extraIndex = true)))(context)
+      test._history = _history
+      sender ! IndexerState.fromHistory(_history)
+    case test.CheckpointSettings() => sender ! dbSettings
   }
 
-  override protected def loaded(state: IndexerState): Receive = {
-    case test.SetCaughtUp(caughtUp: Boolean) =>
+  override protected def loaded(state: IndexerState): Receive = ({
+    case test.SetCaughtUp(caughtUp) =>
       context.become(receive.orElse(loaded(state.copy(caughtUp = caughtUp))))
-    case x => super.loaded(state)(x)
-  }
+    case test.ForceRollback(height) =>
+      beginRollback(state, fullChainHeaderAtHeight(height).get, resume = false)
+    case test.GetLoadedState() => sender ! state
+  }: Receive).orElse(super.loaded(state))
 
   override def caughtUpHook(height: Int = 0): Unit = {
     if(height > 0 && height < chainHeight) return
@@ -37,16 +69,18 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
   }
 
   override def getLastTxForHeight(height: Int): ErgoTransaction = {
-    val header = history.headerIdsAtHeight(height).last
-    val block = history.getFullBlock(history.typedModifierById[Header](header).get)
+    val header = fullChainHeaderAtHeight(height).get
+    val block = history.getFullBlock(header)
     block.get.transactions.last
   }
 
   type ID_LL = mutable.HashMap[ModifierId,(Long,Long)]
 
-  override protected val saveLimit: Int = 1 // save every block
+  private var configuredSaveLimit: Int = 1
+  override protected def saveLimit: Int = configuredSaveLimit
   override protected implicit val segmentThreshold: Int = 8 // split to smaller segments
   override protected implicit val addressEncoder: ErgoAddressEncoder = test.initSettings.chainSettings.addressEncoder
+  override protected val retryDelay = 50.millis
 
   val nodeSettings: NodeConfigurationSettings = NodeConfigurationSettings(StateType.Utxo, verifyTransactions = true,
     -1, UtxoSettings(utxoBootstrap = false, 0, 2), NipopowSettings(nipopowBootstrap = false, 1), mining = false,
@@ -57,16 +91,114 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
 
   private var dir: File = _
   private var stateOpt: Option[UtxoState] = None
+  private var deferredHeaderHeightOpt: Option[Int] = None
+  private var deferredTransactionsHeightOpt: Option[Int] = None
+  private var rollbackFailureProbeOpt: Option[ActorRef] = None
+  private var failRollbackRemoval: Boolean = false
+  private var pauseCatchUpAtHeightOpt: Option[Int] = None
+  private var catchUpPauseProbeOpt: Option[ActorRef] = None
+  private var dbSettings: ErgoSettings = _
+  private var writeFailurePhase = ""
+  private var writeFailureProbe: Option[ActorRef] = None
+  private var writeFailureObserved = false
+  private val completedWriteKinds = mutable.ArrayBuffer.empty[String]
+
+  override protected def index(state: IndexerState, header: Header, targetHeight: Int): Option[IndexerState] = {
+    if (writeFailurePhase == "forward" && writeFailureObserved) {
+      writeFailureProbe.foreach(_ ! "pending-index-attempt")
+      None // Bound the fixture at the unavailable pending-row consumer.
+    } else super.index(state, header, targetHeight)
+  }
+
+  override protected def continueCatchUpAfterIndex(state: IndexerState): Boolean = {
+    if (pauseCatchUpAtHeightOpt.contains(state.indexedHeight)) {
+      pauseCatchUpAtHeightOpt = None
+      catchUpPauseProbeOpt.foreach(_ ! state)
+      catchUpPauseProbeOpt = None
+      false
+    } else true
+  }
+
+  override protected def removeRollbackIndexes(ids: Array[ModifierId]): Try[Unit] =
+    if (failRollbackRemoval) {
+      failRollbackRemoval = false
+      Failure(new IllegalStateException("injected final rollback removal failure"))
+    } else super.removeRollbackIndexes(ids)
+
+  override protected def stopIndexer(): Unit = {
+    if (writeFailurePhase.nonEmpty) writeFailureProbe.foreach(_ ! completedWriteKinds.toVector)
+    rollbackFailureProbeOpt.foreach(_ ! "indexer-stop-requested")
+    rollbackFailureProbeOpt = None
+    super.stopIndexer()
+  }
+
+  override protected def fullChainHeaderAtHeight(height: Int): Option[Header] = {
+    val headerOpt = super.fullChainHeaderAtHeight(height)
+    if (deferredHeaderHeightOpt.contains(height)) {
+      deferredHeaderHeightOpt = None
+      headerOpt.map(_.copy(parentId = bytesToId(Array.fill(32)(0x7f.toByte))))
+    } else {
+      headerOpt
+    }
+  }
+
+  override protected def blockTransactionsForHeader(header: Header): Option[BlockTransactions] = {
+    if (deferredTransactionsHeightOpt.contains(header.height)) {
+      deferredTransactionsHeightOpt = None
+      None
+    } else {
+      super.blockTransactionsForHeader(header)
+    }
+  }
 
   def createDB(blockCount: Int): Unit = {
     if(stateOpt.isEmpty) {
       dir = createTempDir
       dir.mkdirs()
 
-      val fullHistorySettings: ErgoSettings = ErgoSettings(dir.getAbsolutePath, NetworkType.TestNet, test.initSettings.chainSettings,
+      dbSettings = ErgoSettings(dir.getAbsolutePath, NetworkType.TestNet, test.initSettings.chainSettings,
         nodeSettings, test.initSettings.scorexSettings, test.initSettings.walletSettings, test.initSettings.cacheSettings)
 
-      _history = ErgoHistory.readOrGenerate(fullHistorySettings)(null)
+      val initialHistory = ErgoHistory.readOrGenerate(dbSettings)(null)
+      initialHistory.closeStorage()
+      val store = new HistoryStorage(
+        LDBFactory.createKvDb(s"${dir.getAbsolutePath}/history/index"),
+        LDBFactory.createKvDb(s"${dir.getAbsolutePath}/history/objects"),
+        LDBFactory.createKvDb(s"${dir.getAbsolutePath}/history/extra"),
+        dbSettings.cacheSettings
+      ) {
+        override def insertExtraTry(entries: Array[(Array[Byte], Array[Byte])], objects: Array[ExtraIndex]): Try[Unit] = {
+          val marker = entries.find(_._1.sameElements(ExtraIndexer.RollbackToKey)).map(e => ByteBuffer.wrap(e._2).getInt)
+          val shouldFail = writeFailurePhase match {
+            case "forward" => marker.contains(0)
+            case "initial" => marker.exists(_ > 0)
+            case "intermediate" => marker.isEmpty
+            case "final" => marker.contains(0)
+            case _ => false
+          }
+          if (shouldFail) {
+            if (!writeFailureObserved) {
+              writeFailureObserved = true
+              val pendingIds = segments.keys.filter(id => getExtraIndex(id).isEmpty).toSeq
+              writeFailureProbe.foreach(_ ! pendingIds)
+            }
+            Failure(new IllegalStateException(s"injected $writeFailurePhase write failure"))
+          } else super.insertExtraTry(entries, objects).map { _ =>
+            if (writeFailurePhase.nonEmpty) {
+              completedWriteKinds += marker.map(m => if (m > 0) "marked" else "unmarked").getOrElse("rows")
+            }
+          }
+        }
+        override def removeExtraTry(ids: Array[ModifierId]): Try[Unit] = super.removeExtraTry(ids).map { _ =>
+          if (writeFailurePhase.nonEmpty) completedWriteKinds += "remove"
+        }
+      }
+      store.insertExtraTry(Array(ExtraIndexer.SchemaVersionKey -> ExtraIndexer.NewestVersionBytes), Array.empty).get
+      _history = new ErgoHistory with FullBlockSectionProcessor {
+        override protected val settings: ErgoSettings = dbSettings
+        override protected[history] val historyStorage: HistoryStorage = store
+        override val powScheme = dbSettings.chainSettings.powScheme
+      }
     }
 
     stateOpt = Some(ChainGenerator.generate(blockCount, dir, _history, stateOpt))
@@ -86,13 +218,25 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
   }
 
   def reset(): Unit = {
+    resetTransientState()
     stateOpt = None
     test._history = null
     general.clear()
     boxes.clear()
     trees.clear()
+    templates.clear()
     tokens.clear()
     segments.clear()
+    deferredHeaderHeightOpt = None
+    deferredTransactionsHeightOpt = None
+    rollbackFailureProbeOpt = None
+    failRollbackRemoval = false
+    configuredSaveLimit = 1
+    pauseCatchUpAtHeightOpt = None
+    catchUpPauseProbeOpt = None
+    writeFailurePhase = ""
+    writeFailureProbe = None
+    writeFailureObserved = false
     context.become(receive.orElse(loaded(IndexerState(0, 0, 0, 0, caughtUp = false))))
   }
 
@@ -102,6 +246,51 @@ class ExtraIndexerTestActor(test: ExtraIndexerSpecification) extends ExtraIndexe
     test.lock.lock()
     test.created.signal()
     test.lock.unlock()
+  }
+
+  private def cacheBlockTransactions(height: Int, transactions: BlockTransactions): Unit = {
+    putBlockTransactionsInCache(height, transactions)
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def deferNextHeaderOnce(height: Int): Unit = {
+    deferredHeaderHeightOpt = Some(height)
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def deferBlockTransactionsOnce(height: Int): Unit = {
+    deferredTransactionsHeightOpt = Some(height)
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def reload(): Unit = {
+    resetTransientState()
+    context.become(receive.orElse(loaded(IndexerState.fromHistory(_history))))
+    self ! ExtraIndexer.ReceivableMessages.Index()
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def failNextRollbackRemoval(probe: ActorRef): Unit = {
+    rollbackFailureProbeOpt = Some(probe)
+    failRollbackRemoval = true
+    test.lock.lock()
+    test.created.signal()
+    test.lock.unlock()
+  }
+
+  private def pauseBufferedCatchUpAt(height: Int, limit: Int, probe: ActorRef): Unit = {
+    configuredSaveLimit = limit
+    pauseCatchUpAtHeightOpt = Some(height)
+    catchUpPauseProbeOpt = Some(probe)
+    probe ! "configured"
   }
 
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryStorageSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryStorageSpec.scala
@@ -4,11 +4,20 @@ import org.ergoplatform.modifiers.BlockSection
 import org.ergoplatform.modifiers.history.ADProofs
 import org.ergoplatform.modifiers.history.header.Header
 import org.ergoplatform.nodeView.history.ErgoHistoryUtils._
+import org.ergoplatform.nodeView.history.extra.{ExtraIndex, IndexedErgoBox}
 import org.ergoplatform.settings.Algos
 import org.ergoplatform.utils.ErgoCorePropertyTest
 import org.scalacheck.Gen
-import scorex.db.ByteArrayWrapper
+import scorex.db.{ByteArrayWrapper, LDBFactory, LDBKVStore}
 import scorex.util.{ModifierId, idToBytes}
+
+import java.io.IOException
+import java.nio.file.Files
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import org.iq80.leveldb.Options
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Try}
 
 class HistoryStorageSpec extends ErgoCorePropertyTest {
   import org.ergoplatform.utils.ErgoNodeTestConstants._
@@ -38,6 +47,150 @@ class HistoryStorageSpec extends ErgoCorePropertyTest {
     headers.forall(h => !db.get(h.id).exists(_.nonEmpty)) shouldBe true
     modifiers.forall(m => !db.get(m.id).exists(_.nonEmpty)) shouldBe true
     indexes.forall(i => !db.getIndex(i._1).exists(_.nonEmpty)) shouldBe true
+  }
+
+  property("recursive extra index deletion propagates a file failure") {
+    val root = Files.createTempDirectory("extra-index-delete-failure")
+    val sentinel = Files.createFile(root.resolve("sentinel"))
+
+    val result = HistoryStorage.deleteRecursively(root, path => {
+      if (path == sentinel) throw new IOException("injected deletion failure")
+      Files.delete(path)
+    })
+
+    result shouldBe 'failure
+    Files.exists(sentinel) shouldBe true
+    Files.delete(sentinel)
+    Files.delete(root)
+  }
+
+  property("extra serialization failure invalidates mutated cached objects") {
+    import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.ergoBoxGenNoProp
+
+    val indexedBox = new IndexedErgoBox(1, None, None, None, ergoBoxGenNoProp.sample.get, 0L)
+    db.insertExtraTry(Array.empty, Array(indexedBox)).get
+    val cachedBox = db.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox]
+    cachedBox.spendingHeightOpt = Some(2)
+    val unsupported = new ExtraIndex {
+      override def serializedId: Array[Byte] = Array.fill[Byte](32)(0x55.toByte)
+    }
+
+    db.insertExtraTry(Array.empty, Array[ExtraIndex](cachedBox, unsupported)) shouldBe 'failure
+    db.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe None
+    db.insertExtraTry(Array.empty, Array(cachedBox)).get
+    db.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe Some(2)
+  }
+
+  property("extra rows and checkpoint metadata share one batch and preserve returned write failures") {
+    import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.ergoBoxGenNoProp
+
+    val root = Files.createTempDirectory("extra-index-batch-failure")
+    val indexStore = LDBFactory.createKvDb(root.resolve("index").toString)
+    val objectsStore = LDBFactory.createKvDb(root.resolve("objects").toString)
+    val rawExtraDb = LDBFactory.factory.open(root.resolve("extra").toFile, new Options().createIfMissing(true))
+    val writeError = new IOException("injected extra batch write failure")
+    var failWrite = false
+    var batchCount = 0
+    val extraStore = new LDBKVStore(rawExtraDb) {
+      override def update(keys: Array[Array[Byte]], values: Array[Array[Byte]], remove: Array[Array[Byte]]): Try[Unit] = {
+        batchCount += 1
+        if (failWrite) Failure(writeError) else super.update(keys, values, remove)
+      }
+    }
+    val storage = new HistoryStorage(indexStore, objectsStore, extraStore, settings.cacheSettings)
+    val checkpointKey = Algos.hash("test-extra-checkpoint".getBytes(CharsetName))
+    val indexedBox = new IndexedErgoBox(1, None, None, None, ergoBoxGenNoProp.sample.get, 0L)
+
+    try {
+      storage.insertExtraTry(Array(checkpointKey -> Array[Byte](1)), Array(indexedBox)).get
+      batchCount shouldBe 1
+      val cached = storage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox]
+      cached.spendingHeightOpt = Some(2)
+      failWrite = true
+      val result = storage.insertExtraTry(Array(checkpointKey -> Array[Byte](2)), Array(cached))
+      result.failed.get shouldBe writeError
+      batchCount shouldBe 2
+      extraStore.get(checkpointKey).get.toSeq shouldBe Seq[Byte](1)
+      storage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe None
+
+      failWrite = false
+      storage.insertExtraTry(Array(checkpointKey -> Array[Byte](2)), Array(cached)).get
+      batchCount shouldBe 3
+      extraStore.get(checkpointKey).get.toSeq shouldBe Seq[Byte](2)
+      storage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe Some(2)
+
+      failWrite = true
+      storage.removeExtraTry(Array(indexedBox.id)).failed.get shouldBe writeError
+      extraStore.get(indexedBox.serializedId).isDefined shouldBe true
+      storage.getExtraIndex(indexedBox.id).isDefined shouldBe true
+      failWrite = false
+      storage.removeExtraTry(Array(indexedBox.id)).get
+      storage.getExtraIndex(indexedBox.id) shouldBe None
+    } finally storage.close()
+  }
+
+  property("an in-flight cache miss cannot restore stale data after a successful write") {
+    import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.ergoBoxGenNoProp
+
+    implicit val executionContext: ExecutionContext = ExecutionContext.global
+    val root = Files.createTempDirectory("extra-index-cache-race")
+    val oldValueRead = new CountDownLatch(1)
+    val resumeOldRead = new CountDownLatch(1)
+    val writerStarted = new CountDownLatch(1)
+    val writeCommitted = new CountDownLatch(1)
+    @volatile var pauseNextRead = false
+    @volatile var observeWrite = false
+
+    val options = new Options().createIfMissing(true)
+    val indexStore = LDBFactory.createKvDb(root.resolve("index").toString)
+    val objectsStore = LDBFactory.createKvDb(root.resolve("objects").toString)
+    val rawExtraDb = LDBFactory.factory.open(root.resolve("extra").toFile, options)
+    val extraStore = new LDBKVStore(rawExtraDb) {
+      override def get(key: Array[Byte]): Option[Array[Byte]] = {
+        val value = super.get(key)
+        if (pauseNextRead) {
+          pauseNextRead = false
+          oldValueRead.countDown()
+          require(resumeOldRead.await(5, TimeUnit.SECONDS), "timed out waiting to resume cache-miss read")
+        }
+        value
+      }
+
+      override def update(toInsertKeys: Array[Array[Byte]],
+                          toInsertValues: Array[Array[Byte]],
+                          toRemove: Array[Array[Byte]]): Try[Unit] = {
+        val result = super.update(toInsertKeys, toInsertValues, toRemove)
+        if (observeWrite && result.isSuccess) writeCommitted.countDown()
+        result
+      }
+    }
+    val concurrentStorage = new HistoryStorage(indexStore, objectsStore, extraStore, settings.cacheSettings)
+
+    try {
+      val indexedBox = new IndexedErgoBox(1, None, None, None, ergoBoxGenNoProp.sample.get, 0L)
+      concurrentStorage.insertExtraTry(Array.empty, Array(indexedBox)).get
+      pauseNextRead = true
+      val staleRead = Future(concurrentStorage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox])
+      oldValueRead.await(5, TimeUnit.SECONDS) shouldBe true
+
+      indexedBox.spendingHeightOpt = Some(2)
+      observeWrite = true
+      val write = Future {
+        writerStarted.countDown()
+        concurrentStorage.insertExtraTry(Array.empty, Array(indexedBox)).get
+      }
+      writerStarted.await(5, TimeUnit.SECONDS) shouldBe true
+      val committedWhileReadWasPaused = writeCommitted.await(200, TimeUnit.MILLISECONDS)
+      resumeOldRead.countDown()
+
+      Await.result(staleRead, 5.seconds).spendingHeightOpt shouldBe None
+      Await.result(write, 5.seconds)
+      committedWhileReadWasPaused shouldBe false
+      concurrentStorage.getExtraIndex(indexedBox.id).get.asInstanceOf[IndexedErgoBox].spendingHeightOpt shouldBe Some(2)
+    } finally {
+      resumeOldRead.countDown()
+      concurrentStorage.close()
+    }
   }
 
 }


### PR DESCRIPTION
This continues [#2465](https://github.com/ergoplatform/ergo/pull/2465) on `master`. Its deleted `v6.0.4` base prevents reopening the earlier PR. The updated contribution retains its operational policy and addresses the pending-save boundary described below.

ExtraIndexer checkpoints persist the exact indexed header together with forward rows in one database batch. Restart validates checkpoint provenance and terminal mappings instead of assigning the current best header to existing rows. Catch-up follows the selected valid full-block chain and retains the immediate applied-event recovery from [#2476](https://github.com/ergoplatform/ergo/pull/2476).

Failed forward saves retain their buffers and block both indexing entry points until persistence succeeds. This also protects segmented rows whose parent references have already changed. Rollback persists a marker before modifying rows and propagates failures through its final checkpoint. A failed rollback stops only ExtraIndexer; the node continues running, and the next history startup rebuilds the optional index.

Existing nonempty schema-6 extra indexes rebuild once under schema 7. Interrupted, malformed or inconsistent checkpoints also rebuild. Valid schema-7 checkpoints survive restart. Rebuild duration depends on index size and hardware and has not been benchmarked.

Validation: JDK 8, Scala 2.12.20; 30 indexer tests pass on the final candidate, with eight unchanged storage-test results reused. Coverage includes actual non-genesis indexing and reopen, selected full-chain identity, atomic row/checkpoint writes, cache consistency, retry after failed segmented writes, and isolated rollback write-phase failures followed by restart. Independent source and follow-up review completed.

This updates the existing recovery contribution against the current base. It changes the optional derived index, with no consensus or UTXO-state change.

A separate commit includes the already reviewed V2 summary/cache dependency from [#2511](https://github.com/ergoplatform/ergo/pull/2511). Its five files match that contribution. Fourteen focused history, cache, serialization and synchronizer tests pass on this indexer branch, with independent composition review. Those fixtures use the current history/storage code with the optional index disabled; the indexer recovery evidence above remains separate. Review and integrate #2511 first.

The shared test-only follow-up polls selected-header agreement and records bounded rollback observations. Nine observation contracts and independent review pass. All eight [CI checks](https://github.com/ergoplatform/ergo/actions/runs/34072985884) pass at `342e718e705d55603f015e74b84ae0cd4d7b9f5d`. This successful composition does not retrospectively isolate the cause of the previous selected-header disagreement.
