### PR TITLE
Prepare wallet generations before selecting initialized state

### DIFF
--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
@@ -10,9 +10,12 @@ import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.ergoplatform.wallet.settings.SecretStorageSettings
 import scorex.util.encode.Base16
 
-import java.io.{File, FileNotFoundException, PrintWriter}
+import java.io.{File, FileNotFoundException, Writer}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{FileAlreadyExistsException, Files, LinkOption, Path, StandardCopyOption}
 import java.util
 import java.util.UUID
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -89,29 +92,60 @@ final class JsonSecretStorage(val secretFile: File, encryptionSettings: Encrypti
 
 object JsonSecretStorage {
 
+  private val StagingPrefix = ".ergo-secret-staging-"
+
   /**
    * Initializes storage instance with new wallet file encrypted with the given `pass`.
-   * @param seed   - seed bytes
+   * @param seed   - seed bytes, erased on both success and failure
    * @param pass   - encryption password
    * @param usePre1627KeyDerivation - use incorrect(previous) BIP32 derivation, expected to be false for new wallets, and true for old pre-1627 wallets (see https://github.com/ergoplatform/ergo/issues/1627 for details)
    */
   def init(seed: Array[Byte], pass: SecretString, usePre1627KeyDerivation: Boolean)(settings: SecretStorageSettings): JsonSecretStorage = {
-    val iv = scorex.utils.Random.randomBytes(crypto.AES.NonceBitsLen / 8)
-    val salt = scorex.utils.Random.randomBytes(32)
-    val (ciphertext, tag) = crypto.AES.encrypt(seed, pass.getData(), salt, iv)(settings.encryption)
-    val encryptedSecret = EncryptedSecret(ciphertext, salt, iv, tag, settings.encryption, Some(usePre1627KeyDerivation))
-    val uuid = UUID.nameUUIDFromBytes(ciphertext)
-    new File(settings.secretDir).mkdirs()
-    val file = new File(s"${settings.secretDir}/$uuid.json")
-    val outWriter = new PrintWriter(file)
-    val jsonRaw = encryptedSecret.asJson.noSpaces
+    try {
+      val iv = scorex.utils.Random.randomBytes(crypto.AES.NonceBitsLen / 8)
+      val salt = scorex.utils.Random.randomBytes(32)
+      val (ciphertext, tag) = crypto.AES.encrypt(seed, pass.getData(), salt, iv)(settings.encryption)
+      val encryptedSecret = EncryptedSecret(ciphertext, salt, iv, tag, settings.encryption, Some(usePre1627KeyDerivation))
+      val uuid = UUID.nameUUIDFromBytes(ciphertext)
+      val file = new File(s"${settings.secretDir}/$uuid.json")
+      persist(file, encryptedSecret.asJson.noSpaces)
+      new JsonSecretStorage(file, settings.encryption)
+    } finally {
+      util.Arrays.fill(seed, 0: Byte)
+    }
+  }
 
-    outWriter.write(jsonRaw)
-    outWriter.close()
-
-    util.Arrays.fill(seed, 0: Byte)
-
-    new JsonSecretStorage(file, settings.encryption)
+  /** Writes and closes a staging file before publishing it atomically. */
+  private[secrets] def persist(file: File, jsonRaw: String,
+                               openWriter: Path => Writer = path => Files.newBufferedWriter(path, UTF_8)): Unit = {
+    val target = file.toPath.toAbsolutePath
+    Files.createDirectories(target.getParent)
+    if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+      throw new FileAlreadyExistsException(target.toString)
+    }
+    val staging = Files.createTempFile(target.getParent, StagingPrefix, ".tmp")
+    try {
+      val writer = openWriter(staging)
+      var writeFailure: Option[Throwable] = None
+      try {
+        writer.write(jsonRaw)
+      } catch {
+        case NonFatal(error) =>
+          writeFailure = Some(error)
+          throw error
+      } finally {
+        writeFailure match {
+          case Some(error) => Try(writer.close()).failed.foreach(error.addSuppressed)
+          case None => writer.close()
+        }
+      }
+      // Do not expose a partial destination when atomic publication is unavailable.
+      Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE)
+    } catch {
+      case NonFatal(error) =>
+        Try(Files.deleteIfExists(staging)).failed.foreach(error.addSuppressed)
+        throw error
+    }
   }
 
   /**
@@ -133,7 +167,7 @@ object JsonSecretStorage {
   def readFile(settings: SecretStorageSettings): Try[JsonSecretStorage] = {
     val dir = new File(settings.secretDir)
     if (dir.exists()) {
-      dir.listFiles().toList match {
+      dir.listFiles().toList.filterNot(_.getName.startsWith(StagingPrefix)) match {
         case files if files.size > 1 =>
           val jsonFiles = files.filter(_.getName.contains(".json"))
           jsonFiles.headOption match {

--- a/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
+++ b/ergo-wallet/src/main/scala/org/ergoplatform/wallet/secrets/JsonSecretStorage.scala
@@ -10,9 +10,10 @@ import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.ergoplatform.wallet.settings.SecretStorageSettings
 import scorex.util.encode.Base16
 
-import java.io.{File, FileNotFoundException, Writer}
+import java.io.{File, FileNotFoundException, IOException, Writer}
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{FileAlreadyExistsException, Files, LinkOption, Path, StandardCopyOption}
+import java.nio.file.{FileAlreadyExistsException, Files, LinkOption, NoSuchFileException, Path, StandardCopyOption}
+import java.nio.file.attribute.{BasicFileAttributes, PosixFileAttributeView, PosixFilePermissions}
 import java.util
 import java.util.UUID
 import scala.util.control.NonFatal
@@ -94,6 +95,29 @@ object JsonSecretStorage {
 
   private val StagingPrefix = ".ergo-secret-staging-"
 
+  /** Absence only; invalid or unreadable inventories use other failures. */
+  final class SecretFileNotFoundException extends FileNotFoundException("Wallet secret file not found")
+
+  private def storageEntries(settings: SecretStorageSettings): Seq[File] = {
+    val dir = new File(settings.secretDir)
+    val attributes = try {
+      Some(Files.readAttributes(dir.toPath, classOf[BasicFileAttributes], LinkOption.NOFOLLOW_LINKS))
+    } catch {
+      case _: NoSuchFileException => None
+    }
+    attributes match {
+      case None => Seq.empty
+      case Some(attrs) =>
+        // An existing broken link is an invalid inventory, not an absent wallet directory.
+        val isDirectory = if (attrs.isSymbolicLink) {
+          Files.readAttributes(dir.toPath, classOf[BasicFileAttributes]).isDirectory
+        } else attrs.isDirectory
+        if (!isDirectory) throw new IOException("Wallet secret directory is not a directory")
+        Option(dir.listFiles()).getOrElse(throw new IOException("Cannot list wallet secret directory"))
+          .toSeq.filterNot(_.getName.startsWith(StagingPrefix))
+    }
+  }
+
   /**
    * Initializes storage instance with new wallet file encrypted with the given `pass`.
    * @param seed   - seed bytes, erased on both success and failure
@@ -102,6 +126,10 @@ object JsonSecretStorage {
    */
   def init(seed: Array[Byte], pass: SecretString, usePre1627KeyDerivation: Boolean)(settings: SecretStorageSettings): JsonSecretStorage = {
     try {
+      // A fresh encryption produces a new filename; checking only that target cannot prevent reinitialization.
+      if (storageEntries(settings).nonEmpty) {
+        throw new FileAlreadyExistsException("Wallet secret directory is not empty")
+      }
       val iv = scorex.utils.Random.randomBytes(crypto.AES.NonceBitsLen / 8)
       val salt = scorex.utils.Random.randomBytes(32)
       val (ciphertext, tag) = crypto.AES.encrypt(seed, pass.getData(), salt, iv)(settings.encryption)
@@ -116,14 +144,22 @@ object JsonSecretStorage {
   }
 
   /** Writes and closes a staging file before publishing it atomically. */
+  private[secrets] def persist(file: File, jsonRaw: String): Unit =
+    persist(file, jsonRaw, path => Files.newBufferedWriter(path, UTF_8))
+
   private[secrets] def persist(file: File, jsonRaw: String,
-                               openWriter: Path => Writer = path => Files.newBufferedWriter(path, UTF_8)): Unit = {
+                               openWriter: Path => Writer): Unit = {
     val target = file.toPath.toAbsolutePath
     Files.createDirectories(target.getParent)
     if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
       throw new FileAlreadyExistsException(target.toString)
     }
-    val staging = Files.createTempFile(target.getParent, StagingPrefix, ".tmp")
+    val staging = if (Files.getFileAttributeView(target.getParent, classOf[PosixFileAttributeView]) != null) {
+      Files.createTempFile(target.getParent, StagingPrefix, ".tmp",
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")))
+    } else {
+      Files.createTempFile(target.getParent, StagingPrefix, ".tmp")
+    }
     try {
       val writer = openWriter(staging)
       var writeFailure: Option[Throwable] = None
@@ -164,23 +200,11 @@ object JsonSecretStorage {
     init(seed, encryptionPass, usePre1627KeyDerivation)(settings)
   }
 
-  def readFile(settings: SecretStorageSettings): Try[JsonSecretStorage] = {
-    val dir = new File(settings.secretDir)
-    if (dir.exists()) {
-      dir.listFiles().toList.filterNot(_.getName.startsWith(StagingPrefix)) match {
-        case files if files.size > 1 =>
-          val jsonFiles = files.filter(_.getName.contains(".json"))
-          jsonFiles.headOption match {
-            case Some(headFile) => Success(new JsonSecretStorage(headFile, settings.encryption))
-            case None => Failure(new Exception(s"No json files found in dir '$dir'"))
-          }
-        case headFile :: _ =>
-          Success(new JsonSecretStorage(headFile, settings.encryption))
-        case Nil =>
-          Failure(new Exception(s"Cannot readSecretStorage: Secret file not found in dir '$dir'"))
-      }
-    } else {
-      Failure(new FileNotFoundException(s"Cannot readSecretStorage: dir '$dir' doesn't exist"))
+  def readFile(settings: SecretStorageSettings): Try[JsonSecretStorage] = Try {
+    storageEntries(settings) match {
+      case Seq(file) if file.isFile => new JsonSecretStorage(file, settings.encryption)
+      case Seq() => throw new SecretFileNotFoundException
+      case _ => throw new IOException("Wallet secret directory does not contain one unambiguous wallet file")
     }
   }
 

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/JsonSecretStoragePersistenceSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/JsonSecretStoragePersistenceSpec.scala
@@ -1,0 +1,178 @@
+package org.ergoplatform.wallet.secrets
+
+import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.wallet.settings.EncryptionSettings
+import org.ergoplatform.wallet.settings.SecretStorageSettings
+import org.ergoplatform.wallet.utils.FileUtils
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import java.io.{File, IOException, Writer}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{FileAlreadyExistsException, Files, Path}
+
+class JsonSecretStoragePersistenceSpec extends AnyPropSpec with Matchers with FileUtils {
+  private val encryption = EncryptionSettings("HmacSHA256", 1, 256)
+  private val contents = """{"test":"checked persistence"}"""
+
+  private def entries(dir: File): Set[String] = dir.listFiles().map(_.getName).toSet
+
+  property("wallet discovery ignores an unpublished staging file") {
+    val dir = createTempDir
+    Files.createFile(dir.toPath.resolve(".ergo-secret-staging-example.tmp"))
+
+    JsonSecretStorage.readFile(SecretStorageSettings(dir.getAbsolutePath, encryption)) shouldBe 'failure
+  }
+
+  property("initialization erases its seed when the secret directory cannot be created") {
+    val parent = createTempDir
+    val occupied = Files.createFile(parent.toPath.resolve("occupied"))
+    val seed = Array.fill[Byte](32)(1)
+    val settings = SecretStorageSettings(occupied.resolve("wallet").toString, encryption)
+
+    intercept[java.io.IOException] {
+      JsonSecretStorage.init(seed, SecretString.create("test password"), usePre1627KeyDerivation = false)(settings)
+    }
+
+    seed shouldBe Array.fill[Byte](32)(0)
+  }
+
+  property("initialization publishes one complete wallet and erases its seed") {
+    val dir = createTempDir
+    val seed = Array.fill[Byte](32)(1)
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+    val storage = JsonSecretStorage.init(seed, SecretString.create("test password"), usePre1627KeyDerivation = false)(settings)
+
+    entries(dir) shouldBe Set(storage.secretFile.getName)
+    storage.secretFile.getName should endWith(".json")
+    seed shouldBe Array.fill[Byte](32)(0)
+    val reopened = JsonSecretStorage.readFile(settings).get
+    reopened.unlock(SecretString.create("test password")) shouldBe 'success
+    reopened.secret.get.usePre1627KeyDerivation shouldBe false
+    reopened.lock()
+  }
+
+  property("wallet discovery preserves a sole legacy filename alongside staging files") {
+    val dir = createTempDir
+    val legacy = Files.createFile(dir.toPath.resolve("legacy-wallet"))
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+
+    JsonSecretStorage.readFile(settings).get.secretFile.toPath shouldBe legacy
+    Files.createFile(dir.toPath.resolve(".ergo-secret-staging-example.tmp"))
+    JsonSecretStorage.readFile(settings).get.secretFile.toPath shouldBe legacy
+  }
+
+  property("wallet publication occurs only after the checked writer closes") {
+    val dir = createTempDir
+    val file = new File(dir, "wallet.json")
+    var closed = false
+    val openWriter: Path => Writer = path => {
+      file.exists() shouldBe false
+      val delegate = Files.newBufferedWriter(path, UTF_8)
+      new Writer {
+        override def write(chars: Array[Char], offset: Int, length: Int): Unit = {
+          file.exists() shouldBe false
+          delegate.write(chars, offset, length)
+        }
+        override def flush(): Unit = delegate.flush()
+        override def close(): Unit = {
+          file.exists() shouldBe false
+          delegate.close()
+          closed = true
+        }
+      }
+    }
+
+    JsonSecretStorage.persist(file, contents, openWriter)
+
+    closed shouldBe true
+    new String(Files.readAllBytes(file.toPath), UTF_8) shouldBe contents
+    entries(dir) shouldBe Set("wallet.json")
+  }
+
+  property("a writer open error propagates and removes only the owned staging file") {
+    val dir = createTempDir
+    val existing = Files.write(dir.toPath.resolve("existing.json"), contents.getBytes(UTF_8))
+    val file = new File(dir, "wallet.json")
+    val error = new IOException("controlled open failure")
+
+    intercept[IOException] {
+      JsonSecretStorage.persist(file, contents, _ => throw error)
+    } shouldBe error
+
+    entries(dir) shouldBe Set("existing.json")
+    new String(Files.readAllBytes(existing), UTF_8) shouldBe contents
+  }
+
+  for ((failWrite, failClose) <- Seq((true, false), (false, true), (true, true))) {
+    property(s"checked persistence propagates writer failures: write=$failWrite, close=$failClose") {
+      val dir = createTempDir
+      val file = new File(dir, "wallet.json")
+      val writeError = new IOException("controlled write failure")
+      val closeError = new IOException("controlled close failure")
+      var closeCount = 0
+      val openWriter: Path => Writer = path => {
+        val delegate = Files.newBufferedWriter(path, UTF_8)
+        new Writer {
+          override def write(chars: Array[Char], offset: Int, length: Int): Unit = {
+            if (failWrite) throw writeError
+            delegate.write(chars, offset, length)
+          }
+          override def flush(): Unit = delegate.flush()
+          override def close(): Unit = {
+            closeCount += 1
+            delegate.close()
+            if (failClose) throw closeError
+          }
+        }
+      }
+
+      val thrown = intercept[IOException] {
+        JsonSecretStorage.persist(file, contents, openWriter)
+      }
+
+      thrown shouldBe (if (failWrite) writeError else closeError)
+      thrown.getSuppressed.toSeq shouldBe (if (failWrite && failClose) Seq(closeError) else Seq.empty)
+      closeCount shouldBe 1
+      file.exists() shouldBe false
+      entries(dir) shouldBe Set.empty
+    }
+  }
+
+  property("persistence does not overwrite an existing destination") {
+    val dir = createTempDir
+    val file = Files.write(dir.toPath.resolve("wallet.json"), contents.getBytes(UTF_8)).toFile
+
+    intercept[FileAlreadyExistsException] {
+      JsonSecretStorage.persist(file, "replacement")
+    }
+
+    new String(Files.readAllBytes(file.toPath), UTF_8) shouldBe contents
+    entries(dir) shouldBe Set("wallet.json")
+  }
+
+  property("a publication error propagates and removes the owned staging file") {
+    val dir = createTempDir
+    val file = new File(dir, "wallet.json")
+    val openWriter: Path => Writer = path => {
+      val delegate = Files.newBufferedWriter(path, UTF_8)
+      new Writer {
+        override def write(chars: Array[Char], offset: Int, length: Int): Unit = delegate.write(chars, offset, length)
+        override def flush(): Unit = delegate.flush()
+        override def close(): Unit = {
+          delegate.close()
+          // A non-empty destination directory deterministically rejects file publication.
+          Files.createDirectory(file.toPath)
+          Files.write(file.toPath.resolve("existing"), contents.getBytes(UTF_8))
+        }
+      }
+    }
+
+    intercept[IOException] {
+      JsonSecretStorage.persist(file, contents, openWriter)
+    }
+
+    entries(dir) shouldBe Set("wallet.json")
+    new String(Files.readAllBytes(file.toPath.resolve("existing")), UTF_8) shouldBe contents
+  }
+}

--- a/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/JsonSecretStoragePersistenceSpec.scala
+++ b/ergo-wallet/src/test/scala/org/ergoplatform/wallet/secrets/JsonSecretStoragePersistenceSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.propspec.AnyPropSpec
 import java.io.{File, IOException, Writer}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{FileAlreadyExistsException, Files, Path}
+import java.nio.file.attribute.{PosixFileAttributeView, PosixFilePermissions}
 
 class JsonSecretStoragePersistenceSpec extends AnyPropSpec with Matchers with FileUtils {
   private val encryption = EncryptionSettings("HmacSHA256", 1, 256)
@@ -139,7 +140,7 @@ class JsonSecretStoragePersistenceSpec extends AnyPropSpec with Matchers with Fi
     }
   }
 
-  property("persistence does not overwrite an existing destination") {
+  property("low-level persistence refuses an already occupied exact destination") {
     val dir = createTempDir
     val file = Files.write(dir.toPath.resolve("wallet.json"), contents.getBytes(UTF_8)).toFile
 
@@ -149,6 +150,110 @@ class JsonSecretStoragePersistenceSpec extends AnyPropSpec with Matchers with Fi
 
     new String(Files.readAllBytes(file.toPath), UTF_8) shouldBe contents
     entries(dir) shouldBe Set("wallet.json")
+  }
+
+  property("a second initialization refuses an existing wallet and erases the new seed") {
+    val dir = createTempDir
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+    val first = JsonSecretStorage.init(Array.fill[Byte](32)(1), SecretString.create("first password"), false)(settings)
+    val original = Files.readAllBytes(first.secretFile.toPath)
+    val nextSeed = Array.fill[Byte](32)(2)
+
+    intercept[FileAlreadyExistsException] {
+      JsonSecretStorage.init(nextSeed, SecretString.create("second password"), false)(settings)
+    }
+    nextSeed shouldBe Array.fill[Byte](32)(0)
+    entries(dir) shouldBe Set(first.secretFile.getName)
+    Files.readAllBytes(first.secretFile.toPath) shouldBe original
+    first.unlock(SecretString.create("first password")) shouldBe 'success
+    first.lock()
+  }
+
+  property("initialization refuses a legacy filename and leaves it unchanged") {
+    val dir = createTempDir
+    val legacy = Files.write(dir.toPath.resolve("legacy-wallet"), contents.getBytes(UTF_8))
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+    val seed = Array.fill[Byte](32)(1)
+    intercept[FileAlreadyExistsException] {
+      JsonSecretStorage.init(seed, SecretString.create("test password"), false)(settings)
+    }
+    Files.readAllBytes(legacy) shouldBe contents.getBytes(UTF_8)
+    seed shouldBe Array.fill[Byte](32)(0)
+    JsonSecretStorage.readFile(settings).get.secretFile.toPath shouldBe legacy
+  }
+
+  property("wallet discovery rejects ambiguous files instead of choosing directory order") {
+    val dir = createTempDir
+    Files.write(dir.toPath.resolve("first.json"), contents.getBytes(UTF_8))
+    Files.write(dir.toPath.resolve("second.json"), contents.getBytes(UTF_8))
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+    JsonSecretStorage.readFile(settings) shouldBe 'failure
+    val seed = Array.fill[Byte](32)(1)
+    intercept[FileAlreadyExistsException] {
+      JsonSecretStorage.init(seed, SecretString.create("test password"), false)(settings)
+    }
+    seed shouldBe Array.fill[Byte](32)(0)
+    entries(dir) shouldBe Set("first.json", "second.json")
+  }
+
+  property("initialization preserves unrelated staging material and explicitly restricts POSIX permissions") {
+    val dir = createTempDir
+    val staged = Files.write(dir.toPath.resolve(".ergo-secret-staging-other.tmp"), contents.getBytes(UTF_8))
+    val inactive = Files.createDirectory(dir.toPath.resolve(".ergo-secret-staging-wallet-example"))
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+    val storage = JsonSecretStorage.init(Array.fill[Byte](32)(1), SecretString.create("test password"), false)(settings)
+    entries(dir) shouldBe Set(staged.getFileName.toString, inactive.getFileName.toString, storage.secretFile.getName)
+    Files.readAllBytes(staged) shouldBe contents.getBytes(UTF_8)
+    JsonSecretStorage.readFile(settings).get.secretFile shouldBe storage.secretFile
+    if (Files.getFileAttributeView(storage.secretFile.toPath, classOf[PosixFileAttributeView]) != null) {
+      Files.getPosixFilePermissions(storage.secretFile.toPath) shouldBe PosixFilePermissions.fromString("rw-------")
+    }
+  }
+
+  property("wallet discovery rejects a legacy wallet alongside a JSON wallet") {
+    val dir = createTempDir
+    val legacy = Files.write(dir.toPath.resolve("legacy-wallet"), contents.getBytes(UTF_8))
+    val json = Files.write(dir.toPath.resolve("current.json"), contents.getBytes(UTF_8))
+    val settings = SecretStorageSettings(dir.getAbsolutePath, encryption)
+    JsonSecretStorage.readFile(settings) shouldBe 'failure
+    JsonSecretStorage.readFile(settings).failed.get should not be a[JsonSecretStorage.SecretFileNotFoundException]
+    Files.readAllBytes(legacy) shouldBe contents.getBytes(UTF_8)
+    Files.readAllBytes(json) shouldBe contents.getBytes(UTF_8)
+  }
+
+  property("wallet discovery reports a file used as the secret directory as an error") {
+    val dir = createTempDir
+    val occupied = Files.write(dir.toPath.resolve("occupied"), contents.getBytes(UTF_8))
+    val settings = SecretStorageSettings(occupied.toString, encryption)
+    JsonSecretStorage.readFile(settings) shouldBe 'failure
+    JsonSecretStorage.readFile(settings).failed.get should not be a[JsonSecretStorage.SecretFileNotFoundException]
+    Files.readAllBytes(occupied) shouldBe contents.getBytes(UTF_8)
+  }
+
+  property("wallet discovery distinguishes absence from invalid and ambiguous inventory") {
+    val dir = createTempDir
+    val settings = SecretStorageSettings(dir.toPath.resolve("missing").toString, encryption)
+    JsonSecretStorage.readFile(settings).failed.get shouldBe a[JsonSecretStorage.SecretFileNotFoundException]
+    Files.createDirectory(new File(settings.secretDir).toPath)
+    JsonSecretStorage.readFile(settings).failed.get shouldBe a[JsonSecretStorage.SecretFileNotFoundException]
+    Files.write(new File(settings.secretDir).toPath.resolve("one.json"), contents.getBytes(UTF_8))
+    Files.write(new File(settings.secretDir).toPath.resolve("two.json"), contents.getBytes(UTF_8))
+    JsonSecretStorage.readFile(settings).failed.get should not be a[JsonSecretStorage.SecretFileNotFoundException]
+  }
+
+  property("wallet discovery rejects a dangling directory symlink while preserving valid directory links") {
+    val dir = createTempDir
+    if (Files.getFileAttributeView(dir.toPath, classOf[PosixFileAttributeView]) != null) {
+      val missing = dir.toPath.resolve("missing")
+      val link = Files.createSymbolicLink(dir.toPath.resolve("keystore"), missing)
+      val settings = SecretStorageSettings(link.toString, encryption)
+      JsonSecretStorage.readFile(settings) shouldBe 'failure
+      JsonSecretStorage.readFile(settings).failed.get should not be a[JsonSecretStorage.SecretFileNotFoundException]
+      Files.createDirectory(missing)
+      JsonSecretStorage.readFile(settings).failed.get shouldBe a[JsonSecretStorage.SecretFileNotFoundException]
+      val wallet = Files.write(missing.resolve("wallet.json"), contents.getBytes(UTF_8))
+      JsonSecretStorage.readFile(settings).get.secretFile.toPath.toRealPath() shouldBe wallet.toRealPath()
+    }
   }
 
   property("a publication error propagates and removes the owned staging file") {

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.it
 
 import com.typesafe.config.Config
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
+import org.ergoplatform.it.util.ConvergenceObservations
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -27,21 +28,55 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
   val nodes: List[Node] = docker.startDevNetNodes(nodeConfigs).get
 
   it should s"Utxo state nodes synchronisation ($blocksQty blocks)" in {
+    val deadline = 15.minutes.fromNow
+    val observations = new ConvergenceObservations
+    @volatile var recent = Vector.empty[String]
     val result = for {
       initHeight <- Future.traverse(nodes)(_.fullHeight).map(x => math.max(x.max, 1))
       _          <- Future.traverse(nodes)(_.waitForHeight(initHeight + blocksQty))
-      headers <- Future.traverse(nodes)(
-                  _.headerIdsByHeight(initHeight + blocksQty - forkDepth)
-                )
+      headers <- {
+        val height = initHeight + blocksQty - forkDepth
+        val probes = nodes.map { node =>
+          observations.probe(node.singleGet(s"/blocks/at/$height", _.setRequestTimeout(5000))
+            .map { r =>
+              require(r.getStatusCode == 200, "Unexpected observation status")
+              node.ergoJsonAnswerAs[Seq[String]](r.getResponseBody)
+            })
+        }
+        observations.until(deadline, 1.second, 5.seconds) { budget =>
+          Future.traverse(probes.zipWithIndex) { case (probe, index) =>
+            probe.sample(budget).map { result =>
+              val selection = result.fold(error => s"errorClass=$error", ids =>
+                ids.headOption.map(ConvergenceObservations.headerId).getOrElse("missing"))
+              synchronized {
+                recent = (recent :+ s"node$index height=$height selected=$selection sampledAt=${System.currentTimeMillis()}")
+                  .takeRight(nodes.size * 3)
+              }
+              result.toOption.getOrElse(Seq.empty)
+            }
+          }
+        }(ConvergenceObservations.selectedHeadersAgree)(
+          s"Selected headers did not converge at height $height; recent observations: ${recent.mkString("; ")}")
+      }
     } yield {
-      log.info(
-        s"Headers at height ${initHeight + blocksQty - forkDepth}: ${headers.mkString(",")}"
-      )
-      val headerIdsAtSameHeight = headers.flatten
-      val sample                = headerIdsAtSameHeight.head
-      headerIdsAtSameHeight should contain only sample
+      log.info(s"Selected header convergence: ${recent.mkString("; ")}")
+      // `/blocks/at/{height}` returns *every* header id known at the given height, with the
+      // best-chain one first (see `HeadersProcessor.headerIdsAtHeight`). Nodes are in sync
+      // when their best-chain header at that height matches; a node may legitimately also
+      // know orphaned headers of a fork that was already resolved, so flattening all the
+      // returned ids makes the assertion fail on a perfectly synchronised network.
+      // Same convention as ForkResolutionSpec and DeepRollBackSpec, which compare `.head`.
+      headers.foreach(_ should not be empty)
+      val bestChainHeaderIds = headers.map(_.head)
+      val sample             = bestChainHeaderIds.head
+      bestChainHeaderIds should contain only sample
     }
-    Await.result(result, 15.minutes)
+    try Await.result(result, deadline.timeLeft.max(Duration.Zero))
+    catch {
+      case error: java.util.concurrent.TimeoutException =>
+        log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
+        throw error
+    } finally observations.close()
   }
 
 }

--- a/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/UtxoStateNodesSyncSpec.scala
@@ -1,8 +1,9 @@
 package org.ergoplatform.it
 
 import com.typesafe.config.Config
+import io.circe.Json
 import org.ergoplatform.it.container.{IntegrationSuite, Node}
-import org.ergoplatform.it.util.ConvergenceObservations
+import org.ergoplatform.it.util.{ConvergenceObservations, UtxoSyncFailureDiagnostics}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
@@ -75,7 +76,12 @@ class UtxoStateNodesSyncSpec extends AnyFlatSpec with IntegrationSuite {
     catch {
       case error: java.util.concurrent.TimeoutException =>
         log.error(s"UTXO synchronization timed out; recent observations: ${recent.mkString("; ")}")
-        throw error
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(error, nodes.map { node => () =>
+          node.singleGet("/info", _.setRequestTimeout(2000)).map { response =>
+            require(response.getStatusCode == 200, "Unexpected diagnostic status")
+            node.ergoJsonAnswerAs[Json](response.getResponseBody)
+          }
+        })(snapshot => log.error(s"UTXO post-failure diagnostics: $snapshot"))
     } finally observations.close()
   }
 

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,100 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservations.scala
@@ -1,0 +1,110 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory, TimeUnit, TimeoutException}
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Bounded, single-flight observations for integration assertions. */
+final class ConvergenceObservations(implicit ec: ExecutionContext) extends AutoCloseable {
+  private val timer = new ScheduledThreadPoolExecutor(1, new ThreadFactory {
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = new Thread(runnable, "convergence-observations")
+      thread.setDaemon(true)
+      thread
+    }
+  })
+  timer.setRemoveOnCancelPolicy(true)
+
+  private def bounded[A](future: Future[A], budget: FiniteDuration): Future[A] = {
+    val result = Promise[A]()
+    val timeout = timer.schedule(new Runnable {
+      override def run(): Unit = result.tryFailure(new TimeoutException("Observation deadline"))
+    }, math.max(0L, budget.toNanos), TimeUnit.NANOSECONDS)
+    future.onComplete { value =>
+      result.tryComplete(value)
+      timeout.cancel(false)
+    }
+    result.future
+  }
+
+  final class Probe[A](request: () => Future[A]) {
+    private var pending: Option[Future[A]] = None
+
+    def sample(budget: FiniteDuration): Future[Either[String, A]] = {
+      val response = synchronized {
+        val current = pending.filterNot(_.isCompleted).getOrElse {
+          Try(request()) match {
+            case Success(value) => value
+            case Failure(error) => Future.failed(error)
+          }
+        }
+        pending = Some(current)
+        current
+      }
+      bounded(response, budget).map(value => Right(value): Either[String, A]).recover {
+        case scala.util.control.NonFatal(error) => Left(error.getClass.getSimpleName)
+      }
+    }
+  }
+
+  def probe[A](request: => Future[A]): Probe[A] = new Probe(() => request)
+
+  def until[A](deadline: Deadline, interval: FiniteDuration, sampleBudget: FiniteDuration)
+              (observe: FiniteDuration => Future[A])(accept: A => Boolean)
+              (failure: => String): Future[A] = {
+    def expired: Future[A] = Future.failed(new TimeoutException(failure))
+
+    def loop(): Future[A] = {
+      if (deadline.isOverdue()) expired
+      else {
+        val remaining = deadline.timeLeft
+        bounded(observe(sampleBudget.min(remaining)), remaining).flatMap { value =>
+          if (deadline.isOverdue()) expired
+          else if (accept(value)) Future.successful(value)
+          else {
+            val next = Promise[Unit]()
+            timer.schedule(new Runnable {
+              override def run(): Unit = next.trySuccess(())
+            }, interval.min(deadline.timeLeft).max(Duration.Zero).toNanos, TimeUnit.NANOSECONDS)
+            next.future.flatMap(_ => loop())
+          }
+        }.recoverWith {
+          case _: TimeoutException => expired
+        }
+      }
+    }
+
+    loop()
+  }
+
+  override def close(): Unit = timer.shutdownNow()
+}
+
+object ConvergenceObservations {
+  def sameBestBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean = {
+    val sameHeight = infoA.bestBlockHeightOpt.nonEmpty && infoA.bestBlockHeightOpt == infoB.bestBlockHeightOpt
+    val sameBlock = infoA.bestBlockIdOpt.nonEmpty && infoA.bestBlockIdOpt == infoB.bestBlockIdOpt
+    val highEnough = infoA.bestBlockHeightOpt.exists(_ >= minHeight)
+    sameHeight && sameBlock && highEnough
+  }
+
+  def selectedHeadersAgree(headers: Seq[Seq[String]]): Boolean =
+    headers.nonEmpty && headers.forall(_.headOption.exists(_.nonEmpty)) &&
+      headers.map(_.head).distinct.size == 1
+
+  /** Both nodes report mining disabled and share a completely applied selected header tip. */
+  def sameFullyAppliedNonMiningBlock(infoA: NodeInfo, infoB: NodeInfo, minHeight: Int): Boolean =
+    infoA.isMining.contains(false) && infoB.isMining.contains(false) &&
+      sameBestBlock(infoA, infoB, minHeight) &&
+      infoA.bestBlockIdOpt.exists(_.nonEmpty) &&
+      infoA.bestHeaderHeightOpt == infoA.bestBlockHeightOpt &&
+      infoB.bestHeaderHeightOpt == infoB.bestBlockHeightOpt &&
+      infoA.bestHeaderIdOpt == infoA.bestBlockIdOpt &&
+      infoB.bestHeaderIdOpt == infoB.bestBlockIdOpt
+
+  def headerId(value: String): String =
+    if (value.matches("[0-9a-fA-F]{64}")) value else "invalid-header-id"
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,96 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  it should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/ConvergenceObservationsSpec.scala
@@ -1,0 +1,145 @@
+package org.ergoplatform.it.util
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.ergoplatform.it.api.NodeApi.NodeInfo
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class ConvergenceObservationsSpec extends AnyFlatSpec with Matchers {
+  implicit private val ec: ExecutionContext = ExecutionContext.global
+
+  private def withObserver(test: ConvergenceObservations => Unit): Unit = {
+    val observer = new ConvergenceObservations
+    try test(observer)
+    finally observer.close()
+  }
+
+  "Selected header agreement" should "accept retained alternatives only when every first ID agrees" in {
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("a", "c"))) shouldBe true
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a", "b"), Seq("b", "a"))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq("a"), Seq.empty)) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq(Seq(""), Seq(""))) shouldBe false
+    ConvergenceObservations.selectedHeadersAgree(Seq.empty) shouldBe false
+  }
+
+  "Full block agreement" should "require both heights and IDs and the original minimum height" in {
+    val info = NodeInfo(Some("header"), Some("block"), Some(60), Some(50), None, None)
+    ConvergenceObservations.sameBestBlock(info, info, 50) shouldBe true
+    ConvergenceObservations.sameBestBlock(info, info, 51) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = Some(51)), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = Some("other")), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockHeightOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockHeightOpt = None), 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info.copy(bestBlockIdOpt = None), info, 50) shouldBe false
+    ConvergenceObservations.sameBestBlock(info, info.copy(bestBlockIdOpt = None), 50) shouldBe false
+  }
+
+  "Fully applied block agreement" should "accept a complete shared tip at the minimum height" in {
+    val info = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 12) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(info, info, 13) shouldBe false
+  }
+
+  it should "reject a shared 21-header 12-full-block seed despite full-block agreement" in {
+    val lagging = NodeInfo(Some("header21"), Some("block12"), Some(21), Some(12), None, Some(false))
+    ConvergenceObservations.sameBestBlock(lagging, lagging, 1) shouldBe true
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(lagging, lagging, 1) shouldBe false
+  }
+
+  private val completeSeed = NodeInfo(Some("tip"), Some("tip"), Some(12), Some(12), None, Some(false))
+
+  Seq[(String, NodeInfo => NodeInfo)](
+    "missing header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = None)),
+    "missing full-block height" -> ((info: NodeInfo) => info.copy(bestBlockHeightOpt = None)),
+    "missing header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = None)),
+    "missing full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = None)),
+    "different header ID" -> ((info: NodeInfo) => info.copy(bestHeaderIdOpt = Some("other"))),
+    "different full-block ID" -> ((info: NodeInfo) => info.copy(bestBlockIdOpt = Some("other"))),
+    "different header height" -> ((info: NodeInfo) => info.copy(bestHeaderHeightOpt = Some(21))),
+    "unknown mining status" -> ((info: NodeInfo) => info.copy(isMining = None)),
+    "active mining" -> ((info: NodeInfo) => info.copy(isMining = Some(true)))
+  ).foreach { case (fault, change) =>
+    Seq("A", "B").foreach { side =>
+      it should s"reject $fault on node $side independently" in {
+        val (a, b) = if (side == "A") (change(completeSeed), completeSeed)
+                     else (completeSeed, change(completeSeed))
+        ConvergenceObservations.sameFullyAppliedNonMiningBlock(a, b, 1) shouldBe false
+      }
+    }
+  }
+
+  it should "reject two empty tip identifiers" in {
+    val empty = completeSeed.copy(bestHeaderIdOpt = Some(""), bestBlockIdOpt = Some(""))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(empty, empty, 1) shouldBe false
+  }
+
+  it should "reject different complete tips at the same height" in {
+    val other = completeSeed.copy(bestHeaderIdOpt = Some("other"), bestBlockIdOpt = Some("other"))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  it should "reject different complete heights independently of matching IDs" in {
+    val other = completeSeed.copy(bestHeaderHeightOpt = Some(13), bestBlockHeightOpt = Some(13))
+    ConvergenceObservations.sameFullyAppliedNonMiningBlock(completeSeed, other, 1) shouldBe false
+  }
+
+  "Full block agreement" should "resample the entire group until its current selections agree" in withObserver { observer =>
+    val samples = new AtomicInteger()
+    val result = observer.until(2.seconds.fromNow, 1.millis, 100.millis) { _ =>
+      val headers = if (samples.incrementAndGet() == 1) Seq(Seq("a", "b"), Seq("b", "a"))
+                    else Seq(Seq("b", "a"), Seq("b"))
+      Future.successful(headers)
+    }(ConvergenceObservations.selectedHeadersAgree)("selected headers disagree")
+    Await.result(result, 3.seconds).map(_.head) shouldBe Seq("b", "b")
+    samples.get() shouldBe 2
+  }
+
+  it should "fail persistent disagreement within the original deadline with recent evidence" in withObserver { observer =>
+    var recent = "none"
+    val result = observer.until(100.millis.fromNow, 1.millis, 20.millis) { _ =>
+      recent = "node0=a node1=b"
+      Future.successful(Seq(Seq("a"), Seq("b")))
+    }(ConvergenceObservations.selectedHeadersAgree)(s"last: $recent")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage should include("node0=a node1=b")
+  }
+
+  "Observation probes" should "bound a stalled endpoint and not start overlapping requests" in withObserver { observer =>
+    val calls = new AtomicInteger()
+    val never = Promise[Int]()
+    val probe = observer.probe { calls.incrementAndGet(); never.future }
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    Await.result(probe.sample(20.millis), 2.seconds) shouldBe Left("TimeoutException")
+    calls.get() shouldBe 1
+    never.success(3)
+    Await.result(never.future, 2.seconds) shouldBe 3
+    Await.result(probe.sample(100.millis), 2.seconds) shouldBe Right(3)
+    calls.get() shouldBe 2
+  }
+
+  it should "keep successful status available while the peer sample times out" in withObserver { observer =>
+    val status = observer.probe(Future.successful(42)).sample(100.millis)
+    val peers = observer.probe(Promise[Int]().future).sample(30.millis)
+    Await.result(status, 2.seconds) shouldBe Right(42)
+    Await.result(status.zip(peers), 2.seconds) shouldBe (Right(42) -> Left("TimeoutException"))
+  }
+
+  it should "retain only an error class for endpoint failures" in withObserver { observer =>
+    val result = observer.probe(Future.failed[Int](new IllegalArgumentException("private diagnostic payload")))
+    Await.result(result.sample(100.millis), 2.seconds) shouldBe Left("IllegalArgumentException")
+  }
+
+  it should "enforce the convergence deadline even when observation never returns" in withObserver { observer =>
+    val result = observer.until(30.millis.fromNow, 1.millis, 10.millis)(_ => Promise[Boolean]().future)(identity)("recent status")
+    intercept[TimeoutException](Await.result(result, 2.seconds)).getMessage shouldBe "recent status"
+  }
+
+  "Observation identifiers" should "exclude arbitrary response text" in {
+    ConvergenceObservations.headerId("ab" * 32) shouldBe "ab" * 32
+    ConvergenceObservations.headerId("unexpected response text") shouldBe "invalid-header-id"
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnostics.scala
@@ -1,0 +1,60 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/** Additional observations after failure, with their own bound and no effect on the assertion. */
+object UtxoSyncFailureDiagnostics {
+  private val requestBudget = 2.seconds
+  private val collectionBudget = 2500.millis
+  private val numericFields = Seq("headersHeight", "fullHeight", "headersScore", "fullBlocksScore", "peersCount")
+  private val headerFields = Seq("bestHeaderId", "bestFullHeaderId", "genesisBlockId")
+
+  def project(node: Int, sampledAt: Long, response: Either[String, Json]): Json = {
+    val identity = Seq("node" -> Json.fromInt(node), "sampledAt" -> Json.fromLong(sampledAt))
+    def failed(errorClass: String): Json = {
+      val safeClass = if (errorClass.matches("[A-Za-z_$][A-Za-z0-9_$]{0,127}")) errorClass else "ObservationFailure"
+      Json.obj((identity :+ ("errorClass" -> Json.fromString(safeClass))): _*)
+    }
+    response match {
+      case Left(errorClass) => failed(errorClass)
+      case Right(body) if !body.isObject => failed("InvalidInfoResponse")
+      case Right(body) =>
+        def field(name: String)(decode: Json => Option[Json]): (String, Json) = {
+          val value = body.hcursor.downField(name).focus match {
+            case None => Json.Null
+            case Some(value) if value.isNull => Json.Null
+            case Some(value) => decode(value).getOrElse(Json.fromString("invalid"))
+          }
+          name -> value
+        }
+        val numbers = numericFields.map(name => field(name) { value =>
+          value.asNumber.flatMap(_.toBigInt).filter(_ >= 0).map(Json.fromBigInt)
+        })
+        val headers = headerFields.map(name => field(name) { value =>
+          value.asString.map(id => Json.fromString(ConvergenceObservations.headerId(id)))
+        })
+        val mining = field("isMining")(_.asBoolean.map(Json.fromBoolean))
+        Json.obj((identity ++ numbers ++ headers :+ mining): _*)
+    }
+  }
+
+  def rethrowAfterCapture(original: TimeoutException, requests: Seq[() => Future[Json]])
+                         (emit: String => Unit)(implicit ec: ExecutionContext): Unit = {
+    try {
+      val observations = new ConvergenceObservations
+      try {
+        val snapshots = requests.zipWithIndex.map { case (request, index) =>
+          observations.probe(Future(request()).flatMap(response => response))
+            .sample(requestBudget).map(response => project(index, System.currentTimeMillis(), response))
+        }
+        // This bound starts only after the synchronization assertion has already failed.
+        val result = Await.result(Future.sequence(snapshots), collectionBudget)
+        emit(Json.arr(result: _*).noSpaces)
+      } finally observations.close()
+    } finally throw original
+  }
+}

--- a/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
+++ b/src/it/scala/org/ergoplatform/it/util/UtxoSyncFailureDiagnosticsSpec.scala
@@ -1,0 +1,111 @@
+package org.ergoplatform.it.util
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
+
+class UtxoSyncFailureDiagnosticsSpec extends AnyFlatSpec with Matchers {
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private val marker = "untrusted-extra-value"
+  private val header = "ab" * 32
+
+  "Failure diagnostics" should "preserve only typed diagnostic fields and exact cumulative scores" in {
+    val score = BigInt("123456789012345678901234567890")
+    val body = Json.obj(
+      "headersHeight" -> Json.fromInt(13), "fullHeight" -> Json.fromInt(9),
+      "headersScore" -> Json.fromBigInt(score), "fullBlocksScore" -> Json.fromBigInt(score - 4),
+      "bestHeaderId" -> Json.fromString(header), "bestFullHeaderId" -> Json.fromString(header),
+      "genesisBlockId" -> Json.fromString(header), "isMining" -> Json.True,
+      "peersCount" -> Json.fromInt(3), "name" -> Json.fromString(marker),
+      "address" -> Json.fromString(marker), "sampledAt" -> Json.fromString(marker))
+    val result = UtxoSyncFailureDiagnostics.project(2, 123L, Right(body))
+    result.hcursor.get[BigInt]("headersScore") shouldBe Right(score)
+    result.hcursor.get[BigInt]("fullBlocksScore") shouldBe Right(score - 4)
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right(header)
+    result.hcursor.get[Int]("headersHeight") shouldBe Right(13)
+    result.hcursor.get[Int]("fullHeight") shouldBe Right(9)
+    result.hcursor.get[Boolean]("isMining") shouldBe Right(true)
+    result.hcursor.get[Int]("peersCount") shouldBe Right(3)
+    result.hcursor.get[Int]("node") shouldBe Right(2)
+    result.hcursor.get[Long]("sampledAt") shouldBe Right(123L)
+    result.asObject.get.keys.toSet shouldBe Set("node", "sampledAt", "headersHeight", "fullHeight",
+      "headersScore", "fullBlocksScore", "bestHeaderId", "bestFullHeaderId", "genesisBlockId", "isMining", "peersCount")
+    result.noSpaces should not include marker
+  }
+
+  it should "mark malformed fields and preserve missing fields without copying their contents" in {
+    val body = Json.obj("headersHeight" -> Json.fromString(marker), "fullHeight" -> Json.fromInt(-1),
+      "headersScore" -> Json.arr(Json.fromString(marker)), "isMining" -> Json.fromString(marker),
+      "bestHeaderId" -> Json.fromString(marker), "genesisBlockId" -> Json.obj("secret" -> Json.fromString(marker)))
+    val result = UtxoSyncFailureDiagnostics.project(0, 1L, Right(body))
+    Seq("headersHeight", "fullHeight", "headersScore", "isMining", "genesisBlockId").foreach { key =>
+      result.hcursor.get[String](key) shouldBe Right("invalid")
+    }
+    result.hcursor.get[String]("bestHeaderId") shouldBe Right("invalid-header-id")
+    Seq("fullBlocksScore", "peersCount", "bestFullHeaderId").foreach { key =>
+      result.hcursor.downField(key).focus shouldBe Some(Json.Null)
+    }
+    result.noSpaces should not include marker
+    UtxoSyncFailureDiagnostics.project(0, 1L, Right(Json.fromString(marker)))
+      .hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    UtxoSyncFailureDiagnostics.project(0, 1L, Left("bad/class: " + marker)).noSpaces should not include marker
+  }
+
+  it should "retain the original timeout when transport or request creation fails" in {
+    val original = new TimeoutException("original assertion")
+    var captured = ""
+    val requests = Seq[() => Future[Json]](
+      () => Future.successful(Json.obj("name" -> Json.fromString(marker))),
+      () => Future.failed(new IOException(marker)),
+      () => throw new IllegalStateException(marker),
+      () => Future.successful(Json.fromString(marker)))
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, requests)(value => captured = value)
+    }
+    (thrown eq original) shouldBe true
+    val snapshots = parse(captured).toOption.get.asArray.get
+    snapshots.size shouldBe 4
+    snapshots.map(_.hcursor.get[Int]("node").toOption.get) shouldBe Vector(0, 1, 2, 3)
+    snapshots(1).hcursor.get[String]("errorClass") shouldBe Right("IOException")
+    snapshots(2).hcursor.get[String]("errorClass") shouldBe Right("IllegalStateException")
+    snapshots(3).hcursor.get[String]("errorClass") shouldBe Right("InvalidInfoResponse")
+    captured should not include marker
+  }
+
+  it should "retain the original timeout if emitting diagnostics fails" in {
+    val original = new TimeoutException("original assertion")
+    val thrown = intercept[TimeoutException] {
+      UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, Seq(() => Future.successful(Json.obj()))) { _ =>
+        throw new IllegalArgumentException(marker)
+      }
+    }
+    (thrown eq original) shouldBe true
+  }
+
+  it should "start all pending requests and finish collection under its separate bound" in {
+    val original = new TimeoutException("original assertion")
+    val started = new AtomicInteger(0)
+    val pending = Seq.fill(4)(Promise[Json]())
+    var captured = ""
+    val thrown = intercept[TimeoutException] {
+      Await.result(Future {
+        UtxoSyncFailureDiagnostics.rethrowAfterCapture(original, pending.map { promise => () =>
+          started.incrementAndGet()
+          promise.future
+        })(value => captured = value)
+      }, 4.seconds)
+    }
+    (thrown eq original) shouldBe true
+    started.get() shouldBe 4
+    parse(captured).toOption.get.asArray.get.foreach { snapshot =>
+      snapshot.hcursor.get[String]("errorClass") shouldBe Right("TimeoutException")
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletActor.scala
@@ -32,6 +32,8 @@ class ErgoWalletActor(settings: ErgoSettings,
 
   private val ergoAddressEncoder: ErgoAddressEncoder = settings.addressEncoder
 
+  private var initializationOutcomeUnknown: Option[Throwable] = None
+
   override val supervisorStrategy: OneForOneStrategy =
     OneForOneStrategy(maxNrOfRetries = 5, withinTimeRange = 1.minute) {
       case _: ActorKilledException =>
@@ -83,6 +85,24 @@ class ErgoWalletActor(settings: ErgoSettings,
   }
 
   private def loadedWallet(state: ErgoWalletState): Receive = {
+    case InitWallet(walletPass, mnemonicPassOpt) if initializationOutcomeUnknown.isDefined =>
+      walletPass.erase()
+      mnemonicPassOpt.foreach(_.erase())
+      sender() ! Failure(initializationOutcomeUnknown.get)
+
+    case RestoreWallet(mnemonic, mnemonicPassOpt, walletPass, _) if initializationOutcomeUnknown.isDefined =>
+      mnemonic.erase()
+      mnemonicPassOpt.foreach(_.erase())
+      walletPass.erase()
+      sender() ! Failure(initializationOutcomeUnknown.get)
+
+    case UnlockWallet(walletPass) if initializationOutcomeUnknown.isDefined =>
+      walletPass.erase()
+      sender() ! Failure(initializationOutcomeUnknown.get)
+
+    case _: RescanWallet if initializationOutcomeUnknown.isDefined =>
+      sender() ! Failure(initializationOutcomeUnknown.get)
+
     // Init wallet (w. mnemonic generation) if secret is not set yet
     case InitWallet(walletPass, mnemonicPassOpt) if !state.secretIsSet(settings.walletSettings.testMnemonic) =>
       ergoWalletService.initWallet(state, settings, walletPass, mnemonicPassOpt) match {
@@ -93,6 +113,7 @@ class ErgoWalletActor(settings: ErgoSettings,
           sender() ! Success(mnemonic)
         case Failure(t) =>
           walletPass.erase()
+          rememberInitializationFailure(state, t)
           val f = wrapLegalExc(t) // getting nicer message for illegal key size exception
           log.error(s"Wallet initialization is failed, details: ${f.exception.getMessage}")
           sender() ! f
@@ -108,6 +129,7 @@ class ErgoWalletActor(settings: ErgoSettings,
           sender() ! Success(())
         case Failure(t) =>
           walletPass.erase()
+          rememberInitializationFailure(state, t)
           val f = wrapLegalExc(t) //getting nicer message for illegal key size exception
           log.error(s"Wallet restoration is failed, details: ${f.exception.getMessage}")
           sender() ! f
@@ -115,7 +137,12 @@ class ErgoWalletActor(settings: ErgoSettings,
 
     // branch for key already being set
     case _: RestoreWallet | _: InitWallet =>
-      sender() ! Failure(new Exception("Wallet is already initialized or testMnemonic is set. Clear current secret to re-init it."))
+      val reason = if (state.generation.isDefined) {
+        "Wallet is already initialized; use a separate wallet data directory to initialize another wallet."
+      } else {
+        "Wallet is already initialized or testMnemonic is set. Clear current secret to re-init it."
+      }
+      sender() ! Failure(new Exception(reason))
 
     /* READERS */
     case ReadBalances(chainStatus) =>
@@ -359,7 +386,7 @@ class ErgoWalletActor(settings: ErgoSettings,
       val isUnlocked = state.walletVars.proverOpt.isDefined
       val changeAddress = state.getChangeAddress(ergoAddressEncoder)
       val height = state.getWalletHeight
-      val lastError = state.error
+      val lastError = initializationOutcomeUnknown.map(_.getMessage).orElse(state.error)
       val status = WalletStatus(isSecretSet, isUnlocked, changeAddress, height, lastError)
       sender() ! status
 
@@ -490,6 +517,13 @@ class ErgoWalletActor(settings: ErgoSettings,
   }
 
   override def receive: Receive = emptyWallet
+
+  private def rememberInitializationFailure(state: ErgoWalletState, error: Throwable): Unit = error match {
+    case _: WalletInitialization.OutcomeUnknown =>
+      initializationOutcomeUnknown = Some(error)
+      context.become(loadedWallet(state.copy(error = Some(error.getMessage))))
+    case _ =>
+  }
 
   private def wrapLegalExc[T](e: Throwable): Failure[T] =
     if (e.getMessage.startsWith("Illegal key size")) {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletService.scala
@@ -267,6 +267,7 @@ trait ErgoWalletService {
 
 class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends ErgoWalletService with ErgoWalletSupport with FileUtils {
 
+  private[wallet] val walletInitialization: WalletInitialization = new WalletInitialization
 
   override def readWallet(state: ErgoWalletState,
                  testMnemonic: Option[SecretString],
@@ -279,7 +280,15 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
         state.copy(walletVars = state.walletVars.withProver(prover))
       case None =>
         log.info("Trying to read wallet in secure mode ..")
-        JsonSecretStorage.readFile(secretStorageSettings).fold(
+        val secretRead = state.generation match {
+          case Some(generation) => Try {
+            val file = generation.secret(secretStorageSettings)
+            require(file.isFile, "Selected wallet generation secret is missing")
+            new JsonSecretStorage(file, secretStorageSettings.encryption)
+          }
+          case None => JsonSecretStorage.readFile(secretStorageSettings)
+        }
+        secretRead.fold(
           e => {
             e match {
               case e: FileNotFoundException =>
@@ -306,25 +315,20 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
     val entropy = scorex.utils.Random.randomBytes(walletSettings.seedStrengthBits / 8)
     log.info("Initializing wallet")
 
-    def initStorage(mnemonic: SecretString): Try[JsonSecretStorage] =
-      Try(JsonSecretStorage.init(Mnemonic.toSeed(mnemonic, mnemonicPassOpt), walletPass, usePre1627KeyDerivation = false)(walletSettings.secretStorage))
-
-    val result =
+    try {
       new Mnemonic(walletSettings.mnemonicPhraseLanguage, walletSettings.seedStrengthBits)
         .toMnemonic(entropy)
         .flatMap { mnemonic =>
-          initStorage(mnemonic).flatMap { newSecretStorage =>
-            // remove old wallet state, see https://github.com/ergoplatform/ergo/issues/1313
-            recreateRegistry(state, settings).flatMap { stateV1 =>
-              recreateStorage(stateV1, settings).map { stateV2 =>
-                mnemonic -> stateV2.copy(secretStorageOpt = Some(newSecretStorage), walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings))
-              }
-            }
+          walletInitialization.initialize(state, settings, secretSettings =>
+            JsonSecretStorage.init(Mnemonic.toSeed(mnemonic, mnemonicPassOpt), walletPass,
+              usePre1627KeyDerivation = false)(secretSettings)) match {
+            case Success(newState) => Success(mnemonic -> newState)
+            case Failure(error) =>
+              mnemonic.erase()
+              Failure(error)
           }
         }
-
-    java.util.Arrays.fill(entropy, 0: Byte)
-    result
+    } finally java.util.Arrays.fill(entropy, 0: Byte)
   }
 
   override def restoreWallet(state: ErgoWalletState,
@@ -336,15 +340,8 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
     if (settings.nodeSettings.isFullBlocksPruned) {
       Failure(new IllegalArgumentException("Unable to restore wallet when pruning is enabled"))
     } else {
-      Try(JsonSecretStorage.restore(mnemonic, mnemonicPassOpt, walletPass, settings.walletSettings.secretStorage, usePre1627KeyDerivation))
-        .flatMap { secretStorage =>
-          // remove old wallet state, see https://github.com/ergoplatform/ergo/issues/1313
-          recreateRegistry(state, settings).flatMap { stateV1 =>
-            recreateStorage(stateV1, settings).map { stateV2 =>
-              stateV2.copy(secretStorageOpt = Some(secretStorage), walletVars = stateV2.walletVars.copy(stateCacheProvided = stateV2.walletVars.stateCacheOpt)(settings))
-            }
-          }
-        }
+      walletInitialization.initialize(state, settings, secretSettings =>
+        JsonSecretStorage.restore(mnemonic, mnemonicPassOpt, walletPass, secretSettings, usePre1627KeyDerivation))
     }
   }
 
@@ -377,24 +374,24 @@ class ErgoWalletServiceImpl(override val ergoSettings: ErgoSettings) extends Erg
   }
 
   override def recreateRegistry(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] = {
-    val registryFolder = WalletRegistry.registryFolder(settings)
+    val registryFolder = WalletInitialization.registryFolder(state, settings)
     log.info(s"Removing the registry folder $registryFolder")
     state.registry.close()
 
     deleteRecursive(registryFolder)
 
-    WalletRegistry.apply(settings).map { reg =>
+    WalletRegistry.openAt(settings, registryFolder).map { reg =>
       state.copy(registry = reg)
     }
   }
 
   override def recreateStorage(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] =
     Try {
-      val storageFolder = WalletStorage.storageFolder(settings)
+      val storageFolder = WalletInitialization.storageFolder(state, settings)
       log.info(s"Removing the wallet storage folder $storageFolder")
       state.storage.close()
       deleteRecursive(storageFolder)
-      state.copy(storage = WalletStorage.readOrCreate(settings))
+      state.copy(storage = WalletStorage.openAt(settings, storageFolder))
     }
 
   override def getWalletBoxes(state: ErgoWalletState, unspentOnly: Boolean, considerUnconfirmed: Boolean): Seq[WalletBox] = {

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletState.scala
@@ -28,7 +28,8 @@ case class ErgoWalletState(
     parameters: Parameters,
     maxInputsToUse: Int,
     error: Option[String] = None,
-    rescanInProgress: Boolean
+    rescanInProgress: Boolean,
+    generation: Option[WalletGeneration] = None
   ) extends ScorexLogging {
 
   /**
@@ -135,26 +136,6 @@ object ErgoWalletState {
     */
   val noWalletFilter: FilterFn = (_: TrackedBox) => true
 
-  def initial(ergoSettings: ErgoSettings, parameters: Parameters): Try[ErgoWalletState] = {
-    WalletRegistry.apply(ergoSettings).map { registry =>
-      val ergoStorage: WalletStorage = WalletStorage.readOrCreate(ergoSettings)
-      val offChainRegistry = OffChainRegistry.init(registry)
-      val walletVars = WalletVars.apply(ergoStorage, ergoSettings)
-      val maxInputsToUse = ergoSettings.walletSettings.maxInputs
-      ErgoWalletState(
-        ergoStorage,
-        secretStorageOpt = None,
-        registry,
-        offChainRegistry,
-        outputsFilter = None,
-        walletVars,
-        stateReaderOpt = None,
-        mempoolReaderOpt = None,
-        utxoStateReaderOpt = None,
-        parameters,
-        maxInputsToUse,
-        rescanInProgress = false
-      )
-    }
-  }
+  def initial(ergoSettings: ErgoSettings, parameters: Parameters): Try[ErgoWalletState] =
+    WalletInitialization.initial(ergoSettings, parameters)
 }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/ErgoWalletSupport.scala
@@ -45,7 +45,12 @@ trait ErgoWalletSupport extends ScorexLogging {
   protected def addSecretToStorage(state: ErgoWalletState, secret: ExtendedSecretKey): Try[ErgoWalletState] =
     state.walletVars.withExtendedKey(secret).flatMap { newWalletVars =>
       state.storage.addPublicKey(secret.publicKey).flatMap { _ =>
-        newWalletVars.stateCacheOpt.get.withNewPubkey(secret.publicKey).map { updCache =>
+        val cache = newWalletVars.stateCacheProvided match {
+          case Some(provided) => provided.withNewPubkey(secret.publicKey)
+          // The computed cache was already built from the prover containing the new key.
+          case None => Success(newWalletVars.stateCacheOpt.get)
+        }
+        cache.map { updCache =>
           state.copy(walletVars = newWalletVars.copy(stateCacheProvided = Some(updCache))(newWalletVars.settings))
         }
       }

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletInitialization.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletInitialization.scala
@@ -1,0 +1,203 @@
+package org.ergoplatform.nodeView.wallet
+
+import java.io.{File, FileOutputStream, IOException}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, LinkOption, NoSuchFileException, Path, StandardCopyOption}
+import java.util.UUID
+
+import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
+import org.ergoplatform.wallet.secrets.JsonSecretStorage
+import org.ergoplatform.wallet.settings.SecretStorageSettings
+import scorex.util.ScorexLogging
+
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
+
+/** Identifies a prepared wallet without persisting machine-specific directory paths. */
+final case class WalletGeneration(id: String, secretFile: String) {
+  def registryFolder(settings: ErgoSettings): File = new File(WalletInitialization.dataFolder(settings, id), "registry")
+  def storageFolder(settings: ErgoSettings): File = new File(WalletInitialization.dataFolder(settings, id), "storage")
+  def secret(settings: SecretStorageSettings): File = new File(WalletInitialization.secretFolder(settings, id), secretFile)
+}
+
+/**
+  * Prepares a complete generation before publishing its selection. Prior stores and encrypted
+  * recovery material are retained; closing old handles is post-commit maintenance.
+  *
+  * This is a method-level initialization boundary, not an HTTP-delivery or power-loss guarantee.
+  * A failed atomic-move result is reconciled by exact read-back or reported as explicitly unknown.
+  * After adoption, older binaries must not write this wallet. Generation-aware backups include
+  * the selection descriptor, selected data generation and selected configured-keystore generation.
+  */
+private[wallet] class WalletInitialization extends ScorexLogging {
+  import WalletInitialization._
+
+  protected def openRegistry(settings: ErgoSettings, folder: File): WalletRegistry = WalletRegistry.openAt(settings, folder).get
+  protected def openStorage(settings: ErgoSettings, folder: File): WalletStorage = WalletStorage.openAt(settings, folder)
+  protected def closeRegistry(registry: WalletRegistry): Unit = registry.close()
+  protected def closeStorage(storage: WalletStorage): Unit = storage.close()
+  protected def readDescriptor(path: Path): Array[Byte] = Files.readAllBytes(path)
+  protected def moveDescriptor(staging: Path, target: Path): Unit = {
+    Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE)
+    ()
+  }
+
+  protected def buildState(state: ErgoWalletState, settings: ErgoSettings,
+                           generation: WalletGeneration, registry: WalletRegistry,
+                           storage: WalletStorage, secret: JsonSecretStorage): ErgoWalletState = {
+    storage.updateStateContext(state.stateContext).get
+    state.copy(storage = storage, registry = registry, secretStorageOpt = Some(secret),
+      offChainRegistry = OffChainRegistry.init(registry), outputsFilter = None,
+      walletVars = WalletVars(storage, settings), error = None, rescanInProgress = false,
+      generation = Some(generation))
+  }
+
+  def initialize(state: ErgoWalletState, settings: ErgoSettings,
+                  createSecret: SecretStorageSettings => JsonSecretStorage): Try[ErgoWalletState] = Try {
+    require(state.secretStorageOpt.isEmpty && selected(settings).isEmpty, "Wallet is already initialized")
+    require(JsonSecretStorage.readFile(settings.walletSettings.secretStorage).isFailure, "Wallet secret already exists")
+    val id = UUID.randomUUID().toString
+    val folder = dataFolder(settings, id)
+    var registry: Option[WalletRegistry] = None
+    var storage: Option[WalletStorage] = None
+    try {
+      val preparedRegistry = openRegistry(settings, new File(folder, "registry"))
+      registry = Some(preparedRegistry)
+      val preparedStorage = openStorage(settings, new File(folder, "storage"))
+      storage = Some(preparedStorage)
+      val secretSettings = settings.walletSettings.secretStorage.copy(
+        secretDir = secretFolder(settings.walletSettings.secretStorage, id).getPath)
+      val preparedSecret = createSecret(secretSettings)
+      val generation = WalletGeneration(id, preparedSecret.secretFile.getName)
+      validateReferences(generation, settings)
+      val candidate = buildState(state, settings, generation, preparedRegistry, preparedStorage, preparedSecret)
+      publish(generation, settings)
+      // Publication is complete. Cleanup cannot change the result or remove recovery material.
+      Seq[() => Unit](() => closeRegistry(state.registry), () => closeStorage(state.storage)).foreach { close =>
+        Try(close()).failed.foreach(error => log.warn("Wallet initialized; prior store handle could not close", error))
+      }
+      candidate
+    } catch {
+      case t: Throwable =>
+        closeWithFailure(storage.map(s => () => closeStorage(s)).toSeq ++ registry.map(r => () => closeRegistry(r)).toSeq, t)
+        throw t
+    }
+  }
+
+  private def publish(generation: WalletGeneration, settings: ErgoSettings): Unit = {
+    val target = descriptor(settings)
+    // Read errors are never interpreted as absence.
+    Try(readDescriptor(target)) match {
+      case Failure(_: NoSuchFileException) =>
+      case Failure(error) => throw error
+      case Success(_) => throw new IllegalStateException("Wallet generation is already selected")
+    }
+    Files.createDirectories(target.getParent)
+    val staging = Files.createTempFile(target.getParent, ".wallet-generation-", ".tmp")
+    val bytes = encode(generation)
+    val writer = new FileOutputStream(staging.toFile)
+    var writeFailure: Throwable = null
+    try {
+      writer.write(bytes)
+      writer.getFD.sync()
+    } catch {
+      case t: Throwable =>
+        writeFailure = t
+        throw t
+    } finally {
+      try writer.close() catch {
+        case NonFatal(error) if writeFailure != null =>
+          if (error ne writeFailure) writeFailure.addSuppressed(error)
+      }
+    }
+    try moveDescriptor(staging, target) catch {
+      case NonFatal(moveError) =>
+        Try(readDescriptor(target)) match {
+          case Success(observed) if observed.sameElements(bytes) =>
+            log.warn("Wallet generation publication completed despite a reported move error", moveError)
+          case Failure(_: NoSuchFileException) => throw moveError
+          case outcome =>
+            val unknown = new OutcomeUnknown(moveError)
+            outcome.failed.foreach { readError => if (readError ne moveError) unknown.addSuppressed(readError) }
+            throw unknown
+        }
+    }
+  }
+}
+
+private[wallet] object WalletInitialization {
+  private val Format = "ergo-wallet-generation-v1"
+  // #2507 excludes this prefix from legacy secret discovery, including inactive directories.
+  private val SecretPrefix = ".ergo-secret-staging-wallet-"
+
+  final class OutcomeUnknown(cause: Throwable) extends IOException(
+    "Wallet initialization outcome is uncertain. Restart the node before retrying; wallet recovery material has been retained.", cause)
+
+  def descriptor(settings: ErgoSettings): Path = new File(s"${settings.directory}/wallet/active-generation").toPath
+  def dataFolder(settings: ErgoSettings, id: String): File = new File(s"${settings.directory}/wallet/generations/$id")
+  def secretFolder(settings: SecretStorageSettings, id: String): File = new File(settings.secretDir, SecretPrefix + id)
+
+  private def canonicalId(id: String): Boolean = Try(UUID.fromString(id).toString == id).getOrElse(false)
+
+  private def encode(generation: WalletGeneration): Array[Byte] = {
+    require(canonicalId(generation.id), "Invalid wallet generation id")
+    require(generation.secretFile.endsWith(".json") && canonicalId(generation.secretFile.stripSuffix(".json")),
+      "Invalid wallet generation secret filename")
+    s"$Format\n${generation.id}\n${generation.secretFile}\n".getBytes(UTF_8)
+  }
+
+  private def decode(bytes: Array[Byte]): WalletGeneration = {
+    val fields = new String(bytes, UTF_8).split("\n", -1)
+    require(fields.length == 4 && fields(0) == Format && fields(3).isEmpty, "Unsupported wallet generation descriptor")
+    val generation = WalletGeneration(fields(1), fields(2))
+    require(encode(generation).sameElements(bytes), "Noncanonical wallet generation descriptor")
+    generation
+  }
+
+  def selected(settings: ErgoSettings): Option[WalletGeneration] = {
+    try Some(decode(Files.readAllBytes(descriptor(settings)))) catch {
+      case _: NoSuchFileException => None
+    }
+  }
+
+  def validateReferences(generation: WalletGeneration, settings: ErgoSettings): Unit = {
+    val registry = generation.registryFolder(settings)
+    val files = Seq(new File(registry, "ldb_main/CURRENT"), new File(registry, "ldb_undo/CURRENT"),
+      new File(generation.storageFolder(settings), "CURRENT"), generation.secret(settings.walletSettings.secretStorage))
+    require(files.forall(file => Files.isRegularFile(file.toPath, LinkOption.NOFOLLOW_LINKS)),
+      "Selected wallet generation is incomplete; retain its files and restore the complete generation before restarting")
+  }
+
+  def registryFolder(state: ErgoWalletState, settings: ErgoSettings): File =
+    state.generation.map(_.registryFolder(settings)).getOrElse(WalletRegistry.registryFolder(settings))
+
+  def storageFolder(state: ErgoWalletState, settings: ErgoSettings): File =
+    state.generation.map(_.storageFolder(settings)).getOrElse(WalletStorage.storageFolder(settings))
+
+  private def closeWithFailure(closes: Seq[() => Unit], failure: Throwable): Unit = closes.foreach { close =>
+    try close() catch {
+      case NonFatal(error) => if (error ne failure) failure.addSuppressed(error)
+    }
+  }
+
+  def initial(settings: ErgoSettings, parameters: Parameters): Try[ErgoWalletState] = Try {
+    val generation = selected(settings)
+    generation.foreach(validateReferences(_, settings))
+    val registryFolder = generation.map(_.registryFolder(settings)).getOrElse(WalletRegistry.registryFolder(settings))
+    val storageFolder = generation.map(_.storageFolder(settings)).getOrElse(WalletStorage.storageFolder(settings))
+    val registry = WalletRegistry.openAt(settings, registryFolder).get
+    var storage: Option[WalletStorage] = None
+    try {
+      val openedStorage = WalletStorage.openAt(settings, storageFolder)
+      storage = Some(openedStorage)
+      ErgoWalletState(openedStorage, None, registry, OffChainRegistry.init(registry), None,
+        WalletVars(openedStorage, settings), None, None, None, parameters, settings.walletSettings.maxInputs,
+        rescanInProgress = false, generation = generation)
+    } catch {
+      case t: Throwable =>
+        closeWithFailure(storage.map(s => () => s.close()).toSeq :+ (() => registry.close()), t)
+        throw t
+    }
+  }
+}

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/WalletInitialization.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/WalletInitialization.scala
@@ -56,7 +56,11 @@ private[wallet] class WalletInitialization extends ScorexLogging {
   def initialize(state: ErgoWalletState, settings: ErgoSettings,
                   createSecret: SecretStorageSettings => JsonSecretStorage): Try[ErgoWalletState] = Try {
     require(state.secretStorageOpt.isEmpty && selected(settings).isEmpty, "Wallet is already initialized")
-    require(JsonSecretStorage.readFile(settings.walletSettings.secretStorage).isFailure, "Wallet secret already exists")
+    JsonSecretStorage.readFile(settings.walletSettings.secretStorage) match {
+      case Failure(_: JsonSecretStorage.SecretFileNotFoundException) => ()
+      case Failure(error) => throw error
+      case Success(_) => throw new IllegalStateException("Wallet secret already exists")
+    }
     val id = UUID.randomUUID().toString
     val folder = dataFolder(settings, id)
     var registry: Option[WalletRegistry] = None

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletRegistry.scala
@@ -451,8 +451,9 @@ object WalletRegistry {
 
   def registryFolder(settings: ErgoSettings): File = new File(s"${settings.directory}/wallet/registry")
 
-  def apply(settings: ErgoSettings): Try[WalletRegistry] = Try {
-      val dir = registryFolder(settings)
+  def apply(settings: ErgoSettings): Try[WalletRegistry] = openAt(settings, registryFolder(settings))
+
+  private[wallet] def openAt(settings: ErgoSettings, dir: File): Try[WalletRegistry] = Try {
       dir.mkdirs()
       new LDBVersionedStore(dir, settings.nodeSettings.keepVersions)
     }.flatMap {
@@ -460,6 +461,9 @@ object WalletRegistry {
         // Create pre-genesis state checkpoint
         store.update(PreGenesisStateVersion, Seq.empty, Seq.empty).map { _ =>
           new WalletRegistry(store)(settings.walletSettings)
+        }.recoverWith { case error =>
+          Try(store.close()).failed.foreach { closeError => if (closeError ne error) error.addSuppressed(closeError) }
+          Failure(error)
         }
       case store =>
         Success(new WalletRegistry(store)(settings.walletSettings))

--- a/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/wallet/persistence/WalletStorage.scala
@@ -250,8 +250,10 @@ object WalletStorage {
     */
   def storageFolder(settings: ErgoSettings): File = new File(s"${settings.directory}/wallet/storage")
 
-  def readOrCreate(settings: ErgoSettings): WalletStorage = {
-    val db = LDBFactory.createKvDb(storageFolder(settings).getPath)
+  def readOrCreate(settings: ErgoSettings): WalletStorage = openAt(settings, storageFolder(settings))
+
+  private[wallet] def openAt(settings: ErgoSettings, folder: File): WalletStorage = {
+    val db = LDBFactory.createKvDb(folder.getPath)
     new WalletStorage(db, settings)
   }
 

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -5,6 +5,7 @@ import akka.pattern.{StatusReply, ask}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.Timeout
 import org.bouncycastle.util.BigIntegers
+import org.ergoplatform.core.versionToId
 import org.ergoplatform.mining.CandidateGenerator.{Candidate, GenerateCandidate}
 import org.ergoplatform.modifiers.ErgoFullBlock
 import org.ergoplatform.modifiers.history.BlockTransactions
@@ -15,7 +16,7 @@ import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.{Eliminat
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetReaders, Readers}
 import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoHistoryReader}
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
-import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.{StateType, UtxoStateReader}
 import org.ergoplatform.nodeView.wallet.ErgoWalletReader
 import org.ergoplatform.nodeView.{ErgoNodeViewRef, ErgoReadersHolderRef, LocallyGeneratedModifier}
 import org.ergoplatform.settings.NetworkType.DevNet60
@@ -34,6 +35,8 @@ import scorex.util.encode.Base16
 import sigma.data.ProveDlog
 import sigma.serialization.ErgoTreeSerializer
 import sigmastate.crypto.DLogProtocol.DLogProverInput
+
+import java.nio.file.{Files, Paths}
 
 import scala.concurrent.duration._
 
@@ -63,13 +66,67 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   private val defaultSettings60 = defaultSettings.copy(networkType = DevNet60, directory = defaultSettings.directory + "60")
 
-  it should "provider candidate to internal miner and verify and apply his solution" in new TestKit(
-    ActorSystem()
-  ) {
+  private def freshSettings(prototype: ErgoSettings): ErgoSettings = {
+    val root = Paths.get(prototype.directory).toAbsolutePath
+    val parent = Files.createDirectories(root.getParent)
+    val directory = Files.createTempDirectory(parent, s"${root.getFileName}-candidate-")
+    prototype.copy(directory = directory.toString)
+  }
+
+  private def withNodeTest(test: TestKit => Unit): Unit = {
+    val kit = new TestKit(ActorSystem())
+    try test(kit)
+    finally TestKit.shutdownActorSystem(kit.system)
+  }
+
+  private def awaitSetupBlock(testProbe: TestProbe, block: ErgoFullBlock): Unit = {
+    // The direct solution ACK and exact block-application event can arrive in either order.
+    testProbe.fishForMessage(blockValidationDelay) {
+      case StatusReply.Success(()) =>
+        testProbe.expectMsgPF(candidateGenDelay) {
+          case FullBlockApplied(header) if header.id == block.id =>
+        }
+        true
+      case FullBlockApplied(header) if header.id == block.id =>
+        testProbe.expectMsg(StatusReply.Success(()))
+        true
+      case _ => false
+    }
+  }
+
+  private def setupReward(readersHolderRef: ActorRef,
+                          setupBlock: ErgoFullBlock,
+                          emissionBoxId: ErgoBox.BoxId): (Readers, ErgoBox) = {
+    // ReadersHolder receives the state update asynchronously after the application event.
+    eventually(timeout(candidateGenDelay), interval(100.millis)) {
+      val readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+      versionToId(readers.s.version) shouldBe setupBlock.id
+      val header = readers.h.typedModifierById[Header](setupBlock.id).value
+      val appliedBlock = readers.h.getFullBlock(header).value
+      val emissionTransactions = appliedBlock.transactions.filter(
+        _.inputs.exists(_.boxId.sameElements(emissionBoxId))
+      )
+      emissionTransactions should have size 1
+      val rewardScript = ErgoTreePredef
+        .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
+        .bytes
+      val rewards = emissionTransactions.head.outputs.filter(
+        _.propositionBytes.sameElements(rewardScript)
+      )
+      rewards should have size 1
+      val rewardBox = rewards.head
+      readers.s.asInstanceOf[UtxoStateReader].boxById(rewardBox.id).value shouldBe rewardBox
+      (readers, rewardBox)
+    }
+  }
+
+  it should "provider candidate to internal miner and verify and apply his solution" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -77,25 +134,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
-    ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by node view holder" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by node view holder" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -103,13 +159,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -141,25 +197,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "recover when locally mined block is invalidated by full block id" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "recover when locally mined block is invalidated by full block id" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val replyProbe = new TestProbe(system)
     // fake node view holder: solved block is never applied, so solvedBlock stays set
     val viewHolderProbe = new TestProbe(system)
 
     // real readers holder over real node view holder, needed for candidate generation
-    val realViewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val realViewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef  = ErgoReadersHolderRef(realViewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -167,13 +222,13 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderProbe.ref,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val block = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -205,21 +260,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), replyProbe.ref)
     val newBlock = replyProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
     candidateGenerator.tell(newBlock.header.powSolution, replyProbe.ref)
     replyProbe.expectMsg(blockValidationDelay, StatusReply.Success(()))
 
-    system.terminate()
   }
 
-  it should "let multiple miners compete" in new TestKit(ActorSystem()) {
+  it should "let multiple miners compete" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -227,12 +283,12 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val m1 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m2 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
-    val m3 = ErgoMiningThread(defaultSettings, candidateGenerator, defaultMinerSecret.w)
+    val m1 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m2 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
+    val m3 = ErgoMiningThread(settings, candidateGenerator, defaultMinerSecret.w)
 
     // after applying solution from miner
     testProbe.expectMsgClass(newBlockDelay, newBlockSignal)
@@ -253,16 +309,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       testProbe.expectMsgClass(50.millis, classOf[ErgoMiningThread.SolvedBlocksCount])
 
     List(m1Count, m2Count, m3Count).map(_.count).sum should be >= 3
-    system.terminate()
   }
 
-  it should "cache candidate until newly mined block is applied" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "cache candidate until newly mined block is applied" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -270,7 +325,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     expectNoMessage(1.second)
@@ -278,7 +333,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     val block = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
     }
@@ -302,16 +357,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         true
     }
 
-    system.terminate()
   }
 
-  it should "regenerate candidate periodically" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "regenerate candidate periodically" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -319,6 +372,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -332,34 +386,24 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = settingsWithShortRegeneration.chainSettings.powScheme
+        settingsWithShortRegeneration.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -392,14 +436,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             )
         }
     }
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after regeneration" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after regeneration" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
@@ -407,6 +451,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef =
       ErgoNodeViewRef(settingsWithShortRegeneration)
@@ -420,36 +465,26 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -503,15 +538,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
             true
         }
     }
-    system.terminate()
   }
 
-  it should "pool transactions should be removed from pool when block is mined" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "pool transactions should be removed from pool when block is mined" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -519,43 +553,32 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("test".getBytes())).publicImage
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -577,7 +600,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -608,15 +631,14 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       .filter(_.blockTransactions.transactions.map(_.id).contains(tx.id))
     val txs: Seq[ErgoTransaction] = blocks.flatMap(_.blockTransactions.transactions)
     txs should have length 2 // 1 reward and one regular tx, no fee collection tx
-    system.terminate()
   }
 
-  it should "6.0 pool transactions should be added to 6.0 block" in new TestKit(
-    ActorSystem()
-  ) {
+  it should "6.0 pool transactions should be added to 6.0 block" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings60)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
-    val viewHolderRef: ActorRef    = ErgoNodeViewRef(defaultSettings60)
+    val viewHolderRef: ActorRef    = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -624,42 +646,30 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings60
+        settings
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
 
-    val history: ErgoHistoryReader = readers.h
+    val history: ErgoHistoryReader = setupReaders.h
     val startBlock: Option[Header] = history.bestHeaderOpt
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        // let's pretend we are mining at least a bit so it is realistic
-        expectNoMessage(200.millis)
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-
-        // we fish either for ack or SSM as the order is non-deterministic
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    // let's pretend we are mining at least a bit so it is realistic
+    expectNoMessage(200.millis)
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // build new transaction that uses miner's reward as input
-    val newlyMinedBlock    = readers.h.bestFullBlockOpt.get
-
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     rewardBox.propositionBytes shouldBe ErgoTreePredef
       .rewardOutputScript(emission.settings.minerRewardDelay, defaultMinerPk)
       .bytes
@@ -692,7 +702,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidateGenerator.tell(GenerateCandidate(Seq(tx, tx2), reply = true, forced = false), testProbe.ref)
     testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = defaultSettings.chainSettings.powScheme
+        val block = settings.chainSettings.powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
         testProbe.expectNoMessage(200.millis)
@@ -726,17 +736,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
     txs should have length 3 // 1 rewards and two regular txs, no fee collection
 
-    system.terminate()
   }
 
-  it should "use custom miner public key when provided via optPk" in new TestKit(ActorSystem()) {
+  it should "use custom miner public key when provided via optPk" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -744,7 +755,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -766,14 +777,15 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe customPk
     
-    system.terminate()
   }
 
-  it should "use default minerPk when optPk is None" in new TestKit(ActorSystem()) {
+  it should "use default minerPk when optPk is None" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -781,7 +793,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     candidateGenerator.tell(
@@ -798,17 +810,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate.candidateBlock should not be null
     candidate.externalVersion.pk shouldBe defaultMinerSecret.publicImage
 
-    system.terminate()
   }
 
-  it should "generate different candidates for different optPk values" in new TestKit(ActorSystem()) {
+  it should "generate different candidates for different optPk values" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -816,7 +829,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -848,17 +861,18 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate2.externalVersion.pk shouldBe customPk
     candidate1.externalVersion.pk should not be candidate2.externalVersion.pk
 
-    system.terminate()
   }
 
-  it should "handle optPk with empty transactions" in new TestKit(ActorSystem()) {
+  it should "handle optPk with empty transactions" in withNodeTest { kit =>
+    import kit._
+    val settings = freshSettings(defaultSettings)
     import sigmastate.crypto.DLogProtocol.DLogProverInput
     import org.bouncycastle.util.BigIntegers
 
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(defaultSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -866,7 +880,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        defaultSettings
+        settings
       )
 
     // Generate custom key pair
@@ -887,7 +901,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     candidate should not be null
     candidate.txsToInclude shouldBe empty
 
-    system.terminate()
   }
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
@@ -956,20 +969,20 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     }
   }
 
-  it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {
+  it should "preserve previous candidate when forced regeneration occurs" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-preserve-candidate-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1036,24 +1049,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case StatusReply.Success(()) =>
     }
 
-    system.terminate()
   }
 
-  it should "handle multiple consecutive forced regenerations correctly" in new TestKit(ActorSystem()) {
+  it should "handle multiple consecutive forced regenerations correctly" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    // Use unique directory to avoid state conflicts
-    val testDir = s"${defaultSettings.directory}-multi-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 1.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1132,17 +1143,16 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
-  it should "return cached candidate immediately when forced = false" in new TestKit(ActorSystem()) {
+  it should "return cached candidate immediately when forced = false" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-cache-test-${System.currentTimeMillis()}"
-    val testSettings = defaultSettings.copy(directory = testDir)
+    val settings = freshSettings(defaultSettings)
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(testSettings)
+    val viewHolderRef: ActorRef = ErgoNodeViewRef(settings)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
 
     val candidateGenerator: ActorRef =
@@ -1150,7 +1160,7 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         defaultMinerSecret.publicImage,
         readersHolderRef,
         viewHolderRef,
-        testSettings
+        settings
       )
 
     // Get first candidate
@@ -1173,23 +1183,22 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Should be very fast since all are cached (no regeneration)
     elapsed should be < 500L
 
-    system.terminate()
   }
 
-  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in new TestKit(ActorSystem()) {
+  it should "accept solution for previous candidate after forced regeneration triggered by mempool" in withNodeTest { kit =>
+    import kit._
     val testProbe = new TestProbe(system)
     system.eventStream.subscribe(testProbe.ref, newBlockSignal)
 
-    val testDir = s"${defaultSettings.directory}-mempool-forced-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsWithShortRegeneration: ErgoSettings = freshSettings(
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
             .copy(blockCandidateGenerationInterval = 100.millis),
           chainSettings =
-            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
-          directory = testDir
+            ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds)
         )
+    )
 
     val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
     val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
@@ -1202,28 +1211,21 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
         settingsWithShortRegeneration
       )
 
-    val readers: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupReaders: Readers = await((readersHolderRef ? GetReaders).mapTo[Readers])
+    val setupEmissionBoxId = setupReaders.s.asInstanceOf[UtxoStateReader].emissionBoxOpt.value.id
     val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
 
     // generate block to use reward as our tx input
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    testProbe.expectMsgPF(candidateGenDelay) {
+    val setupBlock = testProbe.expectMsgPF(candidateGenDelay) {
       case StatusReply.Success(candidate: Candidate) =>
-        val block = powScheme
+        powScheme
           .proveCandidate(candidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
           .get
-        candidateGenerator.tell(block.header.powSolution, testProbe.ref)
-        testProbe.fishForMessage(blockValidationDelay) {
-          case StatusReply.Success(()) =>
-            testProbe.expectMsgPF(candidateGenDelay) {
-              case FullBlockApplied(header) if header.id != block.header.parentId =>
-            }
-            true
-          case FullBlockApplied(header) if header.id != block.header.parentId =>
-            testProbe.expectMsg(StatusReply.Success(()))
-            true
-        }
     }
+    candidateGenerator.tell(setupBlock.header.powSolution, testProbe.ref)
+    awaitSetupBlock(testProbe, setupBlock)
+    val (readers, rewardBox) = setupReward(readersHolderRef, setupBlock, setupEmissionBoxId)
 
     // Get candidate and solve it
     candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
@@ -1238,8 +1240,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
     // Build new transaction to trigger mempool change
     val prop: ProveDlog =
       DLogProverInput(BigIntegers.fromUnsignedByteArray("forced-mempool-test".getBytes())).publicImage
-    val newlyMinedBlock = readers.h.bestFullBlockOpt.get
-    val rewardBox: ErgoBox = newlyMinedBlock.transactions.last.outputs.last
     val input = Input(rewardBox.id, emptyProverResult)
 
     val outputs = IndexedSeq(
@@ -1277,7 +1277,6 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
       case _ => false
     }
 
-    system.terminate()
   }
 
   private class FixedReadersHolder(readers: Readers) extends Actor {

--- a/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
+++ b/src/test/scala/org/ergoplatform/mining/CandidateGeneratorSpec.scala
@@ -892,74 +892,68 @@ class CandidateGeneratorSpec extends AnyFlatSpec with Matchers with ErgoTestHelp
 
   it should "ignore cached candidate when forced = true" in new TestKit(ActorSystem()) {
     val testProbe = new TestProbe(system)
-    system.eventStream.subscribe(testProbe.ref, newBlockSignal)
+    val viewHolderProbe = new TestProbe(system)
 
     val testDir = s"${defaultSettings.directory}-ignore-cache-${System.currentTimeMillis()}"
-    val settingsWithShortRegeneration: ErgoSettings =
+    val settingsForExplicitForcing: ErgoSettings =
       ErgoSettingsReader.read()
         .copy(
           nodeSettings = defaultSettings.nodeSettings
-            .copy(blockCandidateGenerationInterval = 1.millis),
+            // Keep automatic refresh outside this test of explicit forcing.
+            .copy(blockCandidateGenerationInterval = 1.hour),
           chainSettings =
             ErgoSettingsReader.read().chainSettings.copy(blockInterval = 1.seconds),
           directory = testDir
         )
 
-    val viewHolderRef: ActorRef = ErgoNodeViewRef(settingsWithShortRegeneration)
-    val readersHolderRef: ActorRef = ErgoReadersHolderRef(viewHolderRef)
+    // Keep readers fixed: a later ChangedMempool event may legitimately regenerate the cache.
+    val (initialState, boxes) = createUtxoState(settingsForExplicitForcing)
+    val block = validFullBlock(None, initialState, boxes)
+    val state = initialState.applyModifier(block, None)(_ => ()).get
+    // Initialization computes mining-time averages from pairs of headers.
+    val history = historyWithBestFullBlock(Seq(block))
+    val readers = Readers(history, state, ErgoMemPool.empty(settingsForExplicitForcing), walletStub)
+    val readersHolderRef = system.actorOf(Props(new FixedReadersHolder(readers)))
 
     val candidateGenerator: ActorRef =
       CandidateGenerator(
         defaultMinerSecret.publicImage,
         readersHolderRef,
-        viewHolderRef,
-        settingsWithShortRegeneration
+        viewHolderProbe.ref,
+        settingsForExplicitForcing
       )
 
-    val powScheme = settingsWithShortRegeneration.chainSettings.powScheme
+    try {
+      // Get first candidate from the coherent, already applied block snapshot.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate1.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
 
-    // First mine a block to establish chain (needed for avg mining time calculation)
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val initCandidate = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
+      // Request with forced = false should return cached candidate immediately.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
+      val candidate2 = testProbe.expectMsgPF(100.millis) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+      candidate2 should be theSameInstanceAs candidate1
+      candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
+
+      // Request with forced = true should bypass cache and regenerate.
+      candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
+      val candidate3 = testProbe.expectMsgPF(candidateGenDelay) {
+        case StatusReply.Success(c: Candidate) => c
+      }
+
+      // Identity proves regeneration even when the clock has not advanced.
+      candidate3 should not be theSameInstanceAs(candidate1)
+      candidate3.candidateBlock.parentOpt.map(_.id) shouldBe Some(block.header.id)
+      candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
+    } finally {
+      TestKit.shutdownActorSystem(system)
+      history.closeStorage()
+      state.closeStorage()
     }
-    val initBlock = powScheme
-      .proveCandidate(initCandidate.candidateBlock, defaultMinerSecret.w, 0, 1000)
-      .get
-    candidateGenerator.tell(initBlock.header.powSolution, testProbe.ref)
-    testProbe.fishForMessage(blockValidationDelay) {
-      case StatusReply.Success(()) => true
-      case FullBlockApplied(header) if header.id != initBlock.header.parentId => true
-      case _ => false
-    }
-
-    // Get first candidate after chain is established
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate1 = testProbe.expectMsgPF(candidateGenDelay) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // Request with forced = false should return cached candidate immediately
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = false), testProbe.ref)
-    val candidate2 = testProbe.expectMsgPF(100.millis) {
-      case StatusReply.Success(c: Candidate) => c
-    }
-    // Should be the exact same cached candidate
-    candidate2.candidateBlock.timestamp shouldBe candidate1.candidateBlock.timestamp
-
-    // Request with forced = true should bypass cache and regenerate
-    candidateGenerator.tell(GenerateCandidate(Seq.empty, reply = true, forced = true), testProbe.ref)
-    val candidate3 = testProbe.fishForMessage(candidateGenDelay) {
-      case StatusReply.Success(_: Candidate) => true
-      case _: FullBlockApplied => false
-    } match {
-      case StatusReply.Success(c: Candidate) => c
-    }
-
-    // candidate3 should have timestamp >= candidate1 (regenerated, possibly same or newer)
-    candidate3.candidateBlock.timestamp should be >= candidate1.candidateBlock.timestamp
-
-    system.terminate()
   }
 
   it should "preserve previous candidate when forced regeneration occurs" in new TestKit(ActorSystem()) {

--- a/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/modifiers/mempool/ErgoNodeTransactionSpec.scala
@@ -16,8 +16,6 @@ import org.ergoplatform.wallet.boxes.{ErgoBoxAssetExtractor, ErgoBoxSerializer}
 import org.ergoplatform.wallet.interpreter.TransactionHintsBag
 import org.ergoplatform.wallet.protocol.context.InputContext
 import org.scalacheck.Gen
-import sigma.util.BenchmarkUtil
-import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base16
 import sigma.{Colls, VersionContext}
 import sigma.ast.ErgoTree.DefaultHeader
@@ -326,34 +324,29 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
 
   property("transaction with too many inputs should be rejected") {
 
-    //we assume that verifier must finish verification of any script in less time than 250K hash calculations
-    // (for the Blake2b256 hash function over a single block input)
-    val Timeout: Long = {
-      val hf = Blake2b256
-
-      //just in case to heat up JVM
-      (1 to 5000000).foreach(i => hf(s"$i-$i"))
-
-      val t0 = System.currentTimeMillis()
-      (1 to 250000).foreach(i => hf(s"$i"))
-      val t = System.currentTimeMillis()
-      t - t0
-    }
+    // This test used to calibrate a wall-clock budget by timing 250K Blake2b256 hashes and then
+    // assert that validation fits in it. On a loaded CI machine the calibration window and the
+    // measurement window get different shares of the CPU, so the assertions flipped at random
+    // (see issue #2095). What the node is actually protected by is the block cost limit, not the
+    // clock, so the assertions below are on cost, which is deterministic.
 
     val gen = validErgoTransactionGenTemplate(0, 0, 2000, trueLeafGen)
     val (from, tx) = gen.sample.get
     tx.statelessValidity().isSuccess shouldBe true
 
-    //check that spam transaction is being rejected quickly
     implicit val verifier: ErgoInterpreter = ErgoInterpreter(parameters)
-    val (validity, time0) = BenchmarkUtil.measureTime(tx.statefulValidity(from, IndexedSeq(), emptyStateContext))
+
+    // with the block cost limit in force, the spam transaction is rejected, and validation is
+    // aborted as soon as the accumulated cost passes the limit
+    val validity = tx.statefulValidity(from, IndexedSeq(), emptyStateContext)
     validity.isSuccess shouldBe false
-    assert(time0 <= Timeout)
 
     val cause = validity.failed.get.getMessage
     cause should startWith(ValidationRules.errorMessage(bsBlockTransactionsCost, "", emptyModifierId, ErgoTransaction.modifierTypeId).take(30))
 
-    //check that spam transaction validation with no cost limit is indeed taking too much time
+    // with a cost limit high enough to let it through, the same transaction validates, and the cost
+    // it accumulates is far above the block limit - that gap is what makes it spam, and it does not
+    // depend on how fast the machine running the test is
     import Parameters._
     val maxCost = (Int.MaxValue - 10) / 10 // cannot use Int.MaxValue directly due to overflow when it is converted to block cost
     val ps = Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, maxCost), emptyVSUpdate)
@@ -365,11 +358,15 @@ class ErgoNodeTransactionSpec extends ErgoCorePropertyTest with ErgoCompilerHelp
         Array.fill(3)(0.toByte),
         ErgoValidationSettingsUpdate.empty,
         0.toByte)
-    val (_, time) = BenchmarkUtil.measureTime(
-      tx.statefulValidity(from, IndexedSeq(), sc)(verifier)
-    )
 
-    assert(time > Timeout)
+    val blockCostLimit = emptyStateContext.currentParameters.maxBlockCost
+    val fullCost = tx.statefulValidity(from, IndexedSeq(), sc)(verifier).get
+    // the generator produces exactly `maxInputs` inputs, so this ratio is stable (~4.4x as of today)
+    fullCost.toLong should be > (blockCostLimit.toLong * 2)
+
+    // and it is rejected by any limit below its cost, one unit below included
+    val justBelow = stateContextWith(Parameters(0, DefaultParameters.updated(MaxBlockCostIncrease, fullCost - 1), emptyVSUpdate))
+    tx.statefulValidity(from, IndexedSeq(), justBelow)(ErgoInterpreter(justBelow.currentParameters)) shouldBe 'failure
   }
 
   property("transaction cost") {

--- a/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolSpec.scala
@@ -64,8 +64,13 @@ class ErgoMemPoolSpec extends AnyFlatSpec
     val (us, bh) = createUtxoState(settings)
     val genesis = validFullBlock(None, us, bh)
     val wus = WrappedUtxoState(us, bh, settings).applyModifier(genesis)(_ => ()).get
-    val inputBox = wus.takeBoxes(1).head
-    val feeOut = new ErgoBoxCandidate(inputBox.value, feeProp, creationHeight = 0)
+    val inputBox = wus.takeBoxes(100).find(_.ergoTree == TrueTree).get
+    val feeOut = new ErgoBoxCandidate(
+      inputBox.value,
+      feeProp,
+      creationHeight = 0,
+      additionalTokens = inputBox.additionalTokens
+    )
     val tx = ErgoTransaction(
       IndexedSeq(new Input(inputBox.id, ProverResult.empty)),
       IndexedSeq(feeOut)
@@ -79,8 +84,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerByte,
       ))
 
-    var poolSize = ErgoMemPool.empty(sortBySizeSettings)
-    poolSize = poolSize.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolSize, sizeOutcome) =
+      ErgoMemPool.empty(sortBySizeSettings).process(UnconfirmedTransaction(tx, None), wus)
+    sizeOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val size = tx.size
     poolSize.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, size).weight
 
@@ -89,8 +95,9 @@ class ErgoMemPoolSpec extends AnyFlatSpec
         mempoolSorting = SortingOption.FeePerCycle,
       ))
 
-    var poolCost = ErgoMemPool.empty(sortByCostSettings)
-    poolCost = poolCost.process(UnconfirmedTransaction(tx, None), wus)._1
+    val (poolCost, costOutcome) =
+      ErgoMemPool.empty(sortByCostSettings).process(UnconfirmedTransaction(tx, None), wus)
+    costOutcome.isInstanceOf[ProcessingOutcome.Accepted] shouldBe true
     val validationContext = wus.stateContext.simplifiedUpcoming()
     val cost = wus.validateWithCost(tx, validationContext, Int.MaxValue, None).get
     poolCost.pool.orderedTransactions.firstKey.weight shouldBe OrderedTxPool.weighted(tx, cost).weight

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/ErgoNodeViewHolderSpec.scala
@@ -593,7 +593,9 @@ class ErgoNodeViewHolderSpec extends ErgoCorePropertyTest with NodeViewTestOps w
     val wusAfterGenesis = wus.applyModifier(genesis)(_ => ()).get
 
     // Create a valid tx that pays to a FalseTree output.
-    val box = wusAfterGenesis.takeBoxes(1).head
+    val box = wusAfterGenesis.takeBoxes(wusAfterGenesis.size)
+      .find(_.ergoTree == TrueTree)
+      .getOrElse(fail("Expected an unspent TrueTree box after genesis"))
     val validTx = validTransactionFromBoxes(IndexedSeq(box), outputsProposition = FalseTree)
 
     val validBlock = validFullBlock(Some(genesis), wusAfterGenesis, Seq(validTx))

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.nodeView.wallet
 
+import java.io.File
+
 import org.ergoplatform.ErgoBox.{NonMandatoryRegisterId, R1}
 import org.ergoplatform._
 import org.ergoplatform.db.DBSpec
@@ -20,7 +22,6 @@ import org.ergoplatform.wallet.Constants.{PaymentsScanId, ScanId}
 import org.ergoplatform.wallet.boxes.BoxSelector.BoxSelectionResult
 import org.ergoplatform.wallet.boxes.{ErgoBoxSerializer, ReplaceCompactCollectBoxSelector, TrackedBox}
 import org.ergoplatform.wallet.crypto.ErgoSignature
-import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
 import org.ergoplatform.wallet.mnemonic.Mnemonic
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterAll
@@ -72,6 +73,35 @@ class ErgoWalletServiceSpec
       maxInputsToUse = 1000,
       rescanInProgress = false
     )
+  }
+
+  private final class InitializationFixture(val settings: ErgoSettings) {
+    val service = new ErgoWalletServiceImpl(settings)
+    private var current = ErgoWalletState.initial(settings, parameters).get
+
+    def state: ErgoWalletState = current
+
+    def retain(next: ErgoWalletState): ErgoWalletState = {
+      current = next
+      next
+    }
+
+    def close(): Unit = try current.secretStorageOpt.foreach(_.lock()) finally {
+      try current.storage.close() finally current.registry.close()
+    }
+  }
+
+  // Initialization owns configured paths as well as database handles, so each case gets both roots.
+  private def withInitializationFixture(test: InitializationFixture => Unit): Unit = {
+    val directory = createTempDir
+    val isolated = settings.copy(directory = new File(directory, "node").getPath,
+      nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1),
+      walletSettings = settings.walletSettings.copy(testMnemonic = None,
+        secretStorage = settings.walletSettings.secretStorage.copy(secretDir = new File(directory, "keystore").getPath)))
+    val fixture = new InitializationFixture(isolated)
+    try test(fixture) finally {
+      try fixture.close() finally deleteRecursive(directory)
+    }
   }
 
   property("restoring wallet should fail if pruning is enabled") {
@@ -395,137 +425,84 @@ class ErgoWalletServiceSpec
   }
 
   property("it should lock/unlock wallet") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
-        val walletState = initialState(store, versionedStore)
-        val walletService = new ErgoWalletServiceImpl(settings)
-        val pass = Random.nextString(10)
-        val initializedState = walletService.initWallet(walletState, settings, SecretString.create(pass), Option.empty).get._2
+    withInitializationFixture { fixture =>
+      val walletService = fixture.service
+      val pass = Random.nextString(10)
+      val initializedState = fixture.retain(walletService.initWallet(
+        fixture.state, fixture.settings, SecretString.create(pass), Option.empty).get._2)
 
-        // Wallet unlocked after init, so we're locking it
-        val initLockedWalletState = walletService.lockWallet(initializedState)
-        initLockedWalletState.secretStorageOpt.get.isLocked shouldBe true
-        initLockedWalletState.walletVars.proverOpt shouldBe empty
+      val initLockedWalletState = fixture.retain(walletService.lockWallet(initializedState))
+      initLockedWalletState.secretStorageOpt.get.isLocked shouldBe true
+      initLockedWalletState.walletVars.proverOpt shouldBe empty
 
-        val unlockedWalletState = walletService.unlockWallet(initLockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get
-        unlockedWalletState.secretStorageOpt.get.isLocked shouldBe false
-        unlockedWalletState.storage.readAllKeys().size shouldBe 1
-        unlockedWalletState.walletVars.proverOpt shouldNot be(empty)
+      val unlockedWalletState = fixture.retain(walletService.unlockWallet(
+        initLockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get)
+      unlockedWalletState.secretStorageOpt.get.isLocked shouldBe false
+      unlockedWalletState.storage.readAllKeys().size shouldBe 1
+      unlockedWalletState.walletVars.proverOpt shouldNot be(empty)
 
-        val lockedWalletState = walletService.lockWallet(unlockedWalletState)
-        lockedWalletState.secretStorageOpt.get.isLocked shouldBe true
-        lockedWalletState.walletVars.proverOpt shouldBe empty
+      val lockedWalletState = fixture.retain(walletService.lockWallet(unlockedWalletState))
+      lockedWalletState.secretStorageOpt.get.isLocked shouldBe true
+      lockedWalletState.walletVars.proverOpt shouldBe empty
 
-        val finalUnlockedState = walletService.unlockWallet(lockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get
-        finalUnlockedState.secretStorageOpt.get.isLocked shouldBe false
-        finalUnlockedState.storage.readAllKeys().size shouldBe 1
-        finalUnlockedState.walletVars.proverOpt shouldNot be(empty)
-      }
+      val finalUnlockedState = fixture.retain(walletService.unlockWallet(
+        lockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get)
+      finalUnlockedState.secretStorageOpt.get.isLocked shouldBe false
+      finalUnlockedState.storage.readAllKeys().size shouldBe 1
+      finalUnlockedState.walletVars.proverOpt shouldNot be(empty)
     }
   }
 
   property("it should derive private key correctly") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
+    withInitializationFixture { fixture =>
+      val pass = SecretString.create(Random.nextString(10))
+      val mnemonic = "edge talent poet tortoise trumpet dose"
+      val walletService = fixture.service
+      val ws2 = fixture.retain(walletService.initWallet(
+        fixture.state, fixture.settings, pass, Some(SecretString.create(mnemonic))).get._2)
+      ws2.secretStorageOpt.get.unlock(pass).get
 
-        val pass = SecretString.create(Random.nextString(10))
-        val mnemonic = "edge talent poet tortoise trumpet dose"
+      val path = DerivationPath.fromEncoded("m/44/1/1/0/0").get
+      val sk = ws2.secretStorageOpt.get.secret.get
+      val pk = sk.derive(path).publicKey
 
-        val walletService = new ErgoWalletServiceImpl(settings)
-        val ws1 = initialState(store, versionedStore)
-        val ws2 = walletService.initWallet(ws1, settings, pass, Some(SecretString.create(mnemonic))).get._2
-        ws2.secretStorageOpt.get.unlock(pass)
-
-        val path = DerivationPath.fromEncoded("m/44/1/1/0/0").get
-        val sk = ws2.secretStorageOpt.get.secret.get
-        val pk = sk.derive(path).publicKey
-
-        walletService.getPrivateKeyFromPath(ws2, pk.path).get.w shouldBe sk.derive(path).privateInput.w
-      }
+      walletService.getPrivateKeyFromPath(ws2, pk.path).get.w shouldBe sk.derive(path).privateInput.w
     }
   }
 
   property("key derivation after init wallet") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
-        val wpass = SecretString.create("y")
-        val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
-        val walletState = ErgoWalletState(
-          new WalletStorage(store, settings),
-          secretStorageOpt = Option.empty,
-          new WalletRegistry(versionedStore)(settings.walletSettings),
-          OffChainRegistry.empty,
-          outputsFilter = Option.empty,
-          WalletVars(Some(prover), Seq.empty, None),
-          stateReaderOpt = Option.empty,
-          mempoolReaderOpt = None,
-          utxoStateReaderOpt = Option.empty,
-          parameters,
-          maxInputsToUse = 1000,
-          rescanInProgress = false
-        )
-        val s = settings.copy(nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1))
-        val walletService = new ErgoWalletServiceImpl(s)
-        val ws = walletService.initWallet(
-          walletState,
-          s,
-          walletPass = wpass,
-          None
-        ).get._2
+    withInitializationFixture { fixture =>
+      val wpass = SecretString.create("y")
+      val walletService = fixture.service
+      val ws = fixture.retain(walletService.initWallet(fixture.state, fixture.settings, walletPass = wpass, None).get._2)
 
-        ws.secretStorageOpt.get.unlock(wpass)
-        ws.walletVars.trackedPubKeys.size shouldBe 1
-        val uws = ws
+      val uws = fixture.retain(walletService.unlockWallet(ws, wpass, usePreEip3Derivation = true).get)
+      uws.walletVars.trackedPubKeys.size shouldBe 1
 
-        val uws2 = walletService.deriveNextKey(uws, usePreEip3Derivation = true).get._2
-        uws2.walletVars.trackedPubKeys.size shouldBe 2
+      val uws2 = fixture.retain(walletService.deriveNextKey(uws, usePreEip3Derivation = true).get._2)
+      uws2.walletVars.trackedPubKeys.size shouldBe 2
 
-        val uws3 = walletService.deriveNextKey(uws2, usePreEip3Derivation = false).get._2
-        uws3.walletVars.trackedPubKeys.size shouldBe 3
-      }
+      val uws3 = fixture.retain(walletService.deriveNextKey(uws2, usePreEip3Derivation = false).get._2)
+      uws3.walletVars.trackedPubKeys.size shouldBe 3
     }
   }
 
   property("key derivation after restoring wallet") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
