### PR TITLE
Coordinate versioned-store transitions with a recovery journal

### DIFF
--- a/avldb/src/main/scala/scorex/db/KVStoreReader.scala
+++ b/avldb/src/main/scala/scorex/db/KVStoreReader.scala
@@ -2,7 +2,7 @@ package scorex.db
 
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
-import org.iq80.leveldb.{DB, ReadOptions}
+import org.iq80.leveldb.{DB, ReadOptions, Snapshot}
 
 import scala.collection.mutable
 
@@ -19,6 +19,17 @@ trait KVStoreReader extends AutoCloseable {
 
   protected val lock = new ReentrantReadWriteLock()
 
+  /** Called under the read lock before accessing a store which can require recovery. */
+  protected def ensureReadable(): Unit = ()
+
+  private def readableSnapshot(): Snapshot = {
+    lock.readLock().lock()
+    try {
+      ensureReadable()
+      db.getSnapshot
+    } finally lock.readLock().unlock()
+  }
+
   /**
     * Read database element by its key
     * @param key - key
@@ -27,6 +38,7 @@ trait KVStoreReader extends AutoCloseable {
   def get(key: K): Option[V] = {
     lock.readLock().lock()
     try {
+      ensureReadable()
       Option(db.get(key))
     } finally {
       lock.readLock().unlock()
@@ -41,7 +53,7 @@ trait KVStoreReader extends AutoCloseable {
     */
   def getWithFilter(cond: (K, V) => Boolean): Iterator[(K, V)] = {
     val ro = new ReadOptions()
-    ro.snapshot(db.getSnapshot)
+    ro.snapshot(readableSnapshot())
     val iter = db.iterator(ro)
     try {
       iter.seekToFirst()
@@ -82,11 +94,15 @@ trait KVStoreReader extends AutoCloseable {
     * @return iterable over key-value pairs found in store
     */
   def get(keys: Iterable[K]): Iterable[(K, Option[V])] = {
-    val ret = scala.collection.mutable.ArrayBuffer.empty[(K, Option[V])]
-    keys.foreach { key =>
-      ret += key -> get(key)
-    }
-    ret
+    lock.readLock().lock()
+    try {
+      ensureReadable()
+      val ret = scala.collection.mutable.ArrayBuffer.empty[(K, Option[V])]
+      keys.foreach { key =>
+        ret += key -> get(key)
+      }
+      ret
+    } finally lock.readLock().unlock()
   }
 
   /**
@@ -97,7 +113,7 @@ trait KVStoreReader extends AutoCloseable {
     */
   def getRange(start: K, end: K, limit: Int = Int.MaxValue): Array[(K, V)] = {
     val ro = new ReadOptions()
-    ro.snapshot(db.getSnapshot)
+    ro.snapshot(readableSnapshot())
     val iter = db.iterator(ro)
     try {
       iter.seek(start)

--- a/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
+++ b/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
@@ -11,6 +11,7 @@ import scorex.crypto.hash.Blake2b256
 import scorex.db.LDBVersionedStore.SnapshotReadInterface
 import scorex.util.ScorexLogging
 
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 
@@ -424,20 +425,34 @@ class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
     val ro = new ReadOptions()
     try {
       lock.writeLock().lock()
-      ro.snapshot(db.getSnapshot)
-      lock.writeLock().unlock()
-
-      object readInterface extends SnapshotReadInterface {
-        def get(key: Array[Byte]): Array[Byte] = db.get(key, ro)
+      val snapshot = try {
+        db.getSnapshot
+      } finally {
+        lock.writeLock().unlock()
       }
-      Success(logic(readInterface))
+      var processingFailure: Throwable = null
+      try {
+        ro.snapshot(snapshot)
+        object readInterface extends SnapshotReadInterface {
+          def get(key: Array[Byte]): Array[Byte] = db.get(key, ro)
+        }
+        Success(logic(readInterface))
+      } catch {
+        case t: Throwable =>
+          processingFailure = t
+          throw t
+      } finally {
+        try {
+          snapshot.close()
+        } catch {
+          case NonFatal(t) if processingFailure != null =>
+            if (t ne processingFailure) processingFailure.addSuppressed(t)
+        }
+      }
     } catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         log.info("Error during snapshot processing: ", t)
         Failure(t)
-    } finally {
-      // Close the snapshot to avoid resource leaks
-      ro.snapshot().close()
     }
   }
 

--- a/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
+++ b/avldb/src/main/scala/scorex/db/LDBVersionedStore.scala
@@ -1,341 +1,278 @@
 package scorex.db
 
 import java.io.File
-import scorex.db.LDBFactory.factory
-import org.iq80.leveldb._
-
 import java.nio.ByteBuffer
-import scala.collection.mutable.ArrayBuffer
 import java.util.concurrent.locks.ReentrantReadWriteLock
+
+import org.iq80.leveldb.{DB, Options, ReadOptions}
 import scorex.crypto.hash.Blake2b256
 import scorex.db.LDBVersionedStore.SnapshotReadInterface
+import scorex.db.LDBVersionedStoreJournal.{Change, Metadata, Plan, Version}
 import scorex.util.ScorexLogging
 
+import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
-
 /**
-  * Implementation of versioned storage on top of LevelDB.
+  * Versioned storage with a durable redo journal coordinating main data and undo history.
   *
-  * LevelDB implementation of versioned store is based on maintaining "compensating transaction" list,
-  * list of reverse operations needed to undo changes of applied transactions.
-  * This list is stored in separate LevelDB database (undo) and size of list is limited by the keepVersions parameter.
-  * If keepVersions == 0, then undo list is not maintained and rollback of the committed transactions is not possible.
+  * An ambiguous write result makes this instance unavailable. Close it and reopen the store,
+  * then rebuild its consumers: recovery may complete an operation whose caller received Failure.
+  * Backups must include ldb_main, ldb_undo and ldb_journal together. After journal adoption,
+  * writes by older binaries are unsupported even without pending recovery: they cannot update
+  * the committed journal metadata. Legacy data and undo record encodings are unchanged.
+  * Recovery guards cover the store API; direct access through the raw db handle bypasses them.
   *
-  * @param dir - folder to store data
-  * @param initialKeepVersions - number of versions to keep when the store is created. Can be changed after.
-  *
+  * @param dir folder containing the databases
+  * @param initialKeepVersions rollback depth for this instance; zero retains only the current version
   */
-class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
+class LDBVersionedStore private[db](protected val dir: File,
+                                  val initialKeepVersions: Int,
+                                  openDatabase: (File, String) => DB)
   extends KVStoreReader with ScorexLogging {
 
-  type VersionID = Array[Byte]
+  def this(dir: File, initialKeepVersions: Int) =
+    this(dir, initialKeepVersions, LDBVersionedStore.openDatabase)
 
-  type LSN = Long // logical serial number: type used to provide order of records in undo list
+  type VersionID = Array[Byte]
+  type LSN = Long
+
+  require(initialKeepVersions >= 0, "Negative keepVersions")
 
   private val last_version_key = Blake2b256("last_version")
-
   private var keepVersions: Int = initialKeepVersions
-
-  override val db: DB = createDB(dir, "ldb_main") // storage for main data
   override val lock = new ReentrantReadWriteLock()
+  private var recoveryFailure: Option[Throwable] = None
+  private var closed = false
 
-  private val undo: DB = createDB(dir, "ldb_undo") // storage for undo data
-  private var lsn: LSN = getLastLSN // last assigned logical serial number
-  private var versionLsn = ArrayBuffer.empty[LSN] // LSNs of versions (var because we need to invert this array)
-
-  // mutable array of all the kept versions
-  private val versions: ArrayBuffer[VersionID] = getAllVersions
-  private var lastVersion: Option[VersionID] = versions.lastOption
-
-
-  //default write options, no sync!
-  private val writeOptions = new WriteOptions()
-
-  private def createDB(dir: File, storeName: String): DB = {
-    val op = new Options()
-    op.createIfMissing(true)
-    op.paranoidChecks(true)
-    factory.open(new File(dir, storeName), op)
-  }
-
-  /** Set new keep versions threshold, remove not needed versions and return old value of keep versions */
-  def setKeepVersions(newKeepVersions: Int): Int = {
-    lock.writeLock().lock()
-    val oldKeepVersions = keepVersions
+  private val databases = {
+    val opened = ArrayBuffer.empty[DB]
     try {
-      if (newKeepVersions < oldKeepVersions) {
-        cleanStart(newKeepVersions)
-      }
-      keepVersions = newKeepVersions
-    } finally {
-      lock.writeLock().unlock()
+      Seq("ldb_main", "ldb_undo", "ldb_journal").foreach { name => opened += openDatabase(dir, name) }
+      opened.toVector
+    } catch {
+      case t: Throwable =>
+        opened.reverse.foreach(database => closeAfterFailure(database, t))
+        throw t
     }
-    oldKeepVersions
+  }
+  override val db: DB = databases(0)
+  private val undo: DB = databases(1)
+  private val journal = new LDBVersionedStoreJournal(databases(2), db, undo)
+  private var metadata: Metadata = try journal.initialize(readLegacyMetadata()) catch {
+    case t: Throwable =>
+      databases.reverse.foreach(database => closeAfterFailure(database, t))
+      throw t
   }
 
-  def getKeepVersions: Int = keepVersions
+  private def closeAfterFailure(database: DB, failure: Throwable): Unit = try database.close() catch {
+    case NonFatal(closeError) => if (closeError ne failure) failure.addSuppressed(closeError)
+  }
 
-  /** returns value associated with the key or throws `NoSuchElementException` */
-  def apply(key: K): V = getOrElse(key, {
-    throw new NoSuchElementException()
-  })
-
-
-  /**
-    * Batch get with callback for result value.
-    *
-    * Finds all keys from given iterable.
-    * Results are passed to callable consumer.
-    *
-    * It uses latest (most recent) version available in store
-    *
-    * @param keys     keys to lookup
-    * @param consumer callback method to consume results
-    */
-  def get(keys: Iterable[K], consumer: (K, Option[V]) => Unit): Unit = {
-    for (key <- keys) {
-      val value = get(key)
-      consumer(key, value)
+  override protected def ensureReadable(): Unit = {
+    require(!closed, "Versioned store is closed")
+    recoveryFailure.foreach { cause =>
+      throw new IllegalStateException("Versioned store requires close and reopen before further access", cause)
     }
   }
 
-  def processAll(consumer: (K, V) => Unit): Unit = {
+  private def readLocked[T](body: => T): T = {
     lock.readLock().lock()
+    try {
+      ensureReadable()
+      body
+    } finally lock.readLock().unlock()
+  }
+
+  private def writeLocked[T](body: => T): T = {
+    lock.writeLock().lock()
+    try {
+      ensureReadable()
+      body
+    } finally lock.writeLock().unlock()
+  }
+
+  /** Return the previous threshold only after any required pruning has committed. */
+  def setKeepVersions(newKeepVersions: Int): Int = writeLocked {
+    require(newKeepVersions >= 0, "Negative keepVersions")
+    val previous = keepVersions
+    if (newKeepVersions < previous) commit(pruned(emptyPlan, newKeepVersions))
+    keepVersions = newKeepVersions
+    previous
+  }
+
+  def getKeepVersions: Int = readLocked(keepVersions)
+
+  def apply(key: K): V = getOrElse(key, throw new NoSuchElementException())
+
+  def get(keys: Iterable[K], consumer: (K, Option[V]) => Unit): Unit = {
+    readLocked(())
+    keys.foreach(key => consumer(key, get(key)))
+  }
+
+  def processAll(consumer: (K, V) => Unit): Unit = readLocked {
     val iterator = db.iterator()
     try {
       iterator.seekToFirst()
       while (iterator.hasNext) {
-        val n = iterator.next()
-        consumer(n.getKey, n.getValue)
+        val entry = iterator.next()
+        consumer(entry.getKey, entry.getValue)
       }
-    } finally {
-      iterator.close()
-      lock.readLock().unlock()
-    }
+    } finally iterator.close()
   }
 
-  private def newLSN(): Array[Byte] = {
-    lsn += 1
-    encodeLSN(lsn)
-  }
+  private def decodeLSN(bytes: Array[Byte]): LSN = ~ByteBuffer.wrap(bytes).getLong
 
-  /**
-    * Invert word to provide descending key order.
-    * Java implementation of LevelDB org.iq80.leveldb doesn't support iteration in backward direction.
-    */
-  private def decodeLSN(lsn: Array[Byte]): LSN = {
-    ~ByteBuffer.wrap(lsn).getLong
-  }
+  private def encodeLSN(lsn: LSN): Array[Byte] = ByteBuffer.allocate(8).putLong(~lsn).array()
 
-  private def encodeLSN(lsn: LSN): Array[Byte] = {
-    val buf = ByteBuffer.allocate(8)
-    buf.putLong(~lsn)
-    buf.array()
-  }
+  def lastVersionID: Option[VersionID] = readLocked(metadata.versions.lastOption.map(_.id.clone()))
 
-  private def getLastLSN: LSN = {
-    val iterator = undo.iterator
+  def versionIdExists(versionID: VersionID): Boolean =
+    readLocked(metadata.versions.exists(_.id.sameElements(versionID)))
+
+  /** Adoption preserves the legacy reader's available history; it cannot certify earlier writes. */
+  private def readLegacyMetadata(): Metadata = {
+    val descending = ArrayBuffer.empty[Version]
+    var lastLsn = 0L
+    val iterator = undo.iterator()
     try {
       iterator.seekToFirst()
-      if (iterator.hasNext) {
-        decodeLSN(iterator.peekNext().getKey)
-      } else {
-        0
+      while (iterator.hasNext) {
+        val entry = iterator.next()
+        val currentLsn = decodeLSN(entry.getKey)
+        val version = deserializeUndo(entry.getValue).versionID
+        if (lastLsn == 0L) lastLsn = currentLsn
+        if (descending.lastOption.exists(_.id.sameElements(version))) {
+          descending(descending.size - 1) = Version(version, currentLsn)
+        } else descending += Version(version, currentLsn)
       }
-    } finally {
-      iterator.close()
+    } finally iterator.close()
+    val versions = if (descending.nonEmpty) descending.reverse.toVector else {
+      Option(db.get(last_version_key)).map(id => Vector(Version(id, 0L))).getOrElse(Vector.empty)
     }
+    Metadata(0L, lastLsn, versions)
   }
 
-  def lastVersionID: Option[VersionID] = {
-    lastVersion
-  }
-
-  def versionIdExists(versionID: VersionID): Boolean = {
-    lock.readLock().lock()
-    try {
-      versions.exists(_.sameElements(versionID))
-    } finally {
-      lock.readLock().unlock()
-    }
-  }
-
-  private def getAllVersions: ArrayBuffer[VersionID] = {
-    val versions = ArrayBuffer.empty[VersionID]
-    var lastVersion: Option[VersionID] = None
-    var lastLsn: LSN = 0
-    // We iterate in LSN descending order
-    val iterator = undo.iterator()
-    iterator.seekToFirst()
-    while (iterator.hasNext) {
-      val entry = iterator.next
-      val currVersion = deserializeUndo(entry.getValue).versionID
-      lastLsn = decodeLSN(entry.getKey)
-      if (!lastVersion.exists(_.sameElements(currVersion))) {
-        versionLsn += lastLsn + 1 // this is first LSN of successor version
-        versions += currVersion
-        lastVersion = Some(currVersion)
-      }
-    }
-    iterator.close()
-    // As far as org.iq80.leveldb doesn't support iteration in reverse order, we have to iterate in the order
-    // of decreasing LSNs and then revert version list. For each version we store first (smallest) LSN.
-    versionLsn += lastLsn // first LSN of oldest version
-    versionLsn = versionLsn.reverse // LSNs should be in ascending order
-    versionLsn.remove(versionLsn.size - 1) // remove last element which corresponds to next assigned LSN
-
-    if (versions.nonEmpty) {
-      versions.reverse
-    } else {
-      val dbVersion = db.get(last_version_key)
-      if (dbVersion != null) {
-        versions += dbVersion
-        versionLsn += lastLsn
-      }
-      versions
-    }
-  }
-
-  /**
-    * Undo action. To implement recovery to the specified version, we store in the separate undo database
-    * sequence of undo operations corresponding to the updates done by the committed transactions.
-    */
   case class Undo(versionID: VersionID, key: Array[Byte], value: Array[Byte])
 
   private def serializeUndo(versionID: VersionID, key: Array[Byte], value: Array[Byte]): Array[Byte] = {
     val valueSize = if (value != null) value.length else 0
     val versionSize = versionID.length
     val keySize = key.length
+    require(versionSize <= 0xFF && keySize <= 0xFF)
     val packed = new Array[Byte](2 + versionSize + keySize + valueSize)
-    require(keySize <= 0xFF)
-    packed(0) = versionSize.asInstanceOf[Byte]
-    packed(1) = keySize.asInstanceOf[Byte]
+    packed(0) = versionSize.toByte
+    packed(1) = keySize.toByte
     Array.copy(versionID, 0, packed, 2, versionSize)
     Array.copy(key, 0, packed, 2 + versionSize, keySize)
-    if (value != null) {
-      Array.copy(value, 0, packed, 2 + versionSize + keySize, valueSize)
-    }
+    if (value != null) Array.copy(value, 0, packed, 2 + versionSize + keySize, valueSize)
     packed
   }
 
-  private def deserializeUndo(undo: Array[Byte]): Undo = {
-    val versionSize = undo(0) & 0xFF
-    val keySize = undo(1) & 0xFF
-    val valueSize = undo.length - versionSize - keySize - 2
-    val versionID = undo.slice(2, 2 + versionSize)
-    val key = undo.slice(2 + versionSize, 2 + versionSize + keySize)
-    val value = if (valueSize == 0){
-      null
-    } else{
-      undo.slice(2 + versionSize + keySize, undo.length)
-    }
+  private def deserializeUndo(bytes: Array[Byte]): Undo = {
+    val versionSize = bytes(0) & 0xFF
+    val keySize = bytes(1) & 0xFF
+    val valueSize = bytes.length - versionSize - keySize - 2
+    val versionID = bytes.slice(2, 2 + versionSize)
+    val key = bytes.slice(2 + versionSize, 2 + versionSize + keySize)
+    val value = if (valueSize == 0) null else bytes.slice(2 + versionSize + keySize, bytes.length)
     Undo(versionID, key, value)
   }
 
-  /**
-    * Write versioned batch update to the database, removing keys from the database and adding new key -> value pairs
-    */
-  def update(versionID: VersionID,
-             toRemove: TraversableOnce[Array[Byte]],
-             toUpdate: TraversableOnce[(Array[Byte], Array[Byte])]): Try[Unit] = Try {
-    lock.writeLock().lock()
-    val lastLsn = lsn // remember current LSN value
-    val batch = db.createWriteBatch()
-    val undoBatch = undo.createWriteBatch()
+  private def emptyPlan: Plan = Plan(
+    metadata.copy(transaction = Math.addExact(metadata.transaction, 1L)), Vector.empty, Vector.empty)
+
+  /** The only publication point for a changed data/version/history state. */
+  private def commit(plan: Plan): Unit = {
+    val encoded = journal.encoded(plan)
     try {
-      toRemove.foreach(key => {
-        batch.delete(key)
-        if (keepVersions > 0) {
-          val value = db.get(key)
-          if (value != null) { // attempt to delete not existed key
-            undoBatch.put(newLSN(), serializeUndo(versionID, key, value))
-          }
-        }
-      })
-      for ((key, v) <- toUpdate) {
-        require(key.length != 0) // empty keys are not allowed
-        if (keepVersions > 0) {
-          val old = db.get(key)
-          undoBatch.put(newLSN(), serializeUndo(versionID, key, old))
-        }
-        batch.put(key, v)
-      }
-
-      if (keepVersions > 0) {
-        if (lsn == lastLsn) { // no records were written for this version: generate dummy record
-          undoBatch.put(newLSN(), serializeUndo(versionID, new Array[Byte](0), null))
-        }
-        undo.write(undoBatch, writeOptions)
-        if (lastVersion.isEmpty || !versionID.sameElements(lastVersion.get)) {
-          versions += versionID
-          versionLsn += lastLsn + 1 // first LSN for this version
-          cleanStart(keepVersions)
-        }
-      } else {
-        //keepVersions = 0
-        if (lastVersion.isEmpty || !versionID.sameElements(lastVersion.get)) {
-          batch.put(last_version_key, versionID)
-          versions.clear()
-          versions += versionID
-          if (versionLsn.isEmpty) {
-            versionLsn += lastLsn
-          }
-        }
-      }
-
-      db.write(batch, writeOptions)
-      lastVersion = Some(versionID)
-    } finally {
-      // Make sure you close the batch to avoid resource leaks.
-      batch.close()
-      undoBatch.close()
-      lock.writeLock().unlock()
+      journal.prepare(encoded)
+      journal.applyParticipants(plan)
+      journal.complete(plan)
+      metadata = plan.result
+    } catch {
+      case t: Throwable =>
+        recoveryFailure = Some(t)
+        throw t
     }
   }
+
+  /** Write a recoverable batch. A Failure after a write attempt requires reopening this instance. */
+  def update(versionID: VersionID,
+             toRemove: TraversableOnce[Array[Byte]],
+             toUpdate: TraversableOnce[(Array[Byte], Array[Byte])]): Try[Unit] = Try(writeLocked {
+    val version = versionID.clone()
+    val mainChanges = Vector.newBuilder[Change]
+    val undoChanges = Vector.newBuilder[Change]
+    var nextLsn = metadata.lsn
+    def recordUndo(key: Array[Byte], value: Array[Byte]): Unit = {
+      nextLsn = Math.addExact(nextLsn, 1L)
+      undoChanges += Change(encodeLSN(nextLsn), Some(serializeUndo(version, key, value)))
+    }
+    toRemove.foreach { input =>
+      val key = input.clone()
+      mainChanges += Change(key, None)
+      if (keepVersions > 0) Option(db.get(key)).foreach(value => recordUndo(key, value))
+    }
+    toUpdate.foreach { case (inputKey, inputValue) =>
+      val key = inputKey.clone()
+      val value = inputValue.clone()
+      require(key.nonEmpty, "Empty keys are not allowed")
+      if (keepVersions > 0) recordUndo(key, db.get(key))
+      mainChanges += Change(key, Some(value))
+    }
+
+    val sameVersion = metadata.versions.lastOption.exists(_.id.sameElements(version))
+    val nextVersions = if (keepVersions > 0) {
+      if (nextLsn == metadata.lsn) recordUndo(Array.emptyByteArray, null)
+      if (sameVersion) metadata.versions else metadata.versions :+ Version(version, metadata.lsn + 1L)
+    } else {
+      if (!sameVersion) mainChanges += Change(last_version_key, Some(version.clone()))
+      Vector(Version(version, nextLsn))
+    }
+    val result = Metadata(Math.addExact(metadata.transaction, 1L), nextLsn, nextVersions)
+    val plan = Plan(result, mainChanges.result(), undoChanges.result())
+    commit(if (keepVersions == 0 || !sameVersion) pruned(plan, keepVersions) else plan)
+  })
 
   def insert(versionID: VersionID, toInsert: Seq[(K, V)]): Try[Unit] = update(versionID, Seq.empty, toInsert)
 
   def remove(versionID: VersionID, toRemove: Seq[K]): Try[Unit] = update(versionID, toRemove, Seq.empty)
 
-
-  // Keep last "count"+1 versions and remove undo information for older versions
-  private def cleanStart(count: Int): Unit = {
-    val deteriorated = versions.size - count - 1
-    if (deteriorated >= 0) {
-      val fromLsn = versionLsn(0)
-      val tillLsn = if (deteriorated+1 < versions.size) versionLsn(deteriorated+1) else lsn+1
-      val batch = undo.createWriteBatch()
-      try {
-        for (lsn <- fromLsn until tillLsn) {
-          batch.delete(encodeLSN(lsn))
-        }
-        undo.write(batch, writeOptions)
-      } finally {
-        batch.close()
+  /** Retain count predecessors plus the current version, including the oldest rollback anchor. */
+  private def pruned(plan: Plan, count: Int): Plan = {
+    require(count >= 0, "Negative retention count")
+    val versions = plan.result.versions
+    if (versions.isEmpty || versions.size.toLong <= count.toLong) plan else {
+      val drop = math.max(0, versions.size - count - 1)
+      val cutoff = if (drop + 1 < versions.size) versions(drop + 1).firstLsn else plan.result.lsn + 1L
+      val deletes = Vector.newBuilder[Change]
+      if (cutoff > 0) {
+        val iterator = undo.iterator()
+        try {
+          iterator.seek(encodeLSN(cutoff - 1L))
+          while (iterator.hasNext) deletes += Change(iterator.next().getKey.clone(), None)
+        } finally iterator.close()
       }
+      plan.undo.foreach { change =>
+        if (decodeLSN(change.key) < cutoff) deletes += Change(change.key, None)
+      }
+      val main = if (count == 0) plan.main :+ Change(last_version_key, Some(versions.last.id.clone())) else plan.main
+      plan.copy(result = plan.result.copy(versions = versions.drop(drop)), main = main, undo = plan.undo ++ deletes.result())
+    }
+  }
 
-      versions.remove(0, deteriorated)
-      versionLsn.remove(0, deteriorated)
-      if (count == 0) {
-        db.put(last_version_key, versions(0))
+  def clean(count: Int): Unit = writeLocked {
+    commit(pruned(emptyPlan, count))
+    Seq(undo, db).foreach { database =>
+      Try(database.resumeCompactions()).failed.foreach { error =>
+        log.warn("History retention committed but compaction could not resume", error)
       }
     }
   }
 
-  def clean(count: Int): Unit = {
-    lock.writeLock().lock()
-    try {
-      cleanStart(count)
-    } finally {
-      lock.writeLock().unlock()
-    }
-    undo.resumeCompactions()
-    db.resumeCompactions()
-  }
-
-  def cleanStop(): Unit = {
+  def cleanStop(): Unit = writeLocked {
     undo.suspendCompactions()
     db.suspendCompactions()
   }
@@ -343,89 +280,57 @@ class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
   override def close(): Unit = {
     lock.writeLock().lock()
     try {
-      undo.close()
-      db.close()
-    } finally {
-      lock.writeLock().unlock()
-    }
-  }
-
-  // Rollback to the specified version: undo all changes done after specified version
-  def rollbackTo(versionID: VersionID): Try[Unit] = Try {
-    lock.writeLock().lock()
-    try {
-      val versionIndex = versions.indexWhere(_.sameElements(versionID))
-      if (versionIndex >= 0) {
-        if (versionIndex != versions.size-1) {
-          val batch = db.createWriteBatch()
-          val undoBatch = undo.createWriteBatch()
-          var nUndoRecords: Long = 0
-          val iterator = undo.iterator()
-          var lastLsn: LSN = 0
-          try {
-            var undoing = true
-            iterator.seekToFirst()
-            while (undoing && iterator.hasNext) {
-              val entry = iterator.next()
-              val undo = deserializeUndo(entry.getValue)
-              if (undo.versionID.sameElements(versionID)) {
-                undoing = false
-                lastLsn = decodeLSN(entry.getKey)
-              } else {
-                undoBatch.delete(entry.getKey)
-                nUndoRecords += 1
-                if (undo.value == null) {
-                  if (undo.key.length != 0) { // dummy record
-                    batch.delete(undo.key)
-                  }
-                } else {
-                  batch.put(undo.key, undo.value)
-                }
-              }
-            }
-            db.write(batch, writeOptions)
-            undo.write(undoBatch, writeOptions)
-          } finally {
-            // Make sure you close the batch to avoid resource leaks.
-            iterator.close()
-            batch.close()
-            undoBatch.close()
+      if (!closed) {
+        closed = true
+        var failure: Throwable = null
+        databases.reverse.foreach { database =>
+          try database.close() catch {
+            case NonFatal(error) =>
+              if (failure == null) failure = error else if (failure ne error) failure.addSuppressed(error)
           }
-          val nVersions = versions.size
-          require((versionIndex + 1 == nVersions && nUndoRecords == 0) || (versionIndex + 1 < nVersions && lsn - versionLsn(versionIndex + 1) + 1 == nUndoRecords))
-          versions.remove(versionIndex + 1, nVersions - versionIndex - 1)
-          versionLsn.remove(versionIndex + 1, nVersions - versionIndex - 1)
-          lsn -= nUndoRecords // reuse deleted LSN to avoid holes in LSNs
-          require(lastLsn == 0 || lsn == lastLsn)
-          require(versions.last.sameElements(versionID))
-          lastVersion = Some(versionID)
-        } else {
-          require(lastVersion.get.sameElements(versionID))
         }
-      } else {
-        throw new NoSuchElementException("versionID not found, can not rollback")
+        if (failure != null) throw failure
       }
-    } finally {
-      lock.writeLock().unlock()
+    } finally lock.writeLock().unlock()
+  }
+
+  def rollbackTo(versionID: VersionID): Try[Unit] = Try(writeLocked {
+    val index = metadata.versions.indexWhere(_.id.sameElements(versionID))
+    if (index < 0) throw new NoSuchElementException("versionID not found, can not rollback")
+    if (index < metadata.versions.size - 1) {
+      val boundary = metadata.versions(index + 1).firstLsn
+      val mainChanges = Vector.newBuilder[Change]
+      val undoChanges = Vector.newBuilder[Change]
+      var count = 0L
+      val iterator = undo.iterator()
+      try {
+        iterator.seekToFirst()
+        while (iterator.hasNext && decodeLSN(iterator.peekNext().getKey) >= boundary) {
+          val entry = iterator.next()
+          val record = deserializeUndo(entry.getValue)
+          if (record.key.nonEmpty) mainChanges += Change(record.key, Option(record.value))
+          undoChanges += Change(entry.getKey.clone(), None)
+          count += 1L
+        }
+      } finally iterator.close()
+      require(count == metadata.lsn - boundary + 1L, "Incomplete retained rollback history")
+      val result = Metadata(Math.addExact(metadata.transaction, 1L), boundary - 1L, metadata.versions.take(index + 1))
+      // Keep the legacy fallback marker consistent when it exists; do not add it to ordinary main data.
+      if (db.get(last_version_key) != null) mainChanges += Change(last_version_key, Some(versionID.clone()))
+      commit(Plan(result, mainChanges.result(), undoChanges.result()))
     }
-  }
+  })
 
-  def rollbackVersions(): Iterable[VersionID] = {
-    versions.reverse
-  }
+  def rollbackVersions(): Iterable[VersionID] =
+    readLocked(metadata.versions.reverse.map(_.id.clone()))
 
-  /**
-    * Take database snapshot, process it, and then close the snapshot.
-    * Could be useful when it is needed to process current state of database without blocking database (and so threads
-    * possibly working with it).
-    *
-    * @param logic - processing logic which is getting access to `get` function to read from database snapshot
-    */
+  /** Process a committed snapshot; already acquired snapshots remain valid during later writes. */
   def processSnapshot[T](logic: SnapshotReadInterface => T): Try[T] = {
     val ro = new ReadOptions()
     try {
       lock.writeLock().lock()
       val snapshot = try {
+        ensureReadable()
         db.getSnapshot
       } finally {
         lock.writeLock().unlock()
@@ -455,21 +360,16 @@ class LDBVersionedStore(protected val dir: File, val initialKeepVersions: Int)
         Failure(t)
     }
   }
-
 }
 
 object LDBVersionedStore {
-
-  /**
-    * Interface to read from versioned database snapshot which can be provided to clients in order to serve them with
-    * snapshot. Contains only reader function.
-    */
-  trait SnapshotReadInterface {
-    /**
-      * Read value by key. Client should care about key existence on its side. If key does not exist in database,
-      * an exception will be thrown.
-      */
-    def get(key: Array[Byte]): Array[Byte]
+  private[db] def openDatabase(dir: File, name: String): DB = {
+    val options = new Options().createIfMissing(true).paranoidChecks(true)
+    LDBFactory.factory.open(new File(dir, name), options)
   }
 
+  trait SnapshotReadInterface {
+    /** Returns the stored bytes, or null if the key is absent. */
+    def get(key: Array[Byte]): Array[Byte]
+  }
 }

--- a/avldb/src/main/scala/scorex/db/LDBVersionedStoreJournal.scala
+++ b/avldb/src/main/scala/scorex/db/LDBVersionedStoreJournal.scala
@@ -1,0 +1,172 @@
+package scorex.db
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
+
+import org.iq80.leveldb.{DB, WriteOptions}
+import scorex.util.ScorexLogging
+
+import scala.util.control.NonFatal
+
+/** Private redo journal. Application keys and the legacy undo encoding remain unchanged. */
+private[db] final class LDBVersionedStoreJournal(journal: DB, main: DB, undo: DB) extends ScorexLogging {
+  import LDBVersionedStoreJournal._
+
+  private val synchronous = new WriteOptions().sync(true)
+
+  def initialize(legacy: => Metadata): Metadata = {
+    val committed = Option(journal.get(CommittedKey)).map(decodeMetadata).getOrElse {
+      require(journal.get(PendingKey) == null, "Pending recovery has no committed predecessor")
+      val initial = legacy
+      write(journal, Vector(Change(CommittedKey, Some(encodeMetadata(initial)))))
+      initial
+    }
+    Option(journal.get(PendingKey)) match {
+      case Some(bytes) =>
+        val pending = decodePlan(bytes)
+        require(pending.result.transaction == Math.addExact(committed.transaction, 1L),
+          "Pending recovery does not follow committed metadata")
+        applyParticipants(pending)
+        complete(pending)
+        pending.result
+      case None => committed
+    }
+  }
+
+  /** Serialize before the first write, so encoding errors are ordinary preflight failures. */
+  def encoded(plan: Plan): Array[Byte] = encodePlan(plan)
+
+  def prepare(bytes: Array[Byte]): Unit =
+    write(journal, Vector(Change(PendingKey, Some(bytes))))
+
+  def applyParticipants(plan: Plan): Unit = {
+    write(main, plan.main)
+    write(undo, plan.undo)
+  }
+
+  def complete(plan: Plan): Unit = write(journal, Vector(
+    Change(CommittedKey, Some(encodeMetadata(plan.result))), Change(PendingKey, None)))
+
+  private def write(database: DB, changes: Vector[Change]): Unit = {
+    val batch = database.createWriteBatch()
+    var failure: Throwable = null
+    try {
+      changes.foreach { change =>
+        change.value match {
+          case Some(value) => batch.put(change.key, value)
+          case None => batch.delete(change.key)
+        }
+      }
+      database.write(batch, synchronous)
+    } catch {
+      case t: Throwable =>
+        failure = t
+        throw t
+    } finally {
+      try batch.close() catch {
+        case NonFatal(closeError) if failure != null =>
+          if (closeError ne failure) failure.addSuppressed(closeError)
+        case NonFatal(closeError) =>
+          // The write completed. Cleanup must not turn a committed operation into a failed one.
+          log.warn("Failed to close completed versioned-store write batch", closeError)
+      }
+    }
+  }
+}
+
+private[db] object LDBVersionedStoreJournal {
+  private val Format = 1
+  private val CommittedKey = Array(0.toByte)
+  private val PendingKey = Array(1.toByte)
+
+  final case class Version(id: Array[Byte], firstLsn: Long)
+  final case class Metadata(transaction: Long, lsn: Long, versions: Vector[Version])
+  final case class Change(key: Array[Byte], value: Option[Array[Byte]])
+  final case class Plan(result: Metadata, main: Vector[Change], undo: Vector[Change])
+
+  private def encode(write: DataOutputStream => Unit): Array[Byte] = {
+    val bytes = new ByteArrayOutputStream()
+    val out = new DataOutputStream(bytes)
+    out.writeInt(Format)
+    write(out)
+    out.flush()
+    bytes.toByteArray
+  }
+
+  private def decode[T](bytes: Array[Byte])(read: DataInputStream => T): T = {
+    val in = new DataInputStream(new ByteArrayInputStream(bytes))
+    require(in.readInt() == Format, "Unsupported versioned-store journal format")
+    val result = read(in)
+    require(in.available() == 0, "Trailing versioned-store journal bytes")
+    result
+  }
+
+  private def writeBytes(out: DataOutputStream, bytes: Array[Byte]): Unit = {
+    out.writeInt(bytes.length)
+    out.write(bytes)
+  }
+
+  private def readBytes(in: DataInputStream): Array[Byte] = {
+    val length = in.readInt()
+    require(length >= 0 && length <= in.available(), "Incomplete versioned-store journal field")
+    val bytes = new Array[Byte](length)
+    in.readFully(bytes)
+    bytes
+  }
+
+  private def writeMetadata(out: DataOutputStream, metadata: Metadata): Unit = {
+    out.writeLong(metadata.transaction)
+    out.writeLong(metadata.lsn)
+    out.writeInt(metadata.versions.size)
+    metadata.versions.foreach { version =>
+      writeBytes(out, version.id)
+      out.writeLong(version.firstLsn)
+    }
+  }
+
+  private def readMetadata(in: DataInputStream): Metadata = {
+    val transaction = in.readLong()
+    val lsn = in.readLong()
+    val count = in.readInt()
+    require(transaction >= 0 && lsn >= 0, "Negative versioned-store journal sequence")
+    require(count >= 0 && count <= in.available() / 12, "Incomplete versioned-store version list")
+    val versions = Vector.fill(count) {
+      val id = readBytes(in)
+      val firstLsn = in.readLong()
+      require(firstLsn >= 0 && firstLsn <= Math.addExact(lsn, 1L), "Invalid versioned-store LSN")
+      Version(id, firstLsn)
+    }
+    require(versions.map(_.firstLsn).sliding(2).forall(pair => pair.size < 2 || pair.head <= pair.last),
+      "Unordered versioned-store LSNs")
+    Metadata(transaction, lsn, versions)
+  }
+
+  private def writeChanges(out: DataOutputStream, changes: Vector[Change]): Unit = {
+    out.writeInt(changes.size)
+    changes.foreach { change =>
+      writeBytes(out, change.key)
+      out.writeBoolean(change.value.isDefined)
+      change.value.foreach(writeBytes(out, _))
+    }
+  }
+
+  private def readChanges(in: DataInputStream): Vector[Change] = {
+    val count = in.readInt()
+    require(count >= 0 && count <= in.available() / 5, "Incomplete versioned-store change list")
+    Vector.fill(count) {
+      val key = readBytes(in)
+      val value = if (in.readBoolean()) Some(readBytes(in)) else None
+      Change(key, value)
+    }
+  }
+
+  private def encodeMetadata(metadata: Metadata): Array[Byte] = encode(writeMetadata(_, metadata))
+  private def decodeMetadata(bytes: Array[Byte]): Metadata = decode(bytes)(readMetadata)
+  private def encodePlan(plan: Plan): Array[Byte] = encode { out =>
+    writeMetadata(out, plan.result)
+    writeChanges(out, plan.main)
+    writeChanges(out, plan.undo)
+  }
+  private def decodePlan(bytes: Array[Byte]): Plan = decode(bytes) { in =>
+    Plan(readMetadata(in), readChanges(in), readChanges(in))
+  }
+}

--- a/avldb/src/test/scala/scorex/db/LDBVersionedStoreRecoverySpec.scala
+++ b/avldb/src/test/scala/scorex/db/LDBVersionedStoreRecoverySpec.scala
@@ -1,0 +1,615 @@
+package scorex.db
+
+import java.io.{EOFException, File}
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.util.concurrent.{Callable, CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+import org.iq80.leveldb.{DB, DBException, WriteBatch, WriteOptions}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import scala.util.Try
+
+/** Exercises the journal-enabled store using ordinary data and classified local write outcomes. */
+class LDBVersionedStoreRecoverySpec extends AnyPropSpec with Matchers {
+  private def bytes(n: Int): Array[Byte] = Array(n.toByte)
+  private def versions(store: LDBVersionedStore): Seq[Seq[Byte]] =
+    store.rollbackVersions().toSeq.map(_.toSeq)
+
+  private final class Writes {
+    val error = new DBException("local write result unavailable")
+    val closeError = new java.io.IOException("local batch cleanup failed")
+    private var selected: Option[(String, Int, Boolean)] = None
+    private var closeSelected: Option[String] = None
+    private var openSelected: Option[String] = None
+    private var databaseCloseSelected: Option[String] = None
+    private var batchFailureSelected: Option[(String, String)] = None
+    @volatile private var writeGate: Option[(String, CountDownLatch, CountDownLatch)] = None
+    private val wrappedBatches = new java.util.IdentityHashMap[AnyRef, AnyRef]()
+    private var matchingWrites = 0
+    var syncWrites = Vector.empty[Boolean]
+    var openedDatabases = Vector.empty[String]
+    var closedDatabases = Vector.empty[String]
+    var closedBatches = Vector.empty[String]
+    val snapshots = new AtomicInteger()
+
+    def arm(name: String, occurrence: Int, afterWrite: Boolean): Unit = {
+      selected = Some((name, occurrence, afterWrite))
+      matchingWrites = 0
+    }
+
+    def armBatchClose(name: String): Unit = closeSelected = Some(name)
+    def armOpen(name: String): Unit = openSelected = Some(name)
+    def armDatabaseClose(name: String): Unit = databaseCloseSelected = Some(name)
+    def armBatchFailure(name: String, method: String): Unit = batchFailureSelected = Some(name -> method)
+    def holdNextWrite(name: String): (CountDownLatch, CountDownLatch) = {
+      val entered = new CountDownLatch(1)
+      val release = new CountDownLatch(1)
+      writeGate = Some((name, entered, release))
+      entered -> release
+    }
+
+    def open(dir: File, name: String): DB = {
+      if (openSelected.contains(name)) {
+        openSelected = None
+        throw error
+      }
+      val underlying = LDBVersionedStore.openDatabase(dir, name)
+      openedDatabases :+= name
+      Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+        override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+          val callArgs = Option(args).getOrElse(Array.empty[AnyRef])
+          def delegate(): AnyRef = try {
+            val forwarded = if (method.getName == "write" && callArgs.nonEmpty && wrappedBatches.containsKey(callArgs(0))) {
+              callArgs.updated(0, wrappedBatches.get(callArgs(0)))
+            } else callArgs
+            method.invoke(underlying, forwarded: _*)
+          } catch {
+            case e: InvocationTargetException => throw e.getCause
+          }
+          if (method.getName == "close") {
+            val result = delegate()
+            closedDatabases :+= name
+            if (databaseCloseSelected.contains(name)) {
+              databaseCloseSelected = None
+              throw closeError
+            }
+            result
+          } else if (method.getName == "getSnapshot") {
+            snapshots.incrementAndGet()
+            delegate()
+          } else if (method.getName == "createWriteBatch" && batchFailureSelected.contains(name -> "createWriteBatch")) {
+            batchFailureSelected = None
+            throw error
+          } else if (method.getName == "createWriteBatch" &&
+            (closeSelected.contains(name) || batchFailureSelected.exists(_._1 == name))) {
+            val failClose = closeSelected.contains(name)
+            if (failClose) closeSelected = None
+            val actual = delegate()
+            val wrapped = Proxy.newProxyInstance(classOf[WriteBatch].getClassLoader, Array(classOf[WriteBatch]),
+              new InvocationHandler {
+                override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+                  if (batchFailureSelected.contains(name -> method.getName)) {
+                    batchFailureSelected = None
+                    throw error
+                  }
+                  val result = try method.invoke(actual, Option(args).getOrElse(Array.empty[AnyRef]): _*) catch {
+                    case e: InvocationTargetException => throw e.getCause
+                  }
+                  if (method.getName == "close") {
+                    closedBatches :+= name
+                    if (failClose) throw closeError
+                  }
+                  result
+                }
+              })
+            wrappedBatches.put(wrapped, actual)
+            wrapped
+          } else if (method.getName == "write" && callArgs.length == 2) {
+            writeGate.filter(_._1 == name).foreach { case (_, entered, release) =>
+              writeGate = None
+              entered.countDown()
+              if (!release.await(5, TimeUnit.SECONDS)) throw new IllegalStateException("Write gate timed out")
+            }
+            syncWrites :+= callArgs(1).asInstanceOf[WriteOptions].sync()
+            val fault = selected.filter(_._1 == name).filter { _ =>
+              matchingWrites += 1
+              matchingWrites == selected.get._2
+            }
+            fault match {
+              case Some((_, _, afterWrite)) =>
+                selected = None
+                if (afterWrite) delegate()
+                throw error
+              case None => delegate()
+            }
+          } else delegate()
+        }
+      }).asInstanceOf[DB]
+    }
+  }
+
+  private def withDirectory(test: File => Unit): Unit = {
+    val dir = Files.createTempDirectory("versioned-store-recovery").toFile
+    try test(dir) finally {
+      def remove(file: File): Unit = {
+        Option(file.listFiles()).foreach(_.foreach(remove))
+        if (!file.delete()) file.deleteOnExit()
+      }
+      remove(dir)
+    }
+  }
+
+  private def seed(store: LDBVersionedStore): Unit = {
+    store.update(bytes(1), Nil, Seq(bytes(10) -> bytes(11))).get
+    store.update(bytes(2), Nil, Seq(bytes(10) -> bytes(12), bytes(20) -> bytes(21))).get
+  }
+
+  private def unavailable(store: LDBVersionedStore): Unit = {
+    intercept[IllegalStateException](store.get(bytes(10)))
+    intercept[IllegalStateException](store.lastVersionID)
+    intercept[IllegalStateException](store.rollbackVersions())
+    intercept[IllegalStateException](store.versionIdExists(bytes(2)))
+    intercept[IllegalStateException](store.getAll)
+    intercept[IllegalStateException](store.getRange(bytes(1), bytes(99)))
+    intercept[IllegalStateException](store.processAll((_, _) => ()))
+    store.processSnapshot(_.get(bytes(10))).isFailure shouldBe true
+    store.update(bytes(3), Nil, Nil).isFailure shouldBe true
+    store.rollbackTo(bytes(1)).isFailure shouldBe true
+    intercept[IllegalStateException](store.clean(0))
+    intercept[IllegalStateException](store.setKeepVersions(0))
+  }
+
+  property("ordinary updates, an empty version, rollback and reopening share one version identity") {
+    withDirectory { dir =>
+      var store = new LDBVersionedStore(dir, 2)
+      try {
+        seed(store)
+        store.update(bytes(2), Iterator.empty, Iterator(bytes(10) -> bytes(13))).get
+        store.update(bytes(3), Iterator.empty, Iterator.empty).get
+        store.close()
+        store = new LDBVersionedStore(dir, 2)
+        versions(store) shouldBe Seq(3, 2, 1).map(n => bytes(n).toSeq)
+        store.get(bytes(10)).get.toSeq shouldBe bytes(13).toSeq
+        store.rollbackTo(bytes(1)).get
+        store.close()
+        store = new LDBVersionedStore(dir, 2)
+        versions(store) shouldBe Seq(bytes(1).toSeq)
+        store.get(bytes(10)).get.toSeq shouldBe bytes(11).toSeq
+        store.get(bytes(20)) shouldBe None
+        store.update(bytes(4), Seq(bytes(10)), Seq(bytes(30) -> bytes(31))).get
+        store.rollbackTo(bytes(1)).get
+        store.get(bytes(10)).get.toSeq shouldBe bytes(11).toSeq
+        store.get(bytes(30)) shouldBe None
+      } finally store.close()
+    }
+  }
+
+  property("retention preserves its oldest rollback anchor across reopening and zero retention") {
+    withDirectory { dir =>
+      var store = new LDBVersionedStore(dir, 1)
+      try {
+        seed(store)
+        store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).get
+        versions(store) shouldBe Seq(bytes(3).toSeq, bytes(2).toSeq)
+        store.close()
+        store = new LDBVersionedStore(dir, 1)
+        store.rollbackTo(bytes(2)).get
+        store.get(bytes(10)).get.toSeq shouldBe bytes(12).toSeq
+        store.setKeepVersions(0) shouldBe 1
+        store.close()
+        store = new LDBVersionedStore(dir, 0)
+        store.rollbackTo(bytes(2)).get
+        store.update(bytes(4), Nil, Seq(bytes(10) -> bytes(14))).get
+        store.close()
+        store = new LDBVersionedStore(dir, 0)
+        versions(store) shouldBe Seq(bytes(4).toSeq)
+        store.setKeepVersions(2) shouldBe 0
+        store.update(bytes(5), Nil, Seq(bytes(10) -> bytes(15))).get
+        store.close()
+        store = new LDBVersionedStore(dir, 2)
+        store.rollbackTo(bytes(4)).get
+        store.get(bytes(10)).get.toSeq shouldBe bytes(14).toSeq
+        store.clean(0)
+        store.getKeepVersions shouldBe 2
+      } finally store.close()
+    }
+  }
+
+  for {
+    (database, occurrence) <- Seq("ldb_journal" -> 1, "ldb_main" -> 1, "ldb_undo" -> 1, "ldb_journal" -> 2)
+    afterWrite <- Seq(false, true)
+  } property(s"update recovers after $database write $occurrence with applied=$afterWrite") {
+    withDirectory { dir =>
+      val writes = new Writes
+      var store = new LDBVersionedStore(dir, 2, writes.open)
+      try {
+        seed(store)
+        writes.arm(database, occurrence, afterWrite)
+        store.update(bytes(3), Seq(bytes(20)), Seq(bytes(10) -> bytes(13))).failed.get shouldBe writes.error
+        unavailable(store)
+        store.close()
+        store = new LDBVersionedStore(dir, 2, writes.open)
+        val committed = database != "ldb_journal" || occurrence != 1 || afterWrite
+        store.lastVersionID.get.toSeq shouldBe bytes(if (committed) 3 else 2).toSeq
+        store.get(bytes(10)).get.toSeq shouldBe bytes(if (committed) 13 else 12).toSeq
+        store.get(bytes(20)).map(_.toSeq) shouldBe (if (committed) None else Some(bytes(21).toSeq))
+        store.rollbackTo(bytes(1)).get
+        store.get(bytes(10)).get.toSeq shouldBe bytes(11).toSeq
+        writes.syncWrites.nonEmpty shouldBe true
+        writes.syncWrites.forall(identity) shouldBe true
+      } finally store.close()
+    }
+  }
+
+  for {
+    operation <- Seq("rollback", "clean", "setKeepVersions")
+    database <- Seq("ldb_main", "ldb_undo", "ldb_journal")
+    afterWrite <- Seq(false, true)
+  } property(s"$operation recovers after $database completion with applied=$afterWrite") {
+    withDirectory { dir =>
+      val writes = new Writes
+      var store = new LDBVersionedStore(dir, 2, writes.open)
+      try {
+        seed(store)
+        store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).get
+        writes.arm(database, if (database == "ldb_journal") 2 else 1, afterWrite)
+        operation match {
+          case "rollback" => store.rollbackTo(bytes(1)).failed.get shouldBe writes.error
+          case "clean" => intercept[DBException](store.clean(0)) shouldBe writes.error
+          case _ => intercept[DBException](store.setKeepVersions(0)) shouldBe writes.error
+        }
+        unavailable(store)
+        store.close()
+        store = new LDBVersionedStore(dir, 2, writes.open)
+        val target = if (operation == "rollback") 1 else 3
+        versions(store) shouldBe Seq(bytes(target).toSeq)
+        store.get(bytes(10)).get.toSeq shouldBe bytes(if (operation == "rollback") 11 else 13).toSeq
+        store.getKeepVersions shouldBe 2
+        store.update(bytes(4), Nil, Seq(bytes(10) -> bytes(14))).get
+        store.rollbackTo(bytes(target)).get
+        store.close()
+        store = new LDBVersionedStore(dir, 2, writes.open)
+        versions(store) shouldBe Seq(bytes(target).toSeq)
+      } finally store.close()
+    }
+  }
+
+  property("a preflight rejection leaves the store usable and returned versions cannot change metadata") {
+    withDirectory { dir =>
+      val store = new LDBVersionedStore(dir, 2)
+      try {
+        seed(store)
+        store.rollbackTo(bytes(9)).isFailure shouldBe true
+        val current = store.lastVersionID.get
+        current(0) = 99.toByte
+        val retained = store.rollbackVersions().toSeq
+        retained.head(0) = 99.toByte
+        versions(store) shouldBe Seq(bytes(2).toSeq, bytes(1).toSeq)
+        store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).get
+      } finally store.close()
+    }
+  }
+
+  property("an interrupted recovery preserves its plan and releases database handles for another reopening") {
+    withDirectory { dir =>
+      val writes = new Writes
+      val original = new LDBVersionedStore(dir, 2, writes.open)
+      try {
+        seed(original)
+        writes.arm("ldb_main", 1, afterWrite = false)
+        original.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).isFailure shouldBe true
+      } finally original.close()
+      writes.arm("ldb_undo", 1, afterWrite = true)
+      intercept[DBException](new LDBVersionedStore(dir, 2, writes.open)) shouldBe writes.error
+      val recovered = new LDBVersionedStore(dir, 2, writes.open)
+      try {
+        recovered.lastVersionID.get.toSeq shouldBe bytes(3).toSeq
+        recovered.get(bytes(10)).get.toSeq shouldBe bytes(13).toSeq
+        recovered.rollbackTo(bytes(1)).get
+        recovered.get(bytes(10)).get.toSeq shouldBe bytes(11).toSeq
+      } finally recovered.close()
+    }
+  }
+
+  for (writeFails <- Seq(false, true)) property(s"batch cleanup preserves the write result with failure=$writeFails") {
+    withDirectory { dir =>
+      val writes = new Writes
+      var store = new LDBVersionedStore(dir, 2, writes.open)
+      try {
+        seed(store)
+        writes.armBatchClose("ldb_main")
+        if (writeFails) writes.arm("ldb_main", 1, afterWrite = false)
+        val result = store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13)))
+        if (writeFails) {
+          result.failed.get shouldBe writes.error
+          writes.error.getSuppressed.toSeq should contain(writes.closeError)
+        } else result.get shouldBe (())
+        store.close()
+        store = new LDBVersionedStore(dir, 2, writes.open)
+        store.lastVersionID.get.toSeq shouldBe bytes(3).toSeq
+        store.get(bytes(10)).get.toSeq shouldBe bytes(13).toSeq
+      } finally store.close()
+    }
+  }
+
+  private def rawDatabase[T](dir: File, name: String)(test: DB => T): T = {
+    val database = LDBVersionedStore.openDatabase(dir, name)
+    try test(database) finally database.close()
+  }
+
+  private def pendingUpdate(dir: File): Writes = {
+    val writes = new Writes
+    val store = new LDBVersionedStore(dir, 2, writes.open)
+    try {
+      seed(store)
+      writes.arm("ldb_main", 1, afterWrite = false)
+      store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).failed.get shouldBe writes.error
+    } finally store.close()
+    writes
+  }
+
+  private def replaceInt(data: Array[Byte], offset: Int, value: Int): Array[Byte] =
+    ByteBuffer.wrap(data.clone()).putInt(offset, value).array()
+
+  private def replaceLong(data: Array[Byte], offset: Int, value: Long): Array[Byte] =
+    ByteBuffer.wrap(data.clone()).putLong(offset, value).array()
+
+  private def metadataEnd(data: Array[Byte]): Int = {
+    val buffer = ByteBuffer.wrap(data)
+    val count = buffer.getInt(20)
+    var offset = 24
+    for (_ <- 0 until count) offset += 4 + buffer.getInt(offset) + 8
+    offset
+  }
+
+  private final case class RejectedField(name: String, key: Int, alter: Array[Byte] => Array[Byte],
+                                         reason: String, errorClass: Class[_ <: Throwable] = classOf[IllegalArgumentException])
+
+  private val journalInvalidFields: Seq[RejectedField] = Seq(
+    RejectedField("unknown committed format", 0, data => replaceInt(data, 0, 2),
+      "Unsupported versioned-store journal format"),
+    RejectedField("negative transaction", 0, data => replaceLong(data, 4, -1L),
+      "Negative versioned-store journal sequence"),
+    RejectedField("negative LSN", 0, data => replaceLong(data, 12, -1L),
+      "Negative versioned-store journal sequence"),
+    RejectedField("negative version count", 0, data => replaceInt(data, 20, -1),
+      "Incomplete versioned-store version list"),
+    RejectedField("oversized version count", 0, data => replaceInt(data, 20, Int.MaxValue),
+      "Incomplete versioned-store version list"),
+    RejectedField("negative version length", 0, data => replaceInt(data, 24, -1),
+      "Incomplete versioned-store journal field"),
+    RejectedField("negative version start", 0, data => replaceLong(data, 29, -1L), "Invalid versioned-store LSN"),
+    // Changing only the last start preserves ordering, isolating the upper LSN bound.
+    RejectedField("last version start beyond assigned LSN", 0,
+      data => replaceLong(data, metadataEnd(data) - 8, ByteBuffer.wrap(data).getLong(12) + 2L), "Invalid versioned-store LSN"),
+    RejectedField("unordered version starts", 0, data => replaceLong(data, 29, 3L), "Unordered versioned-store LSNs"),
+    RejectedField("truncated committed metadata", 0, data => data.dropRight(1), null, classOf[EOFException]),
+    RejectedField("trailing committed bytes", 0, data => data :+ 0.toByte, "Trailing versioned-store journal bytes"),
+    RejectedField("unknown pending format", 1, data => replaceInt(data, 0, 2), "Unsupported versioned-store journal format"),
+    RejectedField("negative change count", 1, data => replaceInt(data, metadataEnd(data), -1),
+      "Incomplete versioned-store change list"),
+    RejectedField("oversized change count", 1, data => replaceInt(data, metadataEnd(data), Int.MaxValue),
+      "Incomplete versioned-store change list"),
+    RejectedField("negative change key length", 1, data => replaceInt(data, metadataEnd(data) + 4, -1),
+      "Incomplete versioned-store journal field"),
+    RejectedField("truncated pending metadata", 1, data => data.take(23), null, classOf[EOFException]),
+    // Remove a key byte as well as the final presence flag, so the length check decides rejection.
+    RejectedField("truncated pending changes", 1, data => data.dropRight(2), "Incomplete versioned-store journal field"),
+    RejectedField("trailing pending bytes", 1, data => data :+ 0.toByte, "Trailing versioned-store journal bytes")
+  )
+
+  for (field <- journalInvalidFields) property(s"new journal rejects ${field.name} before participant writes") {
+    withDirectory { dir =>
+      val writes = pendingUpdate(dir)
+      val changed = rawDatabase(dir, "ldb_journal") { journal =>
+        val changed = field.alter(journal.get(bytes(field.key)))
+        journal.put(bytes(field.key), changed, new WriteOptions().sync(true))
+        changed
+      }
+      val writesBeforeOpen = writes.syncWrites.size
+      val opening = Try(new LDBVersionedStore(dir, 2, writes.open))
+      opening.foreach(_.close())
+      val rejection = opening.failed.get
+      rejection.getClass shouldBe field.errorClass
+      val expectedMessage = if (field.errorClass == classOf[IllegalArgumentException]) s"requirement failed: ${field.reason}"
+        else field.reason
+      rejection.getMessage shouldBe expectedMessage
+      writes.syncWrites.size shouldBe writesBeforeOpen
+      writes.closedDatabases.takeRight(3) shouldBe Seq("ldb_journal", "ldb_undo", "ldb_main")
+      rawDatabase(dir, "ldb_journal")(_.get(bytes(field.key)).toSeq) shouldBe changed.toSeq
+      rawDatabase(dir, "ldb_main")(_.get(bytes(10)).toSeq) shouldBe bytes(12).toSeq
+    }
+  }
+
+  for (missingPredecessor <- Seq(false, true)) property(s"new journal requires a consecutive predecessor with missing=$missingPredecessor") {
+    withDirectory { dir =>
+      val writes = pendingUpdate(dir)
+      rawDatabase(dir, "ldb_journal") { journal =>
+        if (missingPredecessor) journal.delete(bytes(0), new WriteOptions().sync(true))
+        else {
+          val pending = journal.get(bytes(1))
+          val committedSequence = ByteBuffer.wrap(journal.get(bytes(0))).getLong(4)
+          journal.put(bytes(1), replaceLong(pending, 4, committedSequence + 2L), new WriteOptions().sync(true))
+        }
+      }
+      val writesBeforeOpen = writes.syncWrites.size
+      val rejection = intercept[IllegalArgumentException](new LDBVersionedStore(dir, 2, writes.open))
+      rejection.getMessage shouldBe (if (missingPredecessor) "requirement failed: Pending recovery has no committed predecessor"
+        else "requirement failed: Pending recovery does not follow committed metadata")
+      writes.syncWrites.size shouldBe writesBeforeOpen
+      rawDatabase(dir, "ldb_journal")(_.get(bytes(1))) should not be null
+      rawDatabase(dir, "ldb_main")(_.get(bytes(10)).toSeq) shouldBe bytes(12).toSeq
+    }
+  }
+
+  for (database <- Seq("ldb_main", "ldb_undo", "ldb_journal")) {
+    property(s"database acquisition failure at $database closes every earlier handle and preserves its error") {
+      withDirectory { dir =>
+        val writes = new Writes
+        writes.armOpen(database)
+        writes.armDatabaseClose("ldb_main")
+        intercept[DBException](new LDBVersionedStore(dir, 2, writes.open)) shouldBe writes.error
+        writes.closedDatabases shouldBe writes.openedDatabases.reverse
+        if (database != "ldb_main") writes.error.getSuppressed.toSeq should contain(writes.closeError)
+        val reopened = new LDBVersionedStore(dir, 2)
+        try reopened.lastVersionID shouldBe None finally reopened.close()
+      }
+    }
+  }
+
+  for (afterWrite <- Seq(false, true)) property(s"journal initialization failure closes handles with applied=$afterWrite") {
+    withDirectory { dir =>
+      val writes = new Writes
+      writes.arm("ldb_journal", 1, afterWrite)
+      writes.armDatabaseClose("ldb_undo")
+      intercept[DBException](new LDBVersionedStore(dir, 2, writes.open)) shouldBe writes.error
+      writes.closedDatabases shouldBe Seq("ldb_journal", "ldb_undo", "ldb_main")
+      writes.error.getSuppressed.toSeq should contain(writes.closeError)
+      val reopened = new LDBVersionedStore(dir, 2)
+      try reopened.lastVersionID shouldBe None finally reopened.close()
+    }
+  }
+
+  for (method <- Seq("createWriteBatch", "put")) property(s"participant batch $method failure preserves a recoverable plan") {
+    withDirectory { dir =>
+      val writes = new Writes
+      var store = new LDBVersionedStore(dir, 2, writes.open)
+      try {
+        seed(store)
+        writes.armBatchFailure("ldb_main", method)
+        store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).failed.get shouldBe writes.error
+        if (method == "put") writes.closedBatches should contain("ldb_main")
+        unavailable(store)
+        store.close()
+        store = new LDBVersionedStore(dir, 2, writes.open)
+        store.lastVersionID.get.toSeq shouldBe bytes(3).toSeq
+        store.get(bytes(10)).get.toSeq shouldBe bytes(13).toSeq
+      } finally store.close()
+    }
+  }
+
+  for {
+    database <- Seq("ldb_main", "ldb_undo", "ldb_journal")
+    afterWrite <- Seq(false, true)
+    if database != "ldb_undo" || !afterWrite // The applied undo case is covered above.
+  } property(s"interrupted replay at $database remains recoverable with applied=$afterWrite") {
+    withDirectory { dir =>
+      val writes = pendingUpdate(dir)
+      writes.arm(database, 1, afterWrite)
+      intercept[DBException](new LDBVersionedStore(dir, 2, writes.open)) shouldBe writes.error
+      writes.closedDatabases.takeRight(3) shouldBe Seq("ldb_journal", "ldb_undo", "ldb_main")
+      val recovered = new LDBVersionedStore(dir, 2)
+      try {
+        recovered.lastVersionID.get.toSeq shouldBe bytes(3).toSeq
+        recovered.get(bytes(10)).get.toSeq shouldBe bytes(13).toSeq
+        recovered.rollbackTo(bytes(1)).get
+        recovered.get(bytes(10)).get.toSeq shouldBe bytes(11).toSeq
+      } finally recovered.close()
+    }
+  }
+
+  property("a new snapshot queued behind an ambiguous write is rejected before snapshot acquisition") {
+    withDirectory { dir =>
+      val writes = new Writes
+      val store = new LDBVersionedStore(dir, 2, writes.open)
+      val executor = Executors.newFixedThreadPool(2)
+      seed(store)
+      val (writeEntered, releaseWrite) = writes.holdNextWrite("ldb_main")
+      try {
+        writes.arm("ldb_main", 1, afterWrite = true)
+        val writer = executor.submit(new Callable[Try[Unit]] {
+          override def call(): Try[Unit] = store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13)))
+        })
+        writeEntered.await(5, TimeUnit.SECONDS) shouldBe true
+        val readerThread = new AtomicReference[Thread]()
+        val readerStarted = new CountDownLatch(1)
+        val reader = executor.submit(new Callable[Try[Array[Byte]]] {
+          override def call(): Try[Array[Byte]] = {
+            readerThread.set(Thread.currentThread())
+            readerStarted.countDown()
+            store.processSnapshot(_.get(bytes(10)))
+          }
+        })
+        readerStarted.await(5, TimeUnit.SECONDS) shouldBe true
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!store.lock.hasQueuedThread(readerThread.get()) && System.nanoTime() < deadline) Thread.`yield`()
+        store.lock.hasQueuedThread(readerThread.get()) shouldBe true
+        writes.snapshots.get() shouldBe 0
+        releaseWrite.countDown()
+        writer.get(5, TimeUnit.SECONDS).failed.get shouldBe writes.error
+        reader.get(5, TimeUnit.SECONDS).failed.get shouldBe a[IllegalStateException]
+        writes.snapshots.get() shouldBe 0
+      } finally {
+        releaseWrite.countDown()
+        executor.shutdownNow()
+        executor.awaitTermination(5, TimeUnit.SECONDS) shouldBe true
+        store.close()
+      }
+    }
+  }
+
+  property("an acquired snapshot keeps its committed view while later snapshot requests are quarantined") {
+    withDirectory { dir =>
+      val writes = new Writes
+      val store = new LDBVersionedStore(dir, 2, writes.open)
+      val executor = Executors.newSingleThreadExecutor()
+      val acquired = new CountDownLatch(1)
+      val resumeSnapshot = new CountDownLatch(1)
+      try {
+        seed(store)
+        val reader = executor.submit(new Callable[Try[Array[Byte]]] {
+          override def call(): Try[Array[Byte]] = store.processSnapshot { snapshot =>
+            acquired.countDown()
+            if (!resumeSnapshot.await(5, TimeUnit.SECONDS)) throw new IllegalStateException("Snapshot gate timed out")
+            snapshot.get(bytes(10))
+          }
+        })
+        acquired.await(5, TimeUnit.SECONDS) shouldBe true
+        writes.arm("ldb_main", 1, afterWrite = true)
+        store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).failed.get shouldBe writes.error
+        store.processSnapshot(_.get(bytes(10))).isFailure shouldBe true
+        writes.snapshots.get() shouldBe 1
+        resumeSnapshot.countDown()
+        reader.get(5, TimeUnit.SECONDS).get.toSeq shouldBe bytes(12).toSeq
+      } finally {
+        resumeSnapshot.countDown()
+        executor.shutdownNow()
+        executor.awaitTermination(5, TimeUnit.SECONDS) shouldBe true
+        store.close()
+      }
+    }
+  }
+
+  for (withHistory <- Seq(false, true)) property(s"healthy legacy database adoption preserves data with history=$withHistory") {
+    withDirectory { dir =>
+      val main = LDBVersionedStore.openDatabase(dir, "ldb_main")
+      val undo = LDBVersionedStore.openDatabase(dir, "ldb_undo")
+      try {
+        main.put(bytes(10), bytes(12), new WriteOptions().sync(true))
+        if (withHistory) {
+          // Existing encoding: version length, key length, version, key, optional previous value.
+          undo.put(ByteBuffer.allocate(8).putLong(~1L).array(), Array[Byte](1, 1, 1, 10), new WriteOptions().sync(true))
+          undo.put(ByteBuffer.allocate(8).putLong(~2L).array(), Array[Byte](1, 1, 2, 10, 11), new WriteOptions().sync(true))
+        } else main.put(scorex.crypto.hash.Blake2b256("last_version"), bytes(2), new WriteOptions().sync(true))
+      } finally {
+        undo.close()
+        main.close()
+      }
+      var store = new LDBVersionedStore(dir, 2)
+      try {
+        store.lastVersionID.get.toSeq shouldBe bytes(2).toSeq
+        store.get(bytes(10)).get.toSeq shouldBe bytes(12).toSeq
+        store.update(bytes(3), Nil, Seq(bytes(10) -> bytes(13))).get
+        store.close()
+        store = new LDBVersionedStore(dir, 2)
+        store.rollbackTo(bytes(if (withHistory) 1 else 2)).get
+        store.get(bytes(10)).get.toSeq shouldBe bytes(if (withHistory) 11 else 12).toSeq
+        if (withHistory) store.getAll.map(_._1.toSeq).toSeq shouldBe Seq(bytes(10).toSeq)
+      } finally store.close()
+    }
+  }
+}

--- a/avldb/src/test/scala/scorex/db/LDBVersionedStoreSnapshotSpec.scala
+++ b/avldb/src/test/scala/scorex/db/LDBVersionedStoreSnapshotSpec.scala
@@ -1,0 +1,196 @@
+package scorex.db
+
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.nio.file.Files
+
+import org.iq80.leveldb.{DB, DBException, ReadOptions, Snapshot}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import scala.util.control.ControlThrowable
+import scala.util.{Failure, Try}
+
+class LDBVersionedStoreSnapshotSpec extends AnyPropSpec with Matchers {
+
+  private class SnapshotCalls {
+    var acquisitionFailure: Option[Throwable] = None
+    var closeFailure: Option[Throwable] = None
+    var acquisitions = 0
+    var closes = 0
+  }
+
+  private def withStore(test: (LDBVersionedStore, SnapshotCalls) => Unit): Unit = {
+    val dir = Files.createTempDirectory("snapshot-lifecycle").toFile
+    val store = new LDBVersionedStore(dir, 2)
+    val original = store.db
+    val calls = new SnapshotCalls
+    var acquired: Snapshot = null
+    var exposedSnapshot: Snapshot = null
+    val proxy = Proxy.newProxyInstance(classOf[DB].getClassLoader, Array(classOf[DB]), new InvocationHandler {
+      override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+        if (method.getName == "getSnapshot") {
+          store.lock.isWriteLockedByCurrentThread shouldBe true
+          calls.acquisitions += 1
+          calls.acquisitionFailure.foreach(throw _)
+          acquired = original.getSnapshot
+          exposedSnapshot = new Snapshot {
+            override def close(): Unit = {
+              calls.closes += 1
+              acquired.close()
+              calls.closeFailure.foreach(throw _)
+            }
+          }
+          exposedSnapshot
+        } else if (method.getName == "get" && args.length == 2) {
+          val options = args(1).asInstanceOf[ReadOptions]
+          options.snapshot() should be theSameInstanceAs exposedSnapshot
+          original.get(args(0).asInstanceOf[Array[Byte]], new ReadOptions().snapshot(acquired))
+        } else {
+          try {
+            method.invoke(original, Option(args).getOrElse(Array.empty[AnyRef]): _*)
+          } catch {
+            case e: InvocationTargetException => throw e.getCause
+          }
+        }
+      }
+    }).asInstanceOf[DB]
+    // Replace only the dependency after the real store has finished initialization.
+    val dbField = classOf[LDBVersionedStore].getDeclaredField("db")
+    dbField.setAccessible(true)
+    dbField.set(store, proxy)
+    try {
+      test(store, calls)
+    } finally {
+      // Permit cleanup even when checking an implementation that retains the lock.
+      while (store.lock.isWriteLockedByCurrentThread) store.lock.writeLock().unlock()
+      store.close()
+      LDBFactory.factory.destroy(new java.io.File(dir, "ldb_main"), new org.iq80.leveldb.Options())
+      LDBFactory.factory.destroy(new java.io.File(dir, "ldb_undo"), new org.iq80.leveldb.Options())
+      dir.delete()
+    }
+  }
+
+  property("snapshot acquisition failure releases the write lock") {
+    withStore { (store, calls) =>
+      calls.acquisitionFailure = Some(new DBException("snapshot acquisition failed"))
+      Try(store.processSnapshot(_ => ()))
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+
+  property("snapshot acquisition failure is returned without processing or closing an absent snapshot") {
+    withStore { (store, calls) =>
+      val failure = new DBException("snapshot acquisition failed")
+      calls.acquisitionFailure = Some(failure)
+      var processed = false
+      Try(store.processSnapshot(_ => processed = true)).flatten shouldBe Failure(failure)
+      processed shouldBe false
+      calls.acquisitions shouldBe 1
+      calls.closes shouldBe 0
+    }
+  }
+
+  property("snapshot processing failure closes the snapshot once") {
+    withStore { (store, calls) =>
+      val failure = new IllegalStateException("processing failed")
+      store.processSnapshot(_ => throw failure) shouldBe Failure(failure)
+      calls.closes shouldBe 1
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+
+  property("snapshot close failure is returned as a Failure") {
+    withStore { (store, calls) =>
+      val failure = new java.io.IOException("snapshot close failed")
+      calls.closeFailure = Some(failure)
+      val result = store.processSnapshot(_ => 42)
+      result shouldBe Failure(failure)
+      calls.closes shouldBe 1
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+
+  property("snapshot processing failure remains primary when closing also fails") {
+    withStore { (store, calls) =>
+      val primary = new IllegalStateException("processing failed")
+      val secondary = new java.io.IOException("snapshot close failed")
+      calls.closeFailure = Some(secondary)
+      Try(store.processSnapshot(_ => throw primary)).flatten shouldBe Failure(primary)
+      primary.getSuppressed.toSeq shouldBe Seq(secondary)
+      calls.closes shouldBe 1
+    }
+  }
+
+  property("the same processing and close failure does not cause self-suppression") {
+    withStore { (store, calls) =>
+      val failure = new IllegalStateException("shared failure")
+      calls.closeFailure = Some(failure)
+      val result = store.processSnapshot(_ => throw failure)
+      result shouldBe Failure(failure)
+      failure.getSuppressed shouldBe empty
+      calls.closes shouldBe 1
+    }
+  }
+
+  private val propagatingFailures: Seq[(String, () => Throwable)] = Seq(
+    "control throwable" -> (() => new ControlThrowable {}),
+    "interrupted exception" -> (() => new InterruptedException("interruption sentinel"))
+  )
+
+  for ((name, newFailure) <- propagatingFailures; processingFails <- Seq(false, true)) {
+    property(s"close $name propagates when ordinary processing failure is $processingFails") {
+      withStore { (store, calls) =>
+        val sentinel = newFailure()
+        val processingFailure = new IllegalStateException("processing failed")
+        calls.closeFailure = Some(sentinel)
+        val thrown = intercept[Throwable] {
+          store.processSnapshot { _ =>
+            if (processingFails) throw processingFailure
+            42
+          }
+        }
+        thrown should be theSameInstanceAs sentinel
+        processingFailure.getSuppressed shouldBe empty
+        calls.closes shouldBe 1
+        store.lock.isWriteLocked shouldBe false
+      }
+    }
+  }
+
+  for ((name, newFailure) <- propagatingFailures; closingFails <- Seq(false, true)) {
+    property(s"processing $name propagates when ordinary close failure is $closingFails") {
+      withStore { (store, calls) =>
+        val sentinel = newFailure()
+        val closingFailure = new java.io.IOException("snapshot close failed")
+        if (closingFails) calls.closeFailure = Some(closingFailure)
+        val thrown = intercept[Throwable] {
+          store.processSnapshot(_ => throw sentinel)
+        }
+        thrown should be theSameInstanceAs sentinel
+        sentinel.getSuppressed.toSeq shouldBe (if (closingFails) Seq(closingFailure) else Seq.empty)
+        calls.closes shouldBe 1
+        store.lock.isWriteLocked shouldBe false
+      }
+    }
+  }
+
+  property("snapshot reads stay stable while processing writes with the lock released") {
+    withStore { (store, calls) =>
+      val key = Array[Byte](1)
+      val before = Array[Byte](2)
+      val after = Array[Byte](3)
+      store.update(Array[Byte](4), Seq.empty, Seq(key -> before)).get
+      val result = store.processSnapshot { reader =>
+        store.lock.isWriteLocked shouldBe false
+        reader.get(key).toSeq shouldBe before.toSeq
+        store.update(Array[Byte](5), Seq.empty, Seq(key -> after)).get
+        reader.get(key).toSeq
+      }
+      result.get shouldBe before.toSeq
+      store.get(key).get.toSeq shouldBe after.toSeq
+      calls.acquisitions shouldBe 1
+      calls.closes shouldBe 1
+      store.lock.isWriteLocked shouldBe false
+    }
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/test/scala/org/ergoplatform/db/VersionedStoreSpec.scala
+++ b/src/test/scala/org/ergoplatform/db/VersionedStoreSpec.scala
@@ -34,7 +34,7 @@ class VersionedStoreSpec extends AnyPropSpec with Matchers with DBSpec {
       store.get(keyD) shouldBe None
       store.get(keyA).get.sameElements(valA) shouldBe true
 
-      store.lastVersionID shouldBe Some(v2)
+      store.lastVersionID.map(_.toVector) shouldBe Some(v2.toVector)
     }
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -5,6 +5,7 @@ import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
+import org.ergoplatform.core.versionToId
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.BlockTransactions
@@ -15,7 +16,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{Eliminat
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
-import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.{StateType, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedModifier}
 import org.ergoplatform.settings.NetworkType.DevNet60
@@ -34,6 +35,8 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 import sigma.serialization.ErgoTreeSerializer
 import sigmastate.crypto.DLogProtocol.DLogProverInput
+
+import java.nio.file.{Files, Paths}
 
 import scala.concurrent.duration._
 
@@ -63,13 +66,67 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
-  it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
-    ActorSystem()
-  ) {
+  private def freshSettings(prototype: ErgoSettings): ErgoSettings = {
+    val root = Paths.get(prototype.directory).toAbsolutePath
+    val parent = Files.createDirectories(root.getParent)
+    val directory = Files.createTempDirectory(parent, s"${root.getFileName}-candidate-")
+    prototype.copy(directory = directory.toString)
+  }
+
+  private def withNodeTest(test: TestKit => Unit): Unit = {
+    val kit = new TestKit(ActorSystem())
+    try test(kit)
+    finally TestKit.shutdownActorSystem(kit.system)
+  }
+
+  private def awaitSetupBlock(testProbe: TestProbe, block: ErgoFullBlock): Unit = {
+    // The direct solution ACK and exact block-application event can arrive in either order.
+    testProbe.fishForMessage(blockValidationDelay) {
+      case StatusReply.Success(()) =>
+        testProbe.expectMsgPF(candidateGenDelay) {
+          case FullBlockApplied(header) if header.id == block.id =>
+        }
+        true
+      case FullBlockApplied(header) if header.id == block.id =>
+        testProbe.expectMsg(StatusReply.Success(()))
+        true
+      case _ => false
+    }
+  }
+
+  private def setupReward(readersHolderRef: ActorRef,
+                          setupBlock: ErgoFullBlock,
+                          emissionBoxId: ErgoBox.BoxId): (Readers, ErgoBox) = {
+    // ReadersHolder receives the state update asynchronously after the application event.
+    eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      val readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      versionToId(readers.s.version) shouldBe setupBlock.id
+      val header = readers.h.typedModifierById[Header](setupBlock.id).value
+      val appliedBlock = readers.h.getFullBlock(header).value
+      val emissionTransactions = appliedBlock.transactions.filter(
+        _.inputs.exists(_.boxId.sameElements(emissionBoxId))
+      )
+      emissionTransactions should have size 1
+      val rewardScript = ErgoTreePredef
+        .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
+        .bytes
+      val rewards = emissionTransactions.head.outputs.filter(
+        _.propositionBytes.sameElements(rewardScript)
+      )
+      rewards should have size 1
+      val rewardBox = rewards.head
+      readers.s.asInstanceOf[UtxoStateReader].boxById(rewardBox.id).value shouldBe rewardBox
+      (readers, rewardBox)
+    }
+  }
+
+  it should "provider candidate to internal miner and verify and apply his solution" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -77,25 +134,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
-    ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by node view holder" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -103,13 +159,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -141,25 +197,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by full block id" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by full block id" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -167,13 +222,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -205,21 +260,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "let multiple miners compete" in new TestKit(ActorSystem()) {
+  it should "let multiple miners compete" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -227,12 +283,12 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val m1 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m2 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m3 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    val m1 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m2 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m3 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
@@ -253,16 +309,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
 
     List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
-    system.terminate()
   }
 
-  it should "cache candidate until newly mined block is applied" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "cache candidate until newly mined block is applied" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -270,7 +325,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     expectNoMessage(1.second)
@@ -278,7 +333,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     val block = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -302,16 +357,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         true
     }
 
-    system.terminate()
   }
 
-  it should "regenerate candidate periodically" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "regenerate candidate periodically" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -319,6 +372,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -332,34 +386,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = settingsWithShortRegeneration.chainSettings.powScheme
+        settingsWithShortRegeneration.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -392,14 +436,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             )
         }
     }
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after regeneration" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -407,6 +451,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -420,36 +465,26 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -503,15 +538,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             true
         }
     }
-    system.terminate()
   }
 
-  it should "pool transactions should be removed from pool when block is mined" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "pool transactions should be removed from pool when block is mined" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -519,43 +553,32 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -577,7 +600,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -608,15 +631,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       .filter(_.blockTransactions.transactions.map(_.id).contains(tx.id))
     val txs: Seq[ErgoTransaction] = blocks.flatMap(_.blockTransactions.transactions)
     txs should have length 2 // 1 reward and one regular tx, no fee collection tx
-    system.terminate()
   }
 
-  it should "6.0 pool transactions should be added to 6.0 block" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "6.0 pool transactions should be added to 6.0 block" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings60)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -624,42 +646,30 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings60
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -692,7 +702,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -726,17 +736,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     txs should have length 3 // 1 rewards and two regular txs, no fee collection
 
