### PR TITLE
Recover paired history insertions before exposing stored objects

### DIFF
--- a/avldb/src/main/scala/scorex/db/LDBKVStore.scala
+++ b/avldb/src/main/scala/scorex/db/LDBKVStore.scala
@@ -1,9 +1,10 @@
 package scorex.db
 
-import org.iq80.leveldb.DB
+import org.iq80.leveldb.{DB, WriteOptions}
 import scorex.util.ScorexLogging
 
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 import spire.syntax.all.cfor
 
 
@@ -15,6 +16,31 @@ import spire.syntax.all.cfor
 class LDBKVStore(protected val db: DB) extends KVStoreReader with ScorexLogging {
   /** Immutable empty array can be shared to avoid allocations. */
   private val emptyArrayOfByteArray = Array.empty[Array[Byte]]
+
+  /** Atomic batch with an explicit durable write acknowledgement. Existing update semantics are unchanged. */
+  def updateDurable(toInsertKeys: Array[K], toInsertValues: Array[V], toRemove: Array[K]): Try[Unit] = {
+    Try {
+      require(toInsertKeys.length == toInsertValues.length)
+      val batch = db.createWriteBatch()
+      var failure: Throwable = null
+      try {
+        cfor(0)(_ < toInsertKeys.length, _ + 1) { i => batch.put(toInsertKeys(i), toInsertValues(i)) }
+        cfor(0)(_ < toRemove.length, _ + 1) { i => batch.delete(toRemove(i)) }
+        db.write(batch, new WriteOptions().sync(true))
+        ()
+      } catch {
+        case error: Throwable =>
+          failure = error
+          throw error
+      } finally {
+        try batch.close() catch {
+          case NonFatal(cleanup) =>
+            if (failure == null) throw cleanup
+            else if (cleanup ne failure) failure.addSuppressed(cleanup)
+        }
+      }
+    }
+  }
 
   /**
     * Update this database atomically with a batch of insertion and removal operations

--- a/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/header/HeaderSerializer.scala
+++ b/ergo-core/src/main/scala/org/ergoplatform/modifiers/history/header/HeaderSerializer.scala
@@ -75,9 +75,10 @@ object HeaderSerializer extends ErgoSerializer[Header] {
   }
 
   override def parse(r: Reader): Header = {
+    val startConsumed = r.consumed
     val headerWithoutPow = parseWithoutPow(r)
     val powSolution = AutolykosSolutionSerializer.parse(r, headerWithoutPow.version)
-    headerWithoutPow.toHeader(powSolution, Some(r.consumed))
+    headerWithoutPow.toHeader(powSolution, Some(r.consumed - startConsumed))
   }
 
 }

--- a/ergo-core/src/test/scala/org/ergoplatform/serialization/HeaderSizeSerializationSpec.scala
+++ b/ergo-core/src/test/scala/org/ergoplatform/serialization/HeaderSizeSerializationSpec.scala
@@ -1,0 +1,62 @@
+package org.ergoplatform.serialization
+
+import java.nio.ByteBuffer
+
+import org.ergoplatform.modifiers.history.HistoryModifierSerializer
+import org.ergoplatform.modifiers.history.header.{Header, HeaderSerializer}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import scorex.util.serialization.VLQByteBufferReader
+
+class HeaderSizeSerializationSpec extends ErgoCorePropertyTest {
+  private def checkHeader(original: Header, parsed: Header): Unit = {
+    val encoded = HeaderSerializer.toBytes(original)
+    parsed.sizeOpt shouldBe Some(encoded.length)
+    parsed.size shouldBe encoded.length
+    parsed.bytes.toSeq shouldBe encoded.toSeq
+    parsed.id shouldBe original.id
+  }
+
+  private def variants(header: Header): Seq[Header] = Seq[Byte](1, 2, 5).map { version =>
+    header.copy(version = version, sizeOpt = None,
+      unparsedBytes = if (version == 5) Array[Byte](7, 8, 9) else Array.emptyByteArray)
+  }
+
+  property("standalone headers retain their serialized size, bytes and identity") {
+    forAll(defaultHeaderGen) { generated =>
+      variants(generated).foreach { header =>
+        checkHeader(header, HeaderSerializer.parseBytes(HeaderSerializer.toBytes(header)))
+      }
+    }
+  }
+
+  property("history-wrapped headers exclude the modifier type from their size") {
+    forAll(defaultHeaderGen) { generated =>
+      variants(generated).foreach { header =>
+        val wrapped = HistoryModifierSerializer.toBytes(header)
+        val parsed = HistoryModifierSerializer.parseBytes(wrapped).asInstanceOf[Header]
+        wrapped.length shouldBe header.bytes.length + 1
+        checkHeader(header, parsed)
+        HistoryModifierSerializer.toBytes(parsed).toSeq shouldBe wrapped.toSeq
+      }
+    }
+  }
+
+  property("consecutive headers count only their own bytes after a nonzero reader entry") {
+    forAll(defaultHeaderGen) { generated =>
+      variants(generated).foreach { header =>
+        val encoded = HeaderSerializer.toBytes(header)
+        val prefix = Array[Byte](1, 2, 3, 4, 5, 6, 7)
+        val suffix: Byte = 99
+        val reader = new VLQByteBufferReader(ByteBuffer.wrap(prefix ++ encoded ++ encoded ++ Array(suffix)))
+        reader.getBytes(prefix.length).toSeq shouldBe prefix.toSeq
+        reader.consumed shouldBe prefix.length
+        checkHeader(header, HeaderSerializer.parse(reader))
+        reader.consumed shouldBe prefix.length + encoded.length
+        checkHeader(header, HeaderSerializer.parse(reader))
+        reader.consumed shouldBe prefix.length + 2 * encoded.length
+        reader.getByte() shouldBe suffix
+      }
+    }
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryInsertionJournal.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryInsertionJournal.scala
@@ -1,0 +1,66 @@
+package org.ergoplatform.nodeView.history.storage
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/** Private redo record; existing history objects and index rows retain their byte formats. */
+private[storage] object HistoryInsertionJournal {
+  // Ordinary history index keys are 32-byte hashes/constants. This distinct key is also explicitly reserved.
+  def key: Array[Byte] = "history-storage/pending-insertion/v1".getBytes(StandardCharsets.US_ASCII)
+  def isReserved(bytes: Array[Byte]): Boolean = java.util.Arrays.equals(bytes, key)
+
+  final case class Intent(objects: Vector[(Array[Byte], Array[Byte])], indexes: Vector[(Array[Byte], Array[Byte])])
+
+  private val Magic = 0x4853494a
+  private val Version = 1
+  private val DigestLength = 32
+  private def digest(bytes: Array[Byte]): Array[Byte] = MessageDigest.getInstance("SHA-256").digest(bytes)
+
+  def encode(intent: Intent): Array[Byte] = {
+    val bytes = new ByteArrayOutputStream()
+    val out = new DataOutputStream(bytes)
+    out.writeInt(Magic)
+    out.writeInt(Version)
+    def rows(values: Vector[(Array[Byte], Array[Byte])]): Unit = {
+      out.writeInt(values.size)
+      values.foreach { case (key, value) =>
+        out.writeInt(key.length)
+        out.write(key)
+        out.writeInt(value.length)
+        out.write(value)
+      }
+    }
+    rows(intent.objects)
+    rows(intent.indexes)
+    out.flush()
+    val payload = bytes.toByteArray
+    payload ++ digest(payload)
+  }
+
+  def decode(bytes: Array[Byte]): Intent = {
+    require(bytes.length >= 16 + DigestLength, "Incomplete history insertion journal")
+    val payload = bytes.dropRight(DigestLength)
+    require(MessageDigest.isEqual(digest(payload), bytes.takeRight(DigestLength)), "History insertion journal checksum mismatch")
+    val in = new DataInputStream(new ByteArrayInputStream(payload))
+    require(in.readInt() == Magic, "Unknown history insertion journal magic")
+    require(in.readInt() == Version, "Unsupported history insertion journal version")
+    def field(): Array[Byte] = {
+      val length = in.readInt()
+      require(length >= 0 && length <= in.available(), "Invalid history insertion journal field length")
+      val value = new Array[Byte](length)
+      in.readFully(value)
+      value
+    }
+    def rows(): Vector[(Array[Byte], Array[Byte])] = {
+      val count = in.readInt()
+      require(count >= 0 && count <= in.available() / 8, "Invalid history insertion journal row count")
+      Vector.fill(count)(field() -> field())
+    }
+    val intent = Intent(rows(), rows())
+    require(in.available() == 0, "Trailing history insertion journal bytes")
+    require(intent.objects.forall(_._1.length == 32), "Invalid history object key")
+    require(intent.indexes.forall(row => !isReserved(row._1)), "Reserved history index key")
+    intent
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/HistoryStorage.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.nodeView.history.storage
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import org.ergoplatform.CriticalSystemException
 import org.ergoplatform.modifiers.{BlockSection, NetworkObjectTypeId}
 import org.ergoplatform.modifiers.history.HistoryModifierSerializer
 import org.ergoplatform.modifiers.history.header.Header
@@ -11,6 +12,7 @@ import scorex.db.{ByteArrayWrapper, LDBFactory, LDBKVStore}
 import scorex.util.{ModifierId, ScorexLogging, idToBytes}
 
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 import spire.syntax.all.cfor
 
 import java.io.File
@@ -30,6 +32,53 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
   extends ScorexLogging
     with AutoCloseable
     with ScorexEncoding {
+
+  private var initialized = false
+  private var unavailable: Option[CriticalSystemException] = None
+
+  private def quarantine(cause: Throwable): CriticalSystemException = {
+    val error = CriticalSystemException("History insertion persistence is incomplete; reopen storage to recover")
+    error.initCause(cause)
+    unavailable = Some(error)
+    error
+  }
+
+  private def rejectReserved(key: Array[Byte]): Unit =
+    require(!HistoryInsertionJournal.isReserved(key), "Reserved history insertion journal key")
+
+  private def finish(intent: HistoryInsertionJournal.Intent): Unit = {
+    objectsStore.updateDurable(intent.objects.map(_._1).toArray, intent.objects.map(_._2).toArray, Array.empty).get
+    indexStore.updateDurable(intent.indexes.map(_._1).toArray, intent.indexes.map(_._2).toArray,
+      Array(HistoryInsertionJournal.key)).get
+  }
+
+  private def decodedObjects(intent: HistoryInsertionJournal.Intent): Vector[BlockSection] =
+    intent.objects.map { case (key, bytes) =>
+      val modifier = HistoryModifierSerializer.parseBytesTry(bytes).get
+      require(java.util.Arrays.equals(key, modifier.serializedId), "History journal object identity mismatch")
+      modifier
+    }
+
+  private def initialize(): Unit = synchronized {
+    unavailable.foreach(throw _)
+    if (!initialized) {
+      try {
+        indexStore.get(HistoryInsertionJournal.key).foreach { bytes =>
+          val intent = HistoryInsertionJournal.decode(bytes)
+          decodedObjects(intent)
+          finish(intent)
+        }
+        initialized = true
+      } catch {
+        case NonFatal(error) => throw quarantine(error)
+      }
+    }
+  }
+
+  private def ready[A](operation: => A): A = synchronized {
+    initialize()
+    operation
+  }
 
   private lazy val headersCache =
     Caffeine.newBuilder()
@@ -65,18 +114,18 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     extraCache.invalidate(id)
   }
 
-  def modifierBytesById(id: ModifierId): Option[Array[Byte]] = {
+  def modifierBytesById(id: ModifierId): Option[Array[Byte]] = ready {
     objectsStore.get(idToBytes(id)).map(_.tail).orElse(extraStore.get(idToBytes(id))) // removing modifier type byte with .tail (only in objectsStore)
   }
 
   /**
     * @return bytes and type of a network object stored in the database with identifier `id`
     */
-  def modifierTypeAndBytesById(id: ModifierId): Option[(NetworkObjectTypeId.Value, Array[Byte])] = {
+  def modifierTypeAndBytesById(id: ModifierId): Option[(NetworkObjectTypeId.Value, Array[Byte])] = ready {
     objectsStore.get(idToBytes(id)).map(bs => (NetworkObjectTypeId.fromByte(bs.head), bs.tail)) // first byte is type id, tail is modifier bytes
   }
 
-  def modifierById(id: ModifierId): Option[BlockSection] =
+  def modifierById(id: ModifierId): Option[BlockSection] = ready {
     lookupModifier(id) orElse objectsStore.get(idToBytes(id)).flatMap { bytes =>
       HistoryModifierSerializer.parseBytesTry(bytes) match {
         case Success(pm) =>
@@ -88,8 +137,9 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
           None
       }
     }
+  }
 
-  def getExtraIndex(id: ModifierId): Option[ExtraIndex] = {
+  def getExtraIndex(id: ModifierId): Option[ExtraIndex] = ready {
     Option(extraCache.getIfPresent(id)) orElse extraStore.get(idToBytes(id)).flatMap { bytes =>
       ExtraIndexSerializer.parseBytesTry(bytes) match {
         case Success(pm) =>
@@ -105,22 +155,24 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     }
   }
 
-  def getIndex(id: ByteArrayWrapper): Option[Array[Byte]] =
+  def getIndex(id: ByteArrayWrapper): Option[Array[Byte]] = ready {
+    rejectReserved(id.data)
     Option(indexCache.getIfPresent(id)).orElse {
       indexStore.get(id.data).map { value =>
         indexCache.put(id, value)
         value
       }
     }
+  }
 
   /**
     * @return object with `id` if it is in the objects database
     */
-  def get(id: ModifierId): Option[Array[Byte]] = {
+  def get(id: ModifierId): Option[Array[Byte]] = ready {
     val idBytes = idToBytes(id)
     objectsStore.get(idBytes).orElse(extraStore.get(idBytes))
   }
-  def get(id: Array[Byte]): Option[Array[Byte]] = objectsStore.get(id).orElse(extraStore.get(id))
+  def get(id: Array[Byte]): Option[Array[Byte]] = ready { objectsStore.get(id).orElse(extraStore.get(id)) }
 
   /**
     * @return if object with `id` is in the objects database
@@ -129,27 +181,31 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
   def contains(id: ModifierId): Boolean = get(id).isDefined
 
   def insert(indexesToInsert: Array[(ByteArrayWrapper, Array[Byte])],
-             objectsToInsert: Array[BlockSection]): Try[Unit] = {
-    objectsStore.insert(
-      objectsToInsert.map(mod => mod.serializedId),
-      objectsToInsert.map(mod => HistoryModifierSerializer.toBytes(mod))
-    ).flatMap { _ =>
-      cfor(0)(_ < objectsToInsert.length, _ + 1) { i => cacheModifier(objectsToInsert(i))}
-      if (indexesToInsert.nonEmpty) {
-        indexStore.insert(
-          indexesToInsert.map(_._1.data),
-          indexesToInsert.map(_._2)
-        ).map { _ =>
-          cfor(0)(_ < indexesToInsert.length, _ + 1) { i =>
-            indexCache.put(indexesToInsert(i)._1, indexesToInsert(i)._2)
-          }
+             objectsToInsert: Array[BlockSection]): Try[Unit] = synchronized {
+    Try(initialize()).flatMap { _ =>
+      // Freeze and validate everything before the first write; serialization failures leave no usable intent.
+      Try {
+        val indexes = indexesToInsert.toVector.map { case (key, value) =>
+          rejectReserved(key.data)
+          key.data.clone() -> value.clone()
         }
-      } else Success(())
+        val objects = objectsToInsert.toVector.map(mod => mod.serializedId.clone() -> HistoryModifierSerializer.toBytes(mod))
+        val intent = HistoryInsertionJournal.Intent(objects, indexes)
+        val modifiers = decodedObjects(intent)
+        (intent, modifiers, HistoryInsertionJournal.encode(intent))
+      }.flatMap { case (intent, modifiers, encoded) =>
+        Try {
+          indexStore.updateDurable(Array(HistoryInsertionJournal.key), Array(encoded), Array.empty).get
+          finish(intent)
+          modifiers.foreach(cacheModifier)
+          intent.indexes.foreach { case (key, value) => indexCache.put(ByteArrayWrapper(key), value) }
+        }.recoverWith { case NonFatal(error) => Failure(quarantine(error)) }
+      }
     }
   }
 
   def insertExtra(indexesToInsert: Array[(Array[Byte], Array[Byte])],
-                  objectsToInsert: Array[ExtraIndex]): Unit = {
+                  objectsToInsert: Array[ExtraIndex]): Unit = ready {
     extraStore.insert(
       objectsToInsert.map(mod => mod.serializedId),
       objectsToInsert.map(mod => ExtraIndexSerializer.toBytes(mod))
@@ -157,7 +213,7 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     cfor(0)(_ < indexesToInsert.length, _ + 1) { i => extraStore.insert(indexesToInsert(i)._1, indexesToInsert(i)._2)}
   }
 
-  def removeExtra(indexesToRemove: Array[ModifierId]) : Unit = {
+  def removeExtra(indexesToRemove: Array[ModifierId]) : Unit = ready {
     extraStore.remove(indexesToRemove.map(idToBytes))
     cfor(0)(_ < indexesToRemove.length, _ + 1) { i => removeModifier(indexesToRemove(i)) }
   }
@@ -171,7 +227,7 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     * @return - Success if insertion was successful, Failure otherwise
     */
   def insert(objectIdToInsert: Array[Byte],
-             objectToInsert: Array[Byte]): Try[Unit] = {
+             objectToInsert: Array[Byte]): Try[Unit] = ready {
     objectsStore.insert(objectIdToInsert, objectToInsert)
   }
 
@@ -183,7 +239,8 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     * @return
     */
   def remove(indicesToRemove: Array[ByteArrayWrapper],
-             idsToRemove: Array[ModifierId]): Try[Unit] = {
+             idsToRemove: Array[ModifierId]): Try[Unit] = ready {
+      indicesToRemove.foreach(key => rejectReserved(key.data))
 
       objectsStore.remove(idsToRemove.map(idToBytes)).map { _ =>
         cfor(0)(_ < idsToRemove.length, _ + 1) { i => removeModifier(idsToRemove(i))}
@@ -194,7 +251,7 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
       }
   }
 
-  override def close(): Unit = {
+  override def close(): Unit = synchronized {
     log.warn("Closing history storage...")
     extraStore.close()
     indexStore.close()
@@ -207,7 +264,7 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
     * @param ergoSettings - settings to use
     * @return new HistoryStorage instance with empty extra database, or this instance in case of failure
     */
-  def deleteExtraDB(ergoSettings: ErgoSettings): HistoryStorage = {
+  def deleteExtraDB(ergoSettings: ErgoSettings): HistoryStorage = ready {
     log.warn(s"Removing extra index database due to old schema.")
     close()
     // org.ergoplatform.wallet.utils.FileUtils
@@ -225,10 +282,28 @@ class HistoryStorage(indexStore: LDBKVStore, objectsStore: LDBKVStore, extraStor
 }
 
 object HistoryStorage {
-  def apply(ergoSettings: ErgoSettings): HistoryStorage = {
-    val indexStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/index")
-    val objectsStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/objects")
-    val extraStore = LDBFactory.createKvDb(s"${ergoSettings.directory}/history/extra")
-    new HistoryStorage(indexStore, objectsStore, extraStore, ergoSettings.cacheSettings)
+  def apply(ergoSettings: ErgoSettings): HistoryStorage = open(ergoSettings, LDBFactory.createKvDb)
+
+  private[storage] def open(ergoSettings: ErgoSettings, createStore: String => LDBKVStore): HistoryStorage = {
+    val acquired = scala.collection.mutable.ArrayBuffer.empty[LDBKVStore]
+    def acquire(name: String): LDBKVStore = {
+      val store = createStore(s"${ergoSettings.directory}/history/$name")
+      acquired += store
+      store
+    }
+    try {
+      val indexStore = acquire("index")
+      val objectsStore = acquire("objects")
+      val extraStore = acquire("extra")
+      val storage = new HistoryStorage(indexStore, objectsStore, extraStore, ergoSettings.cacheSettings)
+      storage.initialize()
+      storage
+    } catch {
+      case NonFatal(error) =>
+        acquired.reverseIterator.foreach { store =>
+          try store.close() catch { case NonFatal(cleanup) => if (cleanup ne error) error.addSuppressed(cleanup) }
+        }
+        throw error
+    }
   }
 }

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -5,6 +5,7 @@ import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
+import org.ergoplatform.core.versionToId
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.BlockTransactions
@@ -15,7 +16,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{Eliminat
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
-import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.{StateType, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedModifier}
 import org.ergoplatform.settings.NetworkType.DevNet60
@@ -34,6 +35,8 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 import sigma.serialization.ErgoTreeSerializer
 import sigmastate.crypto.DLogProtocol.DLogProverInput
+
+import java.nio.file.{Files, Paths}
 
 import scala.concurrent.duration._
 
@@ -63,13 +66,67 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
-  it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
-    ActorSystem()
-  ) {
+  private def freshSettings(prototype: ErgoSettings): ErgoSettings = {
+    val root = Paths.get(prototype.directory).toAbsolutePath
+    val parent = Files.createDirectories(root.getParent)
+    val directory = Files.createTempDirectory(parent, s"${root.getFileName}-candidate-")
+    prototype.copy(directory = directory.toString)
+  }
+
+  private def withNodeTest(test: TestKit => Unit): Unit = {
+    val kit = new TestKit(ActorSystem())
+    try test(kit)
+    finally TestKit.shutdownActorSystem(kit.system)
+  }
+
+  private def awaitSetupBlock(testProbe: TestProbe, block: ErgoFullBlock): Unit = {
+    // The direct solution ACK and exact block-application event can arrive in either order.
+    testProbe.fishForMessage(blockValidationDelay) {
+      case StatusReply.Success(()) =>
+        testProbe.expectMsgPF(candidateGenDelay) {
+          case FullBlockApplied(header) if header.id == block.id =>
+        }
+        true
+      case FullBlockApplied(header) if header.id == block.id =>
+        testProbe.expectMsg(StatusReply.Success(()))
+        true
+      case _ => false
+    }
+  }
+
+  private def setupReward(readersHolderRef: ActorRef,
+                          setupBlock: ErgoFullBlock,
+                          emissionBoxId: ErgoBox.BoxId): (Readers, ErgoBox) = {
+    // ReadersHolder receives the state update asynchronously after the application event.
+    eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      val readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      versionToId(readers.s.version) shouldBe setupBlock.id
+      val header = readers.h.typedModifierById[Header](setupBlock.id).value
+      val appliedBlock = readers.h.getFullBlock(header).value
+      val emissionTransactions = appliedBlock.transactions.filter(
+        _.inputs.exists(_.boxId.sameElements(emissionBoxId))
+      )
+      emissionTransactions should have size 1
+      val rewardScript = ErgoTreePredef
+        .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
+        .bytes
+      val rewards = emissionTransactions.head.outputs.filter(
+        _.propositionBytes.sameElements(rewardScript)
+      )
+      rewards should have size 1
+      val rewardBox = rewards.head
+      readers.s.asInstanceOf[UtxoStateReader].boxById(rewardBox.id).value shouldBe rewardBox
+      (readers, rewardBox)
+    }
+  }
+
+  it should "provider candidate to internal miner and verify and apply his solution" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -77,25 +134,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
-    ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by node view holder" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -103,13 +159,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -141,25 +197,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by full block id" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by full block id" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -167,13 +222,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -205,21 +260,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "let multiple miners compete" in new TestKit(ActorSystem()) {
+  it should "let multiple miners compete" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -227,12 +283,12 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val m1 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m2 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m3 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    val m1 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m2 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m3 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
@@ -253,16 +309,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
 
     List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
-    system.terminate()
   }
 
-  it should "cache candidate until newly mined block is applied" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "cache candidate until newly mined block is applied" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -270,7 +325,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     expectNoMessage(1.second)
@@ -278,7 +333,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     val block = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -302,16 +357,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         true
     }
 
-    system.terminate()
   }
 
-  it should "regenerate candidate periodically" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "regenerate candidate periodically" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -319,6 +372,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -332,34 +386,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = settingsWithShortRegeneration.chainSettings.powScheme
+        settingsWithShortRegeneration.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -392,14 +436,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             )
         }
     }
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after regeneration" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -407,6 +451,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -420,36 +465,26 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -503,15 +538,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             true
         }
     }
-    system.terminate()
   }
 
-  it should "pool transactions should be removed from pool when block is mined" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "pool transactions should be removed from pool when block is mined" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -519,43 +553,32 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -577,7 +600,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -608,15 +631,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       .filter(_.blockTransactions.transactions.map(_.id).contains(tx.id))
     val txs: Seq[ErgoTransaction] = blocks.flatMap(_.blockTransactions.transactions)
     txs should have length 2 // 1 reward and one regular tx, no fee collection tx
-    system.terminate()
   }
 
-  it should "6.0 pool transactions should be added to 6.0 block" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "6.0 pool transactions should be added to 6.0 block" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings60)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -624,42 +646,30 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings60
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -692,7 +702,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -726,17 +736,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     txs should have length 3 // 1 rewards and two regular txs, no fee collection
 
-    system.terminate()
   }
 
-  it should "use custom miner public key when provided via optPk" in new TestKit(ActorSystem()) {
+  it should "use custom miner public key when provided via optPk" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -744,7 +755,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -766,14 +777,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe customPk
     
-    system.terminate()
   }
 
-  it should "use default minerPk when optPk is None" in new TestKit(ActorSystem()) {
+  it should "use default minerPk when optPk is None" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -781,7 +793,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(
@@ -798,17 +810,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe defaultMinerSecret.publicImage
 
-    system.terminate()
   }
 
-  it should "generate different candidates for different optPk values" in new TestKit(ActorSystem()) {
+  it should "generate different candidates for different optPk values" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -816,7 +829,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -848,17 +861,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate2.externalVersion.pk shouldBe customPk
     candidate1.externalVersion.pk should not be candidate2.externalVersion.pk
 
-    system.terminate()
   }
 
-  it should "handle optPk with empty transactions" in new TestKit(ActorSystem()) {
+  it should "handle optPk with empty transactions" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -866,7 +880,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -887,7 +901,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate should not be null
     candidate.txsToInclude shouldBe empty
 
-    system.terminate()
   }
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
@@ -956,20 +969,20 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
   }
 
-  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {
+  it should "preserve previous candidate when forced regeneration occurs" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-preserve-candidate-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1036,24 +1049,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case StatusReply.Success(()) =>
     }
 
-    system.terminate()
   }
 