-        val wpass = SecretString.create("y")
-        val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
-        val walletState = ErgoWalletState(
-          new WalletStorage(store, settings),
-          secretStorageOpt = Option.empty,
-          new WalletRegistry(versionedStore)(settings.walletSettings),
-          OffChainRegistry.empty,
-          outputsFilter = Option.empty,
-          WalletVars(Some(prover), Seq.empty, None),
-          stateReaderOpt = Option.empty,
-          mempoolReaderOpt = None,
-          utxoStateReaderOpt = Option.empty,
-          parameters,
-          maxInputsToUse = 1000,
-          rescanInProgress = false
-        )
-        val s = settings.copy(nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1))
-        val walletService = new ErgoWalletServiceImpl(s)
-        val ws = walletService.restoreWallet(
-          walletState,
-          s,
-          mnemonic = SecretString.create("x"),
-          mnemonicPassOpt = None,
-          walletPass = wpass,
-          usePre1627KeyDerivation = false
-        ).get
+    withInitializationFixture { fixture =>
+      val wpass = SecretString.create("y")
+      val walletService = fixture.service
+      val ws = fixture.retain(walletService.restoreWallet(fixture.state, fixture.settings,
+        mnemonic = SecretString.create("x"), mnemonicPassOpt = None, walletPass = wpass,
+        usePre1627KeyDerivation = false).get)
 
-        ws.secretStorageOpt.get.unlock(wpass)
-        ws.walletVars.trackedPubKeys.size shouldBe 1
-        val uws = ws
+      val uws = fixture.retain(walletService.unlockWallet(ws, wpass, usePreEip3Derivation = true).get)
+      uws.walletVars.trackedPubKeys.size shouldBe 1
 
-        val uws2 = walletService.deriveNextKey(uws, false).get._2
-        uws2.walletVars.trackedPubKeys.size shouldBe 2
+      val uws2 = fixture.retain(walletService.deriveNextKey(uws, false).get._2)
+      uws2.walletVars.trackedPubKeys.size shouldBe 2
 
-        val uws3 = walletService.deriveNextKey(uws2, false).get._2
-        uws3.walletVars.trackedPubKeys.size shouldBe 3
-      }
+      val uws3 = fixture.retain(walletService.deriveNextKey(uws2, false).get._2)
+      uws3.walletVars.trackedPubKeys.size shouldBe 3
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/ErgoWalletServiceSpec.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform.nodeView.wallet
 