-    system.terminate()
   }
 
-  it should "use custom miner public key when provided via optPk" in new TestKit(ActorSystem()) {
+  it should "use custom miner public key when provided via optPk" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -744,7 +755,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -766,14 +777,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe customPk
     
-    system.terminate()
   }
 
-  it should "use default minerPk when optPk is None" in new TestKit(ActorSystem()) {
+  it should "use default minerPk when optPk is None" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -781,7 +793,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(
@@ -798,17 +810,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe defaultMinerSecret.publicImage
 
-    system.terminate()
   }
 
-  it should "generate different candidates for different optPk values" in new TestKit(ActorSystem()) {
+  it should "generate different candidates for different optPk values" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -816,7 +829,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -848,17 +861,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate2.externalVersion.pk shouldBe customPk
     candidate1.externalVersion.pk should not be candidate2.externalVersion.pk
 
-    system.terminate()
   }
 
-  it should "handle optPk with empty transactions" in new TestKit(ActorSystem()) {
+  it should "handle optPk with empty transactions" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -866,7 +880,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -887,7 +901,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate should not be null
     candidate.txsToInclude shouldBe empty
 
-    system.terminate()
   }
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
@@ -956,20 +969,20 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
   }
 
-  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {
+  it should "preserve previous candidate when forced regeneration occurs" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-preserve-candidate-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1036,24 +1049,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case StatusReply.Success(()) =>
     }
 
