### PR TITLE
Own REST binding and drain requests before closing dependencies

### DIFF
--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/main/scala/org/ergoplatform/ErgoApp.scala
+++ b/src/main/scala/org/ergoplatform/ErgoApp.scala
@@ -217,7 +217,7 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
   private val coordinatedShutdown = CoordinatedShutdown(actorSystem)
   coordinatedShutdown.addActorTerminationTask(
-    CoordinatedShutdown.PhaseBeforeServiceUnbind,
+    CoordinatedShutdown.PhaseServiceStop,
     s"closing-network",
     networkControllerRef,
     Some(ShutdownNetwork)
@@ -254,9 +254,11 @@ class ErgoApp(args: Args) extends ScorexLogging {
 
     val bindAddress = scorexSettings.restApi.bindAddress
 
-    Http()
-      .newServerAt(bindAddress.getAddress.getHostAddress, bindAddress.getPort)
-      .bindFlow(httpService.compositeRoute)
+    HttpServerLifecycle.start(httpService.compositeRoute) { route =>
+      Http()
+        .newServerAt(bindAddress.getAddress.getHostAddress, bindAddress.getPort)
+        .bindFlow(route)
+    }
   }
 }
 

--- a/src/main/scala/org/ergoplatform/http/HttpServerLifecycle.scala
+++ b/src/main/scala/org/ergoplatform/http/HttpServerLifecycle.scala
@@ -1,0 +1,91 @@
+package org.ergoplatform.http
+
+import akka.Done
+import akka.actor.{ActorSystem, CoordinatedShutdown}
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Route
+import org.ergoplatform.ErgoApp
+import scorex.util.ScorexLogging
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Owns REST startup and the binding throughout coordinated shutdown. */
+private[ergoplatform] object HttpServerLifecycle extends ScorexLogging {
+
+  def start(route: Route)(bind: Route => Future[ServerBinding])
+           (implicit system: ActorSystem): Future[ServerBinding] = {
+    implicit val ec = system.dispatcher
+    val shutdown = CoordinatedShutdown(system)
+    val ownership = new Object
+    val accepting = new AtomicBoolean(false)
+    var stopping = false
+    var acquired: Option[ServerBinding] = None
+    var bindingFailed = false
+    val selected = Promise[Option[ServerBinding]]()
+    val acquisitionTimeout = shutdown.timeout(CoordinatedShutdown.PhaseServiceUnbind) / 2
+    // Leave time within the phase for connection cleanup after the hard deadline.
+    val drainDeadline = shutdown.timeout(CoordinatedShutdown.PhaseServiceRequestsDone) / 2
+    val guardedRoute: Route = context =>
+      if (accepting.get()) route(context)
+      else context.complete(HttpResponse(StatusCodes.ServiceUnavailable))
+
+    // Register before initiating the bind, including shutdown during pending startup.
+    shutdown.addTask(CoordinatedShutdown.PhaseServiceUnbind, "http-unbind") { () =>
+      ownership.synchronized {
+        stopping = true
+        accepting.set(false)
+        if (acquired.isDefined || bindingFailed) selected.trySuccess(acquired)
+      }
+      val cutoff = system.scheduler.scheduleOnce(acquisitionTimeout) {
+        ownership.synchronized { selected.trySuccess(None) }
+      }
+      selected.future.onComplete(_ => cutoff.cancel())
+      selected.future.flatMap {
+        case Some(server) => server.unbind()
+        case None => Future.successful(Done)
+      }
+    }
+    shutdown.addTask(CoordinatedShutdown.PhaseServiceRequestsDone, "http-drain") { () =>
+      // Never spend this phase waiting for startup, even if the previous phase timed out.
+      val serverToDrain = ownership.synchronized {
+        stopping = true
+        accepting.set(false)
+        selected.trySuccess(acquired)
+        selected.future.value.get.get
+      }
+      serverToDrain match {
+        case Some(server) => server.terminate(drainDeadline).map(_ => Done)
+        case None => Future.successful(Done)
+      }
+    }
+
+    Try(bind(guardedRoute)).fold(Future.failed, identity).andThen {
+      case Success(server) =>
+        val arrivedAfterCutoff = ownership.synchronized {
+          acquired = Some(server)
+          if (stopping) !selected.trySuccess(acquired)
+          else {
+            accepting.set(true)
+            false
+          }
+        }
+        if (arrivedAfterCutoff) {
+          // The closed gate keeps late bindings away from application dependencies.
+          server.terminate(1.millis).failed.foreach { error =>
+            log.error("Failed to terminate a late REST API binding", error)
+          }
+        } else log.info(s"REST API bound to ${server.localAddress}")
+      case Failure(error) =>
+        ownership.synchronized {
+          bindingFailed = true
+          if (stopping) selected.trySuccess(None)
+        }
+        log.error("REST API startup failed; shutting down the node", error)
+        shutdown.run(ErgoApp.InternalShutdown)
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -513,7 +513,7 @@ object ErgoWalletActor extends ScorexLogging {
       .withDispatcher(GlobalConstants.ApiDispatcher)
     val walletActorRef = actorSystem.actorOf(props)
     CoordinatedShutdown(actorSystem).addActorTerminationTask(
-      CoordinatedShutdown.PhaseBeforeServiceUnbind,
+      CoordinatedShutdown.PhaseServiceStop,
       s"closing-wallet",
       walletActorRef,
       Some(CloseWallet)

--- a/src/test/scala/org/ergoplatform/http/HttpServerLifecycleSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/HttpServerLifecycleSpec.scala
@@ -1,0 +1,213 @@
+package org.ergoplatform.http
+
+import akka.Done
+import akka.actor.{ActorSystem, CoordinatedShutdown}
+import akka.http.scaladsl.Http.{HttpServerTerminated, HttpTerminated, ServerBinding}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.Route
+import com.typesafe.config.ConfigFactory
+import org.ergoplatform.ErgoApp
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.InetSocketAddress
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration._
+
+class HttpServerLifecycleSpec extends AnyFlatSpec with Matchers {
+
+  private def withSystem(test: ActorSystem => Unit): Unit = {
+    withSystemConfig("")(test)
+  }
+
+  private def withSystemConfig(overrides: String)(test: ActorSystem => Unit): Unit = {
+    val config = ConfigFactory.parseString(overrides).withFallback(ConfigFactory.parseString("""
+      akka.coordinated-shutdown {
+        terminate-actor-system = off
+        run-by-actor-system-terminate = off
+        run-by-jvm-shutdown-hook = off
+        default-phase-timeout = 5s
+      }
+    """)).withFallback(ConfigFactory.load())
+    val system = ActorSystem(s"http-lifecycle-${UUID.randomUUID()}", config)
+    try test(system)
+    finally Await.result(system.terminate(), 5.seconds)
+  }
+
+  private def start(bind: => Future[ServerBinding])(implicit system: ActorSystem): Future[ServerBinding] =
+    HttpServerLifecycle.start(complete(HttpResponse()))(_ => bind)
+
+  "HTTP lifecycle" should "retain a successful binding and drain its response before dependencies stop" in withSystem { implicit system =>
+    implicit val ec = system.dispatcher
+    val shutdown = CoordinatedShutdown(system)
+    val walletOpen = new AtomicBoolean(true)
+    val unbound = Promise[Unit]()
+    val draining = Promise[FiniteDuration]()
+    val response = Promise[HttpResponse]()
+    val delivered = Promise[HttpResponse]()
+    val admitted = Promise[Done]()
+    val handler = Promise[HttpRequest => Future[HttpResponse]]()
+    val walletClosed = Promise[Done]()
+    val binding = ServerBinding(new InetSocketAddress("127.0.0.1", 0))(
+      () => { unbound.trySuccess(()); Future.successful(()) },
+      deadline => {
+        draining.success(deadline)
+        delivered.future.map(_ => HttpServerTerminated: HttpTerminated)
+      }
+    )
+    shutdown.addTask(CoordinatedShutdown.PhaseServiceStop, "close-wallet") { () =>
+      walletOpen.set(false)
+      walletClosed.success(Done)
+      Future.successful(Done)
+    }
+
+    val route: Route = complete {
+      admitted.trySuccess(Done)
+      response.future.map { result =>
+        walletOpen.get() shouldBe true
+        result
+      }
+    }
+    val startup = HttpServerLifecycle.start(route) { guarded =>
+      handler.success(Route.toFunction(guarded))
+      Future.successful(binding)
+    }
+    Await.result(startup, 5.seconds) shouldBe binding
+    val serve = Await.result(handler.future, 5.seconds)
+    delivered.completeWith(serve(HttpRequest()))
+    Await.result(admitted.future, 5.seconds) shouldBe Done
+    unbound.isCompleted shouldBe false
+    val stopped = shutdown.run(ErgoApp.RemoteShutdown)
+    val deadline = Await.result(draining.future, 5.seconds)
+    unbound.isCompleted shouldBe true
+    deadline should be > Duration.Zero
+    deadline should be < shutdown.timeout(CoordinatedShutdown.PhaseServiceRequestsDone)
+    walletClosed.isCompleted shouldBe false
+    stopped.isCompleted shouldBe false
+    Await.result(serve(HttpRequest()), 5.seconds).status shouldBe StatusCodes.ServiceUnavailable
+
+    // An admitted ordinary response can still read its dependency during the drain.
+    walletOpen.get() shouldBe true
+    response.success(HttpResponse(entity = "wallet response"))
+    Await.result(delivered.future, 5.seconds).status shouldBe StatusCodes.OK
+    Await.result(stopped, 5.seconds) shouldBe Done
+    Await.result(walletClosed.future, 5.seconds) shouldBe Done
+    Await.result(binding.whenTerminated, 5.seconds) shouldBe HttpServerTerminated
+  }
+
+  it should "shut down already started resources after an asynchronous bind failure" in withSystem { implicit system =>
+    val shutdown = CoordinatedShutdown(system)
+    val resourceClosed = Promise[Done]()
+    shutdown.addTask(CoordinatedShutdown.PhaseServiceStop, "close-resource") { () =>
+      resourceClosed.success(Done)
+      Future.successful(Done)
+    }
+    val pending = Promise[ServerBinding]()
+    val startup = start(pending.future)
+    val failure = new IllegalStateException("binding unavailable")
+    pending.failure(failure)
+
+    intercept[IllegalStateException](Await.result(startup, 5.seconds)) shouldBe failure
+    Await.result(resourceClosed.future, 5.seconds) shouldBe Done
+    shutdown.shutdownReason() shouldBe Some(ErgoApp.InternalShutdown)
+  }
+
+  it should "own an exception thrown while initiating the binding" in withSystem { implicit system =>
+    val shutdown = CoordinatedShutdown(system)
+    val resourceClosed = Promise[Done]()
+    shutdown.addTask(CoordinatedShutdown.PhaseServiceStop, "close-resource") { () =>
+      resourceClosed.success(Done)
+      Future.successful(Done)
+    }
+    val failure = new IllegalArgumentException("invalid binding configuration")
+    val startup = start(throw failure)
+
+    intercept[IllegalArgumentException](Await.result(startup, 5.seconds)) shouldBe failure
+    Await.result(resourceClosed.future, 5.seconds) shouldBe Done
+    shutdown.shutdownReason() shouldBe Some(ErgoApp.InternalShutdown)
+  }
+
+  it should "include a pending binding when shutdown starts before startup completes" in withSystem { implicit system =>
+    val shutdown = CoordinatedShutdown(system)
+    val pending = Promise[ServerBinding]()
+    val shutdownStarted = Promise[Done]()
+    val terminated = Promise[Done]()
+    shutdown.addTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "shutdown-started") { () =>
+      shutdownStarted.success(Done)
+      Future.successful(Done)
+    }
+    val startup = start(pending.future)
+    val stopped = shutdown.run(ErgoApp.RemoteShutdown)
+    Await.result(shutdownStarted.future, 5.seconds)
+    val binding = ServerBinding(new InetSocketAddress("127.0.0.1", 0))(
+      () => Future.successful(()),
+      _ => { terminated.success(Done); Future.successful(HttpServerTerminated) }
+    )
+    pending.success(binding)
+
+    Await.result(startup, 5.seconds) shouldBe binding
+    Await.result(stopped, 5.seconds) shouldBe Done
+    Await.result(terminated.future, 5.seconds) shouldBe Done
+  }
+
+  it should "deny application requests until binding ownership is established" in withSystem { implicit system =>
+    val pending = Promise[ServerBinding]()
+    val handler = Promise[HttpRequest => Future[HttpResponse]]()
+    val calls = new AtomicInteger(0)
+    val route: Route = complete {
+      calls.incrementAndGet()
+      HttpResponse()
+    }
+    val startup = HttpServerLifecycle.start(route) { guarded =>
+      handler.success(Route.toFunction(guarded))
+      pending.future
+    }
+    val serve = Await.result(handler.future, 5.seconds)
+    Await.result(serve(HttpRequest()), 5.seconds).status shouldBe StatusCodes.ServiceUnavailable
+    calls.get() shouldBe 0
+    val binding = ServerBinding(new InetSocketAddress("127.0.0.1", 0))(
+      () => Future.successful(()), _ => Future.successful(HttpServerTerminated))
+    pending.success(binding)
+    Await.result(startup, 5.seconds) shouldBe binding
+    Await.result(serve(HttpRequest()), 5.seconds).status shouldBe StatusCodes.OK
+    calls.get() shouldBe 1
+    Await.result(CoordinatedShutdown(system).run(ErgoApp.RemoteShutdown), 5.seconds) shouldBe Done
+  }
+
+  it should "terminate a binding arriving after the acquisition window without admitting dependency calls" in
+    withSystemConfig("akka.coordinated-shutdown.default-phase-timeout = 400ms") { implicit system =>
+      val pending = Promise[ServerBinding]()
+      val handler = Promise[HttpRequest => Future[HttpResponse]]()
+      val calls = new AtomicInteger(0)
+      val stopped = Promise[Done]()
+      val terminated = Promise[FiniteDuration]()
+      val shutdown = CoordinatedShutdown(system)
+      val route: Route = complete {
+        calls.incrementAndGet()
+        HttpResponse()
+      }
+      val startup = HttpServerLifecycle.start(route) { guarded =>
+        handler.success(Route.toFunction(guarded))
+        pending.future
+      }
+      shutdown.addTask(CoordinatedShutdown.PhaseServiceStop, "stop-dependencies") { () =>
+        stopped.success(Done)
+        Future.successful(Done)
+      }
+      Await.result(shutdown.run(ErgoApp.RemoteShutdown), 5.seconds) shouldBe Done
+      Await.result(stopped.future, 5.seconds) shouldBe Done
+      val binding = ServerBinding(new InetSocketAddress("127.0.0.1", 0))(
+        () => Future.successful(()),
+        deadline => { terminated.success(deadline); Future.successful(HttpServerTerminated) })
+      pending.success(binding)
+      Await.result(startup, 5.seconds) shouldBe binding
+      Await.result(terminated.future, 5.seconds) should be > Duration.Zero
+      val serve = Await.result(handler.future, 5.seconds)
+      Await.result(serve(HttpRequest()), 5.seconds).status shouldBe StatusCodes.ServiceUnavailable
+      calls.get() shouldBe 0
+    }
+}

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -5,6 +5,7 @@ import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
+import org.ergoplatform.core.versionToId
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.BlockTransactions
@@ -15,7 +16,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{Eliminat
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
-import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.{StateType, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedModifier}
 import org.ergoplatform.settings.NetworkType.DevNet60
@@ -34,6 +35,8 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 import sigma.serialization.ErgoTreeSerializer
 import sigmastate.crypto.DLogProtocol.DLogProverInput
+
+import java.nio.file.{Files, Paths}
 
 import scala.concurrent.duration._
 
@@ -63,13 +66,67 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
-  it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
-    ActorSystem()
-  ) {
+  private def freshSettings(prototype: ErgoSettings): ErgoSettings = {
+    val root = Paths.get(prototype.directory).toAbsolutePath
+    val parent = Files.createDirectories(root.getParent)
+    val directory = Files.createTempDirectory(parent, s"${root.getFileName}-candidate-")
+    prototype.copy(directory = directory.toString)
+  }
+
+  private def withNodeTest(test: TestKit => Unit): Unit = {
+    val kit = new TestKit(ActorSystem())
+    try test(kit)
+    finally TestKit.shutdownActorSystem(kit.system)
+  }
+
+  private def awaitSetupBlock(testProbe: TestProbe, block: ErgoFullBlock): Unit = {
+    // The direct solution ACK and exact block-application event can arrive in either order.
+    testProbe.fishForMessage(blockValidationDelay) {
+      case StatusReply.Success(()) =>
+        testProbe.expectMsgPF(candidateGenDelay) {
+          case FullBlockApplied(header) if header.id == block.id =>
+        }
+        true
+      case FullBlockApplied(header) if header.id == block.id =>
+        testProbe.expectMsg(StatusReply.Success(()))
+        true
+      case _ => false
+    }
+  }
+
+  private def setupReward(readersHolderRef: ActorRef,
+                          setupBlock: ErgoFullBlock,
+                          emissionBoxId: ErgoBox.BoxId): (Readers, ErgoBox) = {
+    // ReadersHolder receives the state update asynchronously after the application event.
+    eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      val readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      versionToId(readers.s.version) shouldBe setupBlock.id
+      val header = readers.h.typedModifierById[Header](setupBlock.id).value
+      val appliedBlock = readers.h.getFullBlock(header).value
+      val emissionTransactions = appliedBlock.transactions.filter(
+        _.inputs.exists(_.boxId.sameElements(emissionBoxId))
+      )
+      emissionTransactions should have size 1
+      val rewardScript = ErgoTreePredef
+        .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
+        .bytes
+      val rewards = emissionTransactions.head.outputs.filter(
+        _.propositionBytes.sameElements(rewardScript)
+      )
+      rewards should have size 1
+      val rewardBox = rewards.head
+      readers.s.asInstanceOf[UtxoStateReader].boxById(rewardBox.id).value shouldBe rewardBox
+      (readers, rewardBox)
+    }
+  }
+
+  it should "provider candidate to internal miner and verify and apply his solution" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -77,25 +134,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
-    ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by node view holder" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -103,13 +159,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -141,25 +197,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by full block id" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by full block id" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -167,13 +222,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -205,21 +260,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "let multiple miners compete" in new TestKit(ActorSystem()) {
+  it should "let multiple miners compete" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -227,12 +283,12 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val m1 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m2 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m3 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    val m1 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m2 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m3 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
@@ -253,16 +309,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
 
     List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
-    system.terminate()
   }
 
-  it should "cache candidate until newly mined block is applied" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "cache candidate until newly mined block is applied" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -270,7 +325,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     expectNoMessage(1.second)
@@ -278,7 +333,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     val block = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -302,16 +357,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         true
     }
 
-    system.terminate()
   }
 
-  it should "regenerate candidate periodically" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "regenerate candidate periodically" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -319,6 +372,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -332,34 +386,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = settingsWithShortRegeneration.chainSettings.powScheme
+        settingsWithShortRegeneration.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -392,14 +436,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             )
         }
     }
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after regeneration" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -407,6 +451,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -420,36 +465,26 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -503,15 +538,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             true
         }
     }