+import java.io.File
+
 import org.ergoplatform.ErgoBox.{NonMandatoryRegisterId, R1}
 import org.ergoplatform._
 import org.ergoplatform.db.DBSpec
@@ -71,6 +73,35 @@ class ErgoWalletServiceSpec
       maxInputsToUse = 1000,
       rescanInProgress = false
     )
+  }
+
+  private final class InitializationFixture(val settings: ErgoSettings) {
+    val service = new ErgoWalletServiceImpl(settings)
+    private var current = ErgoWalletState.initial(settings, parameters).get
+
+    def state: ErgoWalletState = current
+
+    def retain(next: ErgoWalletState): ErgoWalletState = {
+      current = next
+      next
+    }
+
+    def close(): Unit = try current.secretStorageOpt.foreach(_.lock()) finally {
+      try current.storage.close() finally current.registry.close()
+    }
+  }
+
+  // Initialization owns configured paths as well as database handles, so each case gets both roots.
+  private def withInitializationFixture(test: InitializationFixture => Unit): Unit = {
+    val directory = createTempDir
+    val isolated = settings.copy(directory = new File(directory, "node").getPath,
+      nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1),
+      walletSettings = settings.walletSettings.copy(testMnemonic = None,
+        secretStorage = settings.walletSettings.secretStorage.copy(secretDir = new File(directory, "keystore").getPath)))
+    val fixture = new InitializationFixture(isolated)
+    try test(fixture) finally {
+      try fixture.close() finally deleteRecursive(directory)
+    }
   }
 
   property("restoring wallet should fail if pruning is enabled") {
@@ -299,137 +330,106 @@ class ErgoWalletServiceSpec
   }
 
   property("it should lock/unlock wallet") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