-    system.terminate()
   }
 
-  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(ActorSystem()) {
+  it should "handle multiple consecutive forced regenerations correctly" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    // Use unique directory to avoid state conflicts
-    val testDir = s"${defaultSettings.directory}-multi-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1132,17 +1143,16 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
-  it should "return cached candidate immediately when forced = false" in new TestKit(ActorSystem()) {
+  it should "return cached candidate immediately when forced = false" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-cache-test-${System.currentTimeMillis()}"
-    val testSettings = defaultSettings.copy(directory = testDir)
+    val settings = freshSettings(defaultSettings)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(testSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -1150,7 +1160,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        testSettings
+        settings
       )
 
     // Get first candidate
@@ -1173,23 +1183,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Should be very fast since all are cached (no regeneration)
     elapsed should be < 500L
 
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-mempool-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 100.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1202,28 +1211,21 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // Get candidate and solve it
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -1238,8 +1240,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Build new transaction to trigger mempool change
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("forced-mempool-test".getBytes())).publicImage
-    val newlyMinedBlock = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     val input = Input(rewardBox.id, emptyProverResult)
 
     val outputs = IndexedSeq(
@@ -1277,7 +1277,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
   private class FixedReadersHolder(readers: Readers) extends Actor {

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -892,74 +892,68 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val viewHolderProbe = new TestProbe(system)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsForExplicitForcing: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            // Keep automatic refresh outside this test of explicit forcing.
+            .copy(blockCandidateGenerationInterval = 1.hour),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
-    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+    // Keep readers fixed: a later ChangedMempool event may legitimately regenerate the cache.
+    val (initialState, boxes) = createUtxoState(settingsForExplicitForcing)
+    val block = validFullBlock(None, initialState, boxes)
+    val state = initialState.applyModifier(block, None)(_ => ()).get
+    // Initialization computes mining-time averages from pairs of headers.
+    val history = historyWithBestFullBlock(Seq(block))
+    val readers = Readers(history, state, ErgoMemPool.empty(settingsForExplicitForcing), walletStub)
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
 
     val candidateGenerator: ActorRef =
       CandidateGenerator(
         defaultMinerSecret.publicImage,
         readersHolderRef,
-        viewHolderRef,
-        settingsWithShortRegeneration
+        viewHolderProbe.ref,
+        settingsForExplicitForcing
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    try {
+      // Get first candidate from the coherent, already applied block snapshot.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate1.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
 
-    // First mine a block to establish chain (needed for avg mining time calculation)
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val initCandidate = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+      // Request with forced = false should return cached candidate immediately.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate2 = testProbe.expectMsgPF(100.millis) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate2 should be theSameInstanceAs candidate1
+      candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
+
+      // Request with forced = true should bypass cache and regenerate.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+      val candidate3 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+
+      // Identity proves regeneration even when the clock has not advanced.
+      candidate3 should not be theSameInstanceAs(candidate1)
+      candidate3.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
+      candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    } finally {
+      TestKit.shutdownActorSystem(system)
+      history.closeStorage()
+      state.closeStorage()
     }
-    val initBlock = powScheme
-      .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
-      .get
-    candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
-      case _ => false
-    }
-
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // Request with forced = false should return cached candidate immediately
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate2 = testProbe.expectMsgPF(100.millis) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-    // Should be the exact same cached candidate
-    candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
-
-    // Request with forced = true should bypass cache and regenerate
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-    val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
-      case StatusReply.Success(_: Candidate) => true
-      case _: FullBlockApplied => false
-    } match {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // candidate3 should have timestamp >= candidate1 (regenerated, possibly same or newer)
-    candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-
-    system.terminate()
   }
 
   it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -64,8 +64,13 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val (us, bh) = createUtxoState(settings)
     val genesis = validFullBlock(None, us, bh)
     val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-    val inputBox = wus.takeBoxes(1).head
-    val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+    val inputBox = wus.takeBoxes(100).find(_.ergoTree == TrueTree).get
+    val feeOut = new ErgoBoxCandidate(
+      inputBox.value,
+      feeProp,
+      creationHeight = 0,
+      additionalTokens = inputBox.additionalTokens
+    )
     val tx = ErgoTransaction(
       IndexedSeq(new Input(inputBox.id, ProverResult.empty)),
       IndexedSeq(feeOut)
@@ -79,8 +84,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerByte,
       ))
 
-    var poolSize = ErgoMemPool.empty(sortBySizeSettings)
-    poolSize = poolSize.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolSize, sizeOutcome) =
+      ErgoMemPool.empty(sortBySizeSettings).process(UnconfirmedTransaction(tx, None), wus)
+    sizeOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val size = tx.size
     poolSize.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, size).weight
 
