### PR TITLE
Resume UTXO snapshot discovery after ordinary header synchronization

### DIFF
--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -112,6 +112,10 @@ trait ToDownloadProcessor
       // A regime that do not download and verify transaction
       Nil
     } else if (nodeSettings.utxoSettings.utxoBootstrap && !isUtxoSnapshotApplied) {
+      if (!isHeadersChainSynced && header.isNew(chainSettings.blockInterval * headerChainDiff)) {
+        // Enable snapshot discovery without advancing the full-block retention floor.
+        setHeadersChainSynced()
+      }
       // While bootstrapping from a UTXO set snapshot, do not download full block sections
       // until the snapshot has been applied. Block sections downloaded before the snapshot
       // would be stored as non-best and never applied to the freshly recreated state.

--- a/src/test/scala/org/ergoplatform/nodeView/history/UtxoBootstrapRestartSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/UtxoBootstrapRestartSpecification.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.history
 
+import org.ergoplatform.modifiers.SnapshotsInfoTypeId
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.SortingOption
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.settings._
@@ -11,34 +12,15 @@ import org.ergoplatform.wallet.utils.FileUtils
 import scala.concurrent.duration._
 
 /**
-  * Reproduction of a restart deadlock during UTXO set snapshot bootstrapping.
-  *
-  * Scenario: a node bootstrapping via NiPoPoW proofs + UTXO set snapshot (nipopowBootstrap +
-  * utxoBootstrap) is restarted after the NiPoPoW proof headers were persisted but before the
-  * UTXO set snapshot application completed (e.g. killed in the middle of snapshot chunk
-  * downloading). After the restart the node never resumes bootstrapping:
-  *
-  * - `isHeadersChainSynced` is kept in memory only (FullBlockPruningProcessor.isHeadersChainSyncedVar)
-  *   and is set solely from `updateBestFullBlock` or `setHeadersChainSynced` (the latter is called
-  *   only right after a NiPoPoW proof is applied), so it is false after every restart
-  * - on restart the headers are read from the database, so no new NiPoPoW proof is requested
-  *   (ErgoNodeViewSynchronizer.sendSync asks for proofs only when `bestHeaderOpt` is empty)
-  * - the synchronizer asks for the UTXO set snapshot / block sections only when
-  *   `isHeadersChainSynced` is true (ErgoNodeViewSynchronizer.requestMoreModifiers), and
-  *   ToDownloadProcessor filters block-section invs out while the snapshot is not applied
-  *
-  * Result: headers are at tip, the state is at genesis, and the node loops sending sync
-  * messages forever. Observed on mainnet with a node restarted mid snapshot download.
-  *
-  * The property below simulates the restart by reopening the history database and asserts that
-  * the headers chain is considered synced after the restart, so that snapshot bootstrapping
-  * can resume. It fails before the fix.
+  * Close and reopen actual history stores inside one JVM, then inspect download planning.
+  * Headers are appended normally; these fixtures do not apply a NiPoPoW proof, restart a process,
+  * or establish production-network recovery.
   */
 class UtxoBootstrapRestartSpecification extends ErgoCorePropertyTest with FileUtils {
 
   import org.ergoplatform.utils.ErgoNodeTestConstants._
 
-  private def utxoBootstrapSettings(dir: java.io.File): ErgoSettings = {
+  private def utxoBootstrapSettings(dir: java.io.File, nipopow: Boolean): ErgoSettings = {
     val txCostLimit = initSettings.nodeSettings.maxTransactionCost
     val txSizeLimit = initSettings.nodeSettings.maxTransactionSize
     val nodeSettings = NodeConfigurationSettings(
@@ -46,7 +28,7 @@ class UtxoBootstrapRestartSpecification extends ErgoCorePropertyTest with FileUt
       verifyTransactions = true,
       blocksToKeep = -1,
       UtxoSettings(utxoBootstrap = true, 0, 2),
-      NipopowSettings(nipopowBootstrap = true, 1),
+      NipopowSettings(nipopowBootstrap = nipopow, 1),
       mining = false,
       txCostLimit,
       txSizeLimit,
@@ -71,30 +53,56 @@ class UtxoBootstrapRestartSpecification extends ErgoCorePropertyTest with FileUt
       null, null, settings.cacheSettings)
   }
 
-  property("node restarted after nipopow headers persisted but before snapshot application resumes bootstrap") {
-    val dir = createTempDir
-    val historySettings = utxoBootstrapSettings(dir)
+  for (nipopow <- Seq(false, true)) {
+    property(s"reopened snapshot-bootstrap history resumes discovery with ordinary fresh-header reentry, nipopow=$nipopow") {
+      val dir = createTempDir
+      val historySettings = utxoBootstrapSettings(dir, nipopow)
+      var first: Option[ErgoHistory] = None
+      var reopened: Option[ErgoHistory] = None
+      try {
+        val history = ErgoHistory.readOrGenerate(historySettings)(null)
+        first = Some(history)
+        val stored = applyHeaderChain(history,
+          genHeaderChain(BlocksInChain, history, diffBitsOpt = None, useRealTs = false))
+        val expectedTip = stored.bestHeaderOpt.get.id
+        val expectedHeight = stored.headersHeight
+        val floor = stored.minFullBlockAvailable
+        stored.bestFullBlockOpt shouldBe None
+        stored.isUtxoSnapshotApplied shouldBe false
+        stored.isHeadersChainSynced shouldBe false
 
-    // headers-only chain, result of a NiPoPoW proof application (no full blocks downloaded yet)
-    val history = ErgoHistory.readOrGenerate(historySettings)(null)
-    val headers = genHeaderChain(BlocksInChain, history, diffBitsOpt = None, useRealTs = false)
-    val updHistory = applyHeaderChain(history, headers)
+        // Release the first native store before acquiring the second wrapper over the same files.
+        stored.closeStorage()
+        first = None
+        val restarted = ErgoHistory.readOrGenerate(historySettings)(null)
+        reopened = Some(restarted)
+        restarted.headersHeight shouldBe expectedHeight
+        restarted.bestHeaderOpt.get.id shouldBe expectedTip
+        restarted.bestFullBlockOpt shouldBe None
+        restarted.isUtxoSnapshotApplied shouldBe false
+        restarted.minFullBlockAvailable shouldBe floor
+        // The existing configured startup predicate is distinct from ordinary header synchronization.
+        restarted.isHeadersChainSynced shouldBe nipopow
+        restarted.nextModifiersToDownload(1, (_, _) => true) shouldBe
+          (if (nipopow) Map(SnapshotsInfoTypeId.value -> Seq.empty) else Map.empty)
 
-    updHistory.bestFullBlockOpt shouldBe None
-    updHistory.isUtxoSnapshotApplied shouldBe false
-    updHistory.isHeadersChainSynced shouldBe false // set only via updateBestFullBlock / setHeadersChainSynced
-
-    // simulate node restart: reopen the same database
-    val restarted = ErgoHistory.readOrGenerate(historySettings)(null)
-
-    restarted.headersHeight shouldBe updHistory.headersHeight
-    restarted.bestFullBlockOpt shouldBe None
-    restarted.isUtxoSnapshotApplied shouldBe false
-
-    // without this the synchronizer never asks for the snapshot manifest / blocks
-    // (ErgoNodeViewSynchronizer.requestMoreModifiers -> sendSync loop) and bootstrap
-    // can never resume
-    restarted.isHeadersChainSynced shouldBe true
+        val fresh = nextHeader(restarted.bestHeaderOpt, restarted.difficultyCalculator,
+          tsOpt = Some(System.currentTimeMillis()), useRealTs = true)
+        val (updated, progress) = restarted.append(fresh).get
+        progress.toDownload shouldBe Seq.empty
+        updated.isHeadersChainSynced shouldBe true
+        updated.isUtxoSnapshotApplied shouldBe false
+        updated.bestFullBlockOpt shouldBe None
+        updated.minFullBlockAvailable shouldBe floor
+        updated.nextModifiersToDownload(1, (_, id) => !updated.contains(id)) shouldBe
+          Map(SnapshotsInfoTypeId.value -> Seq.empty)
+      } finally {
+        try reopened.foreach(_.closeStorage())
+        finally {
+          first.foreach(_.closeStorage())
+          deleteRecursive(dir)
+        }
+      }
+    }
   }
-
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
@@ -95,7 +95,9 @@ class UtxoBootstrapToDownloadSpecification extends ErgoCorePropertyTest with Fil
       val directory = createTempDir
       val stateSettings = org.ergoplatform.utils.ErgoNodeTestConstants.settings.copy(directory = directory.getAbsolutePath)
       val boxes = boxesHolderGenOfSize(1024).sample.get
-      val state = UtxoState.fromBoxHolder(boxes, None, new File(directory, "state"), stateSettings, parameters)
+      val stateDirectory = new File(directory, "state")
+      stateDirectory.mkdir() shouldBe true
+      val state = UtxoState.fromBoxHolder(boxes, None, stateDirectory, stateSettings, parameters)
       try {
         state.dumpSnapshot(header.height, state.rootDigest.dropRight(1))
         val manifestId = state.snapshotsDb.readSnapshotsInfo.availableManifests(header.height)

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
@@ -1,133 +1,145 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
+import java.io.File
+
 import org.ergoplatform.modifiers.SnapshotsInfoTypeId
-import org.ergoplatform.modifiers.history.HeaderChain
 import org.ergoplatform.nodeView.history.ErgoHistory
-import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.serialization.ManifestSerializer
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.wallet.utils.FileUtils
+import scorex.db.LDBFactory
 
-/**
-  * Tests for UTXO set snapshot bootstrap behavior in `ToDownloadProcessor` /
-  * `FullBlockPruningProcessor`:
-  * - `setHeadersChainSynced` makes `nextModifiersToDownload` issue a UTXO set snapshot request
-  *   (instead of full blocks) when no full blocks are applied yet
-  * - `toDownload` returns no block sections until a UTXO set snapshot is applied
-  * - without `utxoBootstrap` enabled, none of the above holds
-  */
-class UtxoBootstrapToDownloadSpecification extends ErgoCorePropertyTest {
+/** Ordinary header append and snapshot-download planning contracts, using test history stores. */
+class UtxoBootstrapToDownloadSpecification extends ErgoCorePropertyTest with FileUtils {
   import org.ergoplatform.utils.HistoryTestHelpers._
   import org.ergoplatform.utils.ErgoCoreTestConstants._
   import org.ergoplatform.utils.generators.ChainGenerator._
   import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
-  import org.ergoplatform.utils.generators.ValidBlocksGenerators._
 
-  private def genUtxoBootstrapHistory() =
-    generateHistory(verifyTransactions = true,
-                    StateType.Utxo,
-                    PoPoWBootstrap = false,
-                    BlocksToKeep,
-                    utxoBootstrap = true)
-
-  private def headersWithFreshTail(history: ErgoHistory, extra: Int = 1) = {
-    val chain = genChain(BlocksInChain + extra, history)
-    val headers = HeaderChain(chain.dropRight(extra).map(_.header))
-    val updHistory = applyHeaderChain(history, headers)
-    (updHistory, chain)
+  private def withHistory(keep: Int = BlocksToKeep, verify: Boolean = true, bootstrap: Boolean = true)
+                         (test: ErgoHistory => Unit): Unit = {
+    val history = generateHistory(verify, StateType.Utxo, PoPoWBootstrap = false, keep, utxoBootstrap = bootstrap)
+    try test(history) finally history.closeStorage()
   }
 
-  property("snapshot request is issued when headers chain synced and no full blocks applied") {
-    var history = genUtxoBootstrapHistory()
-    val chain = genChain(BlocksInChain, history)
-    history = applyHeaderChain(history, HeaderChain(chain.map(_.header)))
+  private def staleHeaders(history: ErgoHistory, count: Int = BlocksInChain + 2): ErgoHistory =
+    applyHeaderChain(history, genHeaderChain(count, history, diffBitsOpt = None, useRealTs = false))
 
-    history.bestFullBlockOpt shouldBe None
-    history.isHeadersChainSynced shouldBe false
+  private def freshHeader(history: ErgoHistory) =
+    nextHeader(history.bestHeaderOpt, history.difficultyCalculator,
+      tsOpt = Some(math.max(System.currentTimeMillis(), history.bestHeaderOpt.get.timestamp + 1)), useRealTs = true)
 
-    // nothing to download before headers chain is considered synced
-    history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe
-      Map.empty
+  for (keep <- Seq(-1, 3)) {
+    property(s"ordinary fresh header starts snapshot discovery without moving retention floor, keep=$keep") {
+      withHistory(keep) { initial =>
+        val history = staleHeaders(initial)
+        val floor = history.minFullBlockAvailable
+        history.isHeadersChainSynced shouldBe false
+        history.isUtxoSnapshotApplied shouldBe false
+        history.bestFullBlockOpt shouldBe None
+        history.nextModifiersToDownload(1, (_, _) => true) shouldBe Map.empty
 
-    history.setHeadersChainSynced()
-    history.isHeadersChainSynced shouldBe true
+        val header = freshHeader(history)
+        if (keep > 0) header.height should be > keep
+        val (updated, progress) = history.append(header).get
+        progress.toDownload shouldBe Seq.empty
+        updated.isHeadersChainSynced shouldBe true
+        updated.minFullBlockAvailable shouldBe floor
+        updated.bestFullBlockOpt shouldBe None
+        updated.isUtxoSnapshotApplied shouldBe false
+        updated.nextModifiersToDownload(1, (_, id) => !updated.contains(id)) shouldBe
+          Map(SnapshotsInfoTypeId.value -> Seq.empty)
+      }
+    }
+  }
 
-    // no full blocks applied, no snapshot plan yet => ask peers for UTXO set snapshots
-    history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe
-      Map(SnapshotsInfoTypeId.value -> Seq.empty)
+  property("old headers and disabled transaction verification do not start snapshot discovery") {
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val oldNext = genHeaderChain(1, history, diffBitsOpt = None, useRealTs = false).headers.last
+      history.append(oldNext).get._2.toDownload shouldBe Seq.empty
+      history.isHeadersChainSynced shouldBe false
+      history.nextModifiersToDownload(1, (_, _) => true) shouldBe Map.empty
+    }
+    withHistory(verify = false) { initial =>
+      val history = staleHeaders(initial)
+      val floor = history.minFullBlockAvailable
+      history.append(freshHeader(history)).get._2.toDownload shouldBe Seq.empty
+      history.isHeadersChainSynced shouldBe false
+      history.minFullBlockAvailable shouldBe floor
+      history.isUtxoSnapshotApplied shouldBe false
+      history.nextModifiersToDownload(1, (_, _) => true) shouldBe Map.empty
+    }
+  }
 
-    // setter must be idempotent
-    history.setHeadersChainSynced()
-    history.isHeadersChainSynced shouldBe true
+  property("explicit headers-synced setter remains idempotent and requests snapshot information") {
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val floor = history.minFullBlockAvailable
+      history.isHeadersChainSynced shouldBe false
+      history.setHeadersChainSynced()
+      history.setHeadersChainSynced()
+      history.isHeadersChainSynced shouldBe true
+      history.minFullBlockAvailable shouldBe floor
+      history.nextModifiersToDownload(1, (_, _) => true) shouldBe
+        Map(SnapshotsInfoTypeId.value -> Seq.empty)
+    }
   }
 
   property("no repeated snapshot request once download plan is registered") {
-    var history = genUtxoBootstrapHistory()
-    val (updHistory, chain) = headersWithFreshTail(history)
-    history = updHistory
-    history.setHeadersChainSynced()
-    val freshHeader = chain.last.header
-
-    // manifest of some UTXO set snapshot, needed to create a download plan
-    val bh = boxesHolderGenOfSize(1024).sample.get
-    val us = createUtxoState(bh, parameters)
-    val snapshotHeight = freshHeader.height
-    us.dumpSnapshot(snapshotHeight, us.rootDigest.dropRight(1))
-    val manifestId = us.snapshotsDb.readSnapshotsInfo.availableManifests(snapshotHeight)
-    val manifestBytes = us.snapshotsDb.readManifestBytes(manifestId).get
-    val manifest = ManifestSerializer.defaultSerializer.parseBytes(manifestBytes)
-
-    history.registerManifestToDownload(manifest, snapshotHeight, Seq.empty)
-    history.utxoSetSnapshotDownloadPlan() should not be empty
-    history.isUtxoSnapshotApplied shouldBe false
-
-    // download plan exists, so no new snapshot info request
-    history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe
-      Map.empty
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val header = freshHeader(history)
+      history.append(header).get
+      val directory = createTempDir
+      val stateSettings = org.ergoplatform.utils.ErgoNodeTestConstants.settings.copy(directory = directory.getAbsolutePath)
+      val boxes = boxesHolderGenOfSize(1024).sample.get
+      val state = UtxoState.fromBoxHolder(boxes, None, new File(directory, "state"), stateSettings, parameters)
+      try {
+        state.dumpSnapshot(header.height, state.rootDigest.dropRight(1))
+        val manifestId = state.snapshotsDb.readSnapshotsInfo.availableManifests(header.height)
+        val manifest = ManifestSerializer.defaultSerializer.parseBytes(state.snapshotsDb.readManifestBytes(manifestId).get)
+        history.registerManifestToDownload(manifest, header.height, Seq.empty)
+        history.utxoSetSnapshotDownloadPlan() should not be empty
+        history.isUtxoSnapshotApplied shouldBe false
+        history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe Map.empty
+      } finally {
+        try state.closeStorage() finally {
+          LDBFactory.createKvDb(new File(directory, "snapshots").getAbsolutePath).close()
+          deleteRecursive(directory)
+        }
+      }
+    }
   }
 
   property("toDownload returns no block sections before snapshot, and sections after snapshot") {
-    var history = genUtxoBootstrapHistory()
-    val (updHistory, chain) = headersWithFreshTail(history, extra = 2)
-    history = updHistory
-    history.setHeadersChainSynced()
-    val freshHeader = chain(chain.length - 2).header
-    val nextHeader = chain.last.header
-
-    // headers chain is synced and the header is not too far back, still no block sections
-    // must be downloaded before the UTXO set snapshot is applied
-    val piBefore = history.append(freshHeader).get._2
-    piBefore.toDownload shouldBe Seq.empty
-
-    // apply snapshot at freshHeader's height, so that full blocks downloading
-    // starts from nextHeader
-    history.onUtxoSnapshotApplied(freshHeader.height)
-    history.isUtxoSnapshotApplied shouldBe true
-
-    val piAfter = history.append(nextHeader).get._2
-    piAfter.toDownload shouldBe history.requiredModifiersForHeader(nextHeader)
-    piAfter.toDownload should not be empty
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val first = freshHeader(history)
+      history.append(first).get._2.toDownload shouldBe Seq.empty
+      history.isHeadersChainSynced shouldBe true
+      history.onUtxoSnapshotApplied(first.height)
+      history.isUtxoSnapshotApplied shouldBe true
+      val next = freshHeader(history)
+      val progress = history.append(next).get._2
+      progress.toDownload shouldBe history.requiredModifiersForHeader(next)
+      progress.toDownload should not be empty
+    }
   }
 
   property("without utxoBootstrap no snapshot request and block sections downloaded as usual") {
-    var history =
-      generateHistory(verifyTransactions = true,
-                      StateType.Utxo,
-                      PoPoWBootstrap = false,
-                      BlocksToKeep)
-    val (updHistory, chain) = headersWithFreshTail(history)
-    history = updHistory
-    history.setHeadersChainSynced()
-    val freshHeader = chain.last.header
-
-    // full block sections are requested right away, no snapshot request is involved
-    val pi = history.append(freshHeader).get._2
-    pi.toDownload shouldBe history.requiredModifiersForHeader(freshHeader)
-    pi.toDownload should not be empty
-
-    val toDownloadMap =
-      history.nextModifiersToDownload(1, (_, id) => !history.contains(id))
-    toDownloadMap should not be empty
-    toDownloadMap.contains(SnapshotsInfoTypeId.value) shouldBe false
+    withHistory(bootstrap = false) { initial =>
+      val history = staleHeaders(initial)
+      history.append(freshHeader(history)).get
+      history.isHeadersChainSynced shouldBe true
+      val next = freshHeader(history)
+      val progress = history.append(next).get._2
+      progress.toDownload shouldBe history.requiredModifiersForHeader(next)
+      progress.toDownload should not be empty
+      val requests = history.nextModifiersToDownload(1, (_, id) => !history.contains(id))
+      requests should not be empty
+      requests.contains(SnapshotsInfoTypeId.value) shouldBe false
+    }
   }
-
 }


### PR DESCRIPTION
UTXO snapshot bootstrap with ordinary header synchronization can stall before requesting snapshot information. The pending-snapshot branch returns before a fresh header can set `isHeadersChainSynced`, while the snapshot request path requires that flag.

This follow-up to [#2496](https://github.com/ergoplatform/ergo/pull/2496) addresses [the ordinary-header review finding](https://github.com/ergoplatform/ergo/pull/2496#discussion_r3971458443). It applies the existing header-freshness predicate and sets only the synchronization flag. The full-block retention floor remains unchanged, and block sections remain suppressed until the snapshot is applied.

Review and integration:

- Target: `i2464`, pinned at `85044dc444f18235f2e33393acf005e3a6db4979`. Merge this follow-up into #2496 first.
- Shared correction and scheduling regressions: [464f8cd to d0f09d6](https://github.com/a-shannon/ergo/compare/464f8cd823f08a67969e6f523ddcd79a1d7d66dc...d0f09d6ded54323cc4a8fe7ae017a3427d02fe78). The same prerequisite commit can be reused in [#2424](https://github.com/ergoplatform/ergo/pull/2424) without importing #2496's other restart changes.
- Additional #2496 restart-test correction: [721b06a to 759d9a5](https://github.com/a-shannon/ergo/compare/721b06a23...759d9a53560023308888a636d03850849e6c3565). Close the original history store before reopening it, then assert actual snapshot-request planning.
- Native-storage fixture follow-up: [7c92f54](https://github.com/a-shannon/ergo/commit/7c92f54fd7ddadf3d3007d515ece528763834b89) creates the state directory before opening its nested store. The same commit is included in #2424 and the [combined wallet review](https://github.com/a-shannon/ergo/pull/2).

Validation on the #2496 composition:

- Nine focused tests pass, covering ordinary header arrival, unlimited and limited retention, stale headers, verification disabled, an existing snapshot plan, post-snapshot downloads, and actual store close/reopen.
- The deciding regression fails on the parent because synchronization remains false.
- Replacing the flag setter with `updateBestFullBlock` makes the retention regression fail because the floor advances from 1 to 11.
- Independent source review completed. The seven affected scheduling tests pass after the fixture-directory follow-up. All eight CI checks pass at `036c2c258f7aceef00ead6d92cfa238f1e4722bf`, including native Linux node and integration tests ([run](https://github.com/ergoplatform/ergo/actions/runs/34392359350)).

The ordinary reopen test establishes recovery when the next fresh header arrives. It does not establish immediate recovery without a new header, process-crash recovery, or production-network recovery. Existing proof handling and configured restart predicates are unchanged.