-  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(ActorSystem()) {
+  it should "handle multiple consecutive forced regenerations correctly" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    // Use unique directory to avoid state conflicts
-    val testDir = s"${defaultSettings.directory}-multi-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1132,17 +1143,16 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
-  it should "return cached candidate immediately when forced = false" in new TestKit(ActorSystem()) {
+  it should "return cached candidate immediately when forced = false" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-cache-test-${System.currentTimeMillis()}"
-    val testSettings = defaultSettings.copy(directory = testDir)
+    val settings = freshSettings(defaultSettings)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(testSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -1150,7 +1160,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        testSettings
+        settings
       )
 
     // Get first candidate
@@ -1173,23 +1183,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Should be very fast since all are cached (no regeneration)
     elapsed should be < 500L
 
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-mempool-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 100.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1202,28 +1211,21 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // Get candidate and solve it
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -1238,8 +1240,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Build new transaction to trigger mempool change
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("forced-mempool-test".getBytes())).publicImage
-    val newlyMinedBlock = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     val input = Input(rewardBox.id, emptyProverResult)
 
     val outputs = IndexedSeq(
@@ -1277,7 +1277,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
   private class FixedReadersHolder(readers: Readers) extends Actor {

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -892,74 +892,68 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val viewHolderProbe = new TestProbe(system)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsForExplicitForcing: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            // Keep automatic refresh outside this test of explicit forcing.
+            .copy(blockCandidateGenerationInterval = 1.hour),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
-    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+    // Keep readers fixed: a later ChangedMempool event may legitimately regenerate the cache.
+    val (initialState, boxes) = createUtxoState(settingsForExplicitForcing)
+    val block = validFullBlock(None, initialState, boxes)
+    val state = initialState.applyModifier(block, None)(_ => ()).get
+    // Initialization computes mining-time averages from pairs of headers.
+    val history = historyWithBestFullBlock(Seq(block))
+    val readers = Readers(history, state, ErgoMemPool.empty(settingsForExplicitForcing), walletStub)
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
 
     val candidateGenerator: ActorRef =
       CandidateGenerator(
         defaultMinerSecret.publicImage,
         readersHolderRef,
-        viewHolderRef,
-        settingsWithShortRegeneration
+        viewHolderProbe.ref,
+        settingsForExplicitForcing
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    try {
+      // Get first candidate from the coherent, already applied block snapshot.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate1.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
 
-    // First mine a block to establish chain (needed for avg mining time calculation)
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val initCandidate = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+      // Request with forced = false should return cached candidate immediately.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate2 = testProbe.expectMsgPF(100.millis) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate2 should be theSameInstanceAs candidate1
+      candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
+
+      // Request with forced = true should bypass cache and regenerate.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+      val candidate3 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+
+      // Identity proves regeneration even when the clock has not advanced.
+      candidate3 should not be theSameInstanceAs(candidate1)
+      candidate3.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
+      candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    } finally {
+      TestKit.shutdownActorSystem(system)
+      history.closeStorage()
+      state.closeStorage()
     }
-    val initBlock = powScheme
-      .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
-      .get
-    candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
-      case _ => false
-    }
-
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // Request with forced = false should return cached candidate immediately
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate2 = testProbe.expectMsgPF(100.millis) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-    // Should be the exact same cached candidate
-    candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
-
-    // Request with forced = true should bypass cache and regenerate
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-    val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
-      case StatusReply.Success(_: Candidate) => true
-      case _: FullBlockApplied => false
-    } match {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // candidate3 should have timestamp >= candidate1 (regenerated, possibly same or newer)
-    candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-
-    system.terminate()
   }
 
   it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryDurableBatchSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryDurableBatchSpec.scala
@@ -1,0 +1,132 @@
+package org.ergoplatform.nodeView.history.storage
+
+import java.io.IOException
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import org.ergoplatform.db.DBSpec
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.iq80.leveldb.{DB, WriteBatch, WriteOptions}
+import scorex.db.LDBKVStore
+import scala.util.control.ControlThrowable
+
+class HistoryDurableBatchSpec extends ErgoCorePropertyTest with DBSpec {
+  private def delegate(method: Method, target: AnyRef, arguments: Array[AnyRef]): AnyRef =
+    try method.invoke(target, arguments: _*) catch {
+      case error: InvocationTargetException => throw error.getCause
+    }
+
+  property("durable batch requests sync and atomically inserts and removes ordinary rows") {
+    withDb { db =>
+      var synced = false
+      val decorated = Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+        override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+          if (method.getName == "write" && args.length == 2) synced = args(1).asInstanceOf[WriteOptions].sync()
+          delegate(method, db, Option(args).getOrElse(Array.empty[AnyRef]))
+        }
+      }).asInstanceOf[DB]
+      val store = new LDBKVStore(decorated)
+      store.insert(Array[Byte](1), Array[Byte](2)).get
+      store.updateDurable(Array(Array[Byte](3)), Array(Array[Byte](4)), Array(Array[Byte](1))).get
+      synced shouldBe true
+      store.get(Array[Byte](1)) shouldBe None
+      store.get(Array[Byte](3)).get.toSeq shouldBe Seq[Byte](4)
+    }
+  }
+
+  property("durable batch preserves the write failure and suppresses a cleanup failure") {
+    withDb { db =>
+      val writeError = new org.iq80.leveldb.DBException("classified durable batch write")
+      val cleanupError = new IOException("classified batch cleanup")
+      val realBatch = db.createWriteBatch()
+      val batch = Proxy.newProxyInstance(classOf[WriteBatch].getClassLoader, Array(classOf[WriteBatch]), new InvocationHandler {
+        override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+          if (method.getName == "close") {
+            realBatch.close()
+            throw cleanupError
+          }
+          delegate(method, realBatch, Option(args).getOrElse(Array.empty[AnyRef]))
+        }
+      }).asInstanceOf[WriteBatch]
+      val decorated = Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+        override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = method.getName match {
+          case "createWriteBatch" => batch
+          case "write" => throw writeError
+          case _ => delegate(method, db, Option(args).getOrElse(Array.empty[AnyRef]))
+        }
+      }).asInstanceOf[DB]
+      val error = new LDBKVStore(decorated).updateDurable(Array(Array[Byte](1)), Array(Array[Byte](2)), Array.empty).failed.get
+      error shouldBe writeError
+      error.getSuppressed.toSeq shouldBe Seq(cleanupError)
+      db.get(Array[Byte](1)) shouldBe null
+    }
+  }
+
+  property("durable batch reports cleanup failure even when the write completed") {
+    withDb { db =>
+      val cleanupError = new IOException("classified cleanup after durable write")
+      val realBatch = db.createWriteBatch()
+      val batch = Proxy.newProxyInstance(classOf[WriteBatch].getClassLoader, Array(classOf[WriteBatch]), new InvocationHandler {
+        override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+          if (method.getName == "close") {
+            realBatch.close()
+            throw cleanupError
+          }
+          delegate(method, realBatch, Option(args).getOrElse(Array.empty[AnyRef]))
+        }
+      }).asInstanceOf[WriteBatch]
+      val decorated = Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+        override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = method.getName match {
+          case "createWriteBatch" => batch
+          case "write" => delegate(method, db, Array[AnyRef](realBatch, args(1)))
+          case _ => delegate(method, db, Option(args).getOrElse(Array.empty[AnyRef]))
+        }
+      }).asInstanceOf[DB]
+      val result = new LDBKVStore(decorated).updateDurable(Array(Array[Byte](1)), Array(Array[Byte](2)), Array.empty)
+      result.failed.get shouldBe cleanupError
+      db.get(Array[Byte](1)).toSeq shouldBe Seq[Byte](2)
+    }
+  }
+
+  for {
+    interrupted <- Seq(false, true)
+    writeFails <- Seq(false, true)
+  } {
+    property(s"durable batch propagates cleanup control failure (interrupted=$interrupted, writeFails=$writeFails)") {
+      withDb { db =>
+        val control: Throwable = if (interrupted) new InterruptedException("controlled batch interruption")
+          else new ControlThrowable {}
+        val writeError = new org.iq80.leveldb.DBException("controlled write failure")
+        val realBatch = db.createWriteBatch()
+        // A direct wrapper preserves control throwables without Java Proxy exception wrapping.
+        val batch = new WriteBatch {
+          override def put(key: Array[Byte], value: Array[Byte]): WriteBatch = {
+            realBatch.put(key, value)
+            this
+          }
+          override def delete(key: Array[Byte]): WriteBatch = {
+            realBatch.delete(key)
+            this
+          }
+          override def close(): Unit = {
+            realBatch.close()
+            throw control
+          }
+        }
+        val decorated = Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+          override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = method.getName match {
+            case "createWriteBatch" => batch
+            case "write" if writeFails => throw writeError
+            case "write" => delegate(method, db, Array[AnyRef](realBatch, args(1)))
+            case _ => delegate(method, db, Option(args).getOrElse(Array.empty[AnyRef]))
+          }
+        }).asInstanceOf[DB]
+        val observed = try {
+          new LDBKVStore(decorated).updateDurable(Array(Array[Byte](1)), Array(Array[Byte](2)), Array.empty)
+          fail("A control throwable must escape the durable batch")
+        } catch {
+          case error: Throwable => error
+        }
+        observed shouldBe control
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryInsertionJournalSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryInsertionJournalSpec.scala
@@ -1,0 +1,56 @@
+package org.ergoplatform.nodeView.history.storage
+
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import org.ergoplatform.utils.ErgoCorePropertyTest
+
+class HistoryInsertionJournalSpec extends ErgoCorePropertyTest {
+  import HistoryInsertionJournal.{Intent, decode, encode}
+
+  private val emptyIntent = Intent(Vector.empty, Vector.empty)
+  private def rejects(record: Array[Byte], reason: String): Unit =
+    intercept[IllegalArgumentException](decode(record)).getMessage should include(reason)
+  private def signed(payload: Array[Byte]): Array[Byte] =
+    payload ++ MessageDigest.getInstance("SHA-256").digest(payload)
+  private def changedInt(record: Array[Byte], offset: Int, value: Int): Array[Byte] = {
+    val payload = record.dropRight(32)
+    ByteBuffer.wrap(payload).putInt(offset, value)
+    signed(payload)
+  }
+
+  property("journal round trip preserves exact object and index byte rows") {
+    val intent = Intent(Vector(Array.fill[Byte](32)(1) -> Array[Byte](2, 3)),
+      Vector(Array.fill[Byte](32)(4) -> Array[Byte](5, 6)))
+    val decoded = decode(encode(intent))
+    decoded.objects.map { case (k, v) => k.toSeq -> v.toSeq } shouldBe
+      intent.objects.map { case (k, v) => k.toSeq -> v.toSeq }
+    decoded.indexes.map { case (k, v) => k.toSeq -> v.toSeq } shouldBe
+      intent.indexes.map { case (k, v) => k.toSeq -> v.toSeq }
+  }
+
+  property("journal rejects truncated bytes and checksum changes") {
+    val record = encode(emptyIntent)
+    rejects(record.take(20), "Incomplete history insertion journal")
+    record(record.length - 1) = (record.last ^ 1).toByte
+    rejects(record, "checksum mismatch")
+  }
+
+  property("journal rejects unknown magic and version with otherwise valid checksums") {
+    rejects(changedInt(encode(emptyIntent), 0, 0), "Unknown history insertion journal magic")
+    rejects(changedInt(encode(emptyIntent), 4, 2), "Unsupported history insertion journal version")
+  }
+
+  property("journal bounds row counts and field lengths against available bytes") {
+    rejects(changedInt(encode(emptyIntent), 8, -1), "row count")
+    rejects(changedInt(encode(emptyIntent), 8, Int.MaxValue), "row count")
+    val row = encode(Intent(Vector(Array.fill[Byte](32)(1) -> Array[Byte](2)), Vector.empty))
+    rejects(changedInt(row, 12, -1), "field length")
+    rejects(changedInt(row, 12, Int.MaxValue), "field length")
+  }
+
+  property("journal rejects trailing bytes, non-object keys and reserved index keys") {
+    rejects(signed(encode(emptyIntent).dropRight(32) ++ Array[Byte](0)), "Trailing history insertion journal bytes")
+    rejects(encode(Intent(Vector(Array[Byte](1) -> Array[Byte](2)), Vector.empty)), "Invalid history object key")
+    rejects(encode(Intent(Vector.empty, Vector(HistoryInsertionJournal.key -> Array[Byte](1)))), "Reserved history index key")
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryInsertionRecoverySpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryInsertionRecoverySpec.scala
@@ -1,0 +1,207 @@
+package org.ergoplatform.nodeView.history.storage
+
+import java.io.{File, IOException}
+import org.ergoplatform.CriticalSystemException
+import org.ergoplatform.db.DBSpec
+import org.ergoplatform.modifiers.BlockSection
+import org.ergoplatform.modifiers.history.HistoryModifierSerializer
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.iq80.leveldb.{DB, Options}
+import scorex.db.{ByteArrayWrapper, LDBFactory, LDBKVStore}
+
+import scala.util.{Failure, Try}
+
+class HistoryInsertionRecoverySpec extends ErgoCorePropertyTest with DBSpec {
+  import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+  import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+
+  private case class Fault(role: String, call: Int, afterWrite: Boolean, error: IOException)
+  private class Store(db: DB, role: String, fault: Option[Fault], before: () => Unit) extends LDBKVStore(db) {
+    private var calls = 0
+    override def updateDurable(keys: Array[K], values: Array[V], removals: Array[K]): Try[Unit] = {
+      calls += 1
+      before()
+      val selected = fault.filter(f => f.role == role && f.call == calls)
+      if (selected.exists(!_.afterWrite)) Failure(selected.get.error)
+      else super.updateDurable(keys, values, removals).flatMap { result =>
+        selected.fold[Try[Unit]](scala.util.Success(result))(f => Failure(f.error))
+      }
+    }
+  }
+
+  private class Opened(root: File, fault: Option[Fault] = None, before: () => Unit = () => ()) {
+    private def open(role: String): Store = {
+      val path = new File(root, s"history/$role")
+      path.mkdirs()
+      new Store(LDBFactory.factory.open(path, new Options().createIfMissing(true)), role, fault, before)
+    }
+    val index = open("index")
+    val objects = open("objects")
+    val extra = open("extra")
+    val storage = new HistoryStorage(index, objects, extra, settings.cacheSettings)
+    def close(): Unit = storage.close()
+  }
+
+  private val indexKey = ByteArrayWrapper(Array.fill[Byte](32)(42))
+
+  property("completed insertion preserves object formats, caches and ordinary factory reopen") {
+    val root = createTempDir
+    val opened = new Opened(root)
+    val header = defaultHeaderGen.sample.get
+    val bytes = HistoryModifierSerializer.toBytes(header)
+    try {
+      opened.storage.insert(Array(indexKey -> Array[Byte](7)), Array[BlockSection](header)).get
+      opened.storage.modifierById(header.id).get.id shouldBe header.id
+      opened.storage.get(header.id).get.toSeq shouldBe bytes.toSeq
+      opened.storage.getIndex(indexKey).get.toSeq shouldBe Seq[Byte](7)
+      opened.index.get(HistoryInsertionJournal.key) shouldBe None
+    } finally opened.close()
+    val reopened = HistoryStorage(settings.copy(directory = root.getPath))
+    try {
+      reopened.contains(header.id) shouldBe true
+      reopened.getIndex(indexKey).get.toSeq shouldBe Seq[Byte](7)
+    } finally reopened.close()
+  }
+
+  for ((role, call) <- Seq("index" -> 1, "objects" -> 1, "index" -> 2); after <- Seq(false, true)) {
+    property(s"insertion recovers after $role write $call reports failure ${if (after) "after" else "before"} writing") {
+      val root = createTempDir
+      val cause = new IOException("classified durable write failure")
+      val opened = new Opened(root, Some(Fault(role, call, after, cause)))
+      val header = defaultHeaderGen.sample.get
+      try {
+        val error = opened.storage.insert(Array(indexKey -> Array[Byte](9)), Array[BlockSection](header)).failed.get
+        error shouldBe a[CriticalSystemException]
+        error.getCause shouldBe cause
+        intercept[CriticalSystemException](opened.storage.contains(header.id))
+        intercept[CriticalSystemException](opened.storage.get(header.id))
+        intercept[CriticalSystemException](opened.storage.get(header.serializedId))
+        intercept[CriticalSystemException](opened.storage.modifierBytesById(header.id))
+        intercept[CriticalSystemException](opened.storage.modifierTypeAndBytesById(header.id))
+        intercept[CriticalSystemException](opened.storage.modifierById(header.id))
+        intercept[CriticalSystemException](opened.storage.getIndex(indexKey))
+        intercept[CriticalSystemException](opened.storage.getExtraIndex(header.id))
+        intercept[CriticalSystemException](opened.storage.insert(header.serializedId, Array[Byte](1)))
+        intercept[CriticalSystemException](opened.storage.remove(Array.empty, Array.empty))
+        intercept[CriticalSystemException](opened.storage.insertExtra(Array.empty, Array.empty))
+        intercept[CriticalSystemException](opened.storage.removeExtra(Array.empty))
+        opened.storage.insert(Array.empty[(ByteArrayWrapper, Array[Byte])], Array.empty[BlockSection]).isFailure shouldBe true
+      } finally opened.close()
+      val reopened = new Opened(root)
+      try {
+        val prepared = role != "index" || call != 1 || after
+        reopened.storage.contains(header.id) shouldBe prepared
+        reopened.storage.getIndex(indexKey).map(_.toSeq) shouldBe (if (prepared) Some(Seq[Byte](9)) else None)
+        reopened.index.get(HistoryInsertionJournal.key) shouldBe None
+        reopened.storage.insert(Array(indexKey -> Array[Byte](9)), Array[BlockSection](header)).get
+      } finally reopened.close()
+    }
+  }
+
+  property("a failed recovery preserves its cause and intent for the next ordinary reopen") {
+    val root = createTempDir
+    val header = defaultHeaderGen.sample.get
+    val opened = new Opened(root, Some(Fault("objects", 1, false, new IOException("initial write"))))
+    try opened.storage.insert(Array(indexKey -> Array[Byte](3)), Array[BlockSection](header)).isFailure shouldBe true
+    finally opened.close()
+    val failure = new IOException("recovery write")
+    val recovering = new Opened(root, Some(Fault("objects", 1, false, failure)))
+    try {
+      intercept[CriticalSystemException](recovering.storage.contains(header.id)).getCause shouldBe failure
+      recovering.index.get(HistoryInsertionJournal.key).isDefined shouldBe true
+    } finally recovering.close()
+    val recovered = HistoryStorage(settings.copy(directory = root.getPath))
+    try {
+      recovered.contains(header.id) shouldBe true
+      recovered.getIndex(indexKey).get.toSeq shouldBe Seq[Byte](3)
+    } finally recovered.close()
+  }
+
+  property("freezing failures precede preparation and caller-owned index arrays cannot change the committed values") {
+    val root = createTempDir
+    val key = Array.fill[Byte](32)(8)
+    val value = Array[Byte](4)
+    val opened = new Opened(root, before = () => { key(0) = 99; value(0) = 99 })
+    val header = defaultHeaderGen.sample.get
+    val expectedKey = ByteArrayWrapper(key.clone())
+    try {
+      opened.storage.insert(Array(indexKey -> Array[Byte](1)), Array[BlockSection](null)).isFailure shouldBe true
+      opened.index.get(HistoryInsertionJournal.key) shouldBe None
+      opened.storage.contains(header.id) shouldBe false
+      opened.storage.insert(Array(ByteArrayWrapper(key) -> value), Array[BlockSection](header)).get
+      opened.storage.getIndex(expectedKey).get.toSeq shouldBe Seq[Byte](4)
+      opened.index.get(expectedKey.data).get.toSeq shouldBe Seq[Byte](4)
+      opened.storage.modifierById(header.id).get.id shouldBe header.id
+    } finally opened.close()
+  }
+
+  for (after <- Seq(false, true)) {
+    property(s"recovery can be retried when final indexes fail ${if (after) "after" else "before"} application") {
+      val root = createTempDir
+      val header = defaultHeaderGen.sample.get
+      val opened = new Opened(root, Some(Fault("objects", 1, false, new IOException("initial write"))))
+      try opened.storage.insert(Array(indexKey -> Array[Byte](6)), Array[BlockSection](header)).isFailure shouldBe true
+      finally opened.close()
+      val failure = new IOException("recovery final indexes")
+      val recovering = new Opened(root, Some(Fault("index", 1, after, failure)))
+      try {
+        intercept[CriticalSystemException](recovering.storage.contains(header.id)).getCause shouldBe failure
+        intercept[CriticalSystemException](recovering.storage.getIndex(indexKey))
+        recovering.index.get(HistoryInsertionJournal.key).isDefined shouldBe !after
+      } finally recovering.close()
+      val recovered = HistoryStorage(settings.copy(directory = root.getPath))
+      try {
+        recovered.contains(header.id) shouldBe true
+        recovered.getIndex(indexKey).get.toSeq shouldBe Seq[Byte](6)
+      } finally recovered.close()
+    }
+  }
+
+  for (invalidBytes <- Seq(false, true)) {
+    property(s"recovery rejects ${if (invalidBytes) "invalid object bytes" else "mismatched object identity"} before writing") {
+      val root = createTempDir
+      var writes = 0
+      val opened = new Opened(root, before = () => writes += 1)
+      val header = defaultHeaderGen.sample.get
+      val key = header.serializedId.clone()
+      if (!invalidBytes) key(0) = (key(0) ^ 1).toByte
+      val bytes = if (invalidBytes) Array[Byte](0) else HistoryModifierSerializer.toBytes(header)
+      val record = HistoryInsertionJournal.encode(HistoryInsertionJournal.Intent(
+        Vector(key -> bytes), Vector(indexKey.data -> Array[Byte](1))))
+      try {
+        opened.index.insert(HistoryInsertionJournal.key, record).get
+        val failure = intercept[CriticalSystemException](opened.storage.contains(header.id))
+        if (!invalidBytes) failure.getCause.getMessage should include("object identity mismatch")
+        writes shouldBe 0
+        opened.objects.get(key) shouldBe None
+        opened.index.get(indexKey.data) shouldBe None
+        opened.index.get(HistoryInsertionJournal.key).get.toSeq shouldBe record.toSeq
+      } finally opened.close()
+    }
+  }
+
+  property("reserved journal keys are inaccessible through ordinary index APIs") {
+    val opened = new Opened(createTempDir)
+    val reserved = ByteArrayWrapper(HistoryInsertionJournal.key)
+    try {
+      HistoryInsertionJournal.key.length should not be 32
+      opened.storage.insert(Array(reserved -> Array[Byte](1)), Array.empty[BlockSection]).isFailure shouldBe true
+      intercept[IllegalArgumentException](opened.storage.getIndex(reserved))
+      intercept[IllegalArgumentException](opened.storage.remove(Array(reserved), Array.empty))
+      opened.index.get(HistoryInsertionJournal.key) shouldBe None
+    } finally opened.close()
+  }
+
+  property("unknown journal versions fail opening without discarding the record") {
+    val root = createTempDir
+    val opened = new Opened(root)
+    val encoded = HistoryInsertionJournal.encode(HistoryInsertionJournal.Intent(Vector.empty, Vector.empty))
+    encoded(7) = 2
+    val payload = encoded.dropRight(32)
+    val record = payload ++ java.security.MessageDigest.getInstance("SHA-256").digest(payload)
+    try opened.index.insert(HistoryInsertionJournal.key, record).get finally opened.close()
+    intercept[CriticalSystemException](HistoryStorage(settings.copy(directory = root.getPath)))
+    val inspected = new Opened(root)
+    try inspected.index.get(HistoryInsertionJournal.key).get.toSeq shouldBe record.toSeq finally inspected.close()
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryStorageFactorySpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/HistoryStorageFactorySpec.scala
@@ -1,0 +1,59 @@
+package org.ergoplatform.nodeView.history.storage
+
+import java.io.IOException
+import org.ergoplatform.CriticalSystemException
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import scorex.db.LDBKVStore
+
+import scala.collection.mutable.ArrayBuffer
+
+class HistoryStorageFactorySpec extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+
+  for (failedAcquisition <- Seq(2, 3)) {
+    property(s"factory closes acquired stores in reverse order when acquisition $failedAcquisition fails") {
+      val closed = ArrayBuffer.empty[Int]
+      var created = 0
+      val failure = new IOException("classified store acquisition failure")
+      val cleanup = new IOException("classified acquired-store cleanup failure")
+      def create(path: String): LDBKVStore = {
+        created += 1
+        if (created == failedAcquisition) throw failure
+        val id = created
+        new LDBKVStore(null) {
+          override def close(): Unit = {
+            closed += id
+            if (id == 1) throw cleanup
+          }
+        }
+      }
+      intercept[IOException](HistoryStorage.open(settings, create)) shouldBe failure
+      closed.toSeq shouldBe (1 until failedAcquisition).reverse
+      failure.getSuppressed.toSeq shouldBe Seq(cleanup)
+    }
+  }
+
+  property("factory closes every acquired store after initialization failure and preserves cleanup errors") {
+    val closed = ArrayBuffer.empty[Int]
+    var created = 0
+    val failure = new IOException("classified journal read failure")
+    val extraCleanup = new IOException("classified extra-store cleanup failure")
+    val objectCleanup = new IOException("classified object-store cleanup failure")
+    def create(path: String): LDBKVStore = {
+      created += 1
+      val id = created
+      new LDBKVStore(null) {
+        override def get(key: K): Option[V] = throw failure
+        override def close(): Unit = {
+          closed += id
+          if (id == 3) throw extraCleanup
+          if (id == 2) throw objectCleanup
+        }
+      }
+    }
+    val error = intercept[CriticalSystemException](HistoryStorage.open(settings, create))
+    error.getCause shouldBe failure
+    closed.toSeq shouldBe Seq(3, 2, 1)
+    error.getSuppressed.toSeq shouldBe Seq(extraCleanup, objectCleanup)
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -64,8 +64,13 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val (us, bh) = createUtxoState(settings)
     val genesis = validFullBlock(None, us, bh)
     val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-    val inputBox = wus.takeBoxes(1).head
-    val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+    val inputBox = wus.takeBoxes(100).find(_.ergoTree == TrueTree).get
+    val feeOut = new ErgoBoxCandidate(
+      inputBox.value,
+      feeProp,
+      creationHeight = 0,
+      additionalTokens = inputBox.additionalTokens
+    )
     val tx = ErgoTransaction(
       IndexedSeq(new Input(inputBox.id, ProverResult.empty)),
       IndexedSeq(feeOut)
@@ -79,8 +84,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerByte,
       ))
 
-    var poolSize = ErgoMemPool.empty(sortBySizeSettings)
-    poolSize = poolSize.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolSize, sizeOutcome) =
+      ErgoMemPool.empty(sortBySizeSettings).process(UnconfirmedTransaction(tx, None), wus)
+    sizeOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val size = tx.size
     poolSize.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, size).weight
 
@@ -89,8 +95,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerCycle,
       ))
 
-    var poolCost = ErgoMemPool.empty(sortByCostSettings)
-    poolCost = poolCost.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolCost, costOutcome) =
+      ErgoMemPool.empty(sortByCostSettings).process(UnconfirmedTransaction(tx, None), wus)
+    costOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val validationContext = wus.stateContext.simplifiedUpcoming()
     val cost = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
     poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,9 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    val box = wusAfterGenesis.takeBoxes(wusAfterGenesis.size)