-        val walletState = initialState(store, versionedStore)
-        val walletService = new ErgoWalletServiceImpl(settings)
-        val pass = Random.nextString(10)
-        val initializedState = walletService.initWallet(walletState, settings, SecretString.create(pass), Option.empty).get._2
+    withInitializationFixture { fixture =>
+      val walletState = fixture.state.copy(
+        walletVars = WalletVars(Some(defaultProver), Seq.empty, None)(fixture.settings), maxInputsToUse = 1000)
+      val walletService = fixture.service
+      val pass = Random.nextString(10)
+      val initializedState = fixture.retain(walletService.initWallet(
+        walletState, fixture.settings, SecretString.create(pass), Option.empty).get._2)
 
-        // Wallet unlocked after init, so we're locking it
-        val initLockedWalletState = walletService.lockWallet(initializedState)
-        initLockedWalletState.secretStorageOpt.get.isLocked shouldBe true
-        initLockedWalletState.walletVars.proverOpt shouldBe empty
+      // Wallet unlocked after init, so we're locking it
+      val initLockedWalletState = fixture.retain(walletService.lockWallet(initializedState))
+      initLockedWalletState.secretStorageOpt.get.isLocked shouldBe true
+      initLockedWalletState.walletVars.proverOpt shouldBe empty
 
-        val unlockedWalletState = walletService.unlockWallet(initLockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get
-        unlockedWalletState.secretStorageOpt.get.isLocked shouldBe false
-        unlockedWalletState.storage.readAllKeys().size shouldBe 1
-        unlockedWalletState.walletVars.proverOpt shouldNot be(empty)
+      val unlockedWalletState = fixture.retain(walletService.unlockWallet(initLockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get)
+      unlockedWalletState.secretStorageOpt.get.isLocked shouldBe false
+      unlockedWalletState.storage.readAllKeys().size shouldBe 1
+      unlockedWalletState.walletVars.proverOpt shouldNot be(empty)
 
-        val lockedWalletState = walletService.lockWallet(unlockedWalletState)
-        lockedWalletState.secretStorageOpt.get.isLocked shouldBe true
-        lockedWalletState.walletVars.proverOpt shouldBe empty
+      val lockedWalletState = fixture.retain(walletService.lockWallet(unlockedWalletState))
+      lockedWalletState.secretStorageOpt.get.isLocked shouldBe true
+      lockedWalletState.walletVars.proverOpt shouldBe empty
 
-        val finalUnlockedState = walletService.unlockWallet(lockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get
-        finalUnlockedState.secretStorageOpt.get.isLocked shouldBe false
-        finalUnlockedState.storage.readAllKeys().size shouldBe 1
-        finalUnlockedState.walletVars.proverOpt shouldNot be(empty)
-      }
+      val finalUnlockedState = fixture.retain(walletService.unlockWallet(lockedWalletState, SecretString.create(pass), usePreEip3Derivation = true).get)
+      finalUnlockedState.secretStorageOpt.get.isLocked shouldBe false
+      finalUnlockedState.storage.readAllKeys().size shouldBe 1
+      finalUnlockedState.walletVars.proverOpt shouldNot be(empty)
     }
   }
 
   property("it should derive private key correctly") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
+    withInitializationFixture { fixture =>
+      val pass = SecretString.create(Random.nextString(10))
+      val mnemonic = "edge talent poet tortoise trumpet dose"
 
-        val pass = SecretString.create(Random.nextString(10))
-        val mnemonic = "edge talent poet tortoise trumpet dose"
+      val walletService = fixture.service
+      val ws1 = fixture.state.copy(
+        walletVars = WalletVars(Some(defaultProver), Seq.empty, None)(fixture.settings), maxInputsToUse = 1000)
+      val ws2 = fixture.retain(walletService.initWallet(
+        ws1, fixture.settings, pass, Some(SecretString.create(mnemonic))).get._2)
+      ws2.secretStorageOpt.get.unlock(pass)
 
-        val walletService = new ErgoWalletServiceImpl(settings)
-        val ws1 = initialState(store, versionedStore)
-        val ws2 = walletService.initWallet(ws1, settings, pass, Some(SecretString.create(mnemonic))).get._2
-        ws2.secretStorageOpt.get.unlock(pass)
+      val path = DerivationPath.fromEncoded("m/44/1/1/0/0").get
+      val sk = ws2.secretStorageOpt.get.secret.get
+      val pk = sk.derive(path).publicKey
 
-        val path = DerivationPath.fromEncoded("m/44/1/1/0/0").get
-        val sk = ws2.secretStorageOpt.get.secret.get
-        val pk = sk.derive(path).publicKey
-
-        walletService.getPrivateKeyFromPath(ws2, pk.path).get.w shouldBe sk.derive(path).privateInput.w
-      }
+      walletService.getPrivateKeyFromPath(ws2, pk.path).get.w shouldBe sk.derive(path).privateInput.w
     }
   }
 
   property("key derivation after init wallet") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
