### PR TITLE
Preserve Digest state across snapshot bootstrap and restart

### DIFF
--- a/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
+++ b/src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala
@@ -1612,10 +1612,7 @@ class ErgoNodeViewSynchronizer(networkControllerRef: ActorRef,
         case None => log.warn(s"Asked for snapshot when UTXO set is not supported, remote: $remote")
       }
     case (_: UtxoSnapshotChunkSpec.type, serializedChunk: Array[Byte], remote) =>
-      usrOpt match {
-        case Some(_) => processUtxoSnapshotChunk(serializedChunk, hr, remote)
-        case None => log.warn(s"Asked for snapshot when UTXO set is not supported, remote: $remote")
-      }
+      processUtxoSnapshotChunk(serializedChunk, hr, remote)
     case (_: GetNipopowProofSpec.type, data: NipopowProofData, remote) =>
       sendNipopowProof(data, hr, remote)
     case (_: NipopowProofSpec.type , proofBytes: Array[Byte], remote) =>

--- a/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/ErgoNodeViewHolder.scala
@@ -14,6 +14,7 @@ import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages._
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.{BlockAppliedTransactions, CurrentView, DownloadRequest}
 import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages._
 import org.ergoplatform.nodeView.history.ErgoHistory
+import org.ergoplatform.nodeView.history.storage.modifierprocessors.UtxoSetSnapshotProcessor
 import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.ProcessingOutcome
 import org.ergoplatform.nodeView.state._
@@ -302,9 +303,23 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         history().createPersistentProver(store, history(), height, blockId) match {
           case Success(pp) =>
             log.info(s"Restoring state from prover with digest ${pp.digest} reconstructed for height $height")
-            history().onUtxoSnapshotApplied(height)
-            val newState = new UtxoState(pp, version = VersionTag @@@ blockId, store, settings)
-            updateNodeView(updatedState = Some(newState.asInstanceOf[State]))
+            val prepared: Try[ErgoState[_]] = settings.nodeSettings.stateType match {
+              case StateType.Digest =>
+                ErgoStateReader.reconstructStateContextBeforeEpoch(history(), height, settings).flatMap { stateContext =>
+                  DigestState.fromSnapshot(VersionTag @@@ blockId, pp.digest, stateContext, store, settings)
+                }
+              case StateType.Utxo =>
+                Try(new UtxoState(pp, version = VersionTag @@@ blockId, store, settings))
+            }
+            prepared match {
+              case Success(newState) =>
+                history().onUtxoSnapshotApplied(height)
+                updateNodeView(updatedState = Some(newState.asInstanceOf[State]))
+              case Failure(t) =>
+                abortSnapshotStatePreparation(t)
+            }
+          case Failure(t: UtxoSetSnapshotProcessor.StateWriteFailure) =>
+            abortSnapshotStatePreparation(t)
           case Failure(t) =>
             log.error("UTXO set snapshot application failed: ", t)
         }
@@ -455,7 +470,7 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
     val history = ErgoHistory.readOrGenerate(settings)
     log.info("History database read")
     val memPool = ErgoMemPool.empty(settings)
-    restoreConsistentState(ErgoState.readOrGenerate(settings).asInstanceOf[State], history) match {
+    restoreConsistentState(readStateForStartup(history), history) match {
       case Success(state) =>
         log.info(s"State database read, state synchronized")
         val wallet = ErgoWallet.readOrGenerate(
@@ -601,6 +616,39 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         history.bestHeaderAtHeight(snapshotHeight)
       })
 
+  private def abortSnapshotStatePreparation(error: Throwable): Unit = {
+    log.error("Failed to prepare the configured snapshot state; shutting down", error)
+    // Reconstruction has modified the store behind the old state. Do not serve it.
+    context.become(Actor.emptyBehavior)
+    ErgoApp.shutdownSystem()(context.system)
+  }
+
+  private def readStateForStartup(history: ErgoHistory): State = {
+    if (settings.nodeSettings.stateType == StateType.Digest &&
+        settings.nodeSettings.utxoSettings.utxoBootstrap &&
+        history.isUtxoSnapshotApplied && history.bestFullBlockOpt.isEmpty) {
+      val height = history.minimalFullBlockHeight - 1
+      val restored = for {
+        header <- Try(history.bestHeaderAtHeight(height).getOrElse {
+          throw new IllegalStateException("Applied snapshot has no canonical header")
+        })
+        stateContext <- ErgoStateReader.reconstructStateContextBeforeEpoch(history, height, settings)
+        state <- DigestState.readSnapshot(stateDir(settings), settings, idToVersion(header.id),
+          header.stateRoot, stateContext)
+      } yield state
+      restored match {
+        case Success(state) => state.asInstanceOf[State]
+        case Failure(error) =>
+          // A failed snapshot load must not fall through to genesis recreation.
+          Try(history.closeStorage()).failed.foreach(error.addSuppressed)
+          ErgoApp.shutdownSystem()(context.system)
+          throw error
+      }
+    } else {
+      ErgoState.readOrGenerate(settings).asInstanceOf[State]
+    }
+  }
+
   private def restoreConsistentState(stateIn: State, history: ErgoHistory): Try[State] = {
     (stateIn.version, history.bestFullBlockOpt, stateIn) match {
       case (ErgoState.genesisStateVersion, None, _) =>
@@ -611,6 +659,9 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
         Success(stateIn)
       case (_, None, _) if isPreparedUtxoSnapshotState(stateIn, history) =>
         log.info(s"Prepared UTXO snapshot state ${encoder.encode(stateIn.version)} restored before the first full block")
+        Success(stateIn)
+      case (_, None, _: DigestState) if isPreparedDigestSnapshotState(stateIn, history) =>
+        log.info(s"Prepared Digest snapshot state ${encoder.encode(stateIn.version)} restored before the first full block")
         Success(stateIn)
       case (_, None, _) =>
         log.info("State and history are inconsistent. History is empty on startup, rollback state to genesis.")
@@ -637,6 +688,19 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
           acc.flatMap(_.applyModifier(m, chainTipOpt)(lm => self ! lm))
         }
     }
+  }
+
+  private def isPreparedDigestSnapshotState(state: State, history: ErgoHistory): Boolean = {
+    val snapshotHeight = history.minimalFullBlockHeight - 1
+    ErgoNodeViewHolder.isPreparedDigestSnapshotState(
+      settings.nodeSettings.stateType == StateType.Digest && state.isInstanceOf[DigestState],
+      settings.nodeSettings.utxoSettings.utxoBootstrap,
+      history.isUtxoSnapshotApplied,
+      state.version,
+      state.rootDigest,
+      history.bestHeaderAtHeight(snapshotHeight),
+      state.store.get(ErgoStateReader.ContextKey),
+      ErgoStateReader.reconstructStateContextBeforeEpoch(history, snapshotHeight, settings).toOption.map(_.bytes))
   }
 
   /**
@@ -743,6 +807,21 @@ abstract class ErgoNodeViewHolder[State <: ErgoState[State]](settings: ErgoSetti
 
 
 object ErgoNodeViewHolder {
+
+  private[nodeView] def isPreparedDigestSnapshotState(
+      stateIsDigest: Boolean,
+      utxoBootstrap: => Boolean,
+      snapshotApplied: => Boolean,
+      stateVersion: VersionTag,
+      stateRoot: Array[Byte],
+      snapshotHeaderOpt: => Option[Header],
+      storedContext: => Option[Array[Byte]],
+      expectedContext: => Option[Array[Byte]]): Boolean =
+    stateIsDigest &&
+      utxoBootstrap &&
+      snapshotApplied &&
+      snapshotHeaderOpt.exists(matchesPreparedUtxoSnapshotHeader(stateVersion, stateRoot, _)) &&
+      storedContext.exists(stored => expectedContext.exists(_.sameElements(stored)))
 
   private[nodeView] def isPreparedUtxoSnapshotState(
       stateIsUtxo: Boolean,

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/FullBlockProcessor.scala
@@ -68,7 +68,12 @@ trait FullBlockProcessor extends HeadersProcessor {
     case ToProcess(fullBlock, newModRow, Some(newBestBlockHeader), newBestChain)
       if isValidFirstFullBlock(fullBlock.header) =>
 
-      val headers = headerChainBack(10, fullBlock.header, h => h.height == 1)
+      val headersToApply = if (nodeSettings.utxoSettings.utxoBootstrap && isUtxoSnapshotApplied) {
+        // Snapshot reconstruction has already installed the preceding headers in the state context.
+        Seq.empty
+      } else {
+        headerChainBack(10, fullBlock.header, h => h.height == 1).headers.dropRight(1)
+      }
       val toApply = fullBlock +: newBestChain.tail
         .map(id => typedModifierById[Header](id).flatMap(getFullBlock))
         .takeWhile(_.isDefined)
@@ -76,7 +81,7 @@ trait FullBlockProcessor extends HeadersProcessor {
       logStatus(Seq(), toApply, fullBlock, None)
       val additionalIndexes = toApply.map(b => chainStatusKey(b.id) -> FullBlockProcessor.BestChainMarker)
       updateStorage(newModRow, newBestBlockHeader.id, additionalIndexes).map { _ =>
-        ProgressInfo(None, Seq.empty, headers.headers.dropRight(1) ++ toApply, Seq.empty)
+        ProgressInfo(None, Seq.empty, headersToApply ++ toApply, Seq.empty)
       }
   }
 

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/ToDownloadProcessor.scala
@@ -112,6 +112,10 @@ trait ToDownloadProcessor
       // A regime that do not download and verify transaction
       Nil
     } else if (nodeSettings.utxoSettings.utxoBootstrap && !isUtxoSnapshotApplied) {
+      if (!isHeadersChainSynced && header.isNew(chainSettings.blockInterval * headerChainDiff)) {
+        // Enable snapshot discovery without advancing the full-block retention floor.
+        setHeadersChainSynced()
+      }
       // While bootstrapping from a UTXO set snapshot, do not download full block sections
       // until the snapshot has been applied. Block sections downloaded before the snapshot
       // would be stored as non-best and never applied to the freshly recreated state.

--- a/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoSetSnapshotProcessor.scala
@@ -224,6 +224,8 @@ trait UtxoSetSnapshotProcessor extends MinimalFullBlockHeightFunctions with Scor
                       override val storage: VersionedLDBAVLStorage = ldbStorage
                     }
                 }
+            }.recoverWith { case error =>
+              Failure(new UtxoSetSnapshotProcessor.StateWriteFailure(error))
             }
           case Failure(e) =>
             log.warn("Can't reconstruct state context in createPersistentProver ", e)
@@ -236,4 +238,10 @@ trait UtxoSetSnapshotProcessor extends MinimalFullBlockHeightFunctions with Scor
     }
   }
 
+}
+
+object UtxoSetSnapshotProcessor {
+  /** The reconstruction entered the store-write phase; callers must not serve the previous state. */
+  final class StateWriteFailure(cause: Throwable)
+    extends RuntimeException("Snapshot reconstruction may have changed the state store", cause)
 }