-    system.terminate()
   }
 
-  it should "pool transactions should be removed from pool when block is mined" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "pool transactions should be removed from pool when block is mined" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -519,43 +553,32 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -577,7 +600,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -608,15 +631,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       .filter(_.blockTransactions.transactions.map(_.id).contains(tx.id))
     val txs: Seq[ErgoTransaction] = blocks.flatMap(_.blockTransactions.transactions)
     txs should have length 2 // 1 reward and one regular tx, no fee collection tx
-    system.terminate()
   }
 
-  it should "6.0 pool transactions should be added to 6.0 block" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "6.0 pool transactions should be added to 6.0 block" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings60)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -624,42 +646,30 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings60
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -692,7 +702,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -726,17 +736,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     txs should have length 3 // 1 rewards and two regular txs, no fee collection
 
-    system.terminate()
   }
 
-  it should "use custom miner public key when provided via optPk" in new TestKit(ActorSystem()) {
+  it should "use custom miner public key when provided via optPk" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -744,7 +755,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -766,14 +777,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe customPk
     
-    system.terminate()
   }
 
-  it should "use default minerPk when optPk is None" in new TestKit(ActorSystem()) {
+  it should "use default minerPk when optPk is None" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -781,7 +793,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(
@@ -798,17 +810,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe defaultMinerSecret.publicImage
 
-    system.terminate()
   }
 
-  it should "generate different candidates for different optPk values" in new TestKit(ActorSystem()) {
+  it should "generate different candidates for different optPk values" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -816,7 +829,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -848,17 +861,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate2.externalVersion.pk shouldBe customPk
     candidate1.externalVersion.pk should not be candidate2.externalVersion.pk
 
-    system.terminate()
   }
 
-  it should "handle optPk with empty transactions" in new TestKit(ActorSystem()) {
+  it should "handle optPk with empty transactions" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -866,7 +880,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -887,7 +901,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate should not be null
     candidate.txsToInclude shouldBe empty
 
-    system.terminate()
   }
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
@@ -956,20 +969,20 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
   }
 