-        val wpass = SecretString.create("y")
-        val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
-        val walletState = ErgoWalletState(
-          new WalletStorage(store, settings),
-          secretStorageOpt = Option.empty,
-          new WalletRegistry(versionedStore)(settings.walletSettings),
-          OffChainRegistry.empty,
-          outputsFilter = Option.empty,
-          WalletVars(Some(prover), Seq.empty, None),
-          stateReaderOpt = Option.empty,
-          mempoolReaderOpt = None,
-          utxoStateReaderOpt = Option.empty,
-          parameters,
-          maxInputsToUse = 1000,
-          rescanInProgress = false
-        )
-        val s = settings.copy(nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1))
-        val walletService = new ErgoWalletServiceImpl(s)
-        val ws = walletService.initWallet(
-          walletState,
-          s,
-          walletPass = wpass,
-          None
-        ).get._2
+    withInitializationFixture { fixture =>
+      val wpass = SecretString.create("y")
+      val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
+      val walletState = fixture.state.copy(
+        walletVars = WalletVars(Some(prover), Seq.empty, None)(fixture.settings), maxInputsToUse = 1000)
+      val walletService = fixture.service
+      val ws = fixture.retain(walletService.initWallet(
+        walletState,
+        fixture.settings,
+        walletPass = wpass,
+        None
+      ).get._2)
 
-        ws.secretStorageOpt.get.unlock(wpass)
-        ws.walletVars.trackedPubKeys.size shouldBe 1
-        val uws = ws
+      ws.secretStorageOpt.get.unlock(wpass)
+      ws.walletVars.trackedPubKeys.size shouldBe 1
+      val uws = ws
 
-        val uws2 = walletService.deriveNextKey(uws, usePreEip3Derivation = true).get._2
-        uws2.walletVars.trackedPubKeys.size shouldBe 2
+      val uws2 = fixture.retain(walletService.deriveNextKey(uws, usePreEip3Derivation = true).get._2)
+      uws2.walletVars.trackedPubKeys.size shouldBe 2
 
-        val uws3 = walletService.deriveNextKey(uws2, usePreEip3Derivation = false).get._2
-        uws3.walletVars.trackedPubKeys.size shouldBe 3
-      }
+      val uws3 = fixture.retain(walletService.deriveNextKey(uws2, usePreEip3Derivation = false).get._2)
+      uws3.walletVars.trackedPubKeys.size shouldBe 3
     }
   }
 
   property("key derivation after restoring wallet") {
-    withVersionedStore(2) { versionedStore =>
-      withStore { store =>
-        val wpass = SecretString.create("y")
-        val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
-        val walletState = ErgoWalletState(
-          new WalletStorage(store, settings),
-          secretStorageOpt = Option.empty,
-          new WalletRegistry(versionedStore)(settings.walletSettings),
-          OffChainRegistry.empty,
-          outputsFilter = Option.empty,
-          WalletVars(Some(prover), Seq.empty, None),
-          stateReaderOpt = Option.empty,
-          mempoolReaderOpt = None,
-          utxoStateReaderOpt = Option.empty,
-          parameters,
-          maxInputsToUse = 1000,
-          rescanInProgress = false
-        )
-        val s = settings.copy(nodeSettings = settings.nodeSettings.copy(blocksToKeep = -1))
-        val walletService = new ErgoWalletServiceImpl(s)
-        val ws = walletService.restoreWallet(
-          walletState,
-          s,
-          mnemonic = SecretString.create("x"),
-          mnemonicPassOpt = None,
-          walletPass = wpass,
-          usePre1627KeyDerivation = false
-        ).get
+    withInitializationFixture { fixture =>
+      val wpass = SecretString.create("y")
+      val prover = ErgoProvingInterpreter(defaultRootSecret, parameters)
+      val walletState = fixture.state.copy(
+        walletVars = WalletVars(Some(prover), Seq.empty, None)(fixture.settings), maxInputsToUse = 1000)
+      val walletService = fixture.service
+      val ws = fixture.retain(walletService.restoreWallet(
+        walletState,
+        fixture.settings,
+        mnemonic = SecretString.create("x"),
+        mnemonicPassOpt = None,
+        walletPass = wpass,
+        usePre1627KeyDerivation = false
+      ).get)
 
-        ws.secretStorageOpt.get.unlock(wpass)
-        ws.walletVars.trackedPubKeys.size shouldBe 1
-        val uws = ws
+      ws.secretStorageOpt.get.unlock(wpass)
+      ws.walletVars.trackedPubKeys.size shouldBe 1
+      val uws = ws
 
-        val uws2 = walletService.deriveNextKey(uws, false).get._2
-        uws2.walletVars.trackedPubKeys.size shouldBe 2
+      val uws2 = fixture.retain(walletService.deriveNextKey(uws, false).get._2)
+      uws2.walletVars.trackedPubKeys.size shouldBe 2
 
-        val uws3 = walletService.deriveNextKey(uws2, false).get._2
-        uws3.walletVars.trackedPubKeys.size shouldBe 3
-      }
+      val uws3 = fixture.retain(walletService.deriveNextKey(uws2, false).get._2)
+      uws3.walletVars.trackedPubKeys.size shouldBe 3
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletInitializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletInitializationSpec.scala
@@ -1,0 +1,553 @@
+package org.ergoplatform.nodeView.wallet
+
+import java.io.{File, IOException}
+import java.nio.file.{Files, Path}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.{ActorSystem, Props}
+import akka.testkit.TestProbe
+
+import org.ergoplatform.{ErgoBox, P2PKAddress}
+import org.ergoplatform.nodeView.state.ErgoStateContext
+import org.ergoplatform.nodeView.wallet.persistence.{Balance, OffChainRegistry, WalletRegistry, WalletStorage}
+import org.ergoplatform.nodeView.wallet.scanning.{EqualsScanningPredicate, ScanRequest, ScanWalletInteraction}
+import org.ergoplatform.sdk.SecretString
+import org.ergoplatform.sdk.wallet.secrets.ExtendedPublicKeySerializer
+import org.ergoplatform.settings.{ErgoSettings, Parameters}
+import org.ergoplatform.utils.ErgoCoreTestConstants.{defaultRootSecret, parameters}
+import org.ergoplatform.utils.ErgoNodeTestConstants
+import org.ergoplatform.wallet.secrets.JsonSecretStorage
+import org.ergoplatform.wallet.mnemonic.Mnemonic
+import org.ergoplatform.wallet.settings.SecretStorageSettings
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.ergoplatform.wallet.Constants.PaymentsScanId
+import sigma.ast.LongConstant
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+class WalletInitializationSpec extends AnyPropSpec with Matchers {
+  private def password: SecretString = SecretString.create("wallet-generation-test-password")
+
+  private def withSettings(test: ErgoSettings => Unit): Unit = {
+    val root = Files.createTempDirectory("wallet-initialization").toFile
+    val original = ErgoNodeTestConstants.settings
+    val settings = original.copy(directory = new File(root, "node").getPath,
+      walletSettings = original.walletSettings.copy(testMnemonic = None,
+        secretStorage = original.walletSettings.secretStorage.copy(secretDir = new File(root, "keystore").getPath)))
+    try test(settings) finally {
+      def remove(file: File): Unit = {
+        Option(file.listFiles()).foreach(_.foreach(remove))
+        if (!file.delete()) file.deleteOnExit()
+      }
+      remove(root)
+    }
+  }
+
+  private def close(state: ErgoWalletState): Unit = {
+    state.registry.close()
+    state.storage.close()
+  }
+
+  private def createSecret(settings: SecretStorageSettings): JsonSecretStorage =
+    JsonSecretStorage.init(Array.fill[Byte](32)(1), password, usePre1627KeyDerivation = false)(settings)
+
+  private def populated(settings: ErgoSettings): ErgoWalletState = {
+    val state = ErgoWalletState.initial(settings, parameters).get
+    try {
+      val publicKey = defaultRootSecret.publicKey
+      state.storage.addPublicKey(publicKey).get
+      state.storage.updateChangeAddress(P2PKAddress(publicKey.key)(settings.addressEncoder)).get
+      val box = ErgoNodeTestConstants.genesisBoxes.head
+      val scan = state.storage.addScan(ScanRequest("retained initialization fixture",
+        EqualsScanningPredicate(ErgoBox.R0, LongConstant(box.value)), Some(ScanWalletInteraction.Shared), Some(true))).get
+      state.registry.updateScans(Set(PaymentsScanId, scan.scanId), box).get
+      val tracked = state.registry.getBox(box.id).get
+      val context = ErgoStateContext.empty(settings.chainSettings,
+        new Parameters(7, parameters.parametersTable, parameters.proposedUpdate))
+      state.storage.updateStateContext(context).get
+      val outputs = WalletCache.emptyFilter(settings.walletSettings.walletProfile.outputsFilterSize)
+      outputs.put(box.id)
+      state.copy(walletVars = WalletVars(state.storage, settings),
+        offChainRegistry = OffChainRegistry(5, Seq(tracked.copy(inclusionHeightOpt = None)), Seq(Balance(tracked))),
+        outputsFilter = Some(outputs), error = Some("previous initialization fixture status"), rescanInProgress = true)
+    } catch {
+      case error: Throwable =>
+        close(state)
+        throw error
+    }
+  }
+
+  private def assertPopulated(state: ErgoWalletState): Unit = {
+    val box = ErgoNodeTestConstants.genesisBoxes.head
+    state.storage.readAllKeys().map(_.path) shouldBe Seq(defaultRootSecret.publicKey.path)
+    state.storage.readAllKeys().map(key => ExtendedPublicKeySerializer.toBytes(key).toSeq) shouldBe
+      Seq(ExtendedPublicKeySerializer.toBytes(defaultRootSecret.publicKey).toSeq)
+    state.storage.readChangeAddress.isDefined shouldBe true
+    state.storage.allScans.map(_.scanName) shouldBe Seq("retained initialization fixture")
+    state.storage.allScans.map(_.trackingRule) shouldBe Seq(EqualsScanningPredicate(ErgoBox.R0, LongConstant(box.value)))
+    state.storage.allScans.forall(scan => scan.removeOffchain && scan.walletInteraction == ScanWalletInteraction.Shared) shouldBe true
+    state.registry.getBox(box.id).get.box.id.toSeq shouldBe box.id.toSeq
+    state.registry.getBox(box.id).get.scans shouldBe Set(PaymentsScanId, state.storage.allScans.head.scanId)
+    state.registry.walletUnspentBoxes().map(_.box.id.toSeq) shouldBe Seq(box.id.toSeq)
+    state.registry.fetchDigest().walletBalance shouldBe box.value
+    state.walletVars.trackedPubKeys.map(_.path) shouldBe Seq(defaultRootSecret.publicKey.path)
+    state.walletVars.externalScans.map(_.scanName) shouldBe Seq("retained initialization fixture")
+    state.walletVars.externalScans shouldBe state.storage.allScans
+    state.walletVars.scriptsFilter.mightContain(state.walletVars.trackedBytes.head) shouldBe true
+    state.offChainRegistry.height shouldBe 5
+    state.offChainRegistry.offChainBoxes.map(_.box.id.toSeq) shouldBe Seq(box.id.toSeq)
+    state.offChainRegistry.onChainBalances.map(_.value) shouldBe Seq(box.value)
+    state.outputsFilter.get.mightContain(box.id) shouldBe true
+    state.stateContext.currentParameters.height shouldBe 7
+    state.error shouldBe Some("previous initialization fixture status")
+    state.rescanInProgress shouldBe true
+  }
+
+  private class Calls(failureAt: Option[String] = None, activation: String = "success") extends WalletInitialization {
+    val error = new IOException("initialization fixture operation failed")
+    val closeError = new IOException("initialization fixture cleanup failed")
+    var registriesClosed = Vector.empty[WalletRegistry]
+    var storagesClosed = Vector.empty[WalletStorage]
+    var failOldCleanup = false
+    var failPreparedCleanup = false
+    var old: Option[ErgoWalletState] = None
+    var moveAttempts = 0
+
+    override protected def openRegistry(settings: ErgoSettings, folder: File): WalletRegistry = {
+      if (failureAt.contains("registry")) throw error
+      super.openRegistry(settings, folder)
+    }
+    override protected def openStorage(settings: ErgoSettings, folder: File): WalletStorage = {
+      if (failureAt.contains("storage")) throw error
+      super.openStorage(settings, folder)
+    }
+    override protected def buildState(state: ErgoWalletState, settings: ErgoSettings,
+                                      generation: WalletGeneration, registry: WalletRegistry,
+                                      storage: WalletStorage, secret: JsonSecretStorage): ErgoWalletState = {
+      if (failureAt.contains("state")) throw error
+      super.buildState(state, settings, generation, registry, storage, secret)
+    }
+    override protected def closeRegistry(registry: WalletRegistry): Unit = {
+      registriesClosed :+= registry
+      super.closeRegistry(registry)
+      if ((failOldCleanup && old.exists(_.registry eq registry)) ||
+        (failPreparedCleanup && !old.exists(_.registry eq registry))) throw closeError
+    }
+    override protected def closeStorage(storage: WalletStorage): Unit = {
+      storagesClosed :+= storage
+      super.closeStorage(storage)
+      if ((failOldCleanup && old.exists(_.storage eq storage)) ||
+        (failPreparedCleanup && !old.exists(_.storage eq storage))) throw closeError
+    }
+    override protected def moveDescriptor(staging: Path, target: Path): Unit = {
+      moveAttempts += 1
+      activation match {
+        case "before" | "unknown" => throw error
+        case "after" =>
+          super.moveDescriptor(staging, target)
+          throw error
+        case "unknown-after" =>
+          super.moveDescriptor(staging, target)
+          throw error
+        case "conflict" =>
+          val fields = new String(Files.readAllBytes(staging), UTF_8).split("\n", -1)
+          fields(1) = java.util.UUID.randomUUID().toString
+          Files.write(target, fields.mkString("\n").getBytes(UTF_8))
+          throw error
+        case _ => super.moveDescriptor(staging, target)
+      }
+    }
+    override protected def readDescriptor(path: Path): Array[Byte] = {
+      if (activation == "read-before") throw error
+      if (moveAttempts > 0 && activation.startsWith("unknown")) throw new IOException("descriptor read unavailable")
+      super.readDescriptor(path)
+    }
+  }
+
+  property("initialization selects a complete generation under the configured roots and survives reopening") {
+    withSettings { settings =>
+      val old = populated(settings)
+      assertPopulated(old)
+      val oldContext = old.stateContext.bytes.toSeq
+      val calls = new Calls
+      val current = calls.initialize(old, settings, createSecret).get
+      try {
+        current.generation.isDefined shouldBe true
+        current.secretStorageOpt.get.secretFile.toPath.startsWith(new File(settings.walletSettings.secretStorage.secretDir).toPath) shouldBe true
+        calls.registriesClosed should contain(old.registry)
+        calls.storagesClosed should contain(old.storage)
+        WalletRegistry.registryFolder(settings).isDirectory shouldBe true
+        WalletStorage.storageFolder(settings).isDirectory shouldBe true
+        current.walletVars.trackedPubKeys shouldBe empty
+        current.walletVars.externalScans shouldBe empty
+        current.walletVars.stateCacheOpt shouldBe None
+        current.walletVars.scriptsFilter.mightContain(old.walletVars.trackedBytes.head) shouldBe false
+        current.storage.readAllKeys() shouldBe empty
+        current.storage.allScans shouldBe empty
+        current.storage.readChangeAddress shouldBe None
+        current.registry.walletUnspentBoxes() shouldBe empty
+        current.registry.fetchDigest().walletBalance shouldBe 0L
+        current.offChainRegistry.offChainBoxes shouldBe empty
+        current.offChainRegistry.onChainBalances shouldBe empty
+        current.outputsFilter shouldBe None
+        current.error shouldBe None
+        current.rescanInProgress shouldBe false
+        current.stateContext.bytes.toSeq shouldBe oldContext
+        val retainedRegistry = WalletRegistry(settings).get
+        val retainedStorage = WalletStorage.readOrCreate(settings)
+        try assertPopulated(old.copy(registry = retainedRegistry, storage = retainedStorage))
+        finally {
+          retainedRegistry.close()
+          retainedStorage.close()
+        }
+      } finally close(current)
+      val reopened = ErgoWalletState.initial(settings, parameters).get
+      try {
+        reopened.generation shouldBe current.generation
+        reopened.stateContext.bytes.toSeq shouldBe oldContext
+        val loaded = new ErgoWalletServiceImpl(settings).readWallet(reopened, None, None, settings.walletSettings.secretStorage)
+        loaded.secretStorageOpt.isDefined shouldBe true
+        loaded.secretStorageOpt.get.unlock(password).get
+        loaded.secretStorageOpt.get.lock()
+      } finally close(reopened)
+    }
+  }
+
+  for (phase <- Seq("registry", "storage", "secret", "state")) {
+    property(s"failure preparing $phase preserves the previous usable stores and keeps generation material inactive") {
+      withSettings { settings =>
+        val old = populated(settings)
+        assertPopulated(old)
+        val oldContext = old.stateContext.bytes.toSeq
+        val calls = new Calls(Some(phase))
+        try {
+          val result = calls.initialize(old, settings, s => if (phase == "secret") throw calls.error else createSecret(s))
+          result.failed.get shouldBe calls.error
+          WalletInitialization.selected(settings) shouldBe None
+          assertPopulated(old)
+          old.stateContext.bytes.toSeq shouldBe oldContext
+          calls.registriesClosed should not contain old.registry
+          calls.storagesClosed should not contain old.storage
+          JsonSecretStorage.readFile(settings.walletSettings.secretStorage).isFailure shouldBe true
+          if (phase == "state") {
+            val root = new File(settings.walletSettings.secretStorage.secretDir)
+            root.listFiles().exists(_.getName.startsWith(".ergo-secret-staging-wallet-")) shouldBe true
+          }
+        } finally close(old)
+      }
+    }
+  }
+
+  for (outcome <- Seq("before", "after", "unknown", "unknown-after", "conflict")) {
+    property(s"activation classifies its $outcome result without deleting recovery material") {
+    withSettings { settings =>
+      val old = ErgoWalletState.initial(settings, parameters).get
+      val calls = new Calls(activation = outcome)
+      val result = calls.initialize(old, settings, createSecret)
+      outcome match {
+        case "after" =>
+          val current = result.get
+          try WalletInitialization.selected(settings) shouldBe current.generation finally close(current)
+        case "before" =>
+          try {
+            result.failed.get shouldBe calls.error
+            WalletInitialization.selected(settings) shouldBe None
+            old.registry.fetchDigest()
+          } finally close(old)
+        case _ =>
+          try {
+            result.failed.get shouldBe a[WalletInitialization.OutcomeUnknown]
+            result.failed.get.getCause shouldBe calls.error
+            old.registry.fetchDigest()
+          } finally close(old)
+      }
+      new File(settings.walletSettings.secretStorage.secretDir).listFiles().nonEmpty shouldBe true
+      if (outcome == "unknown-after") {
+        val reconciled = ErgoWalletState.initial(settings, parameters).get
+        try reconciled.generation.isDefined shouldBe true finally close(reconciled)
+      }
+    }
+    }
+  }
+
+  property("old-handle cleanup errors do not change a committed initialization result") {
+    withSettings { settings =>
+      val old = ErgoWalletState.initial(settings, parameters).get
+      val calls = new Calls
+      calls.old = Some(old)
+      calls.failOldCleanup = true
+      val current = calls.initialize(old, settings, createSecret).get
+      try {
+        calls.registriesClosed should contain(old.registry)
+        calls.storagesClosed should contain(old.storage)
+        WalletInitialization.selected(settings) shouldBe current.generation
+      } finally close(current)
+    }
+  }
+
+  property("preparation failure preserves its original error when closing a candidate handle also fails") {
+    withSettings { settings =>
+      val old = ErgoWalletState.initial(settings, parameters).get
+      val calls = new Calls(Some("storage"))
+      calls.old = Some(old)
+      calls.failPreparedCleanup = true
+      try {
+        calls.initialize(old, settings, createSecret).failed.get shouldBe calls.error
+        calls.error.getSuppressed.toSeq should contain(calls.closeError)
+        old.registry.fetchDigest()
+        WalletInitialization.selected(settings) shouldBe None
+      } finally close(old)
+    }
+  }
+
+  for (resource <- Seq("main", "undo", "storage", "secret")) {
+    property(s"startup refuses a missing selected $resource without creating replacement data") {
+      withSettings { settings =>
+        val old = ErgoWalletState.initial(settings, parameters).get
+        val current = new Calls().initialize(old, settings, createSecret).get
+        val generation = current.generation.get
+        close(current)
+        val required = resource match {
+          case "main" => new File(generation.registryFolder(settings), "ldb_main/CURRENT")
+          case "undo" => new File(generation.registryFolder(settings), "ldb_undo/CURRENT")
+          case "storage" => new File(generation.storageFolder(settings), "CURRENT")
+          case _ => generation.secret(settings.walletSettings.secretStorage)
+        }
+        val preserved = required.toPath.resolveSibling(required.getName + ".preserved")
+        Files.move(required.toPath, preserved)
+        val rejection = ErgoWalletState.initial(settings, parameters).failed.get
+        rejection shouldBe a[IllegalArgumentException]
+        rejection.getMessage shouldBe "requirement failed: Selected wallet generation is incomplete; " +
+          "retain its files and restore the complete generation before restarting"
+        required.exists() shouldBe false
+        Files.exists(preserved) shouldBe true
+      }
+    }
+  }
+
+  private val descriptorRejections = Seq(
+    "format" -> "Unsupported wallet generation descriptor",
+    "generation" -> "Invalid wallet generation id",
+    "secret traversal" -> "Invalid wallet generation secret filename",
+    "secret extension" -> "Invalid wallet generation secret filename",
+    "empty secret" -> "Invalid wallet generation secret filename",
+    "extra field" -> "Unsupported wallet generation descriptor",
+    "missing field" -> "Unsupported wallet generation descriptor",
+    "missing terminator" -> "Unsupported wallet generation descriptor"
+  )
+
+  for ((field, expected) <- descriptorRejections) property(s"startup rejects an invalid descriptor $field without legacy fallback") {
+    withSettings { settings =>
+      val old = ErgoWalletState.initial(settings, parameters).get
+      val current = new Calls().initialize(old, settings, createSecret).get
+      close(current)
+      val descriptor = WalletInitialization.descriptor(settings)
+      val fields = new String(Files.readAllBytes(descriptor), UTF_8).split("\n", -1)
+      val altered = field match {
+        case "format" => fields.updated(0, "ergo-wallet-generation-v2")
+        case "generation" => fields.updated(1, "../other-generation")
+        case "secret traversal" => fields.updated(2, "../secret.json")
+        case "secret extension" => fields.updated(2, fields(2).stripSuffix(".json") + ".txt")
+        case "empty secret" => fields.updated(2, "")
+        case "extra field" => fields :+ "extra"
+        case "missing field" => fields.patch(2, Nil, 1)
+        case _ => fields.dropRight(1)
+      }
+      Files.write(descriptor, altered.mkString("\n").getBytes(UTF_8))
+      val rejection = ErgoWalletState.initial(settings, parameters).failed.get
+      rejection shouldBe a[IllegalArgumentException]
+      rejection.getMessage shouldBe s"requirement failed: $expected"
+    }
+  }
+
+  property("a nonabsence descriptor read error prevents publication and preserves populated prior state") {
+    withSettings { settings =>
+      val old = populated(settings)
+      val calls = new Calls(activation = "read-before")
+      try {
+        calls.initialize(old, settings, createSecret).failed.get shouldBe calls.error
+        calls.moveAttempts shouldBe 0
+        WalletInitialization.selected(settings) shouldBe None
+        assertPopulated(old)
+        calls.registriesClosed should not contain old.registry
+        calls.storagesClosed should not contain old.storage
+        JsonSecretStorage.readFile(settings.walletSettings.secretStorage).isFailure shouldBe true
+      } finally close(old)
+    }
+  }
+
+  property("legacy startup continues using the configured secret root when no descriptor exists") {
+    withSettings { settings =>
+      val secret = createSecret(settings.walletSettings.secretStorage)
+      val state = ErgoWalletState.initial(settings, parameters).get
+      try {
+        state.generation shouldBe None
+        val loaded = new ErgoWalletServiceImpl(settings).readWallet(state, None, None, settings.walletSettings.secretStorage)
+        loaded.secretStorageOpt.get.secretFile shouldBe secret.secretFile
+      } finally close(state)
+    }
+  }
+
+  property("service initialization returns its generated mnemonic with the committed state") {
+    withSettings { settings =>
+      val old = ErgoWalletState.initial(settings, parameters).get
+      val service = new ErgoWalletServiceImpl(settings)
+      val (mnemonic, current) = service.initWallet(old, settings, password, None).get
+      try {
+        mnemonic.getData().nonEmpty shouldBe true
+        current.generation shouldBe WalletInitialization.selected(settings)
+        current.secretStorageOpt.isDefined shouldBe true
+      } finally {
+        mnemonic.erase()
+        close(current)
+      }
+    }
+  }
+
+  property("service restoration and later recreation remain bound to their selected generation") {
+    withSettings { configured =>
+      val settings = configured.copy(nodeSettings = configured.nodeSettings.copy(blocksToKeep = -1))
+      val old = ErgoWalletState.initial(settings, parameters).get
+      val service = new ErgoWalletServiceImpl(settings)
+      val entropy = Array.fill[Byte](settings.walletSettings.seedStrengthBits / 8)(2)
+      val mnemonic = new Mnemonic(settings.walletSettings.mnemonicPhraseLanguage, settings.walletSettings.seedStrengthBits)
+        .toMnemonic(entropy).get
+      var current = old
+      try {
+        current = service.restoreWallet(old, settings, mnemonic, None, password, usePre1627KeyDerivation = false).get
+        val selected = current.generation
+        current = service.recreateRegistry(current, settings).get
+        current = service.recreateStorage(current, settings).get
+        current.generation shouldBe selected
+        WalletInitialization.selected(settings) shouldBe selected
+        WalletInitialization.validateReferences(selected.get, settings)
+      } finally {
+        mnemonic.erase()
+        java.util.Arrays.fill(entropy, 0.toByte)
+        close(current)
+      }
+      val reopened = ErgoWalletState.initial(settings, parameters).get
+      try reopened.generation shouldBe current.generation finally close(reopened)
+    }
+  }
+
+  property("successful actor initialization returns its backup, installs state, and supports later unlock and key reads") {
+    withSettings { settings =>
+      import ErgoWalletActorMessages._
+      val system = ActorSystem("wallet-initialization-success")
+      val probe = TestProbe()(system)
+      val service = new ErgoWalletServiceImpl(settings)
+      val actor = system.actorOf(Props(new ErgoWalletActor(settings, parameters, service, null, null)))
+      probe.watch(actor)
+      var backup: Option[SecretString] = None
+      try {
+        probe.send(actor, InitWallet(password, None))
+        val mnemonic = probe.expectMsgType[Success[SecretString]](10.seconds).value
+        backup = Some(mnemonic)
+        mnemonic.getData().nonEmpty shouldBe true
+        WalletInitialization.selected(settings).isDefined shouldBe true
+        probe.awaitAssert({
+          probe.send(actor, GetWalletStatus)
+          val status = probe.expectMsgType[WalletStatus](5.seconds)
+          status.initialized shouldBe true
+          status.unlocked shouldBe true
+          status.error shouldBe None
+        }, 5.seconds, 100.millis)
+        probe.send(actor, LockWallet)
+        probe.send(actor, GetWalletStatus)
+        probe.expectMsgType[WalletStatus](5.seconds).unlocked shouldBe false
+        probe.send(actor, UnlockWallet(password))
+        probe.expectMsgType[Success[Unit]](5.seconds).value shouldBe (())
+        probe.send(actor, CheckSeed(mnemonic, None))
+        probe.expectMsg(true)
+        probe.send(actor, ReadPublicKeys(0, 100))
+        probe.expectMsgType[Seq[P2PKAddress]](5.seconds).nonEmpty shouldBe true
+      } finally {
+        backup.foreach(_.erase())
+        probe.send(actor, CloseWallet)
+        probe.expectTerminated(actor, 5.seconds)
+        Await.result(system.terminate(), 10.seconds)
+      }
+    }
+  }
+
+  property("an initialized generation rejects replacement without recommending deletion of only its secret file") {
+    withSettings { settings =>
+      import ErgoWalletActorMessages._
+      val initial = ErgoWalletState.initial(settings, parameters).get
+      val current = new Calls().initialize(initial, settings, createSecret).get
+      close(current)
+      val system = ActorSystem("wallet-generation-replacement")
+      val probe = TestProbe()(system)
+      val service = new ErgoWalletServiceImpl(settings)
+      val actor = system.actorOf(Props(new ErgoWalletActor(settings, parameters, service, null, null)))
+      probe.watch(actor)
+      try {
+        probe.send(actor, InitWallet(password, None))
+        val error = probe.expectMsgType[Failure[_]](5.seconds).exception
+        error.getMessage shouldBe "Wallet is already initialized; use a separate wallet data directory to initialize another wallet."
+        WalletInitialization.selected(settings) shouldBe current.generation
+      } finally {
+        probe.send(actor, CloseWallet)
+        probe.expectTerminated(actor, 5.seconds)
+        Await.result(system.terminate(), 10.seconds)
+      }
+    }
+  }
+
+  property("an unknown activation result is exposed in status and blocks further initialization, unlock and rescan") {
+    withSettings { settings =>
+      import ErgoWalletActorMessages._
+      val system = ActorSystem("wallet-initialization-guard")
+      val probe = TestProbe()(system)
+      val error = new WalletInitialization.OutcomeUnknown(new IOException("activation result unavailable"))
+      val initCalls = new AtomicInteger()
+      val otherCalls = new AtomicInteger()
+      val service = new ErgoWalletServiceImpl(settings) {
+        override def initWallet(state: ErgoWalletState, settings: ErgoSettings, walletPass: SecretString,
+                                mnemonicPassOpt: Option[SecretString]): Try[(SecretString, ErgoWalletState)] = {
+          initCalls.incrementAndGet()
+          Failure(error)
+        }
+        override def restoreWallet(state: ErgoWalletState, settings: ErgoSettings, mnemonic: SecretString,
+                                   mnemonicPassOpt: Option[SecretString], walletPass: SecretString,
+                                   usePre1627KeyDerivation: Boolean): Try[ErgoWalletState] = {
+          otherCalls.incrementAndGet()
+          Failure(error)
+        }
+        override def unlockWallet(state: ErgoWalletState, walletPass: SecretString,
+                                  usePreEip3Derivation: Boolean): Try[ErgoWalletState] = {
+          otherCalls.incrementAndGet()
+          Failure(error)
+        }
+        override def recreateRegistry(state: ErgoWalletState, settings: ErgoSettings): Try[ErgoWalletState] = {
+          otherCalls.incrementAndGet()
+          Failure(error)
+        }
+      }
+      val actor = system.actorOf(Props(new ErgoWalletActor(settings, parameters, service, null, null)))
+      probe.watch(actor)
+      try {
+        probe.send(actor, InitWallet(password, None))
+        probe.expectMsgType[Failure[_]](5.seconds).exception shouldBe error
+        probe.send(actor, GetWalletStatus)
+        probe.expectMsgType[WalletStatus](5.seconds).error shouldBe Some(error.getMessage)
+        Seq(InitWallet(password, None), RestoreWallet(SecretString.create("unused"), None, password, false),
+          UnlockWallet(password), RescanWallet(0)).foreach { message =>
+          probe.send(actor, message)
+          probe.expectMsgType[Failure[_]](5.seconds).exception shouldBe error
+        }
+        initCalls.get() shouldBe 1
+        otherCalls.get() shouldBe 0
+      } finally {
+        probe.send(actor, CloseWallet)
+        probe.expectTerminated(actor, 5.seconds)
+        Await.result(system.terminate(), 10.seconds)
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletInitializationSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletInitializationSpec.scala
@@ -2,6 +2,7 @@ package org.ergoplatform.nodeView.wallet
 
 import java.io.{File, IOException}
 import java.nio.file.{Files, Path}
+import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -214,6 +215,85 @@ class WalletInitializationSpec extends AnyPropSpec with Matchers {
         loaded.secretStorageOpt.get.unlock(password).get
         loaded.secretStorageOpt.get.lock()
       } finally close(reopened)
+    }
+  }
+
+  for (inventory <- Seq("ambiguous", "mixed-legacy", "not-directory", "unrecognized")) {
+    property(s"initialization rejects $inventory secret inventory before preparing any generation") {
+      withSettings { settings =>
+        val old = populated(settings)
+        val root = new File(settings.walletSettings.secretStorage.secretDir).toPath
+        val bytes = "retained wallet material".getBytes(UTF_8)
+        val retained = if (inventory == "not-directory") {
+          Files.createDirectories(root.getParent)
+          Seq(Files.write(root, bytes))
+        } else {
+          Files.createDirectories(root)
+          val names = inventory match {
+            case "ambiguous" => Seq("first.json", "second.json")
+            case "mixed-legacy" => Seq("legacy-wallet", "current.json")
+            case _ => Seq("first", "second")
+          }
+          names.map(name => Files.write(root.resolve(name), bytes))
+        }
+        var openedRegistries = 0
+        var openedStores = 0
+        var createdSecrets = 0
+        val calls = new WalletInitialization {
+          override protected def openRegistry(s: ErgoSettings, folder: File): WalletRegistry = {
+            openedRegistries += 1
+            super.openRegistry(s, folder)
+          }
+          override protected def openStorage(s: ErgoSettings, folder: File): WalletStorage = {
+            openedStores += 1
+            super.openStorage(s, folder)
+          }
+        }
+        try {
+          val result = calls.initialize(old, settings, s => {
+            createdSecrets += 1
+            createSecret(s)
+          })
+          result shouldBe 'failure
+          result.failed.get shouldBe a[IOException]
+          openedRegistries shouldBe 0
+          openedStores shouldBe 0
+          createdSecrets shouldBe 0
+          WalletInitialization.selected(settings) shouldBe None
+          retained.foreach(path => Files.readAllBytes(path) shouldBe bytes)
+          assertPopulated(old)
+        } finally close(old)
+      }
+    }
+  }
+
+  property("initialization rejects a dangling secret directory link before preparing stores") {
+    withSettings { settings =>
+      val root = new File(settings.walletSettings.secretStorage.secretDir).toPath
+      if (Files.getFileAttributeView(root.getParent, classOf[PosixFileAttributeView]) != null) {
+        val old = populated(settings)
+        val missing = root.getParent.resolve("missing-secret-directory")
+        Files.createSymbolicLink(root, missing)
+        var opened = false
+        var created = false
+        val calls = new WalletInitialization {
+          override protected def openRegistry(s: ErgoSettings, folder: File): WalletRegistry = {
+            opened = true
+            super.openRegistry(s, folder)
+          }
+        }
+        try {
+          val result = calls.initialize(old, settings, s => { created = true; createSecret(s) })
+          result shouldBe 'failure
+          result.failed.get should not be a[JsonSecretStorage.SecretFileNotFoundException]
+          opened shouldBe false
+          created shouldBe false
+          Files.isSymbolicLink(root) shouldBe true
+          Files.exists(missing) shouldBe false
+          WalletInitialization.selected(settings) shouldBe None
+          assertPopulated(old)
+        } finally close(old)
+      }
     }
   }
 

--- a/src/test/scala/org/ergoplatform/nodeView/wallet/WalletKeyCacheSpec.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/wallet/WalletKeyCacheSpec.scala
@@ -1,0 +1,102 @@
+package org.ergoplatform.nodeView.wallet
+
+import java.io.ByteArrayOutputStream
+
+import org.ergoplatform.db.DBSpec
+import org.ergoplatform.nodeView.wallet.persistence.{OffChainRegistry, WalletRegistry, WalletStorage}
+import org.ergoplatform.sdk.wallet.secrets.{ExtendedPublicKey, ExtendedPublicKeySerializer, ExtendedSecretKey}
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.ergoplatform.wallet.interpreter.ErgoProvingInterpreter
+import org.iq80.leveldb.DB
+import scorex.db.LDBKVStore
+
+import scala.util.{Failure, Try}
+
+class WalletKeyCacheSpec extends ErgoCorePropertyTest with DBSpec {
+  private class KeySupport extends ErgoWalletSupport {
+    override val ergoSettings: ErgoSettings = settings
+    def add(state: ErgoWalletState, secret: ExtendedSecretKey): Try[ErgoWalletState] = addSecretToStorage(state, secret)
+  }
+
+  private class ControlledStore(db: DB) extends LDBKVStore(db) {
+    var failure: Option[Throwable] = None
+    override def insert(key: Array[Byte], value: Array[Byte]): Try[Unit] = failure match {
+      case Some(error) => Failure(error)
+      case None => super.insert(key, value)
+    }
+  }
+
+  private final class Fixture(val state: ErgoWalletState, val store: ControlledStore,
+                              val root: ExtendedSecretKey, val first: ExtendedSecretKey, val second: ExtendedSecretKey)
+
+  private def withWallet(providedCache: Boolean)(test: Fixture => Unit): Unit = {
+    withVersionedStore(2) { versioned =>
+      withDb { db =>
+        val store = new ControlledStore(db)
+        val storage = new WalletStorage(store, settings)
+        val root = ExtendedSecretKey.deriveMasterKey(Array.fill[Byte](32)(1), usePre1627KeyDerivation = false)
+        val first = root.child(1)
+        val second = root.child(2)
+        try {
+          storage.addPublicKey(root.publicKey).get
+          val provided = if (providedCache) Some(WalletCache(Seq(root.publicKey), settings)) else None
+          val vars = WalletVars(Some(ErgoProvingInterpreter(root, parameters)), Seq.empty, provided)(settings)
+          val state = ErgoWalletState(storage, None, new WalletRegistry(versioned)(settings.walletSettings),
+            OffChainRegistry.empty, None, vars, None, None, None, parameters, 1000, rescanInProgress = false)
+          test(new Fixture(state, store, root, first, second))
+        } finally {
+          first.zeroSecret()
+          second.zeroSecret()
+          root.zeroSecret()
+        }
+      }
+    }
+  }
+
+  private def identities(keys: Seq[ExtendedPublicKey]): Seq[Seq[Byte]] =
+    keys.map(key => ExtendedPublicKeySerializer.toBytes(key).toSeq)
+
+  private def assertKeys(state: ErgoWalletState, expected: Seq[ExtendedPublicKey]): Unit = {
+    val cached = identities(state.walletVars.trackedPubKeys)
+    cached shouldBe identities(expected)
+    cached.distinct.size shouldBe cached.size
+    identities(state.walletVars.proverOpt.get.hdPubKeys) shouldBe identities(expected)
+    val stored = identities(state.storage.readAllKeys())
+    stored.toSet shouldBe identities(expected).toSet
+    stored.size shouldBe expected.size
+  }
+
+  private def filterBytes(state: ErgoWalletState): Seq[Byte] = {
+    val bytes = new ByteArrayOutputStream()
+    state.walletVars.scriptsFilter.writeTo(bytes)
+    bytes.toByteArray.toSeq
+  }
+
+  for (provided <- Seq(false, true)) {
+    property(s"derived key identity appears once in prover, cache and storage with provided cache=$provided") {
+      withWallet(provided) { fixture =>
+        val support = new KeySupport
+        assertKeys(fixture.state, Seq(fixture.root.publicKey))
+        val first = support.add(fixture.state, fixture.first).get
+        assertKeys(first, Seq(fixture.root.publicKey, fixture.first.publicKey))
+        identities(fixture.state.walletVars.trackedPubKeys) shouldBe identities(Seq(fixture.root.publicKey))
+        val second = support.add(first, fixture.second).get
+        assertKeys(second, Seq(fixture.root.publicKey, fixture.first.publicKey, fixture.second.publicKey))
+      }
+    }
+
+    property(s"a public-key write failure does not publish the new cache with provided cache=$provided") {
+      withWallet(provided) { fixture =>
+        val error = new IllegalStateException("controlled public-key persistence failure")
+        val previousFilter = filterBytes(fixture.state)
+        fixture.store.failure = Some(error)
+        new KeySupport().add(fixture.state, fixture.first).failed.get should be theSameInstanceAs error
+        assertKeys(fixture.state, Seq(fixture.root.publicKey))
+        filterBytes(fixture.state) shouldBe previousFilter
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/ErgoNodeTransactionGenerators.scala
@@ -57,7 +57,13 @@ object ErgoNodeTransactionGenerators extends ScorexLogging {
 
   def ergoBoxGenForTokens(tokens: Seq[(TokenId, Long)],
                           propositionGen: Gen[ErgoTree]): Gen[ErgoBox] = {
-    ergoBoxGen(propGen = propositionGen, tokensGen = Gen.oneOf(tokens, tokens), heightGen = EmptyHistoryHeight)
+    val minValue = BoxUtils.sufficientAmount(extendedParameters)
+    ergoBoxGen(
+      propGen = propositionGen,
+      tokensGen = Gen.oneOf(tokens, tokens),
+      valueGenOpt = Some(validValueGen.map(value => Math.max(value, minValue))),
+      heightGen = EmptyHistoryHeight
+    )
   }
 
   def unspendableErgoBoxGen(minValue: Long = parameters.minValuePerByte * 200,

--- a/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
+++ b/src/test/scala/org/ergoplatform/utils/generators/FundedBoxHolderGeneratorsSpec.scala
@@ -1,0 +1,45 @@
+package org.ergoplatform.utils.generators
+
+import org.ergoplatform.utils.BoxUtils
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.trueLeafGen
+import org.ergoplatform.utils.ErgoNodeTestConstants.extendedParameters
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sigmastate.eval.Extensions._
+
+class FundedBoxHolderGeneratorsSpec extends AnyFlatSpec with Matchers {
+  "Generated box holders" should "fund small input groups and conserve their value" in {
+    val minimum = BoxUtils.sufficientAmount(extendedParameters)
+    // This seed includes a value below the transaction generator's conservative floor.
+    val holder = boxesHolderGenOfSize(5).pureApply(Gen.Parameters.default, Seed(803L))
+    holder.size shouldBe 5
+    val boxes = holder.boxes.values.toIndexedSeq
+    Seq(1, 2).foreach { inputCount =>
+      boxes.grouped(inputCount).foreach { inputs =>
+        val tx = validUnsignedTransactionFromBoxes(inputs, issueNew = false)
+        tx.inputs.map(_.boxId.toSeq) shouldBe inputs.map(_.id.toSeq)
+        tx.outputCandidates.map(_.value).sum shouldBe inputs.map(_.value).sum
+        tx.outputCandidates.foreach { output =>
+          output.value should be >= minimum
+          output.additionalTokens.length shouldBe 0
+        }
+      }
+    }
+    boxes.foreach(_.value should be >= minimum)
+  }
+
+  it should "preserve supplied tokens when the node generator funds a box" in {
+    val token = Array.fill[Byte](32)(1).toTokenId
+    val box = ergoBoxGenForTokens(Seq(token -> 7L), trueLeafGen)
+      .pureApply(Gen.Parameters.default, Seed(803L))
+    val tx = validUnsignedTransactionFromBoxes(IndexedSeq(box), issueNew = false)
+    val tokens = tx.outputCandidates.flatMap(_.additionalTokens.toArray)
+    box.value should be >= BoxUtils.sufficientAmount(extendedParameters)
+    tx.outputCandidates.map(_.value).sum shouldBe box.value
+    tokens.map(_._1.toArray.toSeq).distinct shouldBe Seq(token.toArray.toSeq)
+    tokens.map(_._2).sum shouldBe 7L
+  }
+}


### PR DESCRIPTION
Wallet initialization prepares inactive stores, state and encrypted secret before publishing one generation-selection descriptor. Preparation failure retains the prior stores and recovery material. Startup resolves the selected generation before opening stores; later recreation remains bound to it.

## Review and integration

[#2507](https://github.com/ergoplatform/ergo/pull/2507) owns encrypted-file publication and discovery. Its exact updated head `f17d145d62f4c0375401f7aea64915625d0fe1a8` is retained in [prerequisite merge `4f156f9e1`](https://github.com/a-shannon/ergo/commit/4f156f9e1f119a5345479b09f47017290c948723). Review the [two-file consumer follow-up](https://github.com/a-shannon/ergo/compare/4f156f9e1f119a5345479b09f47017290c948723...1cb6f90b17e8bb15470c8fcd28ecdf300a567e5a) separately. Integrate #2507 before this updated PR.

The preflight now accepts only an explicit absent-secret result. Ambiguous, unrecognized, unreadable or invalid inventory stops initialization before opening new stores, creating secrets or selecting a generation. This is necessary because treating every `readFile` failure as absence would otherwise turn #2507's ambiguity rejection into permission to initialize another wallet.

The [original initialization increment](https://github.com/a-shannon/ergo/compare/ec1929a87fa08aa2ab0e6d509af7d9ae69cd8ced...fe6f15e202c32c03874e62cb9ff9c19f334e85b7) and [earlier key-cache consumer correction](https://github.com/a-shannon/ergo/compare/d843d490f0845a915b5bd760800649fa23962cb8...ca61ce544e8d3309493c304bbd842d4ab39c1ef4) remain available. Shared fixtures remain owned by [#2535](https://github.com/ergoplatform/ergo/pull/2535). The upstream diff remains cumulative until prerequisites are integrated.

The [latest five-file integration-support increment](https://github.com/a-shannon/ergo/compare/1cb6f90b17e8bb15470c8fcd28ecdf300a567e5a...13cf1a252a02e19482e2ae609e264ce3318cd4aa) reuses exact shared commit [`5a360fa48`](https://github.com/a-shannon/ergo/commit/5a360fa48c7abd9b9d25a4d00728b10c782e4031). It retains the selected-header convergence observer, updates its shared contracts and adds bounded diagnostics after an already-decided UTXO timeout. The original 15-minute deadline and exception are preserved. All five integration blobs match the shared commit; this merge leaves production and all node-test files unchanged, including this PR's initialization and key-cache flows. Independent composition review passed and all five added diagnostic tests pass.

## API and recovery boundary

The existing API is preserved. Exact read-back after an atomic-move error distinguishes committed selection, definite nonpublication and an unknown outcome. Unknown outcomes use existing status/error responses and block initialization, restoration, unlock and rescan until restart. Restart may reconcile an unknown result to an initialized wallet. This is not a guarantee that the mnemonic or HTTP response was delivered; confirming the user's backup before activation remains a separate API decision.

Generation-aware backups must retain the descriptor, selected data directory and selected generation under the configured keystore root. Older binaries must not write this wallet after adoption; partial generation backups are unsupported.

## Validation

The composed current source passes 54/54 tests: 36 initialization properties, 14 service tests and four key-cache properties. Five new inventory cases cover two JSON files, mixed legacy/JSON files, unrecognized files, a file used as the directory, and a dangling directory link. They preserve prior populated state and verify no generation is opened or selected. The link case additionally runs on POSIX CI.

Restoring only the old `readFile(...).isFailure` predicate makes all four portable inventory regressions fail. Restoring the correction passes all 54 tests. The unchanged producer's 23 secret-storage tests also passed, with independent source and composition review completed.

Current head is `13cf1a252a02e19482e2ae609e264ce3318cd4aa`. Its [CI run](https://github.com/ergoplatform/ergo/actions/runs/34724204786) passed **all eight jobs**, including Linux node and full integration tests. The prior head's UTXO timeout remains historical evidence; this successful run does not establish its cause. Current priorities, dependencies and reviewed increments are maintained in [#2533](https://github.com/ergoplatform/ergo/issues/2533).