+      .find(_.ergoTree == TrueTree)
+      .getOrElse(fail("Expected an unspent TrueTree box after genesis"))
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
Uses shared test support from [#2535](https://github.com/ergoplatform/ergo/pull/2535). Review the [history increment](https://github.com/a-shannon/ergo/compare/b3ebc6d6f5a36514d28631d0852d1ba91c9f1781...223ea95c677d12e7d9df8d36ac048f1c266548d9); the upstream diff is cumulative until the prerequisite merges.

A paired history insertion can persist an object before its indexes fail. The object's presence then prevents ordinary processing from completing those indexes. Record a durable intent, write the objects, and atomically publish indexes with intent removal. Publish caches afterward. Ordinary persistence failure makes the live instance unavailable; reopening validates and replays its recorded insertion before exposing reads.

The change adds an explicit synchronous batch API, retains existing object/index encodings, and reserves a private non-hash index key for recovery. Acquisition and initialization failures close acquired stores while preserving the original error.

The initial storage increment passed 33 tests across recovery, durable batches, journal decoding, factory cleanup and existing consumers. They cover before/after acknowledged-write outcomes, retried recovery, object identity, exact malformed-record rejection, cache publication and control-exception propagation. Independent source and evidence reviews completed.

Decoded-object caching exposed an existing header-size calculation error: a history type prefix was counted as part of the header. `HeaderSerializer` now measures consumption relative to its own entry. Header bytes and IDs are unchanged. The follow-up passes 18 serialization tests and all 10 blocks API route tests, preserving full JSON equality. All eight checks, including integration, passed at `223ea95c6` ([CI run](https://github.com/ergoplatform/ergo/actions/runs/34294527995)). The earlier integration timeout is historical evidence, not a result attributed to this head.

This covers recorded paired insertions, not repair of existing unjournaled orphan objects or all history mutation APIs. No OS power-loss guarantee is inferred. [#2523](https://github.com/ergoplatform/ergo/pull/2523) retains ownership of removal-error propagation. When composing with [#2424](https://github.com/ergoplatform/ergo/pull/2424), its additional index/raw-removal methods must also respect the availability boundary.