-  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {
+  it should "preserve previous candidate when forced regeneration occurs" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-preserve-candidate-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1036,24 +1049,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case StatusReply.Success(()) =>
     }
 
-    system.terminate()
   }
 
-  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(ActorSystem()) {
+  it should "handle multiple consecutive forced regenerations correctly" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    // Use unique directory to avoid state conflicts
-    val testDir = s"${defaultSettings.directory}-multi-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1132,17 +1143,16 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
-  it should "return cached candidate immediately when forced = false" in new TestKit(ActorSystem()) {
+  it should "return cached candidate immediately when forced = false" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-cache-test-${System.currentTimeMillis()}"
-    val testSettings = defaultSettings.copy(directory = testDir)
+    val settings = freshSettings(defaultSettings)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(testSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -1150,7 +1160,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        testSettings
+        settings
       )
 
     // Get first candidate
@@ -1173,23 +1183,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Should be very fast since all are cached (no regeneration)
     elapsed should be < 500L
 
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-mempool-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 100.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1202,28 +1211,21 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // Get candidate and solve it
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -1238,8 +1240,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Build new transaction to trigger mempool change
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("forced-mempool-test".getBytes())).publicImage
-    val newlyMinedBlock = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     val input = Input(rewardBox.id, emptyProverResult)
 
     val outputs = IndexedSeq(
@@ -1277,7 +1277,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
   private class FixedReadersHolder(readers: Readers) extends Actor {

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -892,74 +892,68 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val viewHolderProbe = new TestProbe(system)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsForExplicitForcing: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            // Keep automatic refresh outside this test of explicit forcing.
+            .copy(blockCandidateGenerationInterval = 1.hour),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
-    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+    // Keep readers fixed: a later ChangedMempool event may legitimately regenerate the cache.
+    val (initialState, boxes) = createUtxoState(settingsForExplicitForcing)
+    val block = validFullBlock(None, initialState, boxes)
+    val state = initialState.applyModifier(block, None)(_ => ()).get
+    // Initialization computes mining-time averages from pairs of headers.
+    val history = historyWithBestFullBlock(Seq(block))
+    val readers = Readers(history, state, ErgoMemPool.empty(settingsForExplicitForcing), walletStub)
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
 
     val candidateGenerator: ActorRef =
       CandidateGenerator(
         defaultMinerSecret.publicImage,
         readersHolderRef,
-        viewHolderRef,
-        settingsWithShortRegeneration
+        viewHolderProbe.ref,
+        settingsForExplicitForcing
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    try {
+      // Get first candidate from the coherent, already applied block snapshot.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate1.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
 
-    // First mine a block to establish chain (needed for avg mining time calculation)
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val initCandidate = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+      // Request with forced = false should return cached candidate immediately.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate2 = testProbe.expectMsgPF(100.millis) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate2 should be theSameInstanceAs candidate1
+      candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
+
+      // Request with forced = true should bypass cache and regenerate.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+      val candidate3 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+
+      // Identity proves regeneration even when the clock has not advanced.
+      candidate3 should not be theSameInstanceAs(candidate1)
+      candidate3.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
+      candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    } finally {
+      TestKit.shutdownActorSystem(system)
+      history.closeStorage()
+      state.closeStorage()
     }
-    val initBlock = powScheme
-      .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
-      .get
-    candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
-      case _ => false
-    }
-
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // Request with forced = false should return cached candidate immediately
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate2 = testProbe.expectMsgPF(100.millis) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-    // Should be the exact same cached candidate
-    candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
-
-    // Request with forced = true should bypass cache and regenerate
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-    val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
-      case StatusReply.Success(_: Candidate) => true
-      case _: FullBlockApplied => false
-    } match {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // candidate3 should have timestamp >= candidate1 (regenerated, possibly same or newer)
-    candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-
-    system.terminate()
   }
 
   it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -64,8 +64,13 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val (us, bh) = createUtxoState(settings)
     val genesis = validFullBlock(None, us, bh)
     val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-    val inputBox = wus.takeBoxes(1).head
-    val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+    val inputBox = wus.takeBoxes(100).find(_.ergoTree == TrueTree).get
+    val feeOut = new ErgoBoxCandidate(
+      inputBox.value,
+      feeProp,
+      creationHeight = 0,
+      additionalTokens = inputBox.additionalTokens
+    )
     val tx = ErgoTransaction(
       IndexedSeq(new Input(inputBox.id, ProverResult.empty)),
       IndexedSeq(feeOut)
@@ -79,8 +84,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerByte,
       ))
 
-    var poolSize = ErgoMemPool.empty(sortBySizeSettings)
-    poolSize = poolSize.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolSize, sizeOutcome) =
+      ErgoMemPool.empty(sortBySizeSettings).process(UnconfirmedTransaction(tx, None), wus)
+    sizeOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val size = tx.size
     poolSize.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, size).weight
 
