### PR TITLE
Expose transaction validation cost in mempool transaction JSON

### DIFF
--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -472,6 +472,16 @@ components:
                 description: Size in bytes
                 type: integer
                 format: int32
+            cost:
+                description: >-
+                  Validation cost of the transaction, as measured when it entered the mempool.
+                  Null when the cost is not known to the node, i.e. when the node is running a
+                  digest state, or when the transaction was returned to the pool by a rollback
+                  and has not been re-validated yet.
+                type: integer
+                format: int32
+                nullable: true
+                example: 21456
 
     IndexedErgoTransaction:
       type: object

--- a/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
+++ b/src/main/scala/org/ergoplatform/http/api/TransactionsApiRoute.scala
@@ -101,8 +101,14 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
 
   /**
     * Creates a transaction JSON representation with resolved input boxes.
+    *
+    * `cost` is the validation cost measured when the transaction entered the pool. It is None
+    * when no script validation was done for it, i.e. when the node runs a digest state, or when
+    * the transaction was returned to the pool by a rollback and has not been re-checked yet.
   */
-  private def createTransactionWithResolvedInputs(tx: ErgoTransaction, resolvedInputs: Map[BoxId, ErgoBox]): Json = {
+  private def createTransactionWithResolvedInputs(tx: ErgoTransaction,
+                                                  resolvedInputs: Map[BoxId, ErgoBox],
+                                                  cost: Option[Int]): Json = {
 
     val enrichedInputs = tx.inputs.map { input =>
       val baseInput = Json.obj(
@@ -123,7 +129,8 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
       "inputs"     -> enrichedInputs.asJson,
       "dataInputs" -> tx.dataInputs.asJson,
       "outputs"    -> tx.outputs.asJson,
-      "size"       -> tx.size.asJson
+      "size"       -> tx.size.asJson,
+      "cost"       -> cost.asJson
     )
   }
 
@@ -137,7 +144,7 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
         val enrichedTxs = transactions.map { unconfirmedTx =>
           val tx             = unconfirmedTx.transaction
           val resolvedInputs = resolveTransactionInputs(tx.inputs, state, pool)
-          createTransactionWithResolvedInputs(tx, resolvedInputs)
+          createTransactionWithResolvedInputs(tx, resolvedInputs, unconfirmedTx.lastCost)
         }
         enrichedTxs.asJson
     }
@@ -145,11 +152,12 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
   /**
     * Resolves inputs for a single transaction and returns it with resolved inputs.
   */
-  private def getUnconfirmedTransactionWithResolvedInputs(transaction: ErgoTransaction): Future[Json] =
+  private def getUnconfirmedTransactionWithResolvedInputs(unconfirmedTx: UnconfirmedTransaction): Future[Json] =
     getStateAndPool.map {
       case (state, pool) =>
+        val transaction    = unconfirmedTx.transaction
         val resolvedInputs = resolveTransactionInputs(transaction.inputs, state, pool)
-      createTransactionWithResolvedInputs(transaction, resolvedInputs)
+        createTransactionWithResolvedInputs(transaction, resolvedInputs, unconfirmedTx.lastCost)
     }
 
   private def getUnconfirmedTransactions(offset: Int, limit: Int): Future[Json] = getUnconfirmedTransactionsWithResolvedInputs(offset, limit)
@@ -247,7 +255,7 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
     (pathPrefix("unconfirmed" / "byTransactionId") & get & modifierId) { modifierId =>
       ApiResponse(
         getMemPool.flatMap { pool =>
-          pool.modifierById(modifierId) match {
+          pool.unconfirmedById(modifierId) match {
             case Some(unconfirmedTx) =>
               getUnconfirmedTransactionWithResolvedInputs(unconfirmedTx)
             case None =>
@@ -292,25 +300,25 @@ case class TransactionsApiRoute(readersHolder: ActorRef,
               val allTxs = pool.getAll
               val txsWithOutputMatch =
                 allTxs
-                  .collect { case tx if tx.transaction.outputs.exists(_.ergoTree.bytesHex == ergoTree) =>
-                    tx.transaction
-                  }.toSet
+                  .filter(_.transaction.outputs.exists(_.ergoTree.bytesHex == ergoTree))
+                  .toSet
 
               getState.flatMap {
                 case state: UtxoStateReader =>
                   val txWithInputMatch =
                     allTxs
-                      .collect { case tx if
-                          tx.transaction.inputs.exists(i => state.boxById(i.boxId).exists(_.ergoTree.bytesHex == ergoTree)) =>
-                        tx.transaction
-                      }
+                      .filter(
+                        _.transaction.inputs.exists(i => state.boxById(i.boxId).exists(_.ergoTree.bytesHex == ergoTree))
+                      )
                       val allMatchingTxs = (txsWithOutputMatch ++ txWithInputMatch).toSeq.slice(offset, offset + limit)
                       Future.sequence(allMatchingTxs.map(getUnconfirmedTransactionWithResolvedInputs)).map(_.asJson)
                 case _ =>
+                      // digest state: inputs cannot be resolved, but the response keeps the shape
+                      // declared by the ErgoTransactionWithInputBoxes schema, `cost` included
                       Future.successful(
                         txsWithOutputMatch
                           .slice(offset, offset + limit)
-                          .map(_.asJson)
+                          .map(utx => createTransactionWithResolvedInputs(utx.transaction, Map.empty, utx.lastCost))
                           .asJson
                       )
               }

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala
@@ -46,7 +46,11 @@ class ErgoMemPool private[mempool](private[mempool] val pool: OrderedTxPool,
   override def size: Int = pool.size
 
   override def modifierById(modifierId: ModifierId): Option[ErgoTransaction] = {
-    pool.get(modifierId).map(unconfirmedTx => unconfirmedTx.transaction)
+    unconfirmedById(modifierId).map(unconfirmedTx => unconfirmedTx.transaction)
+  }
+
+  override def unconfirmedById(modifierId: ModifierId): Option[UnconfirmedTransaction] = {
+    pool.get(modifierId)
   }
 
   override def contains(modifierId: ModifierId): Boolean = {

--- a/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolReader.scala
+++ b/src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPoolReader.scala
@@ -45,6 +45,16 @@ trait ErgoMemPoolReader extends NodeViewComponent with ContainsModifiers[ErgoTra
   def modifierById(modifierId: ModifierId): Option[ErgoTransaction]
 
   /**
+    * Returns the pooled transaction along with the data the pool keeps for it
+    * (validation cost, timestamps, source peer), unlike `modifierById` which returns
+    * the transaction only.
+    *
+    * @param modifierId - transaction id
+    * @return unconfirmed transaction wrapper, or None if the pool does not hold it
+    */
+  def unconfirmedById(modifierId: ModifierId): Option[UnconfirmedTransaction]
+
+  /**
     * Returns transaction ids with weights. Weight depends on a fee a transaction is paying.
     * Resulting transactions are sorted by weight in descending order.
     *

--- a/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
+++ b/src/test/scala/org/ergoplatform/http/routes/TransactionApiRouteSpec.scala
@@ -11,6 +11,7 @@ import org.ergoplatform.ErgoBox.{AdditionalRegisters, NonMandatoryRegisterId, To
 import org.ergoplatform.http.api.{ApiCodecs, TransactionsApiRoute}
 import org.ergoplatform.modifiers.mempool.{ErgoTransaction, UnconfirmedTransaction}
 import org.ergoplatform.nodeView.ErgoReadersHolder.{GetDataFromHistory, GetReaders, Readers}
+import org.ergoplatform.nodeView.mempool.ErgoMemPool
 import org.ergoplatform.settings.RESTApiSettings
 import org.ergoplatform.utils.Stubs
 import org.ergoplatform.{DataInput, ErgoBox, ErgoBoxCandidate, Input}
@@ -71,6 +72,21 @@ class TransactionApiRouteSpec extends AnyFlatSpec
     }
     val readers2 = system.actorOf(Props(new UtxoReadersStub2))
     TransactionsApiRoute(readers2, nodeViewRef, settings).route
+  }
+
+  val txCost = 21456
+
+  // Pool holding exactly `tx`, with a known validation cost, so `cost` is deterministic.
+  val costedRoute: Route = {
+    val mp = ErgoMemPool.empty(settings).put(UnconfirmedTransaction(tx, None).withCost(txCost))
+    class CostedReadersStub extends Actor {
+      def receive: PartialFunction[Any, Unit] = {
+        case GetReaders => sender() ! Readers(history, utxoState, mp, wallet)
+        case GetDataFromHistory(f) => sender() ! f(history)
+      }
+    }
+    val readers = system.actorOf(Props(new CostedReadersStub))
+    TransactionsApiRoute(readers, nodeViewRef, settings).route
   }
 
   it should "post transaction" in {
@@ -316,6 +332,58 @@ class TransactionApiRouteSpec extends AnyFlatSpec
     val searchedRegs = Map.empty[NonMandatoryRegisterId, EvaluatedValue[_ <: SType]].asJson
     Post(prefix + s"/unconfirmed/outputs/byRegisters", searchedRegs) ~> chainedRoute ~> check {
       status shouldBe StatusCodes.BadRequest
+    }
+  }
+
+  it should "report validation cost of unconfirmed tx by id" in {
+    Get(prefix + s"/unconfirmed/byTransactionId/${tx.id}") ~> costedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("cost").as[Int] shouldEqual Right(txCost)
+    }
+  }
+
+  it should "report validation cost in the unconfirmed tx list" in {
+    Get(prefix + "/unconfirmed") ~> costedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val costs = responseAs[List[Json]].map(_.hcursor.downField("cost").as[Int])
+      costs shouldEqual List(Right(txCost))
+    }
+  }
+
+  it should "report the same validation cost from the list and by-id endpoints" in {
+    val listed = Get(prefix + "/unconfirmed") ~> costedRoute ~> check {
+      responseAs[List[Json]].map(_.hcursor.downField("cost").as[Int])
+    }
+    val byId = Get(prefix + s"/unconfirmed/byTransactionId/${tx.id}") ~> costedRoute ~> check {
+      responseAs[Json].hcursor.downField("cost").as[Int]
+    }
+    listed shouldEqual List(byId)
+  }
+
+  it should "report validation cost when searching unconfirmed txs by ergoTree" in {
+    val searchedTree = tx.outputs.head.ergoTree.bytesHex
+    Post(prefix + s"/unconfirmed/byErgoTree", searchedTree) ~> costedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      val costs = responseAs[List[Json]].map(_.hcursor.downField("cost").as[Int])
+      costs shouldEqual List(Right(txCost))
+    }
+  }
+
+  it should "report null validation cost when the node did not measure it" in {
+    // Stubs' mempool holds transactions put without a cost, as happens in digest state
+    // or for transactions returned to the pool by a rollback.
+    Get(prefix + s"/unconfirmed/byTransactionId/${txs.head.id}") ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val cursor = responseAs[Json].hcursor
+      cursor.keys.map(_.toList).getOrElse(Nil) should contain("cost")
+      cursor.downField("cost").focus shouldEqual Some(Json.Null)
+    }
+  }
+
+  it should "keep reporting size alongside cost" in {
+    Get(prefix + s"/unconfirmed/byTransactionId/${tx.id}") ~> costedRoute ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Json].hcursor.downField("size").as[Int] shouldEqual Right(tx.size)
     }
   }
 

--- a/src/test/scala/org/ergoplatform/utils/MempoolTestHelpers.scala
+++ b/src/test/scala/org/ergoplatform/utils/MempoolTestHelpers.scala
@@ -12,6 +12,8 @@ trait MempoolTestHelpers {
 
     override def modifierById(modifierId: ModifierId): Option[ErgoTransaction] = ???
 
+    override def unconfirmedById(modifierId: ModifierId): Option[UnconfirmedTransaction] = ???
+
     override def getAll(ids: Seq[ModifierId]): Seq[UnconfirmedTransaction] = ???
 
     override def size: Int = ???


### PR DESCRIPTION
## Problem

Block assembly is bounded by two limits, `maxBlockSize` and `maxBlockCost`. Both are enforced by `CandidateGenerator.correctLimits`:

```scala
blockTxs.map(_._2).sum < maxBlockCost && blockTxs.map(_._1.size).sum < maxBlockSize
```

The mempool API returns `size`, so external tooling can enforce the size limit. It does not return `cost`, so the cost limit cannot be enforced outside the node.

Anyone assembling blocks externally (block template builders, mempool simulators, throughput analysis) has to re-run script validation against a UTXO set, or guess from `size` and input/output counts. The node already computed the exact value during mempool admission and discarded it at the serialization boundary.

Cost is also already load-bearing inside the pool: `SortingOption.FeePerCycle` orders by fee-per-cost via `lastCost` in `ErgoMemPool.feeFactor`. A node in that mode exposes an ordering clients cannot reproduce.

## Change

Add a `cost` field to the mempool transaction JSON, sourced from `UnconfirmedTransaction.lastCost`.

```json
{
  "id": "...",
  "inputs": [ ... ],
  "dataInputs": [],
  "outputs": [ ... ],
  "size": 344,
  "cost": 21456
}
```

Affected endpoints:

- `GET /transactions/unconfirmed`
- `GET /transactions/unconfirmed/byTransactionId/{txId}`
- `POST /transactions/unconfirmed/byErgoTree`

## Null semantics

`cost` is `null` when the node never measured it:

1. **Digest state.** No script validation happens, so `lastCost` is never set.
2. **Rollback.** `ErgoNodeViewHolder.updateMemPool` returns transactions from disconnected blocks with `UnconfirmedTransaction(tx, None)` and puts them via `put`, which skips `validateWithCost`. They stay `null` until `CleanupWorker` re-validates them.

The key is always present on a node carrying this change, so clients can distinguish "node too old" (key absent) from "cost unknown" (key `null`).

## Implementation notes

**`unconfirmedById` added to `ErgoMemPoolReader`.** The by-id endpoint used `modifierById`, which returns `Option[ErgoTransaction]` and drops the wrapper before the route sees it. The new method returns the `UnconfirmedTransaction`; `modifierById` is now defined in terms of it, so there is one lookup path. `ErgoMemPool` implements it as `pool.get(id)`, identical to what `modifierById` did.

**`byErgoTree` keeps the wrapper.** Its two `collect` blocks mapped to `tx.transaction`, discarding the cost. They become `filter`s. Deduplication across the output-match and input-match sets is unchanged, since `UnconfirmedTransaction.equals` and `hashCode` are defined on the transaction id.

**Digest-state branch of `byErgoTree` now uses the shared JSON builder.** It previously serialized a bare `ErgoTransaction`, which did not match the `ErgoTransactionWithInputBoxes` schema the spec declares for that response. Routing it through the same builder fixes that and means `cost` is never silently absent from a response that otherwise carries it.

## Compatibility

Additive and optional. Not in the schema's `required` list. Clients that ignore unknown keys are unaffected. Confirmed-transaction schemas (`ErgoTransaction`, `IndexedErgoTransaction`, `WalletTransaction`) are untouched, since `lastCost` only exists for unconfirmed transactions.

## Tests

Six cases added to `TransactionApiRouteSpec`, covering cost reported by id, in the list, via `byErgoTree`, agreement between the list and by-id endpoints, the `null` case, and that `size` still reports correctly alongside `cost`.

Run locally on `v6.0.6`:

- `TransactionApiRouteSpec`: 29 passed, 0 failed (23 pre-existing, 6 new)
- Mempool, mempool auditor, wallet service and all HTTP route suites: 191 passed across 19 suites, 0 failed

## Known follow-up, not in this PR

Rollback-restored transactions report `null` until the next cleanup pass. Closing that would mean carrying per-transaction cost from block validation through `updateMemPool`, which is a larger change than exposing a value the pool already holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