@@ -89,8 +95,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerCycle,
       ))
 
-    var poolCost = ErgoMemPool.empty(sortByCostSettings)
-    poolCost = poolCost.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolCost, costOutcome) =
+      ErgoMemPool.empty(sortByCostSettings).process(UnconfirmedTransaction(tx, None), wus)
+    costOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val validationContext = wus.stateContext.simplifiedUpcoming()
     val cost = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
     poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight

--- a/src/test/scala/org/ergoplatform/nodeView/state/StateReopenAfterRollbackSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/StateReopenAfterRollbackSpec.scala
@@ -1,0 +1,137 @@
+package org.ergoplatform.nodeView.state
+
+import org.ergoplatform.core.idToVersion
+import org.ergoplatform.modifiers.ErgoFullBlock
+import org.ergoplatform.settings.Algos
+import org.ergoplatform.utils.{ErgoCorePropertyTest, RandomWrapper}
+import scorex.db.ByteArrayWrapper
+
+class StateReopenAfterRollbackSpec extends ErgoCorePropertyTest {
+  import org.ergoplatform.utils.ErgoNodeTestConstants._
+  import org.ergoplatform.utils.generators.ValidBlocksGenerators._
+
+  private val BaseTimestamp = 1700000000000L
+
+  private def nextBlock(parent: Option[ErgoFullBlock],
+                        state: UtxoState,
+                        holder: BoxHolder,
+                        seed: Int,
+                        timestamp: Long): (ErgoFullBlock, BoxHolder) = {
+    scala.util.Random.setSeed(seed.toLong)
+    val (transactions, nextHolder) =
+      validTransactionsFromBoxHolder(holder, new RandomWrapper(Some(seed)))
+    val block = validFullBlock(parent, state, transactions, Some(timestamp))
+    block -> nextHolder
+  }
+
+  property("UTXO and Digest reopen the rollback checkpoint before any alternate-branch update") {
+    val utxoDir = createTempDir
+    val digestDir = createTempDir
+    val (initialUtxo, initialHolder) =
+      ErgoState.generateGenesisUtxoState(utxoDir, settings)
+    var utxo = initialUtxo
+    var digest =
+      DigestState.create(Some(utxo.version), Some(utxo.rootDigest), digestDir, settings)
+
+    try {
+      val (g, holderG) =
+        nextBlock(None, utxo, initialHolder, seed = 100, BaseTimestamp)
+      utxo = utxo.applyModifier(g, None)(_ => ()).get
+      digest = digest.applyModifier(g, None)(_ => ()).get
+      val versionG = idToVersion(g.id)
+      val rootG = g.header.stateRoot.clone()
+      val utxoContextG = utxo.stateContext.bytes.clone()
+      val digestContextG = digest.stateContext.bytes.clone()
+
+      val (a1, holderA1) =
+        nextBlock(Some(g), utxo, holderG, seed = 101, BaseTimestamp + 1)
+      utxo = utxo.applyModifier(a1, None)(_ => ()).get
+      digest = digest.applyModifier(a1, None)(_ => ()).get
+      val (a2, holderA2) =
+        nextBlock(Some(a1), utxo, holderA1, seed = 102, BaseTimestamp + 2)
+      utxo = utxo.applyModifier(a2, None)(_ => ()).get
+      digest = digest.applyModifier(a2, None)(_ => ()).get
+
+      val aOnlyBox = holderA2.boxes.values
+        .find(box => !holderG.boxes.contains(ByteArrayWrapper(box.id)))
+        .get
+      val gRestoredBox = holderG.boxes.values
+        .find(box => !holderA2.boxes.contains(ByteArrayWrapper(box.id)))
+        .get
+
+      utxo.closeStorage()
+      digest.close()
+      utxo = UtxoState.create(utxoDir, settings)
+      digest = DigestState.create(None, None, digestDir, settings)
+
+      utxo.version shouldEqual idToVersion(a2.id)
+      utxo.rootDigest shouldEqual a2.header.stateRoot
+      utxo.stateContext.currentHeight shouldEqual a2.header.height
+      utxo.boxById(aOnlyBox.id) shouldEqual Some(aOnlyBox)
+      digest.version shouldEqual idToVersion(a2.id)
+      digest.rootDigest shouldEqual a2.header.stateRoot
+      digest.stateContext.currentHeight shouldEqual a2.header.height
+
+      def assertRollbackCheckpoint(): Unit = {
+        utxo.version shouldEqual versionG
+        utxo.rootDigest shouldEqual rootG
+        utxo.stateContext.currentHeight shouldEqual g.header.height
+        utxo.stateContext.bytes shouldEqual utxoContextG
+        utxo.boxById(gRestoredBox.id) shouldEqual Some(gRestoredBox)
+        utxo.boxById(aOnlyBox.id) shouldBe empty
+        digest.version shouldEqual versionG
+        digest.rootDigest shouldEqual rootG
+        digest.stateContext.currentHeight shouldEqual g.header.height
+        digest.stateContext.bytes shouldEqual digestContextG
+      }
+
+      utxo = utxo.rollbackTo(versionG).get
+      digest = digest.rollbackTo(versionG).get
+      assertRollbackCheckpoint()
+
+      utxo.closeStorage()
+      digest.close()
+      utxo = UtxoState.create(utxoDir, settings)
+      digest = DigestState.create(None, None, digestDir, settings)
+      assertRollbackCheckpoint()
+      println(
+        s"ROLLBACK_REOPEN_RESULT version=${g.id} root=${Algos.encode(rootG)} " +
+          s"utxoContext=${Algos.encode(Algos.hash(utxo.stateContext.bytes))} " +
+          s"digestContext=${Algos.encode(Algos.hash(digest.stateContext.bytes))}"
+      )
+
+      val (b1, holderB1) =
+        nextBlock(Some(g), utxo, holderG, seed = 201, BaseTimestamp + 10)
+      b1.id should not equal a1.id
+      utxo = utxo.applyModifier(b1, None)(_ => ()).get
+      digest = digest.applyModifier(b1, None)(_ => ()).get
+      val (b2, holderB2) =
+        nextBlock(Some(b1), utxo, holderB1, seed = 202, BaseTimestamp + 11)
+      b2.id should not equal a2.id
+      utxo = utxo.applyModifier(b2, None)(_ => ()).get
+      digest = digest.applyModifier(b2, None)(_ => ()).get
+      val bOnlyBox = holderB2.boxes.values
+        .find(box => !holderG.boxes.contains(ByteArrayWrapper(box.id)))
+        .get
+
+      utxo.closeStorage()
+      digest.close()
+      utxo = UtxoState.create(utxoDir, settings)
+      digest = DigestState.create(None, None, digestDir, settings)
+      utxo.version shouldEqual idToVersion(b2.id)
+      utxo.rootDigest shouldEqual b2.header.stateRoot
+      utxo.stateContext.currentHeight shouldEqual b2.header.height
+      utxo.boxById(bOnlyBox.id) shouldEqual Some(bOnlyBox)
+      utxo.boxById(aOnlyBox.id) shouldBe empty
+      digest.version shouldEqual idToVersion(b2.id)
+      digest.rootDigest shouldEqual b2.header.stateRoot
+      digest.stateContext.currentHeight shouldEqual b2.header.height
+      println(
+        s"ROLLBACK_CONTINUATION_RESULT g=${g.id} a1=${a1.id} a2=${a2.id} " +
+          s"b1=${b1.id} b2=${b2.id} root=${Algos.encode(utxo.rootDigest)}"
+      )
+    } finally {
+      try utxo.closeStorage() finally digest.close()
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,9 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    val box = wusAfterGenesis.takeBoxes(wusAfterGenesis.size)
+      .find(_.ergoTree == TrueTree)
+      .getOrElse(fail("Expected an unspent TrueTree box after genesis"))
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
Prerequisites: [#2519](https://github.com/ergoplatform/ergo/pull/2519) owns snapshot cleanup, and [#2535](https://github.com/ergoplatform/ergo/pull/2535) owns shared test support. Their exact commits are preserved in the branch graph. Review the [six-file storage increment](https://github.com/a-shannon/ergo/compare/f64eb64d7d959d2ed39622768539c70a1ef2c5c0...a88c3ef9fdaa3ccb92af298f303f64d81fa873ba); the upstream diff remains cumulative until both prerequisites merge.

Versioned-store updates, rollbacks and pruning write main data and undo history separately. A partial failure can leave the exposed version inconsistent with persisted data. Prepare a durable redo plan, apply both participants synchronously, and publish version metadata only after durable completion. Reopening replays pending operations before exposing the store; ambiguous writes make the current instance unavailable through its guarded API.

The existing main and undo encodings are retained, with a private `ldb_journal` database for coordination and retained-version metadata. Healthy legacy stores are adopted without rewriting their application data. Backups must include all three databases together. Older binaries must not write a store after journal adoption, even when no operation is pending. Direct raw-DB access remains outside the guarded API contract.

Validation: 72 direct storage tests, 15 existing snapshot tests, 20 state/wallet consumer tests and three bounded ordinary workload cases pass. Coverage includes acknowledged-write boundaries, retried recovery, exact malformed-record rejection, acquisition/cleanup, queued snapshots, legacy adoption, retention and ordinary UTXO/Digest rollback/reopen. Independent source and test-delta reviews completed. [#2513](https://github.com/ergoplatform/ergo/pull/2513) retains ownership of rollback-result propagation in state consumers.

The durability tradeoff is four sequential synchronous writes per coordinated transition plus journal serialization. Single-run synthetic measurements covered 44 update transactions and up to 4.3 MB of live key/value data, with exact data/version checks through reopen and rollback; these do not establish production throughput or OS power-loss recovery. Existing legacy divergence is not retroactively repaired.

The initial CI passed integration but exposed an existing node assertion comparing `Option[Array[Byte]]` by array identity. Returned version IDs are now defensive copies, so that assertion compares their complete byte contents instead. All three `VersionedStoreSpec` cases pass with the updated assertion; production code is unchanged by this follow-up. All eight checks passed at `a88c3ef9f` ([CI run](https://github.com/ergoplatform/ergo/actions/runs/34293933986)).