@@ -89,8 +95,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerCycle,
       ))
 
-    var poolCost = ErgoMemPool.empty(sortByCostSettings)
-    poolCost = poolCost.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolCost, costOutcome) =
+      ErgoMemPool.empty(sortByCostSettings).process(UnconfirmedTransaction(tx, None), wus)
+    costOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val validationContext = wus.stateContext.simplifiedUpcoming()
     val cost = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
     poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,9 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    val box = wusAfterGenesis.takeBoxes(wusAfterGenesis.size)
+      .find(_.ergoTree == TrueTree)
+      .getOrElse(fail("Expected an unspent TrueTree box after genesis"))
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
Depends on [#2535](https://github.com/ergoplatform/ergo/pull/2535) at `e18df9692` for shared test support. Review the [four-file HTTP increment](https://github.com/a-shannon/ergo/compare/e18df96928b123894d2ae8da6a6d5a13dc1ee731...2a9fc13b10032e179e2973750fcbc5180060968c); the upstream diff remains cumulative until that prerequisite merges. The latest composition adds only the exact shared selected-chain observation correction; all four owned HTTP files match the reviewed `0d37a1601` head.

REST startup currently discards the binding result, and coordinated shutdown can close wallet dependencies before admitted HTTP requests finish. This change owns the binding throughout startup and shutdown: binding failure starts coordinated shutdown, HTTP admissions stop before draining, and wallet/network closure follows the HTTP phases.

Binding acquisition has its own shutdown budget. The application route remains unavailable until the binding is owned, and stays unavailable once shutdown begins. A binding arriving after the acquisition window is terminated without admitting application requests.

Validation: six focused tests pass with real guarded routes, controlled server bindings and coordinated-shutdown phases. They cover ordinary response draining, both forms of bind failure, pending startup, initial admission gating and late binding completion. Independent source and evidence review completed. These tests do not exercise native TCP draining. The previous `0d37a1601` CI failed during Maven Central dependency downloads with HTTP 403 before the affected wallet tests ran ([run](https://github.com/ergoplatform/ergo/actions/runs/34284984642)); two sibling jobs were cancelled. All eight checks passed at `2a9fc13b1` after the shared-fixture composition ([CI run](https://github.com/ergoplatform/ergo/actions/runs/34296897482)).

The first standalone CI run passed integration and 808 of 809 node tests; `ErgoMemPoolSpec` failed by reading an empty pool after unchecked admission. Its fixture correction already belongs to #2535. Reusing that exact prerequisite preserves all four HTTP files unchanged, and the composed local run passes the six HTTP cases plus the corrected sorting case.