--- a/src/main/scala/org/ergoplatform/nodeView/state/DigestState.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/state/DigestState.scala
@@ -153,6 +153,70 @@ class DigestState protected(override val version: VersionTag,
 
 object DigestState extends ScorexLogging with ScorexEncoding {
 
+  /** Read a verified snapshot checkpoint, including the AVL representation written by older nodes. */
+  private[nodeView] def readSnapshot(dir: File,
+                                    settings: ErgoSettings,
+                                    version: VersionTag,
+                                    rootHash: ADDigest,
+                                    stateContext: ErgoStateContext): Try[DigestState] = {
+    Try {
+      dir.mkdirs()
+      new LDBVersionedStore(dir, initialKeepVersions = settings.nodeSettings.keepVersions)
+    }.flatMap { store =>
+      val versionBytes = org.ergoplatform.core.versionToBytes(version)
+      val result = Try {
+        require(stateContext.lastHeaders.headOption.exists { header =>
+          idToVersion(header.id) == version && header.stateRoot.sameElements(rootHash)
+        }, "Snapshot state must match its context header")
+        require(store.get(versionBytes).exists(_.sameElements(rootHash)),
+          "Stored snapshot root does not match canonical history")
+        require(store.get(ErgoStateReader.ContextKey).exists(_.sameElements(stateContext.bytes)),
+          "Stored snapshot context does not match canonical history")
+        store.lastVersionID.getOrElse(throw new IllegalStateException("Snapshot store has no version"))
+      }.flatMap { storedVersion =>
+        if (storedVersion.sameElements(rootHash)) {
+          fromSnapshot(version, rootHash, stateContext, store, settings)
+        } else if (storedVersion.sameElements(versionBytes)) {
+          for {
+            _ <- Try(store.clean(0))
+            _ <- store.update(versionBytes, Seq.empty, Seq.empty)
+            state <- Try(new DigestState(version, rootHash, store, settings))
+          } yield state
+        } else {
+          Failure(new IllegalStateException("Stored snapshot version does not match canonical history"))
+        }
+      }
+      result.failed.foreach { error =>
+        Try(store.close()).failed.foreach(error.addSuppressed)
+      }
+      result
+    }
+  }
+
+  /** Convert a reconstructed snapshot store to Digest's block-ID version namespace. */
+  private[nodeView] def fromSnapshot(version: VersionTag,
+                                    rootHash: ADDigest,
+                                    stateContext: ErgoStateContext,
+                                    store: LDBVersionedStore,
+                                    settings: ErgoSettings): Try[DigestState] = {
+    val versionBytes = org.ergoplatform.core.versionToBytes(version)
+    for {
+      _ <- Try {
+        require(stateContext.lastHeaders.headOption.exists { header =>
+          idToVersion(header.id) == version && header.stateRoot.sameElements(rootHash)
+        }, "Snapshot state must match its context header")
+        require(store.lastVersionID.exists(_.sameElements(rootHash)),
+          "Snapshot store must be at the reconstructed AVL root")
+      }
+      _ <- store.update(versionBytes, Seq.empty, metadata(version, rootHash, stateContext))
+      // AVL versions are root digests, whereas Digest rollback versions must be block IDs.
+      _ <- Try(store.clean(0))
+      // Retain an undo anchor so later block updates can roll back here after reopening.
+      _ <- store.update(versionBytes, Seq.empty, Seq.empty)
+      state <- Try(new DigestState(version, rootHash, store, settings))
+    } yield state
+  }
+
   /**
     * Creates [[DigestState]] with provided `ErgoStateContext` instance corresponding to some version` and `rootHash`.
     */

--- a/src/test/scala/org/ergoplatform/nodeView/history/UtxoBootstrapRestartSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/UtxoBootstrapRestartSpecification.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform.nodeView.history
 
+import org.ergoplatform.modifiers.SnapshotsInfoTypeId
 import org.ergoplatform.nodeView.mempool.ErgoMemPoolUtils.SortingOption
 import org.ergoplatform.nodeView.state.StateType
 import org.ergoplatform.settings._
@@ -11,34 +12,15 @@ import org.ergoplatform.wallet.utils.FileUtils
 import scala.concurrent.duration._
 
 /**
-  * Reproduction of a restart deadlock during UTXO set snapshot bootstrapping.
-  *
-  * Scenario: a node bootstrapping via NiPoPoW proofs + UTXO set snapshot (nipopowBootstrap +
-  * utxoBootstrap) is restarted after the NiPoPoW proof headers were persisted but before the
-  * UTXO set snapshot application completed (e.g. killed in the middle of snapshot chunk
-  * downloading). After the restart the node never resumes bootstrapping:
-  *
-  * - `isHeadersChainSynced` is kept in memory only (FullBlockPruningProcessor.isHeadersChainSyncedVar)
-  *   and is set solely from `updateBestFullBlock` or `setHeadersChainSynced` (the latter is called
-  *   only right after a NiPoPoW proof is applied), so it is false after every restart
-  * - on restart the headers are read from the database, so no new NiPoPoW proof is requested
-  *   (ErgoNodeViewSynchronizer.sendSync asks for proofs only when `bestHeaderOpt` is empty)
-  * - the synchronizer asks for the UTXO set snapshot / block sections only when
-  *   `isHeadersChainSynced` is true (ErgoNodeViewSynchronizer.requestMoreModifiers), and
-  *   ToDownloadProcessor filters block-section invs out while the snapshot is not applied
-  *
-  * Result: headers are at tip, the state is at genesis, and the node loops sending sync
-  * messages forever. Observed on mainnet with a node restarted mid snapshot download.
-  *
-  * The property below simulates the restart by reopening the history database and asserts that
-  * the headers chain is considered synced after the restart, so that snapshot bootstrapping
-  * can resume. It fails before the fix.
+  * Close and reopen actual history stores inside one JVM, then inspect download planning.
+  * Headers are appended normally; these fixtures do not apply a NiPoPoW proof, restart a process,
+  * or establish production-network recovery.
   */
 class UtxoBootstrapRestartSpecification extends ErgoCorePropertyTest with FileUtils {
 
   import org.ergoplatform.utils.ErgoNodeTestConstants._
 
-  private def utxoBootstrapSettings(dir: java.io.File): ErgoSettings = {
+  private def utxoBootstrapSettings(dir: java.io.File, nipopow: Boolean): ErgoSettings = {
     val txCostLimit = initSettings.nodeSettings.maxTransactionCost
     val txSizeLimit = initSettings.nodeSettings.maxTransactionSize
     val nodeSettings = NodeConfigurationSettings(
@@ -46,7 +28,7 @@ class UtxoBootstrapRestartSpecification extends ErgoCorePropertyTest with FileUt
       verifyTransactions = true,
       blocksToKeep = -1,
       UtxoSettings(utxoBootstrap = true, 0, 2),
-      NipopowSettings(nipopowBootstrap = true, 1),
+      NipopowSettings(nipopowBootstrap = nipopow, 1),
       mining = false,
       txCostLimit,
       txSizeLimit,
@@ -71,30 +53,56 @@ class UtxoBootstrapRestartSpecification extends ErgoCorePropertyTest with FileUt
       null, null, settings.cacheSettings)
   }
 
-  property("node restarted after nipopow headers persisted but before snapshot application resumes bootstrap") {
-    val dir = createTempDir
-    val historySettings = utxoBootstrapSettings(dir)
+  for (nipopow <- Seq(false, true)) {
+    property(s"reopened snapshot-bootstrap history resumes discovery with ordinary fresh-header reentry, nipopow=$nipopow") {
+      val dir = createTempDir
+      val historySettings = utxoBootstrapSettings(dir, nipopow)
+      var first: Option[ErgoHistory] = None
+      var reopened: Option[ErgoHistory] = None
+      try {
+        val history = ErgoHistory.readOrGenerate(historySettings)(null)
+        first = Some(history)
+        val stored = applyHeaderChain(history,
+          genHeaderChain(BlocksInChain, history, diffBitsOpt = None, useRealTs = false))
+        val expectedTip = stored.bestHeaderOpt.get.id
+        val expectedHeight = stored.headersHeight
+        val floor = stored.minFullBlockAvailable
+        stored.bestFullBlockOpt shouldBe None
+        stored.isUtxoSnapshotApplied shouldBe false
+        stored.isHeadersChainSynced shouldBe false
 
-    // headers-only chain, result of a NiPoPoW proof application (no full blocks downloaded yet)
-    val history = ErgoHistory.readOrGenerate(historySettings)(null)
-    val headers = genHeaderChain(BlocksInChain, history, diffBitsOpt = None, useRealTs = false)
-    val updHistory = applyHeaderChain(history, headers)
+        // Release the first native store before acquiring the second wrapper over the same files.
+        stored.closeStorage()
+        first = None
+        val restarted = ErgoHistory.readOrGenerate(historySettings)(null)
+        reopened = Some(restarted)
+        restarted.headersHeight shouldBe expectedHeight
+        restarted.bestHeaderOpt.get.id shouldBe expectedTip
+        restarted.bestFullBlockOpt shouldBe None
+        restarted.isUtxoSnapshotApplied shouldBe false
+        restarted.minFullBlockAvailable shouldBe floor
+        // The existing configured startup predicate is distinct from ordinary header synchronization.
+        restarted.isHeadersChainSynced shouldBe nipopow
+        restarted.nextModifiersToDownload(1, (_, _) => true) shouldBe
+          (if (nipopow) Map(SnapshotsInfoTypeId.value -> Seq.empty) else Map.empty)
 
-    updHistory.bestFullBlockOpt shouldBe None
-    updHistory.isUtxoSnapshotApplied shouldBe false
-    updHistory.isHeadersChainSynced shouldBe false // set only via updateBestFullBlock / setHeadersChainSynced
-
-    // simulate node restart: reopen the same database
-    val restarted = ErgoHistory.readOrGenerate(historySettings)(null)
-
-    restarted.headersHeight shouldBe updHistory.headersHeight
-    restarted.bestFullBlockOpt shouldBe None
-    restarted.isUtxoSnapshotApplied shouldBe false
-
-    // without this the synchronizer never asks for the snapshot manifest / blocks
-    // (ErgoNodeViewSynchronizer.requestMoreModifiers -> sendSync loop) and bootstrap
-    // can never resume
-    restarted.isHeadersChainSynced shouldBe true
+        val fresh = nextHeader(restarted.bestHeaderOpt, restarted.difficultyCalculator,
+          tsOpt = Some(System.currentTimeMillis()), useRealTs = true)
+        val (updated, progress) = restarted.append(fresh).get
+        progress.toDownload shouldBe Seq.empty
+        updated.isHeadersChainSynced shouldBe true
+        updated.isUtxoSnapshotApplied shouldBe false
+        updated.bestFullBlockOpt shouldBe None
+        updated.minFullBlockAvailable shouldBe floor
+        updated.nextModifiersToDownload(1, (_, id) => !updated.contains(id)) shouldBe
+          Map(SnapshotsInfoTypeId.value -> Seq.empty)
+      } finally {
+        try reopened.foreach(_.closeStorage())
+        finally {
+          first.foreach(_.closeStorage())
+          deleteRecursive(dir)
+        }
+      }
+    }
   }
-
 }

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
@@ -95,7 +95,9 @@ class UtxoBootstrapToDownloadSpecification extends ErgoCorePropertyTest with Fil
       val directory = createTempDir
       val stateSettings = org.ergoplatform.utils.ErgoNodeTestConstants.settings.copy(directory = directory.getAbsolutePath)
       val boxes = boxesHolderGenOfSize(1024).sample.get
-      val state = UtxoState.fromBoxHolder(boxes, None, new File(directory, "state"), stateSettings, parameters)
+      val stateDirectory = new File(directory, "state")
+      stateDirectory.mkdir() shouldBe true
+      val state = UtxoState.fromBoxHolder(boxes, None, stateDirectory, stateSettings, parameters)
       try {
         state.dumpSnapshot(header.height, state.rootDigest.dropRight(1))
         val manifestId = state.snapshotsDb.readSnapshotsInfo.availableManifests(header.height)

--- a/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/history/storage/modifierprocessors/UtxoBootstrapToDownloadSpecification.scala
@@ -1,133 +1,145 @@
 package org.ergoplatform.nodeView.history.storage.modifierprocessors
 
+import java.io.File
+
 import org.ergoplatform.modifiers.SnapshotsInfoTypeId
-import org.ergoplatform.modifiers.history.HeaderChain
 import org.ergoplatform.nodeView.history.ErgoHistory
-import org.ergoplatform.nodeView.state.StateType
+import org.ergoplatform.nodeView.state.{StateType, UtxoState}
 import org.ergoplatform.serialization.ManifestSerializer
 import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.wallet.utils.FileUtils
+import scorex.db.LDBFactory
 
-/**
-  * Tests for UTXO set snapshot bootstrap behavior in `ToDownloadProcessor` /
-  * `FullBlockPruningProcessor`:
-  * - `setHeadersChainSynced` makes `nextModifiersToDownload` issue a UTXO set snapshot request
-  *   (instead of full blocks) when no full blocks are applied yet
-  * - `toDownload` returns no block sections until a UTXO set snapshot is applied
-  * - without `utxoBootstrap` enabled, none of the above holds
-  */
-class UtxoBootstrapToDownloadSpecification extends ErgoCorePropertyTest {
+/** Ordinary header append and snapshot-download planning contracts, using test history stores. */
+class UtxoBootstrapToDownloadSpecification extends ErgoCorePropertyTest with FileUtils {
   import org.ergoplatform.utils.HistoryTestHelpers._
   import org.ergoplatform.utils.ErgoCoreTestConstants._
   import org.ergoplatform.utils.generators.ChainGenerator._
   import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators._
-  import org.ergoplatform.utils.generators.ValidBlocksGenerators._
 
-  private def genUtxoBootstrapHistory() =
-    generateHistory(verifyTransactions = true,
-                    StateType.Utxo,
-                    PoPoWBootstrap = false,
-                    BlocksToKeep,
-                    utxoBootstrap = true)
-
-  private def headersWithFreshTail(history: ErgoHistory, extra: Int = 1) = {
-    val chain = genChain(BlocksInChain + extra, history)
-    val headers = HeaderChain(chain.dropRight(extra).map(_.header))
-    val updHistory = applyHeaderChain(history, headers)
-    (updHistory, chain)
+  private def withHistory(keep: Int = BlocksToKeep, verify: Boolean = true, bootstrap: Boolean = true)
+                         (test: ErgoHistory => Unit): Unit = {
+    val history = generateHistory(verify, StateType.Utxo, PoPoWBootstrap = false, keep, utxoBootstrap = bootstrap)
+    try test(history) finally history.closeStorage()
   }
 
-  property("snapshot request is issued when headers chain synced and no full blocks applied") {
-    var history = genUtxoBootstrapHistory()
-    val chain = genChain(BlocksInChain, history)
-    history = applyHeaderChain(history, HeaderChain(chain.map(_.header)))
+  private def staleHeaders(history: ErgoHistory, count: Int = BlocksInChain + 2): ErgoHistory =
+    applyHeaderChain(history, genHeaderChain(count, history, diffBitsOpt = None, useRealTs = false))
 
-    history.bestFullBlockOpt shouldBe None
-    history.isHeadersChainSynced shouldBe false
+  private def freshHeader(history: ErgoHistory) =
+    nextHeader(history.bestHeaderOpt, history.difficultyCalculator,
+      tsOpt = Some(math.max(System.currentTimeMillis(), history.bestHeaderOpt.get.timestamp + 1)), useRealTs = true)
 
-    // nothing to download before headers chain is considered synced
-    history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe
-      Map.empty
+  for (keep <- Seq(-1, 3)) {
+    property(s"ordinary fresh header starts snapshot discovery without moving retention floor, keep=$keep") {
+      withHistory(keep) { initial =>
+        val history = staleHeaders(initial)
+        val floor = history.minFullBlockAvailable
+        history.isHeadersChainSynced shouldBe false
+        history.isUtxoSnapshotApplied shouldBe false
+        history.bestFullBlockOpt shouldBe None
+        history.nextModifiersToDownload(1, (_, _) => true) shouldBe Map.empty
 
-    history.setHeadersChainSynced()
-    history.isHeadersChainSynced shouldBe true
+        val header = freshHeader(history)
+        if (keep > 0) header.height should be > keep
+        val (updated, progress) = history.append(header).get
+        progress.toDownload shouldBe Seq.empty
+        updated.isHeadersChainSynced shouldBe true
+        updated.minFullBlockAvailable shouldBe floor
+        updated.bestFullBlockOpt shouldBe None
+        updated.isUtxoSnapshotApplied shouldBe false
+        updated.nextModifiersToDownload(1, (_, id) => !updated.contains(id)) shouldBe
+          Map(SnapshotsInfoTypeId.value -> Seq.empty)
+      }
+    }
+  }
 
-    // no full blocks applied, no snapshot plan yet => ask peers for UTXO set snapshots
-    history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe
-      Map(SnapshotsInfoTypeId.value -> Seq.empty)
+  property("old headers and disabled transaction verification do not start snapshot discovery") {
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val oldNext = genHeaderChain(1, history, diffBitsOpt = None, useRealTs = false).headers.last
+      history.append(oldNext).get._2.toDownload shouldBe Seq.empty
+      history.isHeadersChainSynced shouldBe false
+      history.nextModifiersToDownload(1, (_, _) => true) shouldBe Map.empty
+    }
+    withHistory(verify = false) { initial =>
+      val history = staleHeaders(initial)
+      val floor = history.minFullBlockAvailable
+      history.append(freshHeader(history)).get._2.toDownload shouldBe Seq.empty
+      history.isHeadersChainSynced shouldBe false
+      history.minFullBlockAvailable shouldBe floor
+      history.isUtxoSnapshotApplied shouldBe false
+      history.nextModifiersToDownload(1, (_, _) => true) shouldBe Map.empty
+    }
+  }
 
-    // setter must be idempotent
-    history.setHeadersChainSynced()
-    history.isHeadersChainSynced shouldBe true
+  property("explicit headers-synced setter remains idempotent and requests snapshot information") {
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val floor = history.minFullBlockAvailable
+      history.isHeadersChainSynced shouldBe false
+      history.setHeadersChainSynced()
+      history.setHeadersChainSynced()
+      history.isHeadersChainSynced shouldBe true
+      history.minFullBlockAvailable shouldBe floor
+      history.nextModifiersToDownload(1, (_, _) => true) shouldBe
+        Map(SnapshotsInfoTypeId.value -> Seq.empty)
+    }
   }
 
   property("no repeated snapshot request once download plan is registered") {
-    var history = genUtxoBootstrapHistory()
-    val (updHistory, chain) = headersWithFreshTail(history)
-    history = updHistory
-    history.setHeadersChainSynced()
-    val freshHeader = chain.last.header
-
-    // manifest of some UTXO set snapshot, needed to create a download plan
-    val bh = boxesHolderGenOfSize(1024).sample.get
-    val us = createUtxoState(bh, parameters)
-    val snapshotHeight = freshHeader.height
-    us.dumpSnapshot(snapshotHeight, us.rootDigest.dropRight(1))
-    val manifestId = us.snapshotsDb.readSnapshotsInfo.availableManifests(snapshotHeight)
-    val manifestBytes = us.snapshotsDb.readManifestBytes(manifestId).get
-    val manifest = ManifestSerializer.defaultSerializer.parseBytes(manifestBytes)
-
-    history.registerManifestToDownload(manifest, snapshotHeight, Seq.empty)
-    history.utxoSetSnapshotDownloadPlan() should not be empty
-    history.isUtxoSnapshotApplied shouldBe false
-
-    // download plan exists, so no new snapshot info request
-    history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe
-      Map.empty
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val header = freshHeader(history)
+      history.append(header).get
+      val directory = createTempDir
+      val stateSettings = org.ergoplatform.utils.ErgoNodeTestConstants.settings.copy(directory = directory.getAbsolutePath)
+      val boxes = boxesHolderGenOfSize(1024).sample.get
+      val state = UtxoState.fromBoxHolder(boxes, None, new File(directory, "state"), stateSettings, parameters)
+      try {
+        state.dumpSnapshot(header.height, state.rootDigest.dropRight(1))
+        val manifestId = state.snapshotsDb.readSnapshotsInfo.availableManifests(header.height)
+        val manifest = ManifestSerializer.defaultSerializer.parseBytes(state.snapshotsDb.readManifestBytes(manifestId).get)
+        history.registerManifestToDownload(manifest, header.height, Seq.empty)
+        history.utxoSetSnapshotDownloadPlan() should not be empty
+        history.isUtxoSnapshotApplied shouldBe false
+        history.nextModifiersToDownload(1, (_, id) => !history.contains(id)) shouldBe Map.empty
+      } finally {
+        try state.closeStorage() finally {
+          LDBFactory.createKvDb(new File(directory, "snapshots").getAbsolutePath).close()
+          deleteRecursive(directory)
+        }
+      }
+    }
   }
 
   property("toDownload returns no block sections before snapshot, and sections after snapshot") {
-    var history = genUtxoBootstrapHistory()
-    val (updHistory, chain) = headersWithFreshTail(history, extra = 2)
-    history = updHistory
-    history.setHeadersChainSynced()
-    val freshHeader = chain(chain.length - 2).header
-    val nextHeader = chain.last.header
-
-    // headers chain is synced and the header is not too far back, still no block sections
-    // must be downloaded before the UTXO set snapshot is applied
-    val piBefore = history.append(freshHeader).get._2
-    piBefore.toDownload shouldBe Seq.empty
-
-    // apply snapshot at freshHeader's height, so that full blocks downloading
-    // starts from nextHeader
-    history.onUtxoSnapshotApplied(freshHeader.height)
-    history.isUtxoSnapshotApplied shouldBe true
-
-    val piAfter = history.append(nextHeader).get._2
-    piAfter.toDownload shouldBe history.requiredModifiersForHeader(nextHeader)
-    piAfter.toDownload should not be empty
+    withHistory() { initial =>
+      val history = staleHeaders(initial)
+      val first = freshHeader(history)
+      history.append(first).get._2.toDownload shouldBe Seq.empty
+      history.isHeadersChainSynced shouldBe true
+      history.onUtxoSnapshotApplied(first.height)
+      history.isUtxoSnapshotApplied shouldBe true
+      val next = freshHeader(history)
+      val progress = history.append(next).get._2
+      progress.toDownload shouldBe history.requiredModifiersForHeader(next)
+      progress.toDownload should not be empty
+    }
   }
 
   property("without utxoBootstrap no snapshot request and block sections downloaded as usual") {
-    var history =
-      generateHistory(verifyTransactions = true,
-                      StateType.Utxo,
-                      PoPoWBootstrap = false,
-                      BlocksToKeep)
-    val (updHistory, chain) = headersWithFreshTail(history)
-    history = updHistory
-    history.setHeadersChainSynced()
-    val freshHeader = chain.last.header
-
-    // full block sections are requested right away, no snapshot request is involved
-    val pi = history.append(freshHeader).get._2
-    pi.toDownload shouldBe history.requiredModifiersForHeader(freshHeader)
-    pi.toDownload should not be empty
-
-    val toDownloadMap =
-      history.nextModifiersToDownload(1, (_, id) => !history.contains(id))
-    toDownloadMap should not be empty
-    toDownloadMap.contains(SnapshotsInfoTypeId.value) shouldBe false
+    withHistory(bootstrap = false) { initial =>
+      val history = staleHeaders(initial)
+      history.append(freshHeader(history)).get
+      history.isHeadersChainSynced shouldBe true
+      val next = freshHeader(history)
+      val progress = history.append(next).get._2
+      progress.toDownload shouldBe history.requiredModifiersForHeader(next)
+      progress.toDownload should not be empty
+      val requests = history.nextModifiersToDownload(1, (_, id) => !history.contains(id))
+      requests should not be empty
+      requests.contains(SnapshotsInfoTypeId.value) shouldBe false
+    }
   }
-
 }

--- a/src/test/scala/org/ergoplatform/nodeView/state/DigestSnapshotStateSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/state/DigestSnapshotStateSpecification.scala
@@ -1,0 +1,339 @@
+package org.ergoplatform.nodeView.state
+
+import java.io.File
+import java.nio.file.Files
+import org.ergoplatform.core.{VersionTag, idToVersion, versionToBytes}
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.nodeView.ErgoNodeViewHolder
+import org.ergoplatform.settings.ErgoSettings
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoNodeTestConstants.settings
+import org.ergoplatform.utils.generators.ErgoCoreGenerators.defaultHeaderGen
+import org.ergoplatform.wallet.utils.FileUtils
+import scorex.crypto.authds.ADDigest
+import scorex.db.LDBVersionedStore
+
+import scala.util.{Failure, Try}
+
+/** Direct checkpoint contracts; snapshot reconstruction and actor publication have separate fixtures. */
+class DigestSnapshotStateSpecification extends ErgoCorePropertyTest with FileUtils {
+
+  private def contextFor(header: Header): ErgoStateContext = {
+    val empty = ErgoStateContext.empty(settings.chainSettings, settings.launchParameters)
+    new ErgoStateContext(Seq(header), None, empty.genesisStateDigest, empty.currentParameters,
+      empty.validationSettings, empty.votingData)(settings.chainSettings)
+  }
+
+  private def changed(bytes: Array[Byte]): Array[Byte] = {
+    val result = bytes.clone()
+    result(0) = (result(0) ^ 1).toByte
+    result
+  }
+
+  private class SnapshotStore(dir: File) extends LDBVersionedStore(dir, initialKeepVersions = 10) {
+    val writeError = new IllegalStateException("snapshot checkpoint write failed")
+    val cleanError = new IllegalStateException("snapshot checkpoint cleanup failed")
+    var failWrite = false
+    var failWriteOnCall: Option[Int] = None
+    var writeCalls = 0
+    var failClean = false
+    var cleanCalls = 0
+    private var closed = false
+
+    override def close(): Unit = if (!closed) {
+      super.close()
+      closed = true
+    }
+
+    override def update(versionID: Array[Byte],
+                        toRemove: TraversableOnce[Array[Byte]],
+                        toUpdate: TraversableOnce[(Array[Byte], Array[Byte])]): Try[Unit] = {
+      writeCalls += 1
+      if (failWrite || failWriteOnCall.contains(writeCalls)) Failure(writeError)
+      else super.update(versionID, toRemove, toUpdate)
+    }
+
+    override def clean(count: Int): Unit = {
+      cleanCalls += 1
+      if (failClean) throw cleanError
+      super.clean(count)
+    }
+  }
+
+  private def withStore(test: (SnapshotStore, File, ErgoSettings) => Unit): Unit = {
+    val root = Files.createTempDirectory("digest-snapshot-checkpoint-").toFile
+    val dir = new File(root, "state")
+    Files.createDirectories(dir.toPath)
+    val localSettings = settings.copy(directory = root.getAbsolutePath,
+      nodeSettings = settings.nodeSettings.copy(stateType = StateType.Digest, keepVersions = 10))
+    val store = new SnapshotStore(dir)
+    try test(store, dir, localSettings)
+    finally {
+      store.close()
+      deleteRecursive(root)
+    }
+  }
+
+  private def seed(store: SnapshotStore, root: Array[Byte]): Unit = {
+    // Model the two version namespaces at this helper's input, without claiming AVL reconstruction.
+    store.update(Array.fill[Byte](32)(7), Seq.empty, Seq(Array[Byte](1) -> Array[Byte](2))).get
+    store.update(root, Seq.empty, Seq(Array[Byte](3) -> Array[Byte](4))).get
+  }
+
+  Seq("legacy AVL", "Digest checkpoint").foreach { format =>
+    property(s"read snapshot preserves $format identity and a durable rollback anchor") {
+      val header = defaultHeaderGen.sample.get
+      val version = idToVersion(header.id)
+      val context = contextFor(header)
+      withStore { (store, dir, localSettings) =>
+        seed(store, header.stateRoot)
+        val initialVersion = if (format == "legacy AVL") header.stateRoot else versionToBytes(version)
+        store.update(initialVersion, Seq.empty,
+          UtxoState.metadata(version, header.stateRoot, None, context)).get
+        store.close()
+
+        // Repeated verified reopening must retain the checkpoint's undo anchor.
+        (1 to 2).foreach { _ =>
+          val state = DigestState.readSnapshot(dir, localSettings, version, header.stateRoot, context).get
+          try {
+            state.version shouldBe version
+            state.rootDigest.toSeq shouldBe header.stateRoot.toSeq
+            state.stateContext.bytes.toSeq shouldBe context.bytes.toSeq
+            state.rollbackVersions.toSeq shouldBe Seq(version)
+            state.store.lastVersionID.get.toSeq shouldBe versionToBytes(version).toSeq
+          } finally state.close()
+        }
+
+        val successor = header.copy(timestamp = header.timestamp + 1, stateRoot = ADDigest @@ changed(header.stateRoot))
+        val successorVersion = idToVersion(successor.id)
+        val state = DigestState.readSnapshot(dir, localSettings, version, header.stateRoot, context).get
+        try {
+          // Direct store successor isolates undo retention; actor/full-block validation is tested separately.
+          state.store.update(versionToBytes(successorVersion), Seq.empty, Seq(
+            versionToBytes(successorVersion) -> successor.stateRoot,
+            ErgoStateReader.ContextKey -> contextFor(successor).bytes)).get
+        } finally state.close()
+
+        val reopened = DigestState.create(None, None, dir, localSettings)
+        try {
+          reopened.version shouldBe successorVersion
+          reopened.rollbackVersions.toSeq shouldBe Seq(successorVersion, version)
+          val rolledBack = reopened.rollbackTo(version).get
+          rolledBack.rootDigest.toSeq shouldBe header.stateRoot.toSeq
+          rolledBack.stateContext.bytes.toSeq shouldBe context.bytes.toSeq
+        } finally reopened.close()
+      }
+    }
+  }
+
+  Seq("wrong root", "wrong raw context", "wrong version", "missing root", "missing context").foreach { fault =>
+    property(s"read snapshot rejects $fault without changing stored evidence") {
+      val header = defaultHeaderGen.sample.get
+      val version = idToVersion(header.id)
+      val context = contextFor(header)
+      val versionBytes = versionToBytes(version)
+      withStore { (store, dir, localSettings) =>
+        seed(store, header.stateRoot)
+        val rawRoot = if (fault == "wrong root") changed(header.stateRoot) else header.stateRoot
+        val rawContext = if (fault == "wrong raw context") Array[Byte](0) else context.bytes
+        val storeVersion = if (fault == "wrong version") changed(versionBytes) else header.stateRoot
+        val rows = Seq(
+          versionBytes -> rawRoot,
+          ErgoStateReader.ContextKey -> rawContext).filterNot { case (key, _) =>
+          (fault == "missing root" && key.sameElements(versionBytes)) ||
+            (fault == "missing context" && key.sameElements(ErgoStateReader.ContextKey))
+        }
+        store.update(storeVersion, Seq.empty, rows).get
+        val keys = Seq(versionBytes, ErgoStateReader.ContextKey, Array[Byte](1), Array[Byte](3),
+          versionToBytes(ErgoState.genesisStateVersion))
+        val valuesBefore = keys.map(key => store.get(key).map(_.toSeq))
+        val versionsBefore = store.rollbackVersions().map(_.toSeq).toSeq
+        val lastBefore = store.lastVersionID.map(_.toSeq)
+        store.close()
+
+        // Missing/corrupt metadata must not enter DigestState.create's genesis fallback.
+        DigestState.readSnapshot(dir, localSettings, version, header.stateRoot, context).isFailure shouldBe true
+        val inspected = new LDBVersionedStore(dir, initialKeepVersions = 10)
+        try {
+          keys.map(key => inspected.get(key).map(_.toSeq)) shouldBe valuesBefore
+          inspected.rollbackVersions().map(_.toSeq).toSeq shouldBe versionsBefore
+          inspected.lastVersionID.map(_.toSeq) shouldBe lastBefore
+        } finally inspected.close()
+      }
+    }
+  }
+
+  property("snapshot checkpoint persists header identity and context across store reopen") {
+    val header = defaultHeaderGen.sample.get
+    val context = contextFor(header)
+    withStore { (store, dir, localSettings) =>
+      header.stateRoot.length shouldBe 33
+      seed(store, header.stateRoot)
+      val state = DigestState.fromSnapshot(idToVersion(header.id), header.stateRoot,
+        context, store, localSettings).get
+      state.store should be theSameInstanceAs store
+      state.version shouldBe idToVersion(header.id)
+      state.rootDigest.toSeq shouldBe header.stateRoot.toSeq
+      state.stateContext.bytes.toSeq shouldBe context.bytes.toSeq
+      store.lastVersionID.get.toSeq shouldBe versionToBytes(state.version).toSeq
+      state.rollbackVersions.toSeq shouldBe Seq(idToVersion(header.id))
+      store.close()
+
+      val reopened = DigestState.create(None, None, dir, localSettings)
+      try {
+        reopened.version shouldBe idToVersion(header.id)
+        reopened.rootDigest.toSeq shouldBe header.stateRoot.toSeq
+        reopened.stateContext.bytes.toSeq shouldBe context.bytes.toSeq
+        reopened.rollbackVersions.toSeq shouldBe Seq(idToVersion(header.id))
+        reopened.rollbackTo(idToVersion(header.id)).get.rootDigest.toSeq shouldBe header.stateRoot.toSeq
+      } finally reopened.close()
+    }
+  }
+
+  property("fresh snapshot checkpoint retains rollback anchor before any verified reopen") {
+    val header = defaultHeaderGen.sample.get
+    val version = idToVersion(header.id)
+    val context = contextFor(header)
+    val successor = header.copy(timestamp = header.timestamp + 1, stateRoot = ADDigest @@ changed(header.stateRoot))
+    val successorVersion = idToVersion(successor.id)
+    withStore { (store, dir, localSettings) =>
+      seed(store, header.stateRoot)
+      val state = DigestState.fromSnapshot(version, header.stateRoot, context, store, localSettings).get
+      // Simulate the Digest metadata consumer before the first restart, without readSnapshot anchor repair.
+      state.store.update(versionToBytes(successorVersion), Seq.empty, Seq(
+        versionToBytes(successorVersion) -> successor.stateRoot,
+        ErgoStateReader.ContextKey -> contextFor(successor).bytes)).get
+      store.close()
+
+      val reopened = DigestState.create(None, None, dir, localSettings)
+      try {
+        reopened.version shouldBe successorVersion
+        reopened.rollbackVersions.toSeq shouldBe Seq(successorVersion, version)
+        reopened.store.rollbackVersions().forall(_.length == 32) shouldBe true
+        val rolledBack = reopened.rollbackTo(version).get
+        rolledBack.version shouldBe version
+        rolledBack.rootDigest.toSeq shouldBe header.stateRoot.toSeq
+        rolledBack.stateContext.bytes.toSeq shouldBe context.bytes.toSeq
+      } finally reopened.close()
+    }
+  }
+
+  property("snapshot checkpoint propagates the write failure without cleaning") {
+    val header = defaultHeaderGen.sample.get
+    withStore { (store, _, localSettings) =>
+      seed(store, header.stateRoot)
+      store.failWrite = true
+      val result = DigestState.fromSnapshot(idToVersion(header.id), header.stateRoot,
+        contextFor(header), store, localSettings)
+      result.failed.get should be theSameInstanceAs store.writeError
+      store.cleanCalls shouldBe 0
+      store.lastVersionID.get.toSeq shouldBe header.stateRoot.toSeq
+      store.get(versionToBytes(idToVersion(header.id))) shouldBe None
+    }
+  }
+
+  property("snapshot checkpoint propagates failure to retain its undo anchor") {
+    val header = defaultHeaderGen.sample.get
+    withStore { (store, _, localSettings) =>
+      seed(store, header.stateRoot)
+      store.failWriteOnCall = Some(store.writeCalls + 2)
+      val result = DigestState.fromSnapshot(idToVersion(header.id), header.stateRoot,
+        contextFor(header), store, localSettings)
+      result.failed.get should be theSameInstanceAs store.writeError
+      store.cleanCalls shouldBe 1
+      store.lastVersionID.get.toSeq shouldBe versionToBytes(idToVersion(header.id)).toSeq
+    }
+  }
+
+  property("snapshot checkpoint propagates cleanup failure after metadata persistence") {
+    val header = defaultHeaderGen.sample.get
+    withStore { (store, _, localSettings) =>
+      seed(store, header.stateRoot)
+      store.failClean = true
+      val result = DigestState.fromSnapshot(idToVersion(header.id), header.stateRoot,
+        contextFor(header), store, localSettings)
+      result.failed.get should be theSameInstanceAs store.cleanError
+      store.cleanCalls shouldBe 1
+      store.lastVersionID.get.toSeq shouldBe versionToBytes(idToVersion(header.id)).toSeq
+      store.get(versionToBytes(idToVersion(header.id))).get.toSeq shouldBe header.stateRoot.toSeq
+    }
+  }
+
+  Seq("version", "context root", "context header", "empty context", "store version").foreach { fault =>
+    property(s"snapshot checkpoint rejects isolated $fault mismatch before writing") {
+      val header = defaultHeaderGen.sample.get
+      val wrongRoot = ADDigest @@ changed(header.stateRoot)
+      val fork = header.copy(timestamp = header.timestamp + 1)
+      val version = if (fault == "version") idToVersion(fork.id) else idToVersion(header.id)
+      val root = if (fault == "context root") wrongRoot else header.stateRoot
+      val context = fault match {
+        case "context header" => contextFor(fork)
+        case "empty context" => ErgoStateContext.empty(settings.chainSettings, settings.launchParameters)
+        case _ => contextFor(header)
+      }
+      withStore { (store, _, localSettings) =>
+        val storeVersion = if (fault == "store version") changed(root) else root
+        seed(store, storeVersion)
+        val result = DigestState.fromSnapshot(version, root, context, store, localSettings)
+        result.isFailure shouldBe true
+        store.lastVersionID.get.toSeq shouldBe storeVersion.toSeq
+        store.get(versionToBytes(version)) shouldBe None
+        store.cleanCalls shouldBe 0
+      }
+    }
+  }
+
+  property("prepared Digest snapshot requires each identity and context signal") {
+    val header = defaultHeaderGen.sample.get
+    val context = contextFor(header).bytes
+    val fork = header.copy(timestamp = header.timestamp + 1)
+    fork.stateRoot.toSeq shouldBe header.stateRoot.toSeq
+    fork.id should not be header.id
+
+    case class Signals(kind: Boolean = true, bootstrap: Boolean = true, applied: Boolean = true,
+                       version: VersionTag = idToVersion(header.id), root: Array[Byte] = header.stateRoot,
+                       canonical: Option[Header] = Some(header), stored: Option[Array[Byte]] = Some(context),
+                       expected: Option[Array[Byte]] = Some(context))
+    def accepts(s: Signals): Boolean = ErgoNodeViewHolder.isPreparedDigestSnapshotState(
+      s.kind, s.bootstrap, s.applied, s.version, s.root, s.canonical, s.stored, s.expected)
+
+    accepts(Signals()) shouldBe true
+    val cases = Seq(
+      "state kind" -> Signals(kind = false),
+      "bootstrap disabled" -> Signals(bootstrap = false),
+      "applied marker missing" -> Signals(applied = false),
+      "wrong version" -> Signals(version = idToVersion(fork.id)),
+      "wrong root" -> Signals(root = changed(header.stateRoot)),
+      "canonical header missing" -> Signals(canonical = None),
+      "same-root canonical sibling" -> Signals(canonical = Some(fork)),
+      "stored context missing" -> Signals(stored = None),
+      "stored context different" -> Signals(stored = Some(changed(context))),
+      "expected context missing" -> Signals(expected = None),
+      "expected context different" -> Signals(expected = Some(changed(context)))
+    )
+    cases.foreach { case (clue, signals) => withClue(clue) { accepts(signals) shouldBe false } }
+  }
+
+  property("prepared Digest snapshot stops reading after the first failed trust signal") {
+    val header = defaultHeaderGen.sample.get
+    val context = contextFor(header).bytes
+    (0 to 4).foreach { stop =>
+      var reads = Vector.empty[Int]
+      def gate(index: Int): Boolean = {
+        reads :+= index
+        index != stop
+      }
+      val accepted = ErgoNodeViewHolder.isPreparedDigestSnapshotState(
+        stateIsDigest = stop != 0,
+        utxoBootstrap = gate(1),
+        snapshotApplied = gate(2),
+        stateVersion = idToVersion(header.id),
+        stateRoot = header.stateRoot,
+        snapshotHeaderOpt = if (gate(3)) Some(header) else None,
+        storedContext = if (gate(4)) Some(context) else None,
+        expectedContext = { reads :+= 5; Some(context) })
+      accepted shouldBe false
+      reads shouldBe (1 to stop).toVector
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/DigestSnapshotBootstrapSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/DigestSnapshotBootstrapSpecification.scala
@@ -1,0 +1,298 @@
+package org.ergoplatform.nodeView.viewholder
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.testkit.TestProbe
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import java.io.{File, IOException}
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
+import org.ergoplatform.core.{idToVersion, versionToBytes}
+import org.ergoplatform.mining.DefaultFakePowScheme
+import org.ergoplatform.modifiers.{ErgoFullBlock, SnapshotsInfoTypeId}
+import org.ergoplatform.modifiers.history.header.Header
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedState, InitStateFromSnapshot}
+import org.ergoplatform.nodeView.{ErgoNodeViewHolder, ErgoNodeViewRef}
+import org.ergoplatform.nodeView.history.ErgoHistory
+import org.ergoplatform.nodeView.state.{DigestState, ErgoState, StateType, UtxoState}
+import org.ergoplatform.nodeView.state.wrapped.WrappedUtxoState
+import org.ergoplatform.serialization.ManifestSerializer
+import org.ergoplatform.settings.{Algos, ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.utils.{ErgoCorePropertyTest, NodeViewTestContext, NodeViewTestOps}
+import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+import org.ergoplatform.utils.generators.ValidBlocksGenerators.validFullBlock
+import org.ergoplatform.wallet.utils.FileUtils
+import scorex.db.{LDBFactory, LDBVersionedStore, StoreRegistry}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/** Exercises the snapshot producer and closes the actual stores before reopening the configured state mode. */
+class DigestSnapshotBootstrapSpecification extends ErgoCorePropertyTest with NodeViewTestOps with FileUtils {
+
+  private def parsedSettings(directory: File, mode: StateType): ErgoSettings = {
+    Files.createDirectories(directory.toPath.resolve("wallet/keystore"))
+    val config = ConfigFactory.parseString(
+      s"""ergo.node.stateType = "${mode.stateTypeName}"
+         |ergo.node.utxo.utxoBootstrap = true
+         |ergo.node.nipopow.nipopowBootstrap = false
+         |ergo.node.verifyTransactions = true
+         |ergo.node.mining = false
+         |ergo.node.extraIndex = false
+         |ergo.chain.voting.votingLength = 20
+         |""".stripMargin)
+      .withValue("ergo.directory", ConfigValueFactory.fromAnyRef(directory.getAbsolutePath))
+      .withValue("ergo.wallet.secretStorage.secretDir",
+        ConfigValueFactory.fromAnyRef(new File(directory, "wallet/keystore").getAbsolutePath))
+      .withFallback(ConfigFactory.load())
+      .resolve()
+    val parsed = ErgoSettingsReader.fromConfig(config)
+    parsed.nodeSettings.stateType shouldBe mode
+    parsed.nodeSettings.utxoSettings.utxoBootstrap shouldBe true
+    parsed.nodeSettings.nipopowSettings.nipopowBootstrap shouldBe false
+    parsed.nodeSettings.verifyTransactions shouldBe true
+    parsed.nodeSettings.mining shouldBe false
+    parsed.copy(chainSettings = parsed.chainSettings.copy(
+      powScheme = new DefaultFakePowScheme(parsed.chainSettings.powScheme.k, parsed.chainSettings.powScheme.n)))
+  }
+
+  // The registry reuses unclosed DB handles, so actor recreation alone cannot establish a disk reopen.
+  private def closeOwnedStores(directory: File): Unit = {
+    val root = directory.getCanonicalFile.toPath
+    val registry = LDBFactory.factory.asInstanceOf[StoreRegistry]
+    registry.lock.writeLock().lock()
+    try {
+      registry.map.toVector.collect {
+        case (path, db) if path.getCanonicalFile.toPath.startsWith(root) => db
+      }.foreach(_.close())
+      registry.map.keys.exists(_.getCanonicalFile.toPath.startsWith(root)) shouldBe false
+    } finally registry.lock.writeLock().unlock()
+  }
+
+  private class Session(override val settings: ErgoSettings,
+                        selfShutdown: Boolean = false,
+                        failAfterAvlWrite: Option[AtomicBoolean] = None) extends NodeViewTestContext {
+    override val actorSystem: ActorSystem = if (selfShutdown) {
+      ActorSystem("snapshot-failure", ConfigFactory.parseString(
+        """akka.coordinated-shutdown.terminate-actor-system = on
+          |akka.coordinated-shutdown.exit-jvm = off
+          |""".stripMargin).withFallback(ConfigFactory.load()))
+    } else ActorSystem()
+    override val testProbe: TestProbe = TestProbe()(actorSystem)
+    override val nodeViewHolderRef: ActorRef = failAfterAvlWrite match {
+      case None => ErgoNodeViewRef(settings)(actorSystem)
+      case Some(injected) => actorSystem.actorOf(Props(new ErgoNodeViewHolder[DigestState](settings) {
+        override protected def genesisState = {
+          val (history, initialState, wallet, pool) = super.genesisState
+          initialState.closeStorage()
+          val faultStore = new LDBVersionedStore(new File(settings.directory, "state"),
+            initialKeepVersions = settings.nodeSettings.keepVersions) {
+            override def update(versionID: Array[Byte],
+                                toRemove: TraversableOnce[Array[Byte]],
+                                toUpdate: TraversableOnce[(Array[Byte], Array[Byte])]): Try[Unit] = {
+              super.update(versionID, toRemove, toUpdate).flatMap { _ =>
+                if (versionID.length == 33 && injected.compareAndSet(false, true)) {
+                  Failure(new IOException("injected failure after AVL reconstruction write"))
+                } else Success(())
+              }
+            }
+          }
+          val faultState = new DigestState(initialState.version, initialState.rootDigest, faultStore, settings) {}
+          (history, faultState, wallet, pool)
+        }
+      }))
+    }
+
+    def stop(): Unit = {
+      // Termination also completes when the system has already stopped after an actor failure.
+      // A probe in that stopped system cannot receive a new Terminated acknowledgement.
+      Await.result(actorSystem.terminate(), 30.seconds)
+      closeOwnedStores(new File(settings.directory))
+    }
+  }
+
+  Seq((StateType.Utxo, false, false, false), (StateType.Digest, false, false, false),
+    (StateType.Digest, true, false, false), (StateType.Digest, false, true, false),
+    (StateType.Digest, false, false, true)).foreach { case (mode, invalidAnchor, legacyFormat, postWriteFailure) =>
+    val testName = if (invalidAnchor) "failed Digest snapshot preparation shuts down without marking or publishing state"
+    else if (postWriteFailure) "failed AVL snapshot reconstruction shuts down after a real write without publishing state"
+    else if (legacyFormat) "convert a legacy UTXO-format snapshot checkpoint on Digest reopen and retain rollback"
+    else s"preserve real snapshot root and version after store reopen in ${mode.stateTypeName} mode"
+    property(testName) {
+      val root = Files.createTempDirectory("snapshot-mode-reopen-").toFile
+      val nodeSettings = parsedSettings(new File(root, "node"), mode)
+      // The real UTXO producer writes the legacy physical format; no old binary is executed.
+      val importMode = if (legacyFormat) StateType.Utxo else mode
+      val importSettings = if (legacyFormat) parsedSettings(new File(root, "node"), importMode) else nodeSettings
+      val sourceSettings = parsedSettings(new File(root, "source"), StateType.Utxo)
+      var session: Option[Session] = None
+      var observerSystem: Option[ActorSystem] = None
+      try {
+        val sourceDir = new File(sourceSettings.directory, "state")
+        Files.createDirectories(sourceDir.toPath)
+        val (genesis, boxes) = ErgoState.generateGenesisUtxoState(sourceDir, sourceSettings, Some(parameters))
+        var source = WrappedUtxoState(genesis, boxes, sourceSettings)
+        var parent: Option[ErgoFullBlock] = None
+        val startTime = System.currentTimeMillis() - 20000L
+        val blocks = (1 to 19).map { height =>
+          val block = validFullBlock(parent, source, startTime + height * 1000L)
+          source = source.applyModifier(block)(_ => ()).get
+          parent = Some(block)
+          block
+        }
+        val snapshotHeader = blocks.last.header
+        val successor = validFullBlock(parent, source, startTime + 20000L)
+        snapshotHeader.height shouldBe 19
+        Algos.encode(source.rootDigest) shouldBe Algos.encode(snapshotHeader.stateRoot)
+        source.dumpSnapshot(snapshotHeader.height, source.rootDigest.dropRight(1)).get
+        val manifestId = source.snapshotsDb.readSnapshotsInfo.availableManifests(snapshotHeader.height)
+        val manifest = ManifestSerializer.defaultSerializer.parseBytes(source.snapshotsDb.readManifestBytes(manifestId).get)
+        // Small trees can be fully embedded in the production-depth manifest. Such a fixture
+        // exercises real snapshot import, but does not establish nonzero chunk-transfer coverage.
+        info(s"${mode.stateTypeName} snapshot subtree count: ${manifest.subtreesIds.size}")
+
+        val injectedWrite = new AtomicBoolean(false)
+        val first = new Session(importSettings, selfShutdown = invalidAnchor || postWriteFailure,
+          failAfterAvlWrite = if (postWriteFailure) Some(injectedWrite) else None)
+        session = Some(first)
+        blocks.foreach(block => applyHeader(block.header)(first).get)
+        val history = getHistory(first)
+        history.bestFullBlockOpt shouldBe None
+        history.isUtxoSnapshotApplied shouldBe false
+        history.registerManifestToDownload(manifest, snapshotHeader.height, Seq.empty)
+        manifest.subtreesIds.foreach { id =>
+          history.registerDownloadedChunk(id, source.snapshotsDb.readSubtreeBytes(id).get)
+        }
+        if (invalidAnchor || postWriteFailure) {
+          val observer = ActorSystem("snapshot-failure-observer")
+          observerSystem = Some(observer)
+          val stateEvents = TestProbe()(observer)
+          first.actorSystem.eventStream.subscribe(stateEvents.ref, classOf[ChangedState]) shouldBe true
+          val initialFloor = history.minimalFullBlockHeight
+          // Both failures occur after a real AVL write: either preparation rejects a different
+          // block ID, or the store reports an injected error after committing reconstruction.
+          val requestedAnchor = if (invalidAnchor) Header.GenesisParentId else snapshotHeader.id
+          send(InitStateFromSnapshot(snapshotHeader.height, requestedAnchor))(first)
+          Await.result(first.actorSystem.whenTerminated, 30.seconds)
+          injectedWrite.get() shouldBe postWriteFailure
+          stateEvents.expectNoMessage(300.millis)
+          closeOwnedStores(new File(nodeSettings.directory))
+          session = None
+          val reconstructedStore = new LDBVersionedStore(new File(nodeSettings.directory, "state"),
+            initialKeepVersions = nodeSettings.nodeSettings.keepVersions)
+          try {
+            reconstructedStore.lastVersionID.map(Algos.encode(_)) shouldBe Some(Algos.encode(snapshotHeader.stateRoot))
+          } finally reconstructedStore.close()
+          val reopenedHistory = ErgoHistory.readOrGenerate(nodeSettings)(null)
+          try {
+            reopenedHistory.isUtxoSnapshotApplied shouldBe false
+            reopenedHistory.minimalFullBlockHeight shouldBe initialFloor
+            reopenedHistory.bestFullBlockOpt shouldBe None
+          } finally reopenedHistory.closeStorage()
+        } else {
+        send(InitStateFromSnapshot(snapshotHeader.height, snapshotHeader.id))(first)
+        val importedStateClass = if (importMode == StateType.Digest) classOf[DigestState] else classOf[UtxoState]
+        val expectedStateClass = if (mode == StateType.Digest) classOf[DigestState] else classOf[UtxoState]
+        // send and query both originate from the probe, preserving mailbox ordering.
+        first.testProbe.send(first.nodeViewHolderRef,
+          org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetDataFromCurrentView[ErgoState[_], String](
+            view => view.state.getClass.getName))
+        first.testProbe.expectMsg(20.seconds, importedStateClass.getName)
+        getCurrentState(first).version shouldBe idToVersion(snapshotHeader.id)
+        getRootHash(first) shouldBe Algos.encode(snapshotHeader.stateRoot)
+        val snapshotContext = Algos.encode(getCurrentState(first).stateContext.bytes)
+        if (importMode == StateType.Digest) {
+          val versions = getCurrentState(first).rollbackVersions.toSeq
+          versions.map(version => versionToBytes(version).length) shouldBe Seq(32)
+          versions shouldBe Seq(idToVersion(snapshotHeader.id))
+        }
+        getHistory(first).isUtxoSnapshotApplied shouldBe true
+        getHistory(first).minimalFullBlockHeight shouldBe 20
+        getHistory(first).bestFullBlockOpt shouldBe None
+
+        first.stop()
+        session = None
+        val reopened = new Session(nodeSettings)
+        session = Some(reopened)
+        val reopenedView = getCurrentView(reopened)
+        val requests = reopenedView.history.nextModifiersToDownload(10, (_, id) => !reopenedView.history.contains(id))
+        val observation = s"mode=$mode, runtime=${reopenedView.state.getClass.getSimpleName}, " +
+          s"version=${reopenedView.state.version}, root=${Algos.encode(reopenedView.state.rootDigest)}, " +
+          s"applied=${reopenedView.history.isUtxoSnapshotApplied}, floor=${reopenedView.history.minimalFullBlockHeight}, " +
+          s"fullBlock=${reopenedView.history.bestFullBlockOpt.map(_.id)}, requestTypes=${requests.keySet}"
+        withClue(observation) {
+          reopenedView.history.bestFullBlockOpt shouldBe None
+          reopenedView.history.isUtxoSnapshotApplied shouldBe true
+          reopenedView.history.minimalFullBlockHeight shouldBe 20
+          Algos.encode(reopenedView.state.rootDigest) shouldBe Algos.encode(snapshotHeader.stateRoot)
+          reopenedView.state.version shouldBe idToVersion(snapshotHeader.id)
+          reopenedView.state.getClass.getName shouldBe expectedStateClass.getName
+          Algos.encode(reopenedView.state.stateContext.bytes) shouldBe snapshotContext
+          if (mode == StateType.Digest) {
+            reopenedView.state.rollbackVersions.toSeq shouldBe Seq(idToVersion(snapshotHeader.id))
+          }
+          reopenedView.history.isHeadersChainSynced shouldBe false
+          requests shouldBe Map.empty
+        }
+        // Ordinary header sync is session-local: fresh header arrival must rearm it naturally.
+        applyHeader(successor.header)(reopened).get
+        val rearmedHistory = getHistory(reopened)
+        rearmedHistory.isHeadersChainSynced shouldBe true
+        val rearmedRequests = rearmedHistory.nextModifiersToDownload(10, (_, id) => !rearmedHistory.contains(id))
+        withClue(s"$observation, rearmedRequestTypes=${rearmedRequests.keySet}") {
+          rearmedRequests.contains(SnapshotsInfoTypeId.value) shouldBe false
+          rearmedRequests.values.flatten.toSet shouldBe successor.header.sectionIds
+            .filter { case (typeId, _) => mode.requireProofs || typeId != org.ergoplatform.modifiers.history.ADProofs.modifierTypeId }
+            .map(_._2).toSet
+        }
+        applyPayload(successor)(reopened).get
+        val afterBlock = getCurrentView(reopened)
+        afterBlock.state.version shouldBe idToVersion(successor.id)
+        Algos.encode(afterBlock.state.rootDigest) shouldBe Algos.encode(successor.header.stateRoot)
+        afterBlock.history.bestFullBlockOpt.map(_.id) shouldBe Some(successor.id)
+        val successorContext = Algos.encode(afterBlock.state.stateContext.bytes)
+
+        reopened.stop()
+        session = None
+        val afterBlockRestart = new Session(nodeSettings)
+        session = Some(afterBlockRestart)
+        val afterRestart = getCurrentView(afterBlockRestart)
+        afterRestart.state.getClass.getName shouldBe expectedStateClass.getName
+        afterRestart.state.version shouldBe idToVersion(successor.id)
+        Algos.encode(afterRestart.state.rootDigest) shouldBe Algos.encode(successor.header.stateRoot)
+        Algos.encode(afterRestart.state.stateContext.bytes) shouldBe successorContext
+        afterRestart.history.bestFullBlockOpt.map(_.id) shouldBe Some(successor.id)
+
+        if (mode == StateType.Digest) {
+          afterRestart.state.rollbackVersions.foreach(version => versionToBytes(version).length shouldBe 32)
+          afterBlockRestart.stop()
+          session = None
+          // State-only rollback control: no actor/history reconciliation is invoked after moving
+          // this isolated state back to the anchor while history still records the successor.
+          val persisted = ErgoState.readOrGenerate(nodeSettings).asInstanceOf[DigestState]
+          val rolledBack = persisted.rollbackTo(idToVersion(snapshotHeader.id)).get
+          rolledBack.version shouldBe idToVersion(snapshotHeader.id)
+          Algos.encode(rolledBack.rootDigest) shouldBe Algos.encode(snapshotHeader.stateRoot)
+          Algos.encode(rolledBack.stateContext.bytes) shouldBe snapshotContext
+          rolledBack.closeStorage()
+          closeOwnedStores(new File(nodeSettings.directory))
+          val reopenedAnchor = ErgoState.readOrGenerate(nodeSettings)
+          reopenedAnchor.version shouldBe idToVersion(snapshotHeader.id)
+          Algos.encode(reopenedAnchor.rootDigest) shouldBe Algos.encode(snapshotHeader.stateRoot)
+          Algos.encode(reopenedAnchor.stateContext.bytes) shouldBe snapshotContext
+          reopenedAnchor.closeStorage()
+        }
+        }
+      } finally {
+        try session.foreach(_.stop())
+        finally {
+          try observerSystem.foreach(system => Await.result(system.terminate(), 30.seconds))
+          finally {
+            closeOwnedStores(root)
+            deleteRecursive(root)
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/org/ergoplatform/nodeView/viewholder/DigestSnapshotNetworkSpecification.scala
+++ b/src/test/scala/org/ergoplatform/nodeView/viewholder/DigestSnapshotNetworkSpecification.scala
@@ -1,0 +1,210 @@
+package org.ergoplatform.nodeView
+
+import akka.actor.{ActorSystem, Cancellable}
+import akka.testkit.TestProbe
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import java.io.File
+import java.nio.file.Files
+import org.ergoplatform.mining.DefaultFakePowScheme
+import org.ergoplatform.modifiers.UtxoSnapshotChunkTypeId
+import org.ergoplatform.network.{ErgoNodeViewSynchronizer, ErgoSyncTracker}
+import org.ergoplatform.network.ErgoNodeViewSynchronizerMessages.{ChangedHistory, ChangedMempool, ChangedState, InitStateFromSnapshot}
+import org.ergoplatform.network.message.{GetManifestSpec, GetUtxoSnapshotChunkSpec, Message, UtxoSnapshotChunkSpec}
+import org.ergoplatform.network.peer.PenaltyType
+import org.ergoplatform.nodeView.ErgoNodeViewHolder.ReceivableMessages.GetNodeViewChanges
+import org.ergoplatform.nodeView.history.{ErgoHistory, ErgoSyncInfoMessageSpec}
+import org.ergoplatform.nodeView.mempool.ErgoMemPool
+import org.ergoplatform.nodeView.state.{ErgoState, StateType, UtxoState}
+import org.ergoplatform.serialization.{ManifestSerializer, SubtreeSerializer}
+import org.ergoplatform.settings.{Algos, ErgoSettings, ErgoSettingsReader}
+import org.ergoplatform.utils.ErgoCorePropertyTest
+import org.ergoplatform.utils.ErgoCoreTestConstants.parameters
+import org.ergoplatform.utils.generators.ChainGenerator.genHeaderChain
+import org.ergoplatform.utils.generators.ConnectedPeerGenerators.connectedPeerGen
+import org.ergoplatform.utils.generators.ErgoNodeTransactionGenerators.boxesHolderGenOfSize
+import org.ergoplatform.wallet.utils.FileUtils
+import scorex.core.network.DeliveryTracker
+import scorex.core.network.NetworkController.ReceivableMessages.PenalizePeer
+import scorex.crypto.authds.ADDigest
+import scorex.crypto.authds.avltree.batch.VersionedLDBAVLStorage.splitDigest
+import scorex.crypto.hash.Digest32
+import scorex.db.{LDBFactory, StoreRegistry}
+import scorex.util.bytesToId
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+  * Isolates chunk reception after manifest selection: the manifest and tracker requests are registered
+  * directly. Serialized peer messages enter the production synchronizer, which persists chunks and
+  * requests initialization from its holder. This does not exercise wire manifest negotiation or state import.
+  */
+class DigestSnapshotNetworkSpecification extends ErgoCorePropertyTest with FileUtils {
+
+  private def parsedSettings(directory: File, mode: StateType): ErgoSettings = {
+    Files.createDirectories(directory.toPath.resolve("wallet/keystore"))
+    val config = ConfigFactory.parseString(
+      s"""ergo.node.stateType = "${mode.stateTypeName}"
+         |ergo.node.utxo.utxoBootstrap = true
+         |ergo.node.nipopow.nipopowBootstrap = false
+         |ergo.node.verifyTransactions = true
+         |ergo.node.mining = false
+         |ergo.node.extraIndex = false
+         |ergo.chain.voting.votingLength = 20
+         |scorex.network.syncInterval = 1h
+         |""".stripMargin)
+      .withValue("ergo.directory", ConfigValueFactory.fromAnyRef(directory.getAbsolutePath))
+      .withValue("ergo.wallet.secretStorage.secretDir",
+        ConfigValueFactory.fromAnyRef(new File(directory, "wallet/keystore").getAbsolutePath))
+      .withFallback(ConfigFactory.load()).resolve()
+    val parsed = ErgoSettingsReader.fromConfig(config)
+    parsed.nodeSettings.stateType shouldBe mode
+    parsed.nodeSettings.utxoSettings.utxoBootstrap shouldBe true
+    parsed.copy(chainSettings = parsed.chainSettings.copy(
+      powScheme = new DefaultFakePowScheme(parsed.chainSettings.powScheme.k, parsed.chainSettings.powScheme.n)))
+  }
+
+  private def closeOwnedStores(directory: File): Unit = {
+    val root = directory.getCanonicalFile.toPath
+    val registry = LDBFactory.factory.asInstanceOf[StoreRegistry]
+    registry.lock.writeLock().lock()
+    try {
+      registry.map.toVector.collect {
+        case (path, db) if path.getCanonicalFile.toPath.startsWith(root) => db
+      }.foreach(_.close())
+      registry.map.keys.exists(_.getCanonicalFile.toPath.startsWith(root)) shouldBe false
+    } finally registry.lock.writeLock().unlock()
+  }
+
+  private case class SnapshotBytes(manifest: Array[Byte], chunks: Vector[Array[Byte]], root: ADDigest)
+
+  // Reuse only immutable serialized producer output; actor and database state are isolated per case.
+  private lazy val snapshot: SnapshotBytes = {
+    val directory = Files.createTempDirectory("snapshot-network-source-").toFile
+    val settings = parsedSettings(directory, StateType.Utxo)
+    try {
+      val stateDir = new File(directory, "state")
+      Files.createDirectories(stateDir.toPath)
+      val boxes = boxesHolderGenOfSize(32 * 1024).sample.get
+      val source = UtxoState.fromBoxHolder(boxes, None, stateDir, settings, parameters)
+      ManifestSerializer.MainnetManifestDepth shouldBe 14
+      source.dumpSnapshot(19, source.rootDigest.dropRight(1)).get
+      val id = source.snapshotsDb.readSnapshotsInfo.availableManifests(19)
+      val bytes = source.snapshotsDb.readManifestBytes(id).get
+      val manifest = ManifestSerializer.defaultSerializer.parseBytes(bytes)
+      manifest.subtreesIds should not be empty
+      val (rootHash, height) = splitDigest(source.rootDigest)
+      manifest.verify(Digest32 @@ rootHash, height) shouldBe true
+      val chunks = manifest.subtreesIds.map { subtreeId =>
+        val chunk = source.snapshotsDb.readSubtreeBytes(subtreeId).get
+        SubtreeSerializer.parseBytes(chunk).verify(subtreeId) shouldBe true
+        chunk
+      }.toVector
+      info(s"Production-depth snapshot has ${chunks.size} nonempty subtree messages")
+      SnapshotBytes(bytes, chunks, source.rootDigest)
+    } finally {
+      closeOwnedStores(directory)
+      deleteRecursive(directory)
+    }
+  }
+
+  Seq((StateType.Utxo, "requested"), (StateType.Digest, "requested"),
+    (StateType.Digest, "unsolicited"), (StateType.Digest, "malformed")).foreach { case (mode, input) =>
+    property(s"${mode.stateTypeName} snapshot chunk receive handles $input peer messages") {
+      val fixture = snapshot
+      val directory = Files.createTempDirectory("snapshot-network-receive-").toFile
+      val settings = parsedSettings(directory, mode)
+      implicit val system: ActorSystem = ActorSystem()
+      implicit val ec: scala.concurrent.ExecutionContext = system.dispatcher
+      try {
+        var history = ErgoHistory.readOrGenerate(settings)(null)
+        val generated = genHeaderChain(19, history, diffBitsOpt = None, useRealTs = false).headers
+        // Canonical accepted headers identify the snapshot root, without reconstructing a full-block chain.
+        val headers = generated.dropRight(1) :+ generated.last.copy(stateRoot = fixture.root)
+        headers.foreach(header => history = history.append(header).get._1)
+        val anchor = headers.last
+        history.bestHeaderAtHeight(19).map(_.id) shouldBe Some(anchor.id)
+        history.bestFullBlockOpt shouldBe None
+        val state = ErgoState.readOrGenerate(settings)
+        state.getClass.getSimpleName shouldBe (if (mode == StateType.Digest) "DigestState" else "UtxoState")
+        val pool = ErgoMemPool.empty(settings)
+        val network = TestProbe()
+        val holder = TestProbe()
+        val senderProbe = TestProbe()
+        val peer = connectedPeerGen(TestProbe().ref).sample.get
+        val tracker = DeliveryTracker.empty(settings)
+        val manifest = ManifestSerializer.defaultSerializer.parseBytes(fixture.manifest)
+        history.registerManifestToDownload(manifest, 19, Seq.empty)
+        val chunkIds = history.getChunkIdsToDownload(manifest.subtreesIds.size)
+        chunkIds.size shouldBe fixture.chunks.size
+        if (input != "unsolicited") {
+          chunkIds.foreach { id =>
+            tracker.setRequested(UtxoSnapshotChunkTypeId.value, bytesToId(id), peer) { _ =>
+              Cancellable.alreadyCancelled
+            }
+          }
+        }
+        val initialPlan = history.utxoSetSnapshotDownloadPlan().get
+        initialPlan.fullyDownloaded shouldBe false
+        history.downloadedChunksIterator().toVector shouldBe empty
+        val synchronizer = ErgoNodeViewSynchronizer.make(
+          holder.ref, ErgoSyncInfoMessageSpec, settings,
+          ErgoSyncTracker(settings.scorexSettings.network), tracker)(system, ec)(network.ref)
+        holder.expectMsgType[GetNodeViewChanges](10.seconds)
+        // Same-sender ordering initializes the real reader mode before its first chunk message.
+        senderProbe.send(synchronizer, ChangedState(state))
+        senderProbe.send(synchronizer, ChangedHistory(history))
+        senderProbe.send(synchronizer, ChangedMempool(pool))
+
+        val chunksToSend = input match {
+          case "requested" => fixture.chunks
+          case "unsolicited" => fixture.chunks.take(1)
+          case "malformed" => Vector(Array.emptyByteArray)
+        }
+        chunksToSend.foreach { chunk =>
+          senderProbe.send(synchronizer,
+            Message(UtxoSnapshotChunkSpec, Left(UtxoSnapshotChunkSpec.toBytes(chunk)), Some(peer)))
+        }
+        if (input == "requested") {
+          holder.expectMsg(20.seconds, InitStateFromSnapshot(19, anchor.id))
+          val completed = history.utxoSetSnapshotDownloadPlan().get
+          completed.fullyDownloaded shouldBe true
+          completed.downloadingChunks shouldBe 0
+          history.downloadedChunksIterator().map(chunk => Algos.encode(chunk.id)).toSet shouldBe
+            chunkIds.map(Algos.encode(_)).toSet
+          chunkIds.foreach(id => tracker.getRequestedInfo(UtxoSnapshotChunkTypeId.value, bytesToId(id)) shouldBe None)
+          network.expectNoMessage(200.millis)
+          senderProbe.send(synchronizer,
+            Message(UtxoSnapshotChunkSpec, Left(UtxoSnapshotChunkSpec.toBytes(fixture.chunks.head)), Some(peer)))
+          network.expectMsgType[PenalizePeer](10.seconds).penaltyType shouldBe PenaltyType.SpamPenalty
+          history.utxoSetSnapshotDownloadPlan().get shouldBe completed
+          holder.expectNoMessage(200.millis)
+        } else {
+          val penalty = network.expectMsgType[PenalizePeer](10.seconds)
+          penalty.address shouldBe peer.connectionId.remoteAddress
+          penalty.penaltyType shouldBe (if (input == "unsolicited") PenaltyType.SpamPenalty else PenaltyType.MisbehaviorPenalty)
+          history.utxoSetSnapshotDownloadPlan().get shouldBe initialPlan
+          history.downloadedChunksIterator().toVector shouldBe empty
+          holder.expectNoMessage(200.millis)
+          if (input == "malformed") {
+            chunkIds.foreach(id => tracker.getRequestedInfo(UtxoSnapshotChunkTypeId.value, bytesToId(id)).isDefined shouldBe true)
+          }
+        }
+        if (mode == StateType.Digest) {
+          senderProbe.send(synchronizer,
+            Message(GetManifestSpec, Left(GetManifestSpec.toBytes(manifest.id)), Some(peer)))
+          senderProbe.send(synchronizer,
+            Message(GetUtxoSnapshotChunkSpec, Left(GetUtxoSnapshotChunkSpec.toBytes(chunkIds.head)), Some(peer)))
+          network.expectNoMessage(200.millis)
+          holder.expectNoMessage(200.millis)
+        }
+        // The holder probe observes the initialization request but never performs the state import.
+        history.isUtxoSnapshotApplied shouldBe false
+      } finally {
+        Await.result(system.terminate(), 30.seconds)
+        closeOwnedStores(directory)
+        deleteRecursive(directory)
+      }
+    }
+  }
+}


### PR DESCRIPTION
With `stateType="digest"` and UTXO snapshot bootstrap enabled, the snapshot producer installs a UTXO state and persists AVL-root versions. The Digest loader interprets versions as block IDs. A restart before the first full block can therefore fall back to genesis while history still reports that the snapshot is applied. The regression reproduces this through the real snapshot producer and closed-store reopening; the UTXO control passes.

Digest also drops incoming detached snapshot chunks because the receive branch incorrectly requires a local UTXO reader. An actor regression with real nonempty snapshot chunks passes in UTXO mode and fails in Digest before the correction.

This addresses [the Digest configuration concern in #2496](https://github.com/ergoplatform/ergo/pull/2496#discussion_r3971458455), preserving the [documented mode combination](https://docs.ergoplatform.com/node/modes/).

The correction:

- Installs the configured Digest state, with the snapshot header ID, root and reconstructed context persisted before publishing the applied marker.
- Removes AVL-root versions from the Digest rollback namespace and retains a durable snapshot anchor. The first full block uses the already reconstructed context instead of replaying its preceding headers.
- Converts a valid earlier UTXO-format snapshot checkpoint when reopening as Digest. Canonical history, raw context bytes, root and version must agree. Inconsistent data fails without genesis recreation.
- Stops processing after a reconstruction or preparation failure that may have changed the state store. Pre-write manifest/context failures retain their existing handling.
- Receives requested chunks independently of the local state representation. Parsing, outstanding-ID checks and serving restrictions remain in place; Digest does not gain UTXO snapshot-serving capabilities.

Review and integration:

- Parent: [#2545](https://github.com/ergoplatform/ergo/pull/2545) at `036c2c258f7aceef00ead6d92cfa238f1e4722bf`. Its published head is unchanged.
- Review this [eight-file increment](https://github.com/a-shannon/ergo/compare/036c2c258f7aceef00ead6d92cfa238f1e4722bf...63c9b79dc576461f6266c234612c35d8ed393d73). The [two-file receive follow-up](https://github.com/a-shannon/ergo/compare/43b696e4058412183178b400e5b4555fbb05bc8b...63c9b79dc576461f6266c234612c35d8ed393d73) isolates the changes since the checkpoint review. The upstream target is `i2464`, so its cumulative diff includes #2545 until that prerequisite is integrated and this branch refreshed.
- Integrate #2545 before this follow-up. [#2424](https://github.com/ergoplatform/ergo/pull/2424) at `72140e5dea0934b9f5752a70a458ae4ac863237b` and the [combined wallet review](https://github.com/a-shannon/ergo/pull/2) at `8e475916a0cade7b2dd5ed37607b6a77a47c35d2` publish the adapted checkpoint and receive corrections while preserving their finalization and wallet recovery gates.

Validation at current head `63c9b79dc576461f6266c234612c35d8ed393d73`:

- **35 receive/synchronizer tests pass:** four new network-receive cases and 31 existing synchronizer cases. The new fixture uses a real depth-14 manifest with nonempty detached chunks, actual serialized peer messages, request tracking and history persistence. UTXO and Digest reach the exact initialization request; unsolicited, malformed and duplicate chunks do not advance the plan. Digest serving restrictions remain unchanged.
- **44 checkpoint/lifecycle tests retain their unchanged validated inputs:** five producer/lifecycle cases, 19 checkpoint and negative cases, 17 existing Digest-history cases, and three existing UTXO snapshot-preservation cases.
- The lifecycle cases cover configured state type, real import, close/reopen before the first full block, application of that block, another reopen, rollback and legacy-format conversion. Separate actor failures verify real store mutation, self-shutdown, no state publication and an unchanged unapplied history marker.
- Removing checkpoint metadata, namespace cleanup or the undo anchor each fails its targeted regression. The restored source passes all 19 direct checkpoint tests again.
- Independent source and fixture review completed. **All eight checks passed on current head `63c9b79dc576461f6266c234612c35d8ed393d73`** ([run 34416424462](https://github.com/ergoplatform/ergo/actions/runs/34416424462)). The previous checkpoint head `43b696e4058412183178b400e5b4555fbb05bc8b` also passed all eight checks ([run 34409630823](https://github.com/ergoplatform/ergo/actions/runs/34409630823)); that remains historical evidence for those exact bytes.

The lifecycle fixtures use fake PoW and a small state. The separate receive fixture registers its manifest and outstanding requests directly; its holder probe observes initialization without importing state. Full wire-manifest negotiation, TCP framing, process interruption and production-network qualification remain outside this evidence. Imported AVL payloads remain on disk; inconsistent stores are preserved for recovery. Consensus validation and NiPoPoW proof handling are unchanged. [#2464](https://github.com/ergoplatform/ergo/issues/2464) remains a broader qualification issue.
